### PR TITLE
Fixed required module in IdentityServerHost

### DIFF
--- a/templates/service/host/IdentityServerHost/IdentityServerHostModule.cs
+++ b/templates/service/host/IdentityServerHost/IdentityServerHostModule.cs
@@ -17,6 +17,7 @@ namespace IdentityServerHost
     [DependsOn(
         typeof(AbpAutofacModule),
         typeof(AbpAspNetCoreMvcModule),
+        typeof(AbpIdentityAspNetCoreModule),
         typeof(AbpIdentityServerEntityFrameworkCoreModule),
         typeof(AbpIdentityEntityFrameworkCoreModule),
         typeof(AbpEntityFrameworkCoreSqlServerModule)


### PR DESCRIPTION
AbpIdentityAspNetCoreModule is required to inject SignInManager