### PR TITLE
implement hangfire job execution disable

### DIFF
--- a/framework/src/Volo.Abp.BackgroundJobs.Abstractions/Volo/Abp/BackgroundJobs/AbpBackgroundJobOptions.cs
+++ b/framework/src/Volo.Abp.BackgroundJobs.Abstractions/Volo/Abp/BackgroundJobs/AbpBackgroundJobOptions.cs
@@ -9,7 +9,6 @@ namespace Volo.Abp.BackgroundJobs
         private readonly Dictionary<Type, BackgroundJobConfiguration> _jobConfigurationsByArgsType;
         private readonly Dictionary<string, BackgroundJobConfiguration> _jobConfigurationsByName;
 
-        //TODO: Implement for all providers! (Hangfire does not implement yet)
         /// <summary>
         /// Default: true.
         /// </summary>

--- a/framework/src/Volo.Abp.BackgroundJobs.HangFire/Volo/Abp/BackgroundJobs/Hangfire/AbpBackgroundJobsHangfireModule.cs
+++ b/framework/src/Volo.Abp.BackgroundJobs.HangFire/Volo/Abp/BackgroundJobs/Hangfire/AbpBackgroundJobsHangfireModule.cs
@@ -1,4 +1,7 @@
-﻿using Volo.Abp.Hangfire;
+﻿using Hangfire;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Volo.Abp.Hangfire;
 using Volo.Abp.Modularity;
 
 namespace Volo.Abp.BackgroundJobs.Hangfire
@@ -9,6 +12,24 @@ namespace Volo.Abp.BackgroundJobs.Hangfire
         )]
     public class AbpBackgroundJobsHangfireModule : AbpModule
     {
+        public override void PostConfigureServices(ServiceConfigurationContext context)
+        {
+            base.PostConfigureServices(context);
 
+            var serviceProvider = context.Services.BuildServiceProvider();
+            var backgroundJobOption = serviceProvider.GetRequiredService<IOptions<AbpBackgroundJobOptions>>();
+            if (!backgroundJobOption.Value.IsJobExecutionEnabled)
+            {
+                Configure<AbpHangfireOptions>(options =>
+                {
+                    if (options.ServerOptions == null)
+                    {
+                        options.ServerOptions=new BackgroundJobServerOptions();
+                    }
+                    options.ServerOptions.Queues = new[] {options.EmptyQueueName};
+                });
+            }
+
+        }
     }
 }

--- a/framework/src/Volo.Abp.HangFire/Volo/Abp/Hangfire/AbpHangfireOptions.cs
+++ b/framework/src/Volo.Abp.HangFire/Volo/Abp/Hangfire/AbpHangfireOptions.cs
@@ -18,6 +18,19 @@ namespace Volo.Abp.Hangfire
         [CanBeNull]
         public IEnumerable<IBackgroundProcess> AdditionalProcesses { get; set; }
 
+        public string EmptyQueueName
+        {
+            get => _emptyQueueName;
+            set
+            {
+                if (value == EnqueuedState.DefaultQueue)
+                {
+                    throw new ArgumentException("empty queue name can not be default", nameof(EmptyQueueName));
+                }
+                _emptyQueueName = value;
+            }
+        }
+
         [CanBeNull]
         public JobStorage Storage { get; set; }
 
@@ -28,6 +41,7 @@ namespace Volo.Abp.Hangfire
             set => _backgroundJobServerFactory = Check.NotNull(value, nameof(value));
         }
         private Func<IServiceProvider, BackgroundJobServer> _backgroundJobServerFactory;
+        private string _emptyQueueName = "None";
 
         public AbpHangfireOptions()
         {


### PR DESCRIPTION
Provide a solution for disable hangfire running backround jobs according to AbpBackgroundJobOptions.

I want to enqueue some background jobs in my program but do not want to execute it in the same program. But according to [hangfire/#225](https://github.com/HangfireIO/Hangfire/issues/225) , there has no way to start/stop job execution gracefully now. So this would be a workaround。