### PR TITLE
Fix: set the default mail template culture name to "en"

### DIFF
--- a/framework/src/Volo.Abp.Emailing/Volo/Abp/Emailing/Templates/DefaultEmailTemplateProvider.cs
+++ b/framework/src/Volo.Abp.Emailing/Volo/Abp/Emailing/Templates/DefaultEmailTemplateProvider.cs
@@ -6,10 +6,10 @@ namespace Volo.Abp.Emailing.Templates
     {
         public override void Define(IEmailTemplateDefinitionContext context)
         {
-            context.Add(new EmailTemplateDefinition(StandardEmailTemplates.DefaultLayout, isLayout: true, layout: null)
+            context.Add(new EmailTemplateDefinition(StandardEmailTemplates.DefaultLayout, defaultCultureName: "en", isLayout: true, layout: null)
                 .AddTemplateVirtualFiles("/Volo/Abp/Emailing/Templates/DefaultEmailTemplates/Layout"));
 
-            context.Add(new EmailTemplateDefinition(StandardEmailTemplates.SimpleMessage)
+            context.Add(new EmailTemplateDefinition(StandardEmailTemplates.SimpleMessage, defaultCultureName: "en")
                 .AddTemplateVirtualFiles("/Volo/Abp/Emailing/Templates/DefaultEmailTemplates/Message"));
         }
     }


### PR DESCRIPTION
Fixed : https://github.com/abpframework/abp/issues/2343