### PR TITLE
Cli check npm global packages on-demand

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo.Abp.Cli.Core.csproj
+++ b/framework/src/Volo.Abp.Cli.Core/Volo.Abp.Cli.Core.csproj
@@ -28,10 +28,4 @@
     <ProjectReference Include="..\Volo.Abp.Json\Volo.Abp.Json.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Reference Include="System.Data.SqlXml">
-      <HintPath>C:\Windows\Microsoft.NET\Framework\v2.0.50727\System.Data.SqlXml.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
 </Project>

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/CliService.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/CliService.cs
@@ -42,7 +42,6 @@ namespace Volo.Abp.Cli
             Logger.LogInformation("ABP CLI (https://abp.io)");
 
             await CheckCliVersionAsync();
-            CheckDependencies();
 
             var commandLineArgs = CommandLineArgumentParser.Parse(args);
             var commandType = CommandSelector.Select(commandLineArgs);
@@ -64,32 +63,6 @@ namespace Volo.Abp.Cli
                     Logger.LogException(ex);
                 }
             }
-        }
-
-        private void CheckDependencies()
-        {
-            var installedNpmPackages = CmdHelper.RunCmdAndGetOutput("npm list -g --depth 0");
-
-            if (!installedNpmPackages.Contains(" yarn@"))
-            {
-                InstallYarn();
-            }
-            if (!installedNpmPackages.Contains(" gulp@"))
-            {
-                InstallGulp();
-            }
-        }
-
-        private void InstallYarn()
-        {
-            Logger.LogInformation("Installing yarn...");
-            CmdHelper.RunCmd("npm install yarn -g");
-        }
-
-        private void InstallGulp()
-        {
-            Logger.LogInformation("Installing gulp...");
-            CmdHelper.RunCmd("npm install gulp -g");
         }
 
         private async Task CheckCliVersionAsync()

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/NpmGlobalPackagesChecker.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/NpmGlobalPackagesChecker.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Volo.Abp.Cli.Utils;
+using Volo.Abp.DependencyInjection;
+
+namespace Volo.Abp.Cli.ProjectModification
+{
+    public class NpmGlobalPackagesChecker : ITransientDependency
+    {
+        public ILogger<NpmGlobalPackagesChecker> Logger { get; set; }
+
+        public NpmGlobalPackagesChecker(PackageJsonFileFinder packageJsonFileFinder)
+        {
+            Logger = NullLogger<NpmGlobalPackagesChecker>.Instance;
+        }
+
+        public void Check()
+        {
+            var installedNpmPackages = GetInstalledNpmPackages();
+
+            if (!installedNpmPackages.Contains(" yarn@"))
+            {
+                InstallYarn();
+            }
+            if (!installedNpmPackages.Contains(" gulp@"))
+            {
+                InstallGulp();
+            }
+        }
+
+        protected virtual string GetInstalledNpmPackages()
+        {
+            Logger.LogInformation("Checking installed npm global packages...");
+            return CmdHelper.RunCmdAndGetOutput("npm list -g --depth 0");
+        }
+
+        protected virtual void InstallYarn()
+        {
+            Logger.LogInformation("Installing yarn...");
+            CmdHelper.RunCmd("npm install yarn -g");
+        }
+
+        protected virtual void InstallGulp()
+        {
+            Logger.LogInformation("Installing gulp...");
+            CmdHelper.RunCmd("npm install gulp -g");
+        }
+    }
+}

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/NpmPackagesUpdater.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/NpmPackagesUpdater.cs
@@ -18,12 +18,14 @@ namespace Volo.Abp.Cli.ProjectModification
         public ILogger<NpmPackagesUpdater> Logger { get; set; }
 
         private readonly PackageJsonFileFinder _packageJsonFileFinder;
+        private readonly NpmGlobalPackagesChecker _npmGlobalPackagesChecker;
 
         private readonly Dictionary<string, string> _fileVersionStorage = new Dictionary<string, string>();
 
-        public NpmPackagesUpdater(PackageJsonFileFinder packageJsonFileFinder)
+        public NpmPackagesUpdater(PackageJsonFileFinder packageJsonFileFinder, NpmGlobalPackagesChecker npmGlobalPackagesChecker)
         {
             _packageJsonFileFinder = packageJsonFileFinder;
+            _npmGlobalPackagesChecker = npmGlobalPackagesChecker;
 
             Logger = NullLogger<NpmPackagesUpdater>.Instance;
         }
