### PR TITLE
Fix UseVirtualFiles middleware return type

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore/Microsoft/AspNetCore/Builder/VirtualFileSystemApplicationBuilderExtensions.cs
+++ b/framework/src/Volo.Abp.AspNetCore/Microsoft/AspNetCore/Builder/VirtualFileSystemApplicationBuilderExtensions.cs
@@ -5,9 +5,9 @@ namespace Microsoft.AspNetCore.Builder
 {
     public static class VirtualFileSystemApplicationBuilderExtensions
     {
-        public static void UseVirtualFiles(this IApplicationBuilder app)
+        public static IApplicationBuilder UseVirtualFiles(this IApplicationBuilder app)
         {
-            app.UseStaticFiles(
+            return app.UseStaticFiles(
                 new StaticFileOptions
                 {
                     FileProvider = app.ApplicationServices.GetRequiredService<IWebContentFileProvider>()


### PR DESCRIPTION
All IApplicationBuilder extension methods from [ASP.NET Core built-in middleware](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.builder.iapplicationbuilder?view=aspnetcore-3.0#extension-methods) always return IApplicationBuilder. Most ABP middleware does too. `UseVirtualFiles` seems to be the only exception to the rule and it's stopping use of fluent design. As a result this code throws error: 
`Operator '.' cannot be applied to operand of type 'void'`

```csharp
public override void OnApplicationInitialization(ApplicationInitializationContext context)
{
    context.GetApplicationBuilder()
        .UseCorrelationId()
        .UseVirtualFiles() // <-- VOID
        .UseAbpRequestLocalization()
        .UseRouting()
        .UseMiddleware<FakeAuthenticationMiddleware>()
        .UseAuthorization()
        .UseAuditing()
        .UseUnitOfWork()
        .UseMvcWithDefaultRouteAndArea();
}
```