### PR TITLE
When RemoteService is disabled, the selector of the service or service method is no longer configured.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/Conventions/AbpServiceConvention.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/Conventions/AbpServiceConvention.cs
@@ -171,6 +171,13 @@ namespace Volo.Abp.AspNetCore.Mvc.Conventions
         {
             RemoveEmptySelectors(controller.Selectors);
 
+            var controllerType = controller.ControllerType.AsType();
+            var remoteServiceAtt = ReflectionHelper.GetSingleAttributeOrDefault<RemoteServiceAttribute>(controllerType.GetTypeInfo());
+            if (remoteServiceAtt != null && !remoteServiceAtt.IsEnabledFor(controllerType))
+            {
+                return;
+            }
+
             if (controller.Selectors.Any(selector => selector.AttributeRouteModel != null))
             {
                 return;
@@ -187,6 +194,12 @@ namespace Volo.Abp.AspNetCore.Mvc.Conventions
         protected virtual void ConfigureSelector(string rootPath, string controllerName, ActionModel action, [CanBeNull] ConventionalControllerSetting configuration)
         {
             RemoveEmptySelectors(action.Selectors);
+
+            var remoteServiceAtt = ReflectionHelper.GetSingleAttributeOrDefault<RemoteServiceAttribute>(action.ActionMethod);
+            if (remoteServiceAtt != null && !remoteServiceAtt.IsEnabledFor(action.ActionMethod))
+            {
+                return;
+            }
 
             if (!action.Selectors.Any())
             {


### PR DESCRIPTION
Resolve #2369
