### PR TITLE
add AbpJsonOptions.

### DIFF
--- a/framework/src/Volo.Abp.Json/Volo/Abp/Json/AbpJsonOptions.cs
+++ b/framework/src/Volo.Abp.Json/Volo/Abp/Json/AbpJsonOptions.cs
@@ -1,0 +1,9 @@
+﻿using Newtonsoft.Json;
+
+namespace Volo.Abp.Json
+{
+    public class AbpJsonOptions
+    {
+        public JsonSerializerSettings SerializerSettings { get; } = new JsonSerializerSettings();
+    }
+}

--- a/framework/src/Volo.Abp.Json/Volo/Abp/Json/Newtonsoft/AbpJsonIsoDateTimeConverter.cs
+++ b/framework/src/Volo.Abp.Json/Volo/Abp/Json/Newtonsoft/AbpJsonIsoDateTimeConverter.cs
@@ -1,4 +1,5 @@
 using System;
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Volo.Abp.DependencyInjection;
@@ -10,9 +11,10 @@ namespace Volo.Abp.Json.Newtonsoft
     {
         private readonly IClock _clock;
 
-        public AbpJsonIsoDateTimeConverter(IClock clock)
+        public AbpJsonIsoDateTimeConverter(IClock clock, IOptions<AbpJsonOptions> abpJsonOptions)
         {
             _clock = clock;
+            DateTimeFormat = abpJsonOptions.Value.SerializerSettings.DateFormatString;
         }
 
         public override bool CanConvert(Type objectType)

--- a/framework/src/Volo.Abp.Json/Volo/Abp/Json/Newtonsoft/NewtonsoftJsonSerializer.cs
+++ b/framework/src/Volo.Abp.Json/Volo/Abp/Json/Newtonsoft/NewtonsoftJsonSerializer.cs
@@ -1,4 +1,5 @@
 using System;
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using Volo.Abp.DependencyInjection;
@@ -8,10 +9,12 @@ namespace Volo.Abp.Json.Newtonsoft
     public class NewtonsoftJsonSerializer : IJsonSerializer, ITransientDependency
     {
         private readonly AbpJsonIsoDateTimeConverter _dateTimeConverter;
+        private readonly AbpJsonOptions _abpJsonOptions;
 
-        public NewtonsoftJsonSerializer(AbpJsonIsoDateTimeConverter dateTimeConverter)
+        public NewtonsoftJsonSerializer(AbpJsonIsoDateTimeConverter dateTimeConverter, IOptions<AbpJsonOptions> abpJsonOptions)
         {
             _dateTimeConverter = dateTimeConverter;
+            _abpJsonOptions = abpJsonOptions.Value;
         }
 
         public string Serialize(object obj, bool camelCase = true, bool indented = false)
@@ -31,7 +34,7 @@ namespace Volo.Abp.Json.Newtonsoft
 
         protected virtual JsonSerializerSettings CreateSerializerSettings(bool camelCase = true, bool indented = false)
         {
-            var settings = new JsonSerializerSettings();
+            var settings = _abpJsonOptions.SerializerSettings;
 
             settings.Converters.Insert(0, _dateTimeConverter);
             

--- a/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/Json/JsonResultController.cs
+++ b/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/Json/JsonResultController.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Volo.Abp.AspNetCore.Mvc.Json
+{
+    [Route("api/json-result-test")]
+    public class JsonResultController : AbpController
+    {
+        [HttpGet]
+        [Route("json-result-action")]
+        public Task<JsonResultModel> ObjectResultAction()
+        {
+            return Task.FromResult(new JsonResultModel
+            {
+                Time = DateTime.Parse("2019-01-01 11:59:59")
+            });
+        }
+
+        public class JsonResultModel
+        {
+            public DateTime Time { get; set; }
+        }
+    }
+
+
+}

--- a/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/Json/JsonResultController_Tests.cs
+++ b/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/Json/JsonResultController_Tests.cs
@@ -1,0 +1,32 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Volo.Abp.Json;
+using Xunit;
+
+namespace Volo.Abp.AspNetCore.Mvc.Json
+{
+    public class JsonResultController_Tests : AspNetCoreMvcTestBase
+    {
+        protected override void ConfigureServices(WebHostBuilderContext context, IServiceCollection services)
+        {
+            services.Configure<AbpJsonOptions>(options =>
+            {
+                options.SerializerSettings.DateFormatString = "yyyy*MM*dd";
+            });
+
+            base.ConfigureServices(context, services);
+        }
+
+        [Fact]
+        public async Task DateFormatString_Test()
+        {
+            var time = await GetResponseAsStringAsync(
+                "/api/json-result-test/json-result-action"
+            );
+
+            time.ShouldContain("2019*01*01");
+        }
+    }
+}

--- a/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/Json/JsonSerializer_Tests.cs
+++ b/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/Json/JsonSerializer_Tests.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Volo.Abp.Json;
+using Xunit;
+
+namespace Volo.Abp.AspNetCore.Mvc.Json
+{
+    public class JsonSerializer_Tests : AspNetCoreMvcTestBase
+    {
+        private readonly IJsonSerializer _jsonSerializer;
+
+        public JsonSerializer_Tests()
+        {
+            _jsonSerializer = ServiceProvider.GetRequiredService<IJsonSerializer>();
+        }
+
+        protected override void ConfigureServices(WebHostBuilderContext context, IServiceCollection services)
+        {
+            services.Configure<AbpJsonOptions>(options =>
+            {
+                options.SerializerSettings.DateFormatString = "yyyy*MM*dd";
+            });
+
+            base.ConfigureServices(context, services);
+        }
+
+        [Fact]
+        public void DateFormatString_Test()
+        {
+            var output = _jsonSerializer.Serialize(new
+            {
+                Time = DateTime.Parse("2019-01-01 11:59:59")
+            });
+
+            output.ShouldContain("2019*01*01");
+        }
+    }
+}


### PR DESCRIPTION
Resolve #1487 

Net core 3.0 will use the built-in json component. We may not depend on Newtonsoft.Json after the 3.0 release.