### PR TITLE
fix #743 Use CustomSchemaIds for SwaggerGen.

### DIFF
--- a/modules/blogging/app/Volo.BloggingTestApp/BloggingTestAppModule.cs
+++ b/modules/blogging/app/Volo.BloggingTestApp/BloggingTestAppModule.cs
@@ -90,6 +90,7 @@ namespace Volo.BloggingTestApp
                 {
                     options.SwaggerDoc("v1", new Info { Title = "Blogging API", Version = "v1" });
                     options.DocInclusionPredicate((docName, description) => true);
+                    options.CustomSchemaIds(type => type.FullName);
                 });
 
             var cultures = new List<CultureInfo> { new CultureInfo("en"), new CultureInfo("tr") };

--- a/modules/docs/app/Volo.DocsTestApp/DocsTestAppModule.cs
+++ b/modules/docs/app/Volo.DocsTestApp/DocsTestAppModule.cs
@@ -82,6 +82,7 @@ namespace Volo.DocsTestApp
                 {
                     options.SwaggerDoc("v1", new Info { Title = "Docs API", Version = "v1" });
                     options.DocInclusionPredicate((docName, description) => true);
+                    options.CustomSchemaIds(type => type.FullName);
                 });
 
             var cultures = new List<CultureInfo> { new CultureInfo("en"), new CultureInfo("tr") };

--- a/samples/BookStore/src/Acme.BookStore.Web/BookStoreWebModule.cs
+++ b/samples/BookStore/src/Acme.BookStore.Web/BookStoreWebModule.cs
@@ -134,6 +134,7 @@ namespace Acme.BookStore
                 {
                     options.SwaggerDoc("v1", new Info { Title = "BookStore API", Version = "v1" });
                     options.DocInclusionPredicate((docName, description) => true);
+                    options.CustomSchemaIds(type => type.FullName);
                 });
         }
 

--- a/samples/MicroserviceDemo/microservices/identity/IdentityService.Host/IdentityServiceHostModule.cs
+++ b/samples/MicroserviceDemo/microservices/identity/IdentityService.Host/IdentityServiceHostModule.cs
@@ -52,6 +52,7 @@ namespace IdentityService.Host
             {
                 options.SwaggerDoc("v1", new Info {Title = "Identity Service API", Version = "v1"});
                 options.DocInclusionPredicate((docName, description) => true);
+                options.CustomSchemaIds(type => type.FullName);
             });
 
             Configure<AbpLocalizationOptions>(options =>

--- a/templates/module/app/MyCompanyName.MyProjectName.DemoApp/DemoAppModule.cs
+++ b/templates/module/app/MyCompanyName.MyProjectName.DemoApp/DemoAppModule.cs
@@ -76,6 +76,7 @@ namespace MyCompanyName.MyProjectName.DemoApp
                 {
                     options.SwaggerDoc("v1", new Info { Title = "MyProjectName API", Version = "v1" });
                     options.DocInclusionPredicate((docName, description) => true);
+                    options.CustomSchemaIds(type => type.FullName);
                 });
 
             Configure<AbpLocalizationOptions>(options =>

--- a/templates/mvc/src/MyCompanyName.MyProjectName.Web/MyProjectNameWebModule.cs
+++ b/templates/mvc/src/MyCompanyName.MyProjectName.Web/MyProjectNameWebModule.cs
@@ -153,6 +153,7 @@ namespace MyCompanyName.MyProjectName
                 {
                     options.SwaggerDoc("v1", new Info { Title = "MyProjectName API", Version = "v1" });
                     options.DocInclusionPredicate((docName, description) => true);
+                    options.CustomSchemaIds(type => type.FullName);
                 });
         }
 

--- a/templates/service/host/MyCompanyName.MyProjectName.Host/DemoAppModule.cs
+++ b/templates/service/host/MyCompanyName.MyProjectName.Host/DemoAppModule.cs
@@ -63,6 +63,7 @@ namespace MyCompanyName.MyProjectName.Host
                 {
                     options.SwaggerDoc("v1", new Info { Title = "MyProjectName API", Version = "v1" });
                     options.DocInclusionPredicate((docName, description) => true);
+                    options.CustomSchemaIds(type => type.FullName);
                 });
 
             Configure<AbpLocalizationOptions>(options =>


### PR DESCRIPTION
Add `options.CustomSchemaIds(type => type.FullName)` to the `AddSwaggerGen` method.