### PR TITLE
fix(theme-shared):fix #2107,when use Esc key to close modal ,should trigger destroy to avoid raise an error

### DIFF
--- a/npm/ng-packs/packages/theme-shared/src/lib/components/modal/modal.component.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/components/modal/modal.component.ts
@@ -122,10 +122,12 @@ export class ModalComponent implements OnDestroy {
           this.isConfirmationOpen = false;
           if (status === Toaster.Status.confirm) {
             this.visible = false;
+            this.destroy$.next();
           }
         });
     } else {
       this.visible = false;
+      this.destroy$.next();
     }
   }
 


### PR DESCRIPTION
fix #2107 
when use Esc key to close modal ,should trigger destroy to avoid raise an error