### PR TITLE
Set the message of errorInfo to the message of AbpValidationException.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore/Volo/Abp/AspNetCore/ExceptionHandling/DefaultExceptionToErrorInfoConverter.cs
+++ b/framework/src/Volo.Abp.AspNetCore/Volo/Abp/AspNetCore/ExceptionHandling/DefaultExceptionToErrorInfoConverter.cs
@@ -78,6 +78,11 @@ namespace Volo.Abp.AspNetCore.ExceptionHandling
                 errorInfo.Details = (exception as IHasErrorDetails)?.Details;
             }
 
+            if (exception is AbpValidationException)
+            {
+                errorInfo.Message = exception.Message;
+            }
+
             if (exception is IHasValidationErrors)
             {
                 if (errorInfo.Message.IsNullOrEmpty())


### PR DESCRIPTION
Resolve #2244

I think `BusinessException `should inherit `AbpException`, So we can directly assign the message of AbpException to the message of errorInfo.
