### PR TITLE
fix(theme-shared):fix #2107,when use Esc key to close modal ,should trigger destroy to avoid raise an error

### DIFF
--- a/npm/ng-packs/packages/theme-shared/src/lib/components/modal/modal.component.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/components/modal/modal.component.ts
@@ -44,6 +44,7 @@ export class ModalComponent implements OnDestroy {
     } else {
       this.renderer.removeClass(document.body, 'modal-open');
       this.disappear.emit();
+      this.destroy$.next();
     }
   }
 


### PR DESCRIPTION
#2130 