### PR TITLE
IObjectMapper adding ProjectTo function.

### DIFF
--- a/framework/src/Volo.Abp.AutoMapper/Volo/Abp/AutoMapper/AutoMapperObjectMapper.cs
+++ b/framework/src/Volo.Abp.AutoMapper/Volo/Abp/AutoMapper/AutoMapperObjectMapper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.ObjectMapping;
@@ -24,6 +25,11 @@ namespace Volo.Abp.AutoMapper
         protected override TDestination AutoMap<TSource, TDestination>(TSource source, TDestination destination)
         {
             return MapperAccessor.Mapper.Map(source, destination);
+        }
+
+        protected override IQueryable<TDestination> AutoProjectTo<TDestination>(IQueryable source)
+        {
+            return MapperAccessor.Mapper.ProjectTo<TDestination>(source);
         }
     }
 }

--- a/framework/src/Volo.Abp.ObjectMapping/Volo/Abp/ObjectMapping/DefaultObjectMapper.cs
+++ b/framework/src/Volo.Abp.ObjectMapping/Volo/Abp/ObjectMapping/DefaultObjectMapper.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using System.Linq;
 using Volo.Abp.DependencyInjection;
 
 namespace Volo.Abp.ObjectMapping
@@ -83,6 +84,16 @@ namespace Volo.Abp.ObjectMapping
             }
 
             return AutoMap(source, destination);
+        }
+
+        public IQueryable<TDestination> ProjectTo<TDestination>(IQueryable source)
+        {
+            return AutoProjectTo<TDestination>(source);
+        }
+
+        protected virtual IQueryable<TDestination> AutoProjectTo<TDestination>(IQueryable source)
+        {
+            throw new NotImplementedException($"Can not project to from given object ({source}) to {typeof(TDestination).AssemblyQualifiedName}.");
         }
 
         protected virtual TDestination AutoMap<TSource, TDestination>(object source)

--- a/framework/src/Volo.Abp.ObjectMapping/Volo/Abp/ObjectMapping/IObjectMapper.cs
+++ b/framework/src/Volo.Abp.ObjectMapping/Volo/Abp/ObjectMapping/IObjectMapper.cs
@@ -1,4 +1,6 @@
-﻿namespace Volo.Abp.ObjectMapping
+﻿using System.Linq;
+
+namespace Volo.Abp.ObjectMapping
 {
     /// <summary>
     /// Defines a simple interface to automatically map objects.
@@ -22,6 +24,15 @@
         /// <param name="destination">Destination object</param>
         /// <returns>Returns the same <see cref="destination"/> object after mapping operation</returns>
         TDestination Map<TSource, TDestination>(TSource source, TDestination destination);
+
+        /// <summary>
+        /// Project the input queryable.
+        /// </summary>
+        /// <remarks>Projections are only calculated once and cached</remarks>
+        /// <typeparam name="TDestination">Destination type</typeparam>
+        /// <param name="source">Queryable source</param>
+        /// <returns>Queryable result, use queryable extension methods to project and execute result</returns>
+        IQueryable<TDestination> ProjectTo<TDestination>(IQueryable source);
     }
 
     /// <summary>

--- a/framework/test/Volo.Abp.AutoMapper.Tests/Volo/Abp/AutoMapper/AbpAutoMapperModule_Basic_Tests.cs
+++ b/framework/test/Volo.Abp.AutoMapper.Tests/Volo/Abp/AutoMapper/AbpAutoMapperModule_Basic_Tests.cs
@@ -29,7 +29,7 @@ namespace Volo.Abp.AutoMapper
             dto.Number.ShouldBe(42);
         }
 
-        //[Fact] TODO: Disabled because of https://github.com/AutoMapper/AutoMapper/pull/2379#issuecomment-355899664
+        [Fact]
         public void Should_Not_Map_Objects_With_AutoMap_Attributes()
         {
             Assert.ThrowsAny<Exception>(() =>

--- a/framework/test/Volo.Abp.AutoMapper.Tests/Volo/Abp/AutoMapper/AbpAutoMapperModule_ProjectTo_Tests.cs
+++ b/framework/test/Volo.Abp.AutoMapper.Tests/Volo/Abp/AutoMapper/AbpAutoMapperModule_ProjectTo_Tests.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Volo.Abp.AutoMapper.SampleClasses;
+using Volo.Abp.ObjectMapping;
+using Xunit;
+
+namespace Volo.Abp.AutoMapper
+{
+    public class AbpAutoMapperModule_ProjectTo_Tests : AbpIntegratedTest<AutoMapperTestModule>
+    {
+        private readonly IObjectMapper _objectMapper;
+
+        public AbpAutoMapperModule_ProjectTo_Tests()
+        {
+            _objectMapper = ServiceProvider.GetRequiredService<IObjectMapper>();
+        }
+
+        [Fact]
+        public void ProjectTo_Test()
+        {
+            var myEntities = new List<MyEntity>
+            {
+                new MyEntity
+                {
+                    Number = 42
+                }
+            };
+
+            var myEntityDtos = _objectMapper.ProjectTo<MyEntityDto>(myEntities.AsQueryable()).ToList();
+            myEntityDtos.ShouldNotBeNull();
+            myEntityDtos.Count.ShouldBe(1);
+            myEntityDtos.ShouldContain(x => x.Number == 42);
+        }
+    }
+}


### PR DESCRIPTION
Resolve #1777

If you want to use the `parameters` and `membersToExpand` parameters of the `ProjectTo` method, use `IMapperAccessor` to get the `IMapper` and call it. ABP only provides the most commonly used `ProjectTo` method.

https://github.com/AutoMapper/AutoMapper/blob/master/src/AutoMapper/IMapper.cs#L131
