### PR TITLE
Update PersistedGrant data max length.

### DIFF
--- a/modules/identityserver/src/Volo.Abp.IdentityServer.Domain.Shared/Volo/Abp/IdentityServer/Grants/PersistedGrantConsts.cs
+++ b/modules/identityserver/src/Volo.Abp.IdentityServer.Domain.Shared/Volo/Abp/IdentityServer/Grants/PersistedGrantConsts.cs
@@ -9,6 +9,6 @@
 
         // 50000 chosen to be explicit to allow enough size to avoid truncation, yet stay beneath the MySql row size limit of ~65K
         // apparently anything over 4K converts to nvarchar(max) on SqlServer
-        public const int DataMaxLength = 5000;
+        public const int DataMaxLength = 50000;
     }
 }

--- a/modules/identityserver/src/Volo.Abp.IdentityServer.EntityFrameworkCore/Volo/Abp/IdentityServer/EntityFrameworkCore/IdentityServerDbContextModelCreatingExtensions.cs
+++ b/modules/identityserver/src/Volo.Abp.IdentityServer.EntityFrameworkCore/Volo/Abp/IdentityServer/EntityFrameworkCore/IdentityServerDbContextModelCreatingExtensions.cs
@@ -176,7 +176,15 @@ namespace Volo.Abp.IdentityServer.EntityFrameworkCore
                 grant.Property(x => x.SubjectId).HasMaxLength(PersistedGrantConsts.SubjectIdMaxLength);
                 grant.Property(x => x.ClientId).HasMaxLength(PersistedGrantConsts.ClientIdMaxLength).IsRequired();
                 grant.Property(x => x.CreationTime).IsRequired();
-                grant.Property(x => x.Data).HasMaxLength(PersistedGrantConsts.DataMaxLength).IsRequired();
+
+                if (options.DatabaseProvider == EfCoreDatabaseProvider.MySql)
+                {
+                    grant.Property(x => x.Data).HasMaxLength(10000).IsRequired();
+                }
+                else
+                {
+                    grant.Property(x => x.Data).HasMaxLength(PersistedGrantConsts.DataMaxLength).IsRequired();
+                }
 
                 grant.HasKey(x => x.Key); //TODO: What about Id!!!
 


### PR DESCRIPTION
`DataMaxLength `should be `50000 `instead of `5000`, which requires a new migration.