### PR TITLE
Restore localization files in BookStore sample

### DIFF
--- a/samples/BookStore/src/Acme.BookStore.Domain.Shared/Localization/BookStore/cs.json
+++ b/samples/BookStore/src/Acme.BookStore.Domain.Shared/Localization/BookStore/cs.json
@@ -14,7 +14,7 @@
     "NewBook": "Nová kniha",
     "Books": "Knihy",
     "Update": "Aktualizovat",
-    "BookDeletionConfirmationMessage": "Opravdu chcete smazat tuto knihu: {0}",
+    "BookDeletionConfirmationMessage": "Opravdu chcete smazat knihu {0}?",
     "SuccessfullyDeleted": "Úspěšně smazáno."
   }
 }

--- a/samples/BookStore/src/Acme.BookStore.Domain.Shared/Localization/BookStore/cs.json
+++ b/samples/BookStore/src/Acme.BookStore.Domain.Shared/Localization/BookStore/cs.json
@@ -3,6 +3,18 @@
   "texts": {
     "Menu:Home": "Úvod",
     "Welcome": "Vítejte",
-    "LongWelcomeMessage": "Vítejte v aplikaci. Toto je startovací projekt založený na ABP frameworku. Pro více informací, navštivte abp.io."
+    "LongWelcomeMessage": "Vítejte v aplikaci. Toto je startovací projekt založený na ABP frameworku. Pro více informací, navštivte abp.io.",
+    "Menu:BookStore": "Knihkupectví",
+    "Menu:Books": "Knihy",
+    "Name": "Název",
+    "Type": "Typ",
+    "PublishDate": "Publikováno",
+    "Price": "Cena",
+    "CreationTime": "Vytvořeno",
+    "NewBook": "Nová kniha",
+    "Books": "Knihy",
+    "Update": "Aktualizovat",
+    "BookDeletionConfirmationMessage": "Opravdu chcete smazat tuto knihu: {0}",
+    "SuccessfullyDeleted": "Úspěšně smazáno."
   }
 }

--- a/samples/BookStore/src/Acme.BookStore.Domain.Shared/Localization/BookStore/en.json
+++ b/samples/BookStore/src/Acme.BookStore.Domain.Shared/Localization/BookStore/en.json
@@ -14,7 +14,7 @@
     "NewBook": "New book",
     "Books": "Books",
     "Update": "Update",
-    "BookDeletionConfirmationMessage": "Are you sure to delete this book: {0}",
+    "BookDeletionConfirmationMessage": "Are you sure to delete the book {0}?",
     "SuccessfullyDeleted": "Successfully deleted."
   }
 }

--- a/samples/BookStore/src/Acme.BookStore.Domain.Shared/Localization/BookStore/en.json
+++ b/samples/BookStore/src/Acme.BookStore.Domain.Shared/Localization/BookStore/en.json
@@ -6,6 +6,15 @@
     "LongWelcomeMessage": "Welcome to the application. This is a startup project based on the ABP framework. For more information, visit abp.io.",
     "Menu:BookStore": "Book Store",
     "Menu:Books": "Books",
-    "BookDeletionConfirmationMessage": "Are you sure to delete the book {0}?" 
+    "Name": "Name",
+    "Type": "Type",
+    "PublishDate": "Publish Date",
+    "Price": "Price",
+    "CreationTime": "Creation Time",
+    "NewBook": "New book",
+    "Books": "Books",
+    "Update": "Update",
+    "BookDeletionConfirmationMessage": "Are you sure to delete this book: {0}",
+    "SuccessfullyDeleted": "Successfully deleted."
   }
 }