@@ -32,11 +34,16 @@ namespace Volo.Abp.Cli.ProjectModification
         {
             var fileList = _packageJsonFileFinder.Find(rootDirectory);
 
-            foreach (var file in fileList)
+            if (fileList.Any())
             {
-                UpdatePackagesInFile(file);
+                _npmGlobalPackagesChecker.Check();
 
-                RunYarnAndGulp(file);
+                foreach (var file in fileList)
+                {
+                    UpdatePackagesInFile(file);
+
+                    RunYarnAndGulp(file);
+                }
             }
         }
 

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/SolutionModuleAdder.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/SolutionModuleAdder.cs
@@ -21,8 +21,9 @@ namespace Volo.Abp.Cli.ProjectModification
         protected ProjectNugetPackageAdder ProjectNugetPackageAdder { get; }
         protected DbContextFileBuilderConfigureAdder DbContextFileBuilderConfigureAdder { get; }
         protected EfCoreMigrationAdder EfCoreMigrationAdder { get; }
-        protected ProjectNpmPackageAdder ProjectNpmPackageAdder { get; }
         protected DerivedClassFinder DerivedClassFinder { get; }
+        protected ProjectNpmPackageAdder ProjectNpmPackageAdder { get; }
+        protected NpmGlobalPackagesChecker NpmGlobalPackagesChecker { get; }
 
         public SolutionModuleAdder(
             IJsonSerializer jsonSerializer,
@@ -30,14 +31,16 @@ namespace Volo.Abp.Cli.ProjectModification
             DbContextFileBuilderConfigureAdder dbContextFileBuilderConfigureAdder,
             EfCoreMigrationAdder efCoreMigrationAdder,
             DerivedClassFinder derivedClassFinder,
-            ProjectNpmPackageAdder projectNpmPackageAdder)
+            ProjectNpmPackageAdder projectNpmPackageAdder,
+            NpmGlobalPackagesChecker npmGlobalPackagesChecker)
         {
-            EfCoreMigrationAdder = efCoreMigrationAdder;
-            DerivedClassFinder = derivedClassFinder;
             JsonSerializer = jsonSerializer;
             ProjectNugetPackageAdder = projectNugetPackageAdder;
             DbContextFileBuilderConfigureAdder = dbContextFileBuilderConfigureAdder;
+            EfCoreMigrationAdder = efCoreMigrationAdder;
+            DerivedClassFinder = derivedClassFinder;
             ProjectNpmPackageAdder = projectNpmPackageAdder;
+            NpmGlobalPackagesChecker = npmGlobalPackagesChecker;
             Logger = NullLogger<SolutionModuleAdder>.Instance;
         }
 
@@ -72,6 +75,8 @@ namespace Volo.Abp.Cli.ProjectModification
                 var targetProjects = ProjectFinder.FindNpmTargetProjectFile(projectFiles);
                 if (targetProjects.Any())
                 {
+                    NpmGlobalPackagesChecker.Check();
+
                     foreach (var targetProject in targetProjects)
                     {
                         foreach (var npmPackage in module.NpmPackages.Where(p => p.ApplicationType.HasFlag(NpmApplicationType.Mvc)))

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Utils/CmdHelper.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Utils/CmdHelper.cs
@@ -61,7 +61,7 @@ namespace Volo.Abp.Cli.Utils
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                //TODO: Test this. it should work for both operaion systems.
+                //TODO: Test this. it should work for both operation systems.
                 return "/bin/bash";
             }
 


### PR DESCRIPTION
Currently, Cli check the npm global packages every time on startup, it spent 5 seconds or even more:
```shell
[10:26:00 INF] ABP CLI (https://abp.io)
[10:26:00 INF] Version 0.18.1 (Stable channel)
[10:26:06 INF]
Usage:

    abp <command> <target> [options]
```

---

After this changing:
```shell
[10:51:37 INF] ABP CLI (https://abp.io)
[10:51:37 INF] Version 0.18.1 (Stable channel)
[10:51:38 INF]
Usage:

    abp <command> <target> [options]
```