### PR TITLE
Added cosmosdb provider

### DIFF
--- a/framework/Volo.Abp.sln
+++ b/framework/Volo.Abp.sln
@@ -252,9 +252,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Volo.Abp.ObjectMapping.Test
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Volo.Abp.Ddd.Application.Contracts", "src\Volo.Abp.Ddd.Application.Contracts\Volo.Abp.Ddd.Application.Contracts.csproj", "{73559227-EBF0-475F-835B-1FF0CD9132AA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Volo.Abp.Minify", "src\Volo.Abp.Minify\Volo.Abp.Minify.csproj", "{928DC30D-C078-4BB4-A9F8-FE7252C67DC6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Volo.Abp.Minify", "src\Volo.Abp.Minify\Volo.Abp.Minify.csproj", "{928DC30D-C078-4BB4-A9F8-FE7252C67DC6}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Volo.Abp.Minify.Tests", "test\Volo.Abp.Minify.Tests\Volo.Abp.Minify.Tests.csproj", "{E69182B3-350A-43F5-A935-5EBBEBECEF97}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Volo.Abp.Minify.Tests", "test\Volo.Abp.Minify.Tests\Volo.Abp.Minify.Tests.csproj", "{E69182B3-350A-43F5-A935-5EBBEBECEF97}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Volo.Abp.EntityFrameworkCore.CosmosDB", "src\Volo.Abp.EntityFrameworkCore.CosmosDB\Volo.Abp.EntityFrameworkCore.CosmosDB.csproj", "{8DBDBC04-DA3E-4018-84C4-25D64F74767E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -762,6 +764,10 @@ Global
 		{E69182B3-350A-43F5-A935-5EBBEBECEF97}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E69182B3-350A-43F5-A935-5EBBEBECEF97}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E69182B3-350A-43F5-A935-5EBBEBECEF97}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8DBDBC04-DA3E-4018-84C4-25D64F74767E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8DBDBC04-DA3E-4018-84C4-25D64F74767E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8DBDBC04-DA3E-4018-84C4-25D64F74767E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8DBDBC04-DA3E-4018-84C4-25D64F74767E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -892,6 +898,7 @@ Global
 		{73559227-EBF0-475F-835B-1FF0CD9132AA} = {5DF0E140-0513-4D0D-BE2E-3D4D85CD70E6}
 		{928DC30D-C078-4BB4-A9F8-FE7252C67DC6} = {5DF0E140-0513-4D0D-BE2E-3D4D85CD70E6}
 		{E69182B3-350A-43F5-A935-5EBBEBECEF97} = {447C8A77-E5F0-4538-8687-7383196D04EA}
+		{8DBDBC04-DA3E-4018-84C4-25D64F74767E} = {5DF0E140-0513-4D0D-BE2E-3D4D85CD70E6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BB97ECF4-9A84-433F-A80B-2A3285BDD1D5}

--- a/framework/src/Volo.Abp.EntityFrameworkCore.CosmosDB/Microsoft/EntityFrameworkCore/CosmosDbContextOptionsExtensions.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore.CosmosDB/Microsoft/EntityFrameworkCore/CosmosDbContextOptionsExtensions.cs
@@ -1,0 +1,51 @@
+﻿using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Volo.Abp;
+// Microsoft.EntityFrameworkCore.Cosmos doesn't have single connectionString parameter DbContextOptionsBuilder in {ApplicationName}.EntityFrameworkCore.DbMigrations\{ApplicationName}MigrationsDbContextFactory
+namespace Microsoft.EntityFrameworkCore
+{
+    public static class CosmosDbContextOptionsExtensions
+    {
+        public static DbContextOptionsBuilder<TContext> UseCosmos<TContext>(
+            [NotNull] this DbContextOptionsBuilder<TContext> optionsBuilder,
+            [NotNull] string connectionString,
+            [CanBeNull] Action<CosmosDbContextOptionsBuilder> cosmosOptionsAction = null)
+            where TContext : DbContext
+            => (DbContextOptionsBuilder<TContext>)UseCosmos(
+                (DbContextOptionsBuilder)optionsBuilder,
+                connectionString,
+                cosmosOptionsAction
+                );
+
+        public static DbContextOptionsBuilder UseCosmos(
+            [NotNull] this DbContextOptionsBuilder optionsBuilder,
+            [NotNull] string connectionString,
+            [CanBeNull] Action<CosmosDbContextOptionsBuilder> cosmosOptionsAction = null)
+        {
+            var connStringParts = connectionString.ParseConnectionString();
+            var accountEndpoint = connStringParts["AccountEndpoint"];
+            if (string.IsNullOrEmpty(accountEndpoint))
+                throw new AbpException($"CosmosDb AccountName can not be null or empty!");
+
+            var accountKey = connStringParts["AccountKey"];
+            if (string.IsNullOrEmpty(accountEndpoint))
+                throw new AbpException($"CosmosDb AccountKey can not be null or empty!");
+
+            var databaseName = connStringParts["DatabaseName"];
+            if (string.IsNullOrEmpty(accountEndpoint))
+                throw new AbpException($"CosmosDb DatabaseName can not be null or empty!");
+
+            return optionsBuilder.UseCosmos(accountEndpoint: accountEndpoint, accountKey: accountKey, databaseName: databaseName, cosmosOptionsAction);
+        }
+
+        static Dictionary<string, string> ParseConnectionString(this string connString)
+        {
+            return connString.Split(';')
+            .Select(t => t.Split(new char[] { '=' }, 2))
+            .ToDictionary(t => t[0].Trim(), t => t[1].Trim(), StringComparer.InvariantCultureIgnoreCase);
+        }
+    }
+}

--- a/framework/src/Volo.Abp.EntityFrameworkCore.CosmosDB/Volo.Abp.EntityFrameworkCore.CosmosDB.csproj
+++ b/framework/src/Volo.Abp.EntityFrameworkCore.CosmosDB/Volo.Abp.EntityFrameworkCore.CosmosDB.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\..\..\common.props" />
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <AssemblyName>Volo.Abp.EntityFrameworkCore.CosmosDB</AssemblyName>
+    <PackageId>Volo.Abp.EntityFrameworkCore.CosmosDB</PackageId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Volo.Abp.EntityFrameworkCore\Volo.Abp.EntityFrameworkCore.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Cosmos" Version="3.1.0" />
+  </ItemGroup>
+
+</Project>

--- a/framework/src/Volo.Abp.EntityFrameworkCore.CosmosDB/Volo/Abp/EntityFrameworkCore/AbpDbContextConfigurationContextCosmosDBExtensions.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore.CosmosDB/Volo/Abp/EntityFrameworkCore/AbpDbContextConfigurationContextCosmosDBExtensions.cs
@@ -1,0 +1,63 @@
+﻿using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore;
+using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Volo.Abp.EntityFrameworkCore.DependencyInjection;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace Volo.Abp.EntityFrameworkCore
+{
+    public static class AbpDbContextConfigurationContextCosmosDBExtensions
+    {
+        public static DbContextOptionsBuilder UseCosmos(
+           [NotNull] this AbpDbContextConfigurationContext context,
+           [CanBeNull] Action<CosmosDbContextOptionsBuilder> cosmosOptionsAction = null)
+        {
+            //context.ConnectionStringName = "AbpBackgroundJobs" hits all the time
+            if (context.ExistingConnection != null)
+            {
+                var connStringParts = context.ExistingConnection.ConnectionString.ParseConnectionString();
+
+                var accountEndpoint = connStringParts["AccountEndpoint"];
+                if (string.IsNullOrEmpty(accountEndpoint))
+                    throw new AbpException($"CosmosDb AccountName can not be null or empty!");
+
+                var accountKey = connStringParts["AccountKey"];
+                if (string.IsNullOrEmpty(accountEndpoint))
+                    throw new AbpException($"CosmosDb AccountKey can not be null or empty!");
+
+                var databaseName = connStringParts["DatabaseName"];
+                if (string.IsNullOrEmpty(accountEndpoint))
+                    throw new AbpException($"CosmosDb DatabaseName can not be null or empty!");
+
+                return context.DbContextOptions.UseCosmos(accountEndpoint: accountEndpoint, accountKey: accountKey, databaseName: databaseName, cosmosOptionsAction);
+            }
+            else
+            {
+                var connStringParts = context.ConnectionString.ParseConnectionString();
+
+                var accountEndpoint = connStringParts["AccountEndpoint"];
+                if (string.IsNullOrEmpty(accountEndpoint))
+                    throw new AbpException($"CosmosDb AccountName can not be null or empty!");
+
+                var accountKey = connStringParts["AccountKey"];
+                if (string.IsNullOrEmpty(accountEndpoint))
+                    throw new AbpException($"CosmosDb AccountKey can not be null or empty!");
+
+                var databaseName = connStringParts["DatabaseName"];
+                if (string.IsNullOrEmpty(accountEndpoint))
+                    throw new AbpException($"CosmosDb DatabaseName can not be null or empty!");
+
+                return context.DbContextOptions.UseCosmos(accountEndpoint: accountEndpoint, accountKey: accountKey, databaseName: databaseName, cosmosOptionsAction);
+            }
+        }
+
+        static Dictionary<string, string> ParseConnectionString(this string connString)
+        {
+            return connString.Split(';')
+            .Select(t => t.Split(new char[] { '=' }, 2))
+            .ToDictionary(t => t[0].Trim(), t => t[1].Trim(), StringComparer.InvariantCultureIgnoreCase);
+        }
+    }
+}

--- a/framework/src/Volo.Abp.EntityFrameworkCore.CosmosDB/Volo/Abp/EntityFrameworkCore/AbpDbContextOptionsCosmosExtensions.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore.CosmosDB/Volo/Abp/EntityFrameworkCore/AbpDbContextOptionsCosmosExtensions.cs
@@ -1,0 +1,30 @@
+﻿using JetBrains.Annotations;
+using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace Volo.Abp.EntityFrameworkCore
+{
+    public static class AbpDbContextOptionsCosmosExtensions
+    {
+        public static void UseCosmos(
+            [NotNull] this AbpDbContextOptions options,
+            [CanBeNull] Action<CosmosDbContextOptionsBuilder> cosmosOptionsAction = null)
+        {
+            options.Configure(context =>
+            {
+                context.UseCosmos(cosmosOptionsAction);
+            });
+        }
+
+        public static void UseCosmos<TDbContext>(
+            [NotNull] this AbpDbContextOptions options,
+            [CanBeNull] Action<CosmosDbContextOptionsBuilder> cosmosOptionsAction = null)
+            where TDbContext : AbpDbContext<TDbContext>
+        {
+            options.Configure<TDbContext>(context =>
+            {
+                context.UseCosmos(cosmosOptionsAction);
+            });
+        }
+    }
+}

--- a/framework/src/Volo.Abp.EntityFrameworkCore.CosmosDB/Volo/Abp/EntityFrameworkCore/CosmosDB/AbpEntityFrameworkCoreCosmosModule.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore.CosmosDB/Volo/Abp/EntityFrameworkCore/CosmosDB/AbpEntityFrameworkCoreCosmosModule.cs
@@ -1,0 +1,11 @@
+﻿using Volo.Abp.Modularity;
+
+namespace Volo.Abp.EntityFrameworkCore.Cosmos
+{
+    [DependsOn(
+        typeof(AbpEntityFrameworkCoreModule)
+        )]
+    public class AbpEntityFrameworkCoreCosmosModule : AbpModule
+    {
+    }
+}


### PR DESCRIPTION
Added provider. Uses `EF Core Azure Cosmos DB Provider` underline which 

> only works with the SQL API of Azure Cosmos DB

Current problems;
Seeder doesn't work (probably related with UoW but even disabling UoW transactions globally didn't work).