### PR TITLE
Make sure the database is created correctly

### DIFF
--- a/samples/BookStore/src/Acme.BookStore.EntityFrameworkCore.DbMigrations/EntityFrameworkCore/EntityFrameworkCoreBookStoreDbSchemaMigrator.cs
+++ b/samples/BookStore/src/Acme.BookStore.EntityFrameworkCore.DbMigrations/EntityFrameworkCore/EntityFrameworkCoreBookStoreDbSchemaMigrator.cs
@@ -18,6 +18,7 @@ namespace Acme.BookStore.EntityFrameworkCore
 
         public async Task MigrateAsync()
         {
+            await _dbContext.Database.EnsureCreatedAsync();
             await _dbContext.Database.MigrateAsync();
         }
     }

--- a/templates/mvc/src/MyCompanyName.MyProjectName.EntityFrameworkCore.DbMigrations/EntityFrameworkCore/EntityFrameworkCoreMyProjectNameDbSchemaMigrator.cs
+++ b/templates/mvc/src/MyCompanyName.MyProjectName.EntityFrameworkCore.DbMigrations/EntityFrameworkCore/EntityFrameworkCoreMyProjectNameDbSchemaMigrator.cs
@@ -18,6 +18,7 @@ namespace MyCompanyName.MyProjectName.EntityFrameworkCore
 
         public async Task MigrateAsync()
         {
+            await _dbContext.Database.EnsureCreatedAsync();
             await _dbContext.Database.MigrateAsync();
         }
     }


### PR DESCRIPTION
When using mysql, if the database does not exist, it will not be executing migrate. So we need to make sure the database has been created before executing migrate.