--- a/samples/BookStore/src/Acme.BookStore.Domain.Shared/Localization/BookStore/tr.json
+++ b/samples/BookStore/src/Acme.BookStore.Domain.Shared/Localization/BookStore/tr.json
@@ -3,6 +3,18 @@
   "texts": {
     "Menu:Home": "Ana sayfa",
     "Welcome": "Hoşgeldiniz",
-    "LongWelcomeMessage": "Uygulamaya hoşgeldiniz. Bu, ABP framework'ü üzerine bina edilmiş bir başlangıç projesidir. Daha fazla bilgi için abp.io adresini ziyaret edebilirsiniz."
+    "LongWelcomeMessage": "Uygulamaya hoşgeldiniz. Bu, ABP framework'ü üzerine bina edilmiş bir başlangıç projesidir. Daha fazla bilgi için abp.io adresini ziyaret edebilirsiniz.",
+    "Menu:BookStore": "Kitap Mağazası",
+    "Menu:Books": "Kitaplar",
+    "Name": "İsim",
+    "Type": "Tür",
+    "PublishDate": "Yayınlanma Tarihi",
+    "Price": "Fiyat",
+    "CreationTime": "Oluşturulma zamanı",
+    "NewBook": "Yeni kitap",
+    "Books": "Kitaplar",
+    "Update": "Güncelle",
+    "BookDeletionConfirmationMessage": "Bu kitabı silmek istediğinize emin misiniz: {0}",
+    "SuccessfullyDeleted": "Başarıyla silindi."
   }
 }

--- a/samples/BookStore/src/Acme.BookStore.Domain.Shared/Localization/BookStore/zh-Hans.json
+++ b/samples/BookStore/src/Acme.BookStore.Domain.Shared/Localization/BookStore/zh-Hans.json
@@ -1,20 +1,20 @@
 {
   "culture": "zh-Hans",
-"texts": {
-  "Menu:Home": "首页",
-  "Welcome": "欢迎",
-  "LongWelcomeMessage": "欢迎来到该应用程序. 这是一个基于ABP框架的启动项目. 有关更多信息, 请访问 cn.abp.io.",
-  "Menu:BookStore": "图书商店",
-  "Menu:Books": "图书",
-  "Name": "名称",
-  "Type": "类型",
-  "PublishDate": "出版时间",
-  "Price": "价格",
-  "CreationTime": "添加时间",
-  "NewBook": "新书籍",
-  "Books": "图书",
-  "Update": "更新",
-  "BookDeletionConfirmationMessage": "你确定删除书箱: {0} 吗",
-  "SuccessfullyDeleted": "删除成功."
-}
+  "texts": {
+    "Menu:Home": "首页",
+    "Welcome": "欢迎",
+    "LongWelcomeMessage": "欢迎来到该应用程序. 这是一个基于ABP框架的启动项目. 有关更多信息, 请访问 cn.abp.io.",
+    "Menu:BookStore": "图书商店",
+    "Menu:Books": "图书",
+    "Name": "名称",
+    "Type": "类型",
+    "PublishDate": "出版时间",
+    "Price": "价格",
+    "CreationTime": "添加时间",
+    "NewBook": "新书籍",
+    "Books": "图书",
+    "Update": "更新",
+    "BookDeletionConfirmationMessage": "你确定删除书箱: {0} 吗",
+    "SuccessfullyDeleted": "删除成功."
+  }
 }

--- a/samples/BookStore/src/Acme.BookStore.Domain.Shared/Localization/BookStore/zh-Hans.json
+++ b/samples/BookStore/src/Acme.BookStore.Domain.Shared/Localization/BookStore/zh-Hans.json
@@ -1,8 +1,20 @@
 {
-    "culture": "zh-Hans",
-    "texts": {
-      "Menu:Home": "首页",
-      "Welcome": "欢迎",
-      "LongWelcomeMessage": "欢迎来到该应用程序. 这是一个基于ABP框架的启动项目. 有关更多信息, 请访问 cn.abp.io."
-    }
-  }
+  "culture": "zh-Hans",
+"texts": {
+  "Menu:Home": "首页",
+  "Welcome": "欢迎",
+  "LongWelcomeMessage": "欢迎来到该应用程序. 这是一个基于ABP框架的启动项目. 有关更多信息, 请访问 cn.abp.io.",
+  "Menu:BookStore": "图书商店",
+  "Menu:Books": "图书",
+  "Name": "名称",
+  "Type": "类型",
+  "PublishDate": "出版时间",
+  "Price": "价格",
+  "CreationTime": "添加时间",
+  "NewBook": "新书籍",
+  "Books": "图书",
+  "Update": "更新",
+  "BookDeletionConfirmationMessage": "你确定删除书箱: {0} 吗",
+  "SuccessfullyDeleted": "删除成功."
+}
+}


### PR DESCRIPTION
dc214152e010530e8e25b7ad4e2ff8f52c4b748c made the BookStore sample use localization files from latest template instead of sample originals. Seeing those strings are still in use and aren't localized anymore, I assume this wasn't entirely intended change? Thanks for the review.