### PR TITLE
Resolve #1536 Use minified version of the script/style.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/Scripts/ScriptBundler.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/Scripts/ScriptBundler.cs
@@ -1,3 +1,4 @@
+using System;
 using Volo.Abp.AspNetCore.Mvc.UI.Minification.Scripts;
 using Volo.Abp.AspNetCore.VirtualFileSystem;
 
@@ -10,6 +11,11 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bundling.Scripts
         public ScriptBundler(IWebContentFileProvider webContentFileProvider, IJavascriptMinifier minifier)
             : base(webContentFileProvider, minifier)
         {
+        }
+
+        protected override string NormalizedCode(string code)
+        {
+            return code.EnsureEndsWith(';') + Environment.NewLine;
         }
     }
 }


### PR DESCRIPTION
When the js/css file ends with min or there is a file ending with min with the same name, splicing these files instead of Minify them again.

If it is a js file, we are making sure that the file ends with a semicolon.