### PR TITLE
Fixed mongo repository expression error in AuditLogging module.

### DIFF
--- a/modules/audit-logging/src/Volo.Abp.AuditLogging.MongoDB/Volo/Abp/AuditLogging/MongoDB/MongoAuditLogRepository.cs
+++ b/modules/audit-logging/src/Volo.Abp.AuditLogging.MongoDB/Volo/Abp/AuditLogging/MongoDB/MongoAuditLogRepository.cs
@@ -124,12 +124,13 @@ namespace Volo.Abp.AuditLogging.MongoDB
 
         public async Task<Dictionary<DateTime, double>> GetAverageExecutionDurationPerDayAsync(DateTime startDate, DateTime endDate)
         {
-            var result = await GetMongoQueryable()
+            var result = (await GetMongoQueryable()
                 .Where(a => a.ExecutionTime < endDate.AddDays(1) && a.ExecutionTime > startDate)
                 .OrderBy(t => t.ExecutionTime)
+                .ToListAsync())
                 .GroupBy(t => new { t.ExecutionTime.Date })
                 .Select(g => new { Day = g.Min(t => t.ExecutionTime), avgExecutionTime = g.Average(t => t.ExecutionDuration) })
-                .ToListAsync();
+                .ToList();
 
             return result.ToDictionary(element => element.Day.ClearTime(), element => element.avgExecutionTime);
         }

--- a/modules/audit-logging/src/Volo.Abp.AuditLogging.MongoDB/Volo/Abp/AuditLogging/MongoDB/MongoAuditLogRepository.cs
+++ b/modules/audit-logging/src/Volo.Abp.AuditLogging.MongoDB/Volo/Abp/AuditLogging/MongoDB/MongoAuditLogRepository.cs
@@ -124,13 +124,17 @@ namespace Volo.Abp.AuditLogging.MongoDB
 
         public async Task<Dictionary<DateTime, double>> GetAverageExecutionDurationPerDayAsync(DateTime startDate, DateTime endDate)
         {
-            var result = (await GetMongoQueryable()
+            var result = await GetMongoQueryable()
                 .Where(a => a.ExecutionTime < endDate.AddDays(1) && a.ExecutionTime > startDate)
                 .OrderBy(t => t.ExecutionTime)
-                .ToListAsync())
-                .GroupBy(t => new { t.ExecutionTime.Date })
+                .GroupBy(t => new
+                {
+                    t.ExecutionTime.Year,
+                    t.ExecutionTime.Month,
+                    t.ExecutionTime.Day
+                })
                 .Select(g => new { Day = g.Min(t => t.ExecutionTime), avgExecutionTime = g.Average(t => t.ExecutionDuration) })
-                .ToList();
+                .ToListAsync();
 
             return result.ToDictionary(element => element.Day.ClearTime(), element => element.avgExecutionTime);
         }


### PR DESCRIPTION
MongoDB.Driver's `GroupBy` method cannot translate `DateTime.Property`.
eg `GroupBy(t => ExecutionTime.Date)` 