### PR TITLE
Ensure GitHub root url ends with forward slash in docs module

### DIFF
--- a/modules/docs/src/Volo.Docs.Domain/Volo/Docs/GitHub/Documents/GithubDocumentStore.cs
+++ b/modules/docs/src/Volo.Docs.Domain/Volo/Docs/GitHub/Documents/GithubDocumentStore.cs
@@ -206,7 +206,8 @@ namespace Volo.Docs.GitHub.Documents
         {
             return rootUrl
                 .Replace("github.com", "raw.githubusercontent.com")
-                .ReplaceFirst("/tree/", "/").EnsureEndsWith('/');
+                .ReplaceFirst("/tree/", "/")
+                .EnsureEndsWith('/');
         }
     }
 }

--- a/modules/docs/src/Volo.Docs.Domain/Volo/Docs/GitHub/Documents/GithubDocumentStore.cs
+++ b/modules/docs/src/Volo.Docs.Domain/Volo/Docs/GitHub/Documents/GithubDocumentStore.cs
@@ -206,7 +206,7 @@ namespace Volo.Docs.GitHub.Documents
         {
             return rootUrl
                 .Replace("github.com", "raw.githubusercontent.com")
-                .ReplaceFirst("/tree/", "/");
+                .ReplaceFirst("/tree/", "/").EnsureEndsWith('/');
         }
     }
 }


### PR DESCRIPTION
If user forgot to put a forward slash at the end of github repo's root url (it's common for urls copied from the web browser's address bar), the code "rawRootUrl + documentName" will return an invalid url path.