### PR TITLE
EntityHelper build id expression strong typed

### DIFF
--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Entities/EntityHelper.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Entities/EntityHelper.cs
@@ -76,7 +76,8 @@ namespace Volo.Abp.Domain.Entities
         {
             var lambdaParam = Expression.Parameter(typeof(TEntity));
             var leftExpression = Expression.PropertyOrField(lambdaParam, "Id");
-            Expression<Func<TKey>> closure = () => id;
+            var idValue = Convert.ChangeType(id, typeof(TKey));
+            Expression<Func<object>> closure = () => idValue;
             var rightExpression = Expression.Convert(closure.Body, leftExpression.Type);
             var lambdaBody = Expression.Equal(leftExpression, rightExpression);
             return Expression.Lambda<Func<TEntity, bool>>(lambdaBody, lambdaParam);

--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Entities/EntityHelper.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Entities/EntityHelper.cs
@@ -76,7 +76,7 @@ namespace Volo.Abp.Domain.Entities
         {
             var lambdaParam = Expression.Parameter(typeof(TEntity));
             var leftExpression = Expression.PropertyOrField(lambdaParam, "Id");
-            Expression<Func<object>> closure = () => id;
+            Expression<Func<TKey>> closure = () => id;
             var rightExpression = Expression.Convert(closure.Body, leftExpression.Type);
             var lambdaBody = Expression.Equal(leftExpression, rightExpression);
             return Expression.Lambda<Func<TEntity, bool>>(lambdaBody, lambdaParam);


### PR DESCRIPTION

Try this test

```
    public class EntityHelper_Tests: Repository_Basic_Tests<AbpEntityFrameworkCoreTestModule>
    {

        [Fact]
        public virtual async Task Insert_FindById_Should_Not_Be_Null()
        {
            await WithUnitOfWorkAsync(async () =>
            {
                var personId = Guid.NewGuid();

                await PersonRepository.InsertAsync(new Person(personId, "Adam", 42));

                var person =
                    PersonRepository.FirstOrDefault(EntityHelper.CreateEqualityExpressionForId<Person, Guid>(personId));
                person.ShouldNotBeNull();
            });

        }

    }

```

previous EntityHelper will cause an exception

```
System.InvalidOperationException : Null TypeMapping in Sql Tree
 SqlTypeMappingVerifyingExpressionVisitor.VisitExtension(Expression node)
    Expression.Accept(ExpressionVisitor visitor)
    ExpressionVisitor.Visit(Expression node)
    SqlUnaryExpression.VisitChildren(ExpressionVisitor visitor)
    ExpressionVisitor.VisitExtension(Expression node)
    SqlTypeMappingVerifyingExpressionVisitor.VisitExtension(Expression node)
    Expression.Accept(ExpressionVisitor visitor)
    ExpressionVisitor.Visit(Expression node)
    SqlBinaryExpression.VisitChildren(ExpressionVisitor visitor)
    ExpressionVisitor.VisitExtension(Expression node)
    SqlTypeMappingVerifyingExpressionVisitor.VisitExtension(Expression node)
    Expression.Accept(ExpressionVisitor visitor)
    ExpressionVisitor.Visit(Expression node)
    RelationalSqlTranslatingExpressionVisitor.Translate(Expression expression)
    RelationalQueryableMethodTranslatingExpressionVisitor.TranslateExpression(Expression expression)
    RelationalQueryableMethodTranslatingExpressionVisitor.TranslateLambdaExpression(ShapedQueryExpression shapedQueryExpression, LambdaExpression lambdaExpression)
    RelationalQueryableMethodTranslatingExpressionVisitor.TranslateWhere(ShapedQueryExpression source, LambdaExpression predicate)
    QueryableMethodTranslatingExpressionVisitor.VisitMethodCall(MethodCallExpression methodCallExpression)
    RelationalQueryableMethodTranslatingExpressionVisitor.VisitMethodCall(MethodCallExpression methodCallExpression)
    MethodCallExpression.Accept(ExpressionVisitor visitor)
    ExpressionVisitor.Visit(Expression node)
    QueryableMethodTranslatingExpressionVisitor.VisitMethodCall(MethodCallExpression methodCallExpression)
    RelationalQueryableMethodTranslatingExpressionVisitor.VisitMethodCall(MethodCallExpression methodCallExpression)
    MethodCallExpression.Accept(ExpressionVisitor visitor)
    ExpressionVisitor.Visit(Expression node)
    QueryCompilationContext.CreateQueryExecutor[TResult](Expression query)
    Database.CompileQuery[TResult](Expression query, Boolean async)
    QueryCompiler.CompileQueryCore[TResult](IDatabase database, Expression query, IModel model, Boolean async)
    <>c__DisplayClass9_0`1.<Execute>b__0()
    CompiledQueryCache.GetOrAddQueryCore[TFunc](Object cacheKey, Func`1 compiler)
    CompiledQueryCache.GetOrAddQuery[TResult](Object cacheKey, Func`1 compiler)
    QueryCompiler.Execute[TResult](Expression query)
    EntityQueryProvider.Execute[TResult](Expression expression)
    Queryable.FirstOrDefault[TSource](IQueryable`1 source, Expression`1 predicate)
    EntityHelper_Tests.<Insert_FindById_Should_Not_Be_Null>b__0_0() 行 26
    TestAppTestBase`1.WithUnitOfWorkAsync(AbpUnitOfWorkOptions options, Func`1 action) 行 52
    EntityHelper_Tests.Insert_FindById_Should_Not_Be_Null() 行 20
```

I believe it's a problem for EF 3.0
But there is no reason to cast id type to object