### PR TITLE
Fixed Namespace Issue

### DIFF
--- a/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/AbpUiNavigationModule.cs
+++ b/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/AbpUiNavigationModule.cs
@@ -1,7 +1,7 @@
 ﻿using Volo.Abp.Localization;
 using Volo.Abp.Modularity;
-using Volo.Abp.Ui.Navigation;
-using Volo.Abp.Ui.Navigation.Localization.Resource;
+using Volo.Abp.UI.Navigation;
+using Volo.Abp.UI.Navigation.Localization.Resource;
 using Volo.Abp.VirtualFileSystem;
 
 namespace Volo.Abp.UI.Navigation

--- a/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/ApplicationMenu.cs
+++ b/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/ApplicationMenu.cs
@@ -1,5 +1,5 @@
 using JetBrains.Annotations;
-using Volo.Abp.Ui.Navigation;
+using Volo.Abp.UI.Navigation;
 
 namespace Volo.Abp.UI.Navigation
 {

--- a/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/ApplicationMenuExtensions.cs
+++ b/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/ApplicationMenuExtensions.cs
@@ -1,6 +1,6 @@
 using JetBrains.Annotations;
 using System.Linq;
-using Volo.Abp.Ui.Navigation;
+using Volo.Abp.UI.Navigation;
 
 namespace Volo.Abp.UI.Navigation
 {

--- a/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/ApplicationMenuItem.cs
+++ b/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/ApplicationMenuItem.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using JetBrains.Annotations;
-using Volo.Abp.Ui.Navigation;
+using Volo.Abp.UI.Navigation;
 
 namespace Volo.Abp.UI.Navigation
 {

--- a/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/ApplicationMenuItemList.cs
+++ b/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/ApplicationMenuItemList.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Volo.Abp.UI.Navigation;
 
-namespace Volo.Abp.Ui.Navigation
+namespace Volo.Abp.UI.Navigation
 {
     public class ApplicationMenuItemList : List<ApplicationMenuItem>
     {

--- a/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/DefaultMenuContributor.cs
+++ b/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/DefaultMenuContributor.cs
@@ -1,10 +1,10 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using System.Threading.Tasks;
-using Volo.Abp.Ui.Navigation.Localization.Resource;
+using Volo.Abp.UI.Navigation.Localization.Resource;
 using Volo.Abp.UI.Navigation;
 
-namespace Volo.Abp.Ui.Navigation
+namespace Volo.Abp.UI.Navigation
 {
     public class DefaultMenuContributor : IMenuContributor
     {

--- a/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/DefaultMenuNames.cs
+++ b/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/DefaultMenuNames.cs
@@ -1,4 +1,4 @@
-﻿namespace Volo.Abp.Ui.Navigation
+﻿namespace Volo.Abp.UI.Navigation
 {
     public static class DefaultMenuNames
     {

--- a/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/HasMenuItemsExtensions.cs
+++ b/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/HasMenuItemsExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using JetBrains.Annotations;
 using Volo.Abp.UI.Navigation;
 
-namespace Volo.Abp.Ui.Navigation
+namespace Volo.Abp.UI.Navigation
 {
     public static class HasMenuItemsExtensions
     {

--- a/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/IHasMenuItems.cs
+++ b/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/IHasMenuItems.cs
@@ -1,4 +1,4 @@
-using Volo.Abp.Ui.Navigation;
+using Volo.Abp.UI.Navigation;
 
 namespace Volo.Abp.UI.Navigation
 {

--- a/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/Localization/Resource/AbpUiNavigationResource.cs
+++ b/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/Localization/Resource/AbpUiNavigationResource.cs
@@ -1,6 +1,6 @@
 ﻿using Volo.Abp.Localization;
 
-namespace Volo.Abp.Ui.Navigation.Localization.Resource
+namespace Volo.Abp.UI.Navigation.Localization.Resource
 {
     [LocalizationResourceName("AbpUiNavigation")]
     public class AbpUiNavigationResource

--- a/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/Urls/AppUrlOptions.cs
+++ b/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/Urls/AppUrlOptions.cs
@@ -1,4 +1,4 @@
-﻿namespace Volo.Abp.Ui.Navigation.Urls
+﻿namespace Volo.Abp.UI.Navigation.Urls
 {
     public class AppUrlOptions
     {

--- a/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/Urls/AppUrlProvider.cs
+++ b/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/Urls/AppUrlProvider.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Options;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.MultiTenancy;
 
-namespace Volo.Abp.Ui.Navigation.Urls
+namespace Volo.Abp.UI.Navigation.Urls
 {
     public class AppUrlProvider : IAppUrlProvider, ITransientDependency
     {

--- a/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/Urls/ApplicationUrlDictionary.cs
+++ b/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/Urls/ApplicationUrlDictionary.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace Volo.Abp.Ui.Navigation.Urls
+namespace Volo.Abp.UI.Navigation.Urls
 {
     public class ApplicationUrlDictionary
     {

--- a/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/Urls/ApplicationUrlInfo.cs
+++ b/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/Urls/ApplicationUrlInfo.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace Volo.Abp.Ui.Navigation.Urls
+namespace Volo.Abp.UI.Navigation.Urls
 {
     public class ApplicationUrlInfo
     {

--- a/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/Urls/IAppUrlProvider.cs
+++ b/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/Urls/IAppUrlProvider.cs
@@ -1,7 +1,7 @@
 ﻿using System.Threading.Tasks;
 using JetBrains.Annotations;
 
-namespace Volo.Abp.Ui.Navigation.Urls
+namespace Volo.Abp.UI.Navigation.Urls
 {
     public interface IAppUrlProvider
     {

--- a/framework/test/Volo.Abp.UI.Navigation.Tests/Volo/Abp/Ui/Navigation/MenuManager_Tests.cs
+++ b/framework/test/Volo.Abp.UI.Navigation.Tests/Volo/Abp/Ui/Navigation/MenuManager_Tests.cs
@@ -2,7 +2,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
 using Volo.Abp.Modularity;
-using Volo.Abp.Ui.Navigation;
+using Volo.Abp.UI.Navigation;
 using Xunit;
 
 namespace Volo.Abp.UI.Navigation


### PR DESCRIPTION
`Volo.Abp.UI.Navigation` was split into two namespaces - Volo.Abp.**Ui** and Volo.Abp.**UI** .  Updated the `Volo.Abp.Ui` namespaces to match the base namespace of `Volo.Abp.UI`