### PR TITLE
code optimization

### DIFF
--- a/framework/src/Volo.Abp.Core/Microsoft/Extensions/DependencyInjection/ServiceCollectionCommonExtensions.cs
+++ b/framework/src/Volo.Abp.Core/Microsoft/Extensions/DependencyInjection/ServiceCollectionCommonExtensions.cs
@@ -42,13 +42,9 @@ namespace Microsoft.Extensions.DependencyInjection
 
 		    foreach (var service in services)
 		    {
-			    var factoryInterface = service.ImplementationInstance?.GetType()
-				    .GetTypeInfo()
-				    .GetInterfaces()
-				    .FirstOrDefault(i => i.GetTypeInfo().IsGenericType &&
-				                         i.GetGenericTypeDefinition() == typeof(IServiceProviderFactory<>));
-
-			    if (factoryInterface == null)
+			    var factoryInterface = service.ServiceType;
+			    if (service.ServiceType==null || !service.ServiceType.IsGenericType  ||
+			        service.ServiceType.GetTypeInfo().GetGenericTypeDefinition() != typeof(IServiceProviderFactory<>))
 			    {
 				    continue;
 			    }


### PR DESCRIPTION
Now that the following code：
```
var serviceProviderFactory = services.GetSingletonInstanceOrNull<IServiceProviderFactory<TContainerBuilder>>();
if (serviceProviderFactory == null)
		    {
			    throw new AbpException($"Could not find {typeof(IServiceProviderFactory<TContainerBuilder>).FullName} in {services}.");
		    }
```

requires  'IServiceProviderFactory<TContainerBuilder>' Service Type,
For intuition and efficiency, my code may be better. And strickly saying, they are not of equal value.  If registered service type 'XxxServiceProviderFactory<TContainerBuilder>', the former code may `throw AbpException($"Could not find {typeof(IServiceProviderFactory<TContainerBuilder>).FullName} in {services}.")`, my code won't.
It will just return 'services.BuildServiceProvider()'.