### PR TITLE
Remove redundant type attributes

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/TagHelpers/AbpTagHelperScriptService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/TagHelpers/AbpTagHelperScriptService.cs
@@ -39,7 +39,7 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bundling.TagHelpers
 
         protected override void AddHtmlTag(TagHelperContext context, TagHelperOutput output, string file)
         {
-            output.Content.AppendHtml($"<script src=\"{file}\" type=\"text/javascript\"></script>{Environment.NewLine}");
+            output.Content.AppendHtml($"<script src=\"{file}\"></script>{Environment.NewLine}");
         }
     }
 }

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/TagHelpers/AbpTagHelperStyleService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/TagHelpers/AbpTagHelperStyleService.cs
@@ -11,12 +11,12 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bundling.TagHelpers
     public class AbpTagHelperStyleService : AbpTagHelperResourceService
     {
         public AbpTagHelperStyleService(
-            IBundleManager bundleManager, 
+            IBundleManager bundleManager,
             IWebContentFileProvider webContentFileProvider,
             IOptions<BundlingOptions> options,
             IHostingEnvironment hostingEnvironment
             ) : base(
-                bundleManager, 
+                bundleManager,
                 webContentFileProvider,
                 options,
                 hostingEnvironment)
@@ -39,7 +39,7 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bundling.TagHelpers
 
         protected override void AddHtmlTag(TagHelperContext context, TagHelperOutput output, string file)
         {
-            output.Content.AppendHtml($"<link rel=\"stylesheet\" type=\"text/css\" href=\"{file}\" />{Environment.NewLine}");
+            output.Content.AppendHtml($"<link rel=\"stylesheet\" href=\"{file}\" />{Environment.NewLine}");
         }
     }
 }

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic/Themes/Basic/Layouts/Account.cshtml
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic/Themes/Basic/Layouts/Account.cshtml
@@ -75,8 +75,8 @@
 
     <abp-script-bundle name="@BasicThemeBundles.Scripts.Global" />
 
-    <script type="text/javascript" src="~/Abp/ApplicationConfigurationScript"></script>
-    <script type="text/javascript" src="~/Abp/ServiceProxyScript"></script>
+    <script src="~/Abp/ApplicationConfigurationScript"></script>
+    <script src="~/Abp/ServiceProxyScript"></script>
 
     @await RenderSectionAsync("scripts", false)
 

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic/Themes/Basic/Layouts/Application.cshtml
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic/Themes/Basic/Layouts/Application.cshtml
@@ -60,8 +60,8 @@
 
     <abp-script-bundle name="@BasicThemeBundles.Scripts.Global" />
 
-    <script type="text/javascript" src="~/Abp/ApplicationConfigurationScript"></script>
-    <script type="text/javascript" src="~/Abp/ServiceProxyScript"></script>
+    <script src="~/Abp/ApplicationConfigurationScript"></script>
+    <script src="~/Abp/ServiceProxyScript"></script>
 
     @await RenderSectionAsync("scripts", false)
 

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic/Themes/Basic/Layouts/Empty.cshtml
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic/Themes/Basic/Layouts/Empty.cshtml
@@ -54,8 +54,8 @@
 
     <abp-script-bundle name="@BasicThemeBundles.Scripts.Global" />
 
-    <script type="text/javascript" src="~/Abp/ApplicationConfigurationScript"></script>
-    <script type="text/javascript" src="~/Abp/ServiceProxyScript"></script>
+    <script src="~/Abp/ApplicationConfigurationScript"></script>
+    <script src="~/Abp/ServiceProxyScript"></script>
 
     @await RenderSectionAsync("scripts", false)
 


### PR DESCRIPTION
Type attributes on `<script>` and `<link ref="stylesheet">` are redundant because currently set values are the default, which leads to warnings in [the W3C Markup Validation Service](https://validator.w3.org)

![image](https://user-images.githubusercontent.com/5835044/61575959-7fc5c680-aad3-11e9-94f3-f33a970c36ee.png)

---

Quote from [HTML 5.2 W3C Recommendation (§ 4.12.1. The script element)](https://www.w3.org/TR/html52/semantics-scripting.html#element-attrdef-script-type)

>The type attribute allows customization of the type of script represented:
>
>Omitting the attribute, or setting it to a JavaScript MIME type, means that the script is a classic script, to be interpreted according to the JavaScript Script top-level production. Classic scripts are affected by the charset, async, and defer attributes. Authors should omit the attribute, instead of redundantly giving a JavaScript MIME type.

Quote from [HTML 5.2 W3C Recommendation (§ 4.8.6.11. Link type "stylesheet")](https://www.w3.org/TR/html52/links.html#link-type-stylesheet)

>The default type for resources given by the stylesheet keyword is text/css.
