### PR TITLE
Make AbpDictionaryValueComparer support generics to resolve migration errors.

### DIFF
--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/Modeling/AbpEntityTypeBuilderExtensions.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/Modeling/AbpEntityTypeBuilderExtensions.cs
@@ -59,7 +59,7 @@ namespace Volo.Abp.EntityFrameworkCore.Modeling
                 b.Property<Dictionary<string, object>>(nameof(IHasExtraProperties.ExtraProperties))
                     .HasColumnName(nameof(IHasExtraProperties.ExtraProperties))
                     .HasConversion(new AbpJsonValueConverter<Dictionary<string, object>>())
-                    .Metadata.SetValueComparer(new AbpDictionaryValueComparer());
+                    .Metadata.SetValueComparer(new AbpDictionaryValueComparer<string, object>());
             }
         }
 

--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/ValueComparers/AbpDictionaryValueComparer.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/ValueComparers/AbpDictionaryValueComparer.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Volo.Abp.EntityFrameworkCore.ValueComparers
 {
-    public class AbpDictionaryValueComparer : ValueComparer<Dictionary<string, object>>
+    public class AbpDictionaryValueComparer<TKey, TValue> : ValueComparer<Dictionary<TKey, TValue>>
     {
         public AbpDictionaryValueComparer()
             : base(

--- a/modules/identityserver/src/Volo.Abp.IdentityServer.EntityFrameworkCore/Volo/Abp/IdentityServer/EntityFrameworkCore/IdentityServerDbContextModelCreatingExtensions.cs
+++ b/modules/identityserver/src/Volo.Abp.IdentityServer.EntityFrameworkCore/Volo/Abp/IdentityServer/EntityFrameworkCore/IdentityServerDbContextModelCreatingExtensions.cs
@@ -204,8 +204,8 @@ namespace Volo.Abp.IdentityServer.EntityFrameworkCore
                 identityResource.Property(x => x.DisplayName).HasMaxLength(IdentityResourceConsts.DisplayNameMaxLength);
                 identityResource.Property(x => x.Description).HasMaxLength(IdentityResourceConsts.DescriptionMaxLength);
                 identityResource.Property(x => x.Properties)
-                    .HasConversion(new AbpJsonValueConverter<Dictionary<string, object>>())
-                    .Metadata.SetValueComparer(new AbpDictionaryValueComparer());
+                    .HasConversion(new AbpJsonValueConverter<Dictionary<string, string>>())
+                    .Metadata.SetValueComparer(new AbpDictionaryValueComparer<string, string>());
 
                 identityResource.HasMany(x => x.UserClaims).WithOne().HasForeignKey(x => x.IdentityResourceId).IsRequired();
             });
@@ -229,8 +229,8 @@ namespace Volo.Abp.IdentityServer.EntityFrameworkCore
                 apiResource.Property(x => x.DisplayName).HasMaxLength(ApiResourceConsts.DisplayNameMaxLength);
                 apiResource.Property(x => x.Description).HasMaxLength(ApiResourceConsts.DescriptionMaxLength);
                 apiResource.Property(x => x.Properties)
-                    .HasConversion(new AbpJsonValueConverter<Dictionary<string, object>>())
-                    .Metadata.SetValueComparer(new AbpDictionaryValueComparer());
+                    .HasConversion(new AbpJsonValueConverter<Dictionary<string, string>>())
+                    .Metadata.SetValueComparer(new AbpDictionaryValueComparer<string, string>());
 
                 apiResource.HasMany(x => x.Secrets).WithOne().HasForeignKey(x => x.ApiResourceId).IsRequired();
                 apiResource.HasMany(x => x.Scopes).WithOne().HasForeignKey(x => x.ApiResourceId).IsRequired();


### PR DESCRIPTION
Related: https://github.com/abpframework/abp/pull/2462/files#diff-4b7d308ccd7b244e9ea6b78f245294cfR206-R232

`Properties` of `ApiResource `and `IdentityResource `are `Dictionary<string, string>`


![image](https://user-images.githubusercontent.com/6908465/72048443-c31d2700-32f7-11ea-9ef3-fd6a6f94a7d7.png)
