### PR TITLE
Fix for [Serializable] Attribute in ApplicationFeatureConfigurationDto and added unit tests

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc.Contracts/Volo/Abp/AspNetCore/Mvc/ApplicationConfigurations/ApplicationFeatureConfigurationDto.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.Contracts/Volo/Abp/AspNetCore/Mvc/ApplicationConfigurations/ApplicationFeatureConfigurationDto.cs
@@ -1,7 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations
 {
+    [Serializable]
     public class ApplicationFeatureConfigurationDto
     {
         public Dictionary<string, string> Values { get; set; }

--- a/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo.Abp.AspNetCore.Mvc.Tests.csproj
+++ b/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo.Abp.AspNetCore.Mvc.Tests.csproj
@@ -25,8 +25,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Volo.Abp.AspNetCore.Mvc.Contracts\Volo.Abp.AspNetCore.Mvc.Contracts.csproj" />
     <ProjectReference Include="..\..\src\Volo.Abp.AspNetCore.Mvc\Volo.Abp.AspNetCore.Mvc.csproj" />
     <ProjectReference Include="..\..\src\Volo.Abp.Autofac\Volo.Abp.Autofac.csproj" />
+    <ProjectReference Include="..\..\src\Volo.Abp.Serialization\Volo.Abp.Serialization.csproj" />
     <ProjectReference Include="..\Volo.Abp.AspNetCore.Tests\Volo.Abp.AspNetCore.Tests.csproj" />
     <ProjectReference Include="..\Volo.Abp.MemoryDb.Tests\Volo.Abp.MemoryDb.Tests.csproj" />
   </ItemGroup>

--- a/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/Contracts/ClassSerialization_Tests.cs
+++ b/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/Contracts/ClassSerialization_Tests.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using Volo.Abp.Modularity;
+using Volo.Abp.Reflection;
+using Volo.Abp.Serialization;
+using Xunit;
+
+namespace Volo.Abp.AspNetCore.Mvc.Contracts
+{
+    public class ClassSerialization_Tests : AspNetCoreMvcTestBase
+    {
+
+
+        [Fact]
+        public void Should_Have_Serializable_Attribute()
+        {
+            var assemblyFinder = GetRequiredService<IAssemblyFinder>();
+
+            var assembly = assemblyFinder.Assemblies
+                                         .Where(x => x.ManifestModule.Name == "Volo.Abp.AspNetCore.Mvc.Contracts.dll")
+                                         .Single();
+
+            var classes = assembly.DefinedTypes
+                                  .Where(x => x.IsClass)
+                                  .Where(x => !x.IsAssignableTo<AbpModule>())
+                                  .ToList();
+
+            foreach (var typeInfo in classes)
+            {
+                var attr = typeInfo.GetCustomAttribute<SerializableAttribute>();
+                if (attr == null)
+                    throw new Exception($"Class {typeInfo.FullName} does not contain [Serializable] attribute.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
In Microservices Demo, when running PublicWebSite service or BackendAdmin app there is an error in the logs that ApplicationFeatureConfigurationDto is not serializable.

This class was added without the attribute.

I also have added one very simple approach to check all classes in the Mvc.Contracts project to be serializable (we can extend later for other projects/patterns)