### PR TITLE
Add TenantName to Audit logs

### DIFF
--- a/framework/src/Volo.Abp.Auditing/Volo/Abp/Auditing/AuditLogActionInfo.cs
+++ b/framework/src/Volo.Abp.Auditing/Volo/Abp/Auditing/AuditLogActionInfo.cs
@@ -5,6 +5,7 @@ using Volo.Abp.MultiTenancy;
 
 namespace Volo.Abp.Auditing
 {
+    [Serializable]
     public class AuditLogActionInfo : IMultiTenant, IHasExtraProperties
     {
         public Guid? TenantId { get; set; }

--- a/framework/src/Volo.Abp.Auditing/Volo/Abp/Auditing/AuditLogInfo.cs
+++ b/framework/src/Volo.Abp.Auditing/Volo/Abp/Auditing/AuditLogInfo.cs
@@ -7,7 +7,7 @@ using Volo.Abp.MultiTenancy;
 
 namespace Volo.Abp.Auditing
 {
-    //TODO: Make serializable!
+    [Serializable]
     public class AuditLogInfo : IMultiTenant, IHasExtraProperties
     {
         public string ApplicationName { get; set; }
@@ -17,6 +17,8 @@ namespace Volo.Abp.Auditing
         public string UserName { get; set; }
 
         public Guid? TenantId { get; set; }
+
+        public string TenantName { get; set; }
 
         public Guid? ImpersonatorUserId { get; set; }
 

--- a/framework/src/Volo.Abp.Auditing/Volo/Abp/Auditing/AuditingHelper.cs
+++ b/framework/src/Volo.Abp.Auditing/Volo/Abp/Auditing/AuditingHelper.cs
@@ -92,6 +92,7 @@ namespace Volo.Abp.Auditing
             {
                 ApplicationName = Options.ApplicationName,
                 TenantId = CurrentTenant.Id,
+                TenantName = CurrentTenant.
                 UserId = CurrentUser.Id,
                 UserName = CurrentUser.UserName,
                 ClientId = CurrentClient.Id,

--- a/framework/src/Volo.Abp.Auditing/Volo/Abp/Auditing/EntityChangeInfo.cs
+++ b/framework/src/Volo.Abp.Auditing/Volo/Abp/Auditing/EntityChangeInfo.cs
@@ -6,6 +6,7 @@ using Volo.Abp.MultiTenancy;
 
 namespace Volo.Abp.Auditing
 {
+    [Serializable]
     public class EntityChangeInfo : IMultiTenant, IHasExtraProperties
     {
         public DateTime ChangeTime { get; set; }

--- a/framework/src/Volo.Abp.Auditing/Volo/Abp/Auditing/EntityPropertyChangeInfo.cs
+++ b/framework/src/Volo.Abp.Auditing/Volo/Abp/Auditing/EntityPropertyChangeInfo.cs
@@ -3,6 +3,7 @@ using Volo.Abp.MultiTenancy;
 
 namespace Volo.Abp.Auditing
 {
+    [Serializable]
     public class EntityPropertyChangeInfo : IMultiTenant
     {
         /// <summary>

--- a/modules/audit-logging/src/Volo.Abp.AuditLogging.Domain.Shared/Volo/Abp/AuditLogging/AuditLogConsts.cs
+++ b/modules/audit-logging/src/Volo.Abp.AuditLogging.Domain.Shared/Volo/Abp/AuditLogging/AuditLogConsts.cs
@@ -23,5 +23,7 @@
         public const int MaxHttpMethodLength = 16;
 
         public const int MaxUserNameLength = 256;
+
+        public const int MaxTenantNameLength = 64;
     }
 }

--- a/modules/audit-logging/src/Volo.Abp.AuditLogging.Domain/Volo/Abp/AuditLogging/AuditLog.cs
+++ b/modules/audit-logging/src/Volo.Abp.AuditLogging.Domain/Volo/Abp/AuditLogging/AuditLog.cs
@@ -19,6 +19,8 @@ namespace Volo.Abp.AuditLogging
 
         public virtual Guid? TenantId { get; protected set; }
 
+        public virtual string TenantName { get; protected set; }
+
         public virtual Guid? ImpersonatorUserId { get; protected set; }
 
         public virtual Guid? ImpersonatorTenantId { get; protected set; }
@@ -31,9 +33,9 @@ namespace Volo.Abp.AuditLogging
 
         public virtual string ClientName { get; protected set; }
 
-        public string ClientId { get; set; }
+        public virtual string ClientId { get; set; }
 
-        public string CorrelationId { get; set; }
+        public virtual string CorrelationId { get; set; }
 
         public virtual string BrowserInfo { get; protected set; }
 
@@ -59,8 +61,9 @@ namespace Volo.Abp.AuditLogging
         public AuditLog(IGuidGenerator guidGenerator, AuditLogInfo auditInfo)
         {
             Id = guidGenerator.Create();
-            ApplicationName = auditInfo.ApplicationName;
+            ApplicationName = auditInfo.ApplicationName.Truncate(AuditLogConsts.MaxApplicationNameLength);
             TenantId = auditInfo.TenantId;
+            TenantName = auditInfo.TenantName.Truncate(AuditLogConsts.MaxTenantNameLength);
             UserId = auditInfo.UserId;
             UserName = auditInfo.UserName.Truncate(AuditLogConsts.MaxUserNameLength);
             ExecutionTime = auditInfo.ExecutionTime;


### PR DESCRIPTION
Resolves #891

- [x] Make audit objects serializable
- [x] Add TenantName property to Audit log Info
- [x] Write Tenant Name to Audit log Info (needs tenant name to be available)