### PR TITLE
feat(cli): add default proxy support to cli

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/AbpCliCoreModule.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/AbpCliCoreModule.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System;
+using System.Text;
 using Volo.Abp.Cli.Commands;
 using Volo.Abp.Domain;
 using Volo.Abp.IdentityModel;
@@ -17,6 +18,10 @@ namespace Volo.Abp.Cli
         public override void ConfigureServices(ServiceConfigurationContext context)
         {
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
+            // TODO: workaround until subsequent issues of https://github.com/dotnet/corefx/issues/30166 are resolved
+            // a permanent fix will probably be published with the release of .net core 3.0: https://github.com/dotnet/corefx/issues/36553
+            AppContext.SetSwitch("System.Net.Http.UseSocketsHttpHandler", false);
 
             Configure<CliOptions>(options =>
             {

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Http/CliHttpClient.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Http/CliHttpClient.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+
+namespace Volo.Abp.Cli.Http
+{
+    public class CliHttpClient : HttpClient
+    {
+        public CliHttpClient() : base(new CliHttpClientHandler())
+        {
+            Timeout = TimeSpan.FromSeconds(30);
+
+            AddAuthentication(this);
+        }
+
+        private static void AddAuthentication(HttpClient client)
+        {
+            if (File.Exists(CliPaths.AccessToken))
+            {
+                var accessToken = File.ReadAllText(CliPaths.AccessToken, Encoding.UTF8);
+                if (!accessToken.IsNullOrEmpty())
+                {
+                    client.SetBearerToken(accessToken);
+                }
+            }
+        }
+    }
+}

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Http/CliHttpClientHandler.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Http/CliHttpClientHandler.cs
@@ -1,0 +1,14 @@
+﻿using System.Net;
+using System.Net.Http;
+
+namespace Volo.Abp.Cli.Http
+{
+    public class CliHttpClientHandler : HttpClientHandler
+    {
+        public CliHttpClientHandler()
+        {
+            Proxy = WebRequest.GetSystemWebProxy();
+            DefaultProxyCredentials = CredentialCache.DefaultCredentials;
+        }
+    }
+}

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/NuGet/NuGetService.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/NuGet/NuGetService.cs
@@ -3,8 +3,8 @@ using NuGet.Versioning;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Threading.Tasks;
+using Volo.Abp.Cli.Http;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Json;
 using Volo.Abp.Threading;
@@ -26,10 +26,8 @@ namespace Volo.Abp.Cli.NuGet
 
         public async Task<SemanticVersion> GetLatestVersionOrNullAsync(string packageId, bool includePreviews = false, bool includeNightly = false)
         {
-            using (var client = new HttpClient())
+            using (var client = new CliHttpClient())
             {
-                client.Timeout = TimeSpan.FromSeconds(30);
-
                 var url = includeNightly ?
                     $"https://www.myget.org/F/abp-nightly/api/v3/flatcontainer/{packageId.ToLowerInvariant()}/index.json" :
                     $"https://api.nuget.org/v3-flatcontainer/{packageId.ToLowerInvariant()}/index.json";

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectBuilding/AbpIoTemplateStore.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectBuilding/AbpIoTemplateStore.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using Volo.Abp.Cli.Http;
 using Volo.Abp.Cli.ProjectBuilding.Building;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Http;
@@ -82,12 +83,8 @@ namespace Volo.Abp.Cli.ProjectBuilding
         {
             var postData = JsonSerializer.Serialize(new GetLatestTemplateVersionDto { Name = name });
 
-            using (var client = new HttpClient())
+            using (var client = new CliHttpClient())
             {
-                client.Timeout = TimeSpan.FromSeconds(30);
-
-                AddAuthentication(client);
-
                 var responseMessage = await client.PostAsync(
                     $"{CliUrls.WwwAbpIo}api/download/template/get-version/",
                     new StringContent(postData, Encoding.UTF8, MimeTypes.Application.Json),
@@ -108,12 +105,8 @@ namespace Volo.Abp.Cli.ProjectBuilding
         {
             var postData = JsonSerializer.Serialize(input);
 
-            using (var client = new HttpClient())
+            using (var client = new CliHttpClient())
             {
-                client.Timeout = TimeSpan.FromMinutes(3);
-
-                AddAuthentication(client);
-
                 var responseMessage = await client.PostAsync(
                     $"{CliUrls.WwwAbpIo}api/download/template/",
                     new StringContent(postData, Encoding.UTF8, MimeTypes.Application.Json),
@@ -126,18 +119,6 @@ namespace Volo.Abp.Cli.ProjectBuilding
                 }
 
                 return await responseMessage.Content.ReadAsByteArrayAsync();
-            }
-        }
-
-        private static void AddAuthentication(HttpClient client)
-        {
-            if (File.Exists(CliPaths.AccessToken))
-            {
-                var accessToken = File.ReadAllText(CliPaths.AccessToken, Encoding.UTF8);
-                if (!accessToken.IsNullOrEmpty())
-                {
-                    client.SetBearerToken(accessToken);
-                }
             }
         }
 

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/ProjectNugetPackageAdder.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/ProjectNugetPackageAdder.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Volo.Abp.Cli.Http;
 using Volo.Abp.Cli.Utils;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.IO;
@@ -71,7 +71,7 @@ namespace Volo.Abp.Cli.ProjectModification
 
         protected virtual async Task<NugetPackageInfo> FindNugetPackageInfoAsync(string moduleName)
         {
-            using (var client = new HttpClient())
+            using (var client = new CliHttpClient())
             {
                 var url = $"{CliUrls.WwwAbpIo}api/app/nugetPackage/byName/?name=" + moduleName;
 

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/SolutionModuleAdder.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/SolutionModuleAdder.cs
@@ -6,8 +6,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Threading.Tasks;
+using Volo.Abp.Cli.Http;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Json;
 
@@ -123,7 +123,7 @@ namespace Volo.Abp.Cli.ProjectModification
 
         protected virtual async Task<ModuleInfo> FindModuleInfoAsync(string moduleName)
         {
-            using (var client = new HttpClient())
+            using (var client = new CliHttpClient())
             {
                 var url = $"{CliUrls.WwwAbpIo}api/app/module/byName/?name=" + moduleName;
 


### PR DESCRIPTION
The `dotnet abp` cli will now try to use the default windows proxy and credentials if they are set.

I needed to implement a workaround for using the old `.net standard 2.0` http library for web requests since proxy support is not yet fully functional in the new version.

This will probably implemented with the release of `.net core 3.0`: https://github.com/dotnet/corefx/issues/36553

When it's released the proxy support implementation should be re-evaluated and tried without the workaround in the `framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/AbpCliCoreModule.cs` file.

Closes #1373