### PR TITLE
feature (abp) Resolve #844 add automapper profiles by AbpModule(assembly)

### DIFF
--- a/framework/src/Volo.Abp.AutoMapper/Volo/Abp/AutoMapper/AbpAutoMapperOptions.cs
+++ b/framework/src/Volo.Abp.AutoMapper/Volo/Abp/AutoMapper/AbpAutoMapperOptions.cs
@@ -30,5 +30,13 @@ namespace Volo.Abp.AutoMapper
                 ValidatingProfiles.Add<TProfile>();
             }
         }
+
+        public void AddProfiles<TAbpModule>()
+        {
+            Configurators.Add(context =>
+            {
+                context.MapperConfiguration.AddMaps(typeof(TAbpModule).Assembly);
+            });
+        }
     }
 }

--- a/framework/test/Volo.Abp.AutoMapper.Tests/Volo/Abp/AutoMapper/AutoMapper_ConfigurationValidation_Tests.cs
+++ b/framework/test/Volo.Abp.AutoMapper.Tests/Volo/Abp/AutoMapper/AutoMapper_ConfigurationValidation_Tests.cs
@@ -7,7 +7,39 @@ using IObjectMapper = Volo.Abp.ObjectMapping.IObjectMapper;
 
 namespace Volo.Abp.AutoMapper
 {
-    public class AutoMapper_ConfigurationValidation_Tests : AbpIntegratedTest<AutoMapper_ConfigurationValidation_Tests.TestModule>
+    public class MySourceClass
+    {
+        public string Value { get; set; }
+    }
+
+    public class MyClassValidated
+    {
+        public string Value { get; set; }
+    }
+
+    public class MyClassNonValidated
+    {
+        public string ValueNotMatched { get; set; }
+    }
+
+    public class ValidatedProfile : Profile
+    {
+        public ValidatedProfile()
+        {
+            CreateMap<MySourceClass, MyClassValidated>();
+        }
+    }
+
+    public class NonValidatedProfile : Profile
+    {
+        public NonValidatedProfile()
+        {
+            CreateMap<MySourceClass, MyClassNonValidated>();
+        }
+    }
+
+    public abstract class AutoMapper_ConfigurationValidation_Tests<TStartupModule> : AbpIntegratedTest<TStartupModule>
+                where TStartupModule : IAbpModule
     {
         private readonly IObjectMapper _objectMapper;
 
@@ -22,20 +54,10 @@ namespace Volo.Abp.AutoMapper
             _objectMapper.Map<MySourceClass, MyClassValidated>(new MySourceClass {Value = "42"}).Value.ShouldBe("42");
             _objectMapper.Map<MySourceClass, MyClassNonValidated>(new MySourceClass {Value = "42"}).ValueNotMatched.ShouldBe(null);
         }
+    }
 
-        [DependsOn(typeof(AbpAutoMapperModule))]
-        public class TestModule : AbpModule
-        {
-            public override void ConfigureServices(ServiceConfigurationContext context)
-            {
-                Configure<AbpAutoMapperOptions>(options =>
-                {
-                    options.AddProfile<ValidatedProfile>(true);
-                    options.AddProfile<NonValidatedProfile>();
-                });
-            }
-        }
-
+    public class AutoMapper_ConfigurationValidation_Tests : AutoMapper_ConfigurationValidation_Tests<AutoMapper_ConfigurationValidation_Tests.TestModule>
+    {
         public class ValidatedProfile : Profile
         {
             public ValidatedProfile()
@@ -52,19 +74,33 @@ namespace Volo.Abp.AutoMapper
             }
         }
 
-        public class MySourceClass
+        [DependsOn(typeof(AbpAutoMapperModule))]
+        public class TestModule : AbpModule
         {
-            public string Value { get; set; }
+            public override void ConfigureServices(ServiceConfigurationContext context)
+            {
+                Configure<AbpAutoMapperOptions>(options =>
+                {
+                    options.AddProfile<ValidatedProfile>(true);
+                    options.AddProfile<NonValidatedProfile>();
+                });
+            }
         }
+    }
 
-        public class MyClassValidated
-        {
-            public string Value { get; set; }
-        }
+    public class AutoMapper_Configuration_AddProfilesFromAssembly_Tests : AutoMapper_ConfigurationValidation_Tests<AutoMapper_Configuration_AddProfilesFromAssembly_Tests.TestModule>
+    {
 
-        public class MyClassNonValidated
+        [DependsOn(typeof(AbpAutoMapperModule))]
+        public class TestModule : AbpModule
         {
-            public string ValueNotMatched { get; set; }
+            public override void ConfigureServices(ServiceConfigurationContext context)
+            {
+                Configure<AbpAutoMapperOptions>(options =>
+                {
+                    options.AddProfiles<TestModule>();
+                });
+            }
         }
     }
 }


### PR DESCRIPTION
Resolve #844
1.just expose MapperConfiguration.AddMaps method to AbpAutoMapperOptions 
2.refactory test code  for run the same as AutoMapper_ConfigurationValidation_Tests,but startup module is different