### PR TITLE
refactory and enhance CrudAppService 

### DIFF
--- a/framework/src/Volo.Abp.Ddd.Application.Contracts/Volo/Abp/Application/Services/IBaseCrudAppService.cs
+++ b/framework/src/Volo.Abp.Ddd.Application.Contracts/Volo/Abp/Application/Services/IBaseCrudAppService.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Volo.Abp.Application.Dtos;
+
+namespace Volo.Abp.Application.Services
+{
+    public interface IBaseCrudAppService<TGetOutputDto, TGetListOutputDto,in TKey,in TGetListInput,in TCreateInput,in TUpdateInput>
+        : IApplicationService
+        where TGetOutputDto : IEntityDto
+        where TGetListOutputDto : IEntityDto
+    {
+        Task<PagedResultDto<TGetOutputDto>> GetListWithDetailsAsync(TGetListInput input);
+        Task<TGetOutputDto> CreateAsync(TCreateInput input);
+        Task DeleteAsync(TKey id);
+        Task<PagedResultDto<TGetListOutputDto>> GetListAsync(TGetListInput input);
+        Task<TGetOutputDto> UpdateAsync(TKey id, TUpdateInput input);
+    }
+}

--- a/framework/src/Volo.Abp.Ddd.Application.Contracts/Volo/Abp/Application/Services/IBaseCrudAppService.cs
+++ b/framework/src/Volo.Abp.Ddd.Application.Contracts/Volo/Abp/Application/Services/IBaseCrudAppService.cs
@@ -12,9 +12,9 @@ namespace Volo.Abp.Application.Services
         where TGetListOutputDto : IEntityDto
     {
         Task<PagedResultDto<TGetOutputDto>> GetListWithDetailsAsync(TGetListInput input);
-        Task<TGetOutputDto> CreateAsync(TCreateInput input);
-        Task DeleteAsync(TKey id);
         Task<PagedResultDto<TGetListOutputDto>> GetListAsync(TGetListInput input);
+        Task<TGetOutputDto> CreateAsync(TCreateInput input);
         Task<TGetOutputDto> UpdateAsync(TKey id, TUpdateInput input);
+        Task DeleteAsync(TKey id);
     }
 }

--- a/framework/src/Volo.Abp.Ddd.Application.Contracts/Volo/Abp/Application/Services/IBaseCrudAppService.cs
+++ b/framework/src/Volo.Abp.Ddd.Application.Contracts/Volo/Abp/Application/Services/IBaseCrudAppService.cs
@@ -6,13 +6,11 @@ using Volo.Abp.Application.Dtos;
 
 namespace Volo.Abp.Application.Services
 {
-    public interface IBaseCrudAppService<TGetOutputDto, TGetListOutputDto,in TKey,in TGetListInput,in TCreateInput,in TUpdateInput>
+    public interface IBaseCrudAppService<TGetOutputDto,in TKey,in TGetListInput,in TCreateInput,in TUpdateInput>
         : IApplicationService
         where TGetOutputDto : IEntityDto
-        where TGetListOutputDto : IEntityDto
     {
-        Task<PagedResultDto<TGetOutputDto>> GetListWithDetailsAsync(TGetListInput input);
-        Task<PagedResultDto<TGetListOutputDto>> GetListAsync(TGetListInput input);
+        Task<PagedResultDto<TGetOutputDto>> GetListAsync(TGetListInput input);
         Task<TGetOutputDto> CreateAsync(TCreateInput input);
         Task<TGetOutputDto> UpdateAsync(TKey id, TUpdateInput input);
         Task DeleteAsync(TKey id);

--- a/framework/src/Volo.Abp.Ddd.Application.Contracts/Volo/Abp/Application/Services/ICrudAppService.cs
+++ b/framework/src/Volo.Abp.Ddd.Application.Contracts/Volo/Abp/Application/Services/ICrudAppService.cs
@@ -32,18 +32,18 @@ namespace Volo.Abp.Application.Services
     }
 
     public interface ICrudAppService<TGetOutputDto, TGetListOutputDto, in TKey, in TGetListInput, in TCreateInput, in TUpdateInput>
-        : IApplicationService
+        : IBaseCrudAppService<TGetOutputDto, TGetListOutputDto, TKey, TGetListInput, TCreateInput, TUpdateInput>
         where TGetOutputDto : IEntityDto<TKey>
         where TGetListOutputDto : IEntityDto<TKey>
     {
         Task<TGetOutputDto> GetAsync(TKey id);
+    }
 
-        Task<PagedResultDto<TGetListOutputDto>> GetListAsync(TGetListInput input);
-
-        Task<TGetOutputDto> CreateAsync(TCreateInput input);
-
-        Task<TGetOutputDto> UpdateAsync(TKey id, TUpdateInput input);
-
-        Task DeleteAsync(TKey id);
+    public interface ICrudAppService<TGetOutputDto, TGetListOutputDto, in TKey,in TFind, in TGetListInput, in TCreateInput, in TUpdateInput>
+        : IBaseCrudAppService<TGetOutputDto, TGetListOutputDto, TKey, TGetListInput, TCreateInput, TUpdateInput>
+        where TGetOutputDto : IEntityDto
+        where TGetListOutputDto : IEntityDto
+    {
+        Task<TGetOutputDto> GetFindAsync(TFind key);
     }
 }

--- a/framework/src/Volo.Abp.Ddd.Application.Contracts/Volo/Abp/Application/Services/ICrudAppService.cs
+++ b/framework/src/Volo.Abp.Ddd.Application.Contracts/Volo/Abp/Application/Services/ICrudAppService.cs
@@ -38,12 +38,4 @@ namespace Volo.Abp.Application.Services
     {
         Task<TGetOutputDto> GetAsync(TKey id);
     }
-
-    public interface ICrudAppService<TGetOutputDto, TGetListOutputDto, in TKey,in TFind, in TGetListInput, in TCreateInput, in TUpdateInput>
-        : IBaseCrudAppService<TGetOutputDto, TGetListOutputDto, TKey, TGetListInput, TCreateInput, TUpdateInput>
-        where TGetOutputDto : IEntityDto
-        where TGetListOutputDto : IEntityDto
-    {
-        Task<TGetOutputDto> GetFindAsync(TFind key);
-    }
 }

--- a/framework/src/Volo.Abp.Ddd.Application.Contracts/Volo/Abp/Application/Services/ICrudAppService.cs
+++ b/framework/src/Volo.Abp.Ddd.Application.Contracts/Volo/Abp/Application/Services/ICrudAppService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Volo.Abp.Application.Dtos;
 
@@ -25,17 +26,17 @@ namespace Volo.Abp.Application.Services
     }
 
     public interface ICrudAppService<TEntityDto, in TKey, in TGetListInput, in TCreateInput, in TUpdateInput>
-        : ICrudAppService<TEntityDto, TEntityDto, TKey, TGetListInput, TCreateInput, TUpdateInput>
+        : IBaseCrudAppService<TEntityDto, TKey, TGetListInput, TCreateInput, TUpdateInput>
         where TEntityDto : IEntityDto<TKey>
     {
-
+        Task<TEntityDto> GetAsync(TKey id);
     }
 
+    [Obsolete("This class is obsolete.Use ICrudAppService<TEntity, TEntityDto, TKey, TGetListInput, TCreateInput, TUpdateInput> instead.",false)]
     public interface ICrudAppService<TGetOutputDto, TGetListOutputDto, in TKey, in TGetListInput, in TCreateInput, in TUpdateInput>
-        : IBaseCrudAppService<TGetOutputDto, TGetListOutputDto, TKey, TGetListInput, TCreateInput, TUpdateInput>
+        : ICrudAppService<TGetOutputDto, TKey, TGetListInput, TCreateInput, TUpdateInput>
         where TGetOutputDto : IEntityDto<TKey>
         where TGetListOutputDto : IEntityDto<TKey>
     {
-        Task<TGetOutputDto> GetAsync(TKey id);
     }
 }

--- a/framework/src/Volo.Abp.Ddd.Application.Contracts/Volo/Abp/Application/Services/IEntityWithCompositeKeyCrudAppService.cs
+++ b/framework/src/Volo.Abp.Ddd.Application.Contracts/Volo/Abp/Application/Services/IEntityWithCompositeKeyCrudAppService.cs
@@ -3,10 +3,9 @@ using Volo.Abp.Application.Dtos;
 
 namespace Volo.Abp.Application.Services
 {
-    public interface IEntityWithCompositeKeyCrudAppService<TGetOutputDto, TGetListOutputDto, in TKey, in TGetListInput, in TCreateInput, in TUpdateInput>
-        : IBaseCrudAppService<TGetOutputDto, TGetListOutputDto, TKey, TGetListInput, TCreateInput, TUpdateInput>
+    public interface IEntityWithCompositeKeyCrudAppService<TGetOutputDto, in TKey, in TGetListInput, in TCreateInput, in TUpdateInput>
+        : IBaseCrudAppService<TGetOutputDto, TKey, TGetListInput, TCreateInput, TUpdateInput>
         where TGetOutputDto : IEntityDto
-        where TGetListOutputDto : IEntityDto
     {
         Task<TGetOutputDto> GetFindAsync(TKey key);
 

--- a/framework/src/Volo.Abp.Ddd.Application.Contracts/Volo/Abp/Application/Services/IEntityWithCompositeKeyCrudAppService.cs
+++ b/framework/src/Volo.Abp.Ddd.Application.Contracts/Volo/Abp/Application/Services/IEntityWithCompositeKeyCrudAppService.cs
@@ -1,0 +1,15 @@
+﻿using System.Threading.Tasks;
+using Volo.Abp.Application.Dtos;
+
+namespace Volo.Abp.Application.Services
+{
+    public interface IEntityWithCompositeKeyCrudAppService<TGetOutputDto, TGetListOutputDto, in TKey, in TGetListInput, in TCreateInput, in TUpdateInput>
+        : IBaseCrudAppService<TGetOutputDto, TGetListOutputDto, TKey, TGetListInput, TCreateInput, TUpdateInput>
+        where TGetOutputDto : IEntityDto
+        where TGetListOutputDto : IEntityDto
+    {
+        Task<TGetOutputDto> GetFindAsync(TKey key);
+
+        Task<TGetOutputDto> UpdateAsync(TUpdateInput input);
+    }
+}

--- a/framework/src/Volo.Abp.Ddd.Application/Volo/Abp/Application/IPagedAndSortedOperation.cs
+++ b/framework/src/Volo.Abp.Ddd.Application/Volo/Abp/Application/IPagedAndSortedOperation.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Linq;
+using Volo.Abp.Application.Dtos;
+using Volo.Abp.Domain.Entities;
+using Volo.Abp.Linq;
+
+namespace Volo.Abp.Application
+{
+    public interface IPagedAndSortedOperation: Volo.Abp.DependencyInjection.ITransientDependency
+    {
+        System.Threading.Tasks.Task<(int TotalCount, System.Collections.Generic.List<TEntity> Entities)> ListAsync<TEntity, TInput>(
+            TInput input,
+            System.Func<TInput, System.Linq.IQueryable<TEntity>> createFilteredQuery,
+            Func<IQueryable<TEntity>, TInput, IQueryable<TEntity>> applySorting = null,
+            Func<IQueryable<TEntity>, TInput, IQueryable<TEntity>> applyPaging = null)
+            where TEntity : class, IEntity;
+
+        IQueryable<TEntity> ApplySorting<TEntity, TInput>(IQueryable<TEntity> query, TInput input)
+            where TEntity : class, IEntity;
+
+        IQueryable<TEntity> ApplyPaging<TEntity, TInput>(IQueryable<TEntity> query, TInput input)
+            where TEntity : class, IEntity;
+    }
+}

--- a/framework/src/Volo.Abp.Ddd.Application/Volo/Abp/Application/PagedAndSortedOperation.cs
+++ b/framework/src/Volo.Abp.Ddd.Application/Volo/Abp/Application/PagedAndSortedOperation.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Volo.Abp.Application.Dtos;
+using Volo.Abp.Domain.Entities;
+using Volo.Abp.Linq;
+using System.Linq.Dynamic.Core;
+using Volo.Abp.Auditing;
+
+namespace Volo.Abp.Application
+{
+    public class PagedAndSortedOperation : IPagedAndSortedOperation
+    {
+        protected IAsyncQueryableExecuter AsyncQueryableExecuter { get; set; }
+
+        public PagedAndSortedOperation()
+        {
+            AsyncQueryableExecuter = DefaultAsyncQueryableExecuter.Instance;
+        }
+
+        public virtual async Task<(int TotalCount, List<TEntity> Entities)> ListAsync<TEntity, TInput>(
+            TInput input,
+            Func<TInput, IQueryable<TEntity>> createFilteredQuery,
+            Func<IQueryable<TEntity>, TInput, IQueryable<TEntity>> applySorting = null,
+            Func<IQueryable<TEntity>, TInput, IQueryable<TEntity>> applyPaging = null)
+            where TEntity : class, IEntity
+        {
+            if (createFilteredQuery == null) throw new Exception("createFilteredQuery must be not null");
+            var query = createFilteredQuery.Invoke(input);
+
+            var totalCount = await AsyncQueryableExecuter.CountAsync(query).ConfigureAwait(false);
+
+            query = applySorting != null ? applySorting.Invoke(query, input) : ApplySorting(query, input);
+            query = applyPaging != null ? applyPaging.Invoke(query, input) : ApplyPaging(query, input);
+
+            var entities = await AsyncQueryableExecuter.ToListAsync(query).ConfigureAwait(false);
+
+            return (TotalCount: totalCount, Entities: entities);
+        }
+
+        /// <summary>
+        /// Should apply sorting if needed.
+        /// </summary>
+        /// <param name="query">The query.</param>
+        /// <param name="input">The input.</param>
+        public virtual IQueryable<TEntity> ApplySorting<TEntity, TInput>(IQueryable<TEntity> query, TInput input)
+            where TEntity : class, IEntity
+        {
+            //Try to sort query if available
+            if (input is ISortedResultRequest sortInput)
+            {
+                if (!sortInput.Sorting.IsNullOrWhiteSpace())
+                {
+                    return query.OrderBy(sortInput.Sorting);
+                }
+            }
+
+            //IQueryable.Take requires sorting, so we should sort if Take will be used.
+            if (input is ILimitedResultRequest)
+            {
+                if (typeof(TEntity).IsAssignableTo<IHasCreationTime>())
+                {
+                    return query.OrderBy($"{nameof(IHasCreationTime.CreationTime)} Desc");
+                }
+                if (Volo.Abp.Reflection.ReflectionHelper.IsAssignableToGenericType(typeof(TEntity), typeof(IEntity<>)))
+                {
+                    
+                    return query.OrderBy($"{nameof(IEntity<Guid>.Id)} Desc");
+                }
+                
+            }
+
+            //No sorting
+            return query;
+        }
+
+        /// <summary>
+        /// Should apply paging if needed.
+        /// </summary>
+        /// <param name="query">The query.</param>
+        /// <param name="input">The input.</param>
+        public virtual IQueryable<TEntity> ApplyPaging<TEntity, TInput>(IQueryable<TEntity> query, TInput input)
+            where TEntity : class, IEntity
+        {
+            //Try to use paging if available
+            if (input is IPagedResultRequest pagedInput)
+            {
+                return query.PageBy(pagedInput);
+            }
+
+            //Try to limit query result if available
+            if (input is ILimitedResultRequest limitedInput)
+            {
+                return query.Take(limitedInput.MaxResultCount);
+            }
+
+            //No paging
+            return query;
+        }
+
+
+
+    }
+}

--- a/framework/src/Volo.Abp.Ddd.Application/Volo/Abp/Application/Services/BaseCrudAppService.cs
+++ b/framework/src/Volo.Abp.Ddd.Application/Volo/Abp/Application/Services/BaseCrudAppService.cs
@@ -1,0 +1,293 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Dynamic.Core;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Volo.Abp.Application.Dtos;
+using Volo.Abp.Domain.Entities;
+using Volo.Abp.Domain.Repositories;
+using Volo.Abp.Linq;
+using Volo.Abp.MultiTenancy;
+
+namespace Volo.Abp.Application.Services
+{
+    public abstract class BaseCrudAppService<TEntity, TGetOutputDto, TGetListOutputDto, TKey, TGetListInput, TCreateInput, TUpdateInput>
+            : Volo.Abp.Application.Services.ApplicationService,
+            Volo.Abp.Application.Services.IBaseCrudAppService<TGetOutputDto, TGetListOutputDto, TKey, TGetListInput, TCreateInput, TUpdateInput>
+            where TEntity : class, IEntity
+            where TGetOutputDto : IEntityDto
+            where TGetListOutputDto : IEntityDto
+    {
+        public IAsyncQueryableExecuter AsyncQueryableExecuter { get; set; }
+
+        protected IRepository<TEntity> Repository { get; }
+
+        private IPagedAndSortedOperation _pagedAndSortedOperation;
+        protected IPagedAndSortedOperation PagedAndSortedOperation => LazyGetRequiredService(ref _pagedAndSortedOperation);
+
+        protected virtual string GetPolicyName { get; set; }
+
+        protected virtual string GetListPolicyName { get; set; }
+
+        protected virtual string CreatePolicyName { get; set; }
+
+        protected virtual string UpdatePolicyName { get; set; }
+
+        protected virtual string DeletePolicyName { get; set; }
+
+        public BaseCrudAppService(IRepository<TEntity> repository)
+        {
+            Repository = repository;
+            AsyncQueryableExecuter = DefaultAsyncQueryableExecuter.Instance;
+        }
+
+
+
+
+        public virtual async Task<PagedResultDto<TGetListOutputDto>> GetListAsync(TGetListInput input)
+        {
+            await CheckGetListPolicyAsync().ConfigureAwait(false);
+
+            var result = await PagedAndSortedOperation.ListAsync(
+                input,
+                (x) => CreateFilteredQuery(input),
+                (query, i) => this.ApplySorting(query, input),
+                (query, i) => this.ApplyPaging(query, input));
+
+            return CreatePagedResultDto<TGetListOutputDto>(result);
+        }
+
+        public virtual async Task<PagedResultDto<TGetOutputDto>> GetListWithDetailsAsync(TGetListInput input)
+        {
+            await CheckGetListPolicyAsync().ConfigureAwait(false);
+
+            var result = await PagedAndSortedOperation.ListAsync(
+                input,
+                (x) => ((IRepository<TEntity>)CreateFilteredQuery(input)).WithDetails(),
+                (query, i) => this.ApplySorting(query, input),
+                (query, i) => this.ApplyPaging(query, input));
+
+            return CreatePagedResultDto<TGetOutputDto>(result);
+        }
+
+        public async Task<TGetOutputDto> CreateAsync(TCreateInput input)
+        {
+            await CheckCreatePolicyAsync().ConfigureAwait(false);
+
+            var entity = MapToEntity(input);
+
+            TryToSetTenantId(entity);
+
+            await Repository.InsertAsync(entity, autoSave: true).ConfigureAwait(false);
+
+            return MapToDto<TGetOutputDto>(entity);
+        }
+
+        public async Task<TGetOutputDto> UpdateAsync(TKey id, TUpdateInput input)
+        {
+            await CheckUpdatePolicyAsync().ConfigureAwait(false);
+
+            var entity = await GetEntityByIdAsync(id).ConfigureAwait(false);
+            //TODO: Check if input has id different than given id and normalize if it's default value, throw ex otherwise
+            MapToEntity(input, entity);
+
+            await Repository.UpdateAsync(entity, autoSave: true).ConfigureAwait(false);
+
+            return MapToDto<TGetOutputDto>(entity);
+        }
+
+        public async Task DeleteAsync(TKey id)
+        {
+            await CheckDeletePolicyAsync().ConfigureAwait(false);
+
+            await Repository.DeleteAsync(createEqualityExpression(new { Id = id })).ConfigureAwait(false);
+        }
+
+        protected virtual Task<TEntity> GetEntityByIdAsync<TGetById>(TGetById id)
+        {
+            var isEntityWithIdKey = Volo.Abp.Reflection.ReflectionHelper.IsAssignableToGenericType(typeof(TEntity), typeof(IEntity<>));
+
+            if (isEntityWithIdKey)
+            {
+                return Task.FromResult(Repository.FirstOrDefault(createEqualityExpression(new { Id = id })));
+            }
+            else
+            {
+                return Task.FromResult(Repository.FirstOrDefault(createEqualityExpression(id)));
+            }
+        }
+
+        protected virtual async Task CheckGetPolicyAsync()
+        {
+            await CheckPolicyAsync(GetPolicyName).ConfigureAwait(false);
+        }
+
+        protected virtual async Task CheckGetListPolicyAsync()
+        {
+            await CheckPolicyAsync(GetListPolicyName).ConfigureAwait(false);
+        }
+
+        protected virtual async Task CheckCreatePolicyAsync()
+        {
+            await CheckPolicyAsync(CreatePolicyName).ConfigureAwait(false);
+        }
+
+        protected virtual async Task CheckUpdatePolicyAsync()
+        {
+            await CheckPolicyAsync(UpdatePolicyName).ConfigureAwait(false);
+        }
+
+        protected virtual async Task CheckDeletePolicyAsync()
+        {
+            await CheckPolicyAsync(DeletePolicyName).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Should apply sorting if needed.
+        /// </summary>
+        /// <param name="query">The query.</param>
+        /// <param name="input">The input.</param>
+        protected virtual IQueryable<TEntity> ApplySorting(IQueryable<TEntity> query, TGetListInput input)
+        {
+            return PagedAndSortedOperation.ApplyPaging(query, input);//default Strategy
+        }
+
+        /// <summary>
+        /// Should apply paging if needed.
+        /// </summary>
+        /// <param name="query">The query.</param>
+        /// <param name="input">The input.</param>
+        protected virtual IQueryable<TEntity> ApplyPaging(IQueryable<TEntity> query, TGetListInput input)
+        {
+            return PagedAndSortedOperation.ApplySorting(query, input);//default Strategy
+        }
+
+        protected virtual IQueryable<TEntity> CreateFilteredQuery(TGetListInput input)
+        {
+            return Repository;
+        }
+
+
+
+
+
+        protected virtual PagedResultDto<TDto> CreatePagedResultDto<TDto>((int TotalCount, System.Collections.Generic.List<TEntity> Entities) queryResult)
+        {
+            return new PagedResultDto<TDto>(
+                queryResult.TotalCount,
+                queryResult.Entities.Select(x => MapToDto<TDto>(x)).ToList());
+        }
+        protected virtual TDto MapToDto<TDto>(TEntity entity)
+        {
+            return ObjectMapper.Map<TEntity, TDto>(entity);
+        }
+
+        /// <summary>
+        /// Maps <see cref="TCreateInput"/> to <see cref="TEntity"/> to create a new entity.
+        /// It uses <see cref="IObjectMapper"/> by default.
+        /// It can be overriden for custom mapping.
+        /// </summary>
+        protected virtual TEntity MapToEntity(TCreateInput createInput)
+        {
+            var entity = ObjectMapper.Map<TCreateInput, TEntity>(createInput);
+            SetIdForGuids(entity);
+            return entity;
+        }
+
+        /// <summary>
+        /// Sets Id value for the entity if <see cref="TKey"/> is <see cref="Guid"/>.
+        /// It's used while creating a new entity.
+        /// </summary>
+        protected virtual void SetIdForGuids(TEntity entity)
+        {
+            var entityWithGuidId = entity as IEntity<Guid>;
+
+            if (entityWithGuidId == null || entityWithGuidId.Id != Guid.Empty)
+            {
+                return;
+            }
+
+            EntityHelper.TrySetId(
+                entityWithGuidId,
+                () => GuidGenerator.Create(),
+                true
+            );
+        }
+
+        protected virtual void MapToEntity(TUpdateInput updateInput, TEntity entity)
+        {
+            if (updateInput is IEntityDto<TKey> entityDto && entity is EntityDto<TKey> entityWithId)
+            {
+                entityDto.Id = entityWithId.Id;
+            }
+
+            ObjectMapper.Map(updateInput, entity);
+        }
+
+        protected virtual void TryToSetTenantId(TEntity entity)
+        {
+            if (entity is IMultiTenant && HasTenantIdProperty(entity))
+            {
+                var tenantId = CurrentTenant.Id;
+
+                if (!tenantId.HasValue)
+                {
+                    return;
+                }
+
+                var propertyInfo = entity.GetType().GetProperty(nameof(IMultiTenant.TenantId));
+
+                if (propertyInfo == null || propertyInfo.GetSetMethod(true) == null)
+                {
+                    return;
+                }
+
+                propertyInfo.SetValue(entity, tenantId);
+            }
+        }
+        protected virtual bool HasTenantIdProperty(TEntity entity)
+        {
+            return entity.GetType().GetProperty(nameof(IMultiTenant.TenantId)) != null;
+        }
+
+        internal static Expression<Func<TEntity, bool>> createEqualityExpression(object compositekey)
+        {
+            var keyProperties = compositekey.GetType().GetProperties();
+
+            var entityParameter = Expression.Parameter(typeof(TEntity), "e");
+
+            return Expression.Lambda<Func<TEntity, bool>>(
+                buildPredicate(keyProperties, compositekey, entityParameter), entityParameter);
+        }
+        internal static BinaryExpression buildPredicate<TEntityCompositeKeyDto>(
+            IReadOnlyList<PropertyInfo> keyProperties,
+            TEntityCompositeKeyDto keyValues,
+            ParameterExpression entityParameter)
+        {
+            var keyValuesConstant = Expression.Constant(keyValues);
+
+            var predicate = GenerateEqualExpression(keyProperties[0], 0);
+
+            for (var i = 1; i < keyProperties.Count; i++)
+            {
+                predicate = Expression.AndAlso(predicate, GenerateEqualExpression(keyProperties[i], i));
+            }
+
+            return predicate;
+
+            BinaryExpression GenerateEqualExpression(PropertyInfo property, int i) =>
+                Expression.Equal(
+                    Expression.PropertyOrField(entityParameter, property.Name),
+                    Expression.Convert(
+                        Expression.Property(
+                            keyValuesConstant,
+                            property),
+                        property.PropertyType));
+        }
+
+
+    }
+}

--- a/framework/src/Volo.Abp.Ddd.Application/Volo/Abp/Application/Services/BaseCrudAppService.cs
+++ b/framework/src/Volo.Abp.Ddd.Application/Volo/Abp/Application/Services/BaseCrudAppService.cs
@@ -262,9 +262,9 @@ namespace Volo.Abp.Application.Services
             return Expression.Lambda<Func<TEntity, bool>>(
                 buildPredicate(keyProperties, compositekey, entityParameter), entityParameter);
         }
-        internal static BinaryExpression buildPredicate<TEntityCompositeKeyDto>(
+        internal static BinaryExpression buildPredicate(
             IReadOnlyList<PropertyInfo> keyProperties,
-            TEntityCompositeKeyDto keyValues,
+            object keyValues,
             ParameterExpression entityParameter)
         {
             var keyValuesConstant = Expression.Constant(keyValues);

--- a/framework/src/Volo.Abp.Ddd.Application/Volo/Abp/Application/Services/CrudAppService.cs
+++ b/framework/src/Volo.Abp.Ddd.Application/Volo/Abp/Application/Services/CrudAppService.cs
@@ -48,23 +48,9 @@ namespace Volo.Abp.Application.Services
     }
 
     public abstract class CrudAppService<TEntity, TEntityDto, TKey, TGetListInput, TCreateInput, TUpdateInput>
-        : CrudAppService<TEntity, TEntityDto, TEntityDto, TKey, TGetListInput, TCreateInput, TUpdateInput>
+        : BaseCrudAppService<TEntity, TEntityDto, TKey, TGetListInput, TCreateInput, TUpdateInput>
         where TEntity : class, IEntity<TKey>
         where TEntityDto : IEntityDto<TKey>
-    {
-        protected CrudAppService(IRepository<TEntity, TKey> repository)
-            : base(repository)
-        {
-
-        }
-    }
-
-    public abstract class CrudAppService<TEntity, TGetOutputDto, TGetListOutputDto, TKey, TGetListInput, TCreateInput, TUpdateInput>
-       : BaseCrudAppService<TEntity, TGetOutputDto, TGetListOutputDto, TKey, TGetListInput, TCreateInput, TUpdateInput>,
-        ICrudAppService<TGetOutputDto, TGetListOutputDto, TKey, TGetListInput, TCreateInput, TUpdateInput>
-           where TEntity : class, IEntity<TKey>
-        where TGetOutputDto : IEntityDto<TKey>
-        where TGetListOutputDto : IEntityDto<TKey>
     {
         protected new IRepository<TEntity, TKey> Repository { get; }
 
@@ -74,13 +60,27 @@ namespace Volo.Abp.Application.Services
             this.Repository = repository;
         }
 
-        public virtual async Task<TGetOutputDto> GetAsync(TKey id)
+        public virtual async Task<TEntityDto> GetAsync(TKey id)
         {
             await CheckGetPolicyAsync().ConfigureAwait(false);
 
             var entity = await GetEntityByIdAsync(id).ConfigureAwait(false);
 
-            return MapToDto<TGetOutputDto>(entity);
+            return MapToDto<TEntityDto>(entity);
+        }
+    }
+
+    [Obsolete("This class is obsolete.Use CrudAppService<TEntity, TEntityDto, TKey, TGetListInput, TCreateInput, TUpdateInput> instead.",false)]
+    public abstract class CrudAppService<TEntity, TGetOutputDto, TGetListOutputDto, TKey, TGetListInput, TCreateInput, TUpdateInput>
+       : CrudAppService<TEntity, TGetOutputDto, TKey, TGetListInput, TCreateInput, TUpdateInput>,
+        ICrudAppService<TGetOutputDto, TKey, TGetListInput, TCreateInput, TUpdateInput>
+           where TEntity : class, IEntity<TKey>
+        where TGetOutputDto : IEntityDto<TKey>
+        where TGetListOutputDto : IEntityDto<TKey>
+    {
+        protected CrudAppService(IRepository<TEntity, TKey> repository)
+            : base(repository)
+        {
         }
     }
 

--- a/framework/src/Volo.Abp.Ddd.Application/Volo/Abp/Application/Services/CrudAppService.cs
+++ b/framework/src/Volo.Abp.Ddd.Application/Volo/Abp/Application/Services/CrudAppService.cs
@@ -57,282 +57,52 @@ namespace Volo.Abp.Application.Services
         {
 
         }
-
-        protected override TEntityDto MapToGetListOutputDto(TEntity entity)
-        {
-            return MapToGetOutputDto(entity);
-        }
     }
 
     public abstract class CrudAppService<TEntity, TGetOutputDto, TGetListOutputDto, TKey, TGetListInput, TCreateInput, TUpdateInput>
-       : ApplicationService,
+       : BaseCrudAppService<TEntity, TGetOutputDto, TGetListOutputDto, TKey, TGetListInput, TCreateInput, TUpdateInput>,
         ICrudAppService<TGetOutputDto, TGetListOutputDto, TKey, TGetListInput, TCreateInput, TUpdateInput>
            where TEntity : class, IEntity<TKey>
         where TGetOutputDto : IEntityDto<TKey>
         where TGetListOutputDto : IEntityDto<TKey>
     {
-        public IAsyncQueryableExecuter AsyncQueryableExecuter { get; set; }
-
-        protected IRepository<TEntity, TKey> Repository { get; }
-
-        protected virtual string GetPolicyName { get; set; }
-
-        protected virtual string GetListPolicyName { get; set; }
-
-        protected virtual string CreatePolicyName { get; set; }
-
-        protected virtual string UpdatePolicyName { get; set; }
-
-        protected virtual string DeletePolicyName { get; set; }
+        protected new IRepository<TEntity, TKey> Repository { get; }
 
         protected CrudAppService(IRepository<TEntity, TKey> repository)
+            : base(repository)
         {
-            Repository = repository;
-            AsyncQueryableExecuter = DefaultAsyncQueryableExecuter.Instance;
+            this.Repository = repository;
         }
 
         public virtual async Task<TGetOutputDto> GetAsync(TKey id)
         {
-            await CheckGetPolicyAsync();
+            await CheckGetPolicyAsync().ConfigureAwait(false);
 
-            var entity = await GetEntityByIdAsync(id);
-            return MapToGetOutputDto(entity);
-        }
+            var entity = await GetEntityByIdAsync(id).ConfigureAwait(false);
 
-        public virtual async Task<PagedResultDto<TGetListOutputDto>> GetListAsync(TGetListInput input)
-        {
-            await CheckGetListPolicyAsync();
-
-            var query = CreateFilteredQuery(input);
-
-            var totalCount = await AsyncQueryableExecuter.CountAsync(query);
-
-            query = ApplySorting(query, input);
-            query = ApplyPaging(query, input);
-
-            var entities = await AsyncQueryableExecuter.ToListAsync(query);
-
-            return new PagedResultDto<TGetListOutputDto>(
-                totalCount,
-                entities.Select(MapToGetListOutputDto).ToList()
-            );
-        }
-
-        public virtual async Task<TGetOutputDto> CreateAsync(TCreateInput input)
-        {
-            await CheckCreatePolicyAsync();
-
-            var entity = MapToEntity(input);
-
-            TryToSetTenantId(entity);
-
-            await Repository.InsertAsync(entity, autoSave: true);
-
-            return MapToGetOutputDto(entity);
-        }
-
-        public virtual async Task<TGetOutputDto> UpdateAsync(TKey id, TUpdateInput input)
-        {
-            await CheckUpdatePolicyAsync();
-
-            var entity = await GetEntityByIdAsync(id);
-            //TODO: Check if input has id different than given id and normalize if it's default value, throw ex otherwise
-            MapToEntity(input, entity);
-            await Repository.UpdateAsync(entity, autoSave: true);
-
-            return MapToGetOutputDto(entity);
-        }
-
-        public virtual async Task DeleteAsync(TKey id)
-        {
-            await CheckDeletePolicyAsync();
-
-            await Repository.DeleteAsync(id);
-        }
-
-        protected virtual Task<TEntity> GetEntityByIdAsync(TKey id)
-        {
-            return Repository.GetAsync(id);
-        }
-
-        protected virtual async Task CheckGetPolicyAsync()
-        {
-            await CheckPolicyAsync(GetPolicyName);
-        }
-
-        protected virtual async Task CheckGetListPolicyAsync()
-        {
-            await CheckPolicyAsync(GetListPolicyName);
-        }
-
-        protected virtual async Task CheckCreatePolicyAsync()
-        {
-            await CheckPolicyAsync(CreatePolicyName);
-        }
-
-        protected virtual async Task CheckUpdatePolicyAsync()
-        {
-            await CheckPolicyAsync(UpdatePolicyName);
-        }
-
-        protected virtual async Task CheckDeletePolicyAsync()
-        {
-            await CheckPolicyAsync(DeletePolicyName);
-        }
-
-        /// <summary>
-        /// Should apply sorting if needed.
-        /// </summary>
-        /// <param name="query">The query.</param>
-        /// <param name="input">The input.</param>
-        protected virtual IQueryable<TEntity> ApplySorting(IQueryable<TEntity> query, TGetListInput input)
-        {
-            //Try to sort query if available
-            if (input is ISortedResultRequest sortInput)
-            {
-                if (!sortInput.Sorting.IsNullOrWhiteSpace())
-                {
-                    return query.OrderBy(sortInput.Sorting);
-                }
-            }
-
-            //IQueryable.Task requires sorting, so we should sort if Take will be used.
-            if (input is ILimitedResultRequest)
-            {
-                return query.OrderByDescending(e => e.Id);
-            }
-
-            //No sorting
-            return query;
-        }
-
-        /// <summary>
-        /// Should apply paging if needed.
-        /// </summary>
-        /// <param name="query">The query.</param>
-        /// <param name="input">The input.</param>
-        protected virtual IQueryable<TEntity> ApplyPaging(IQueryable<TEntity> query, TGetListInput input)
-        {
-            //Try to use paging if available
-            if (input is IPagedResultRequest pagedInput)
-            {
-                return query.PageBy(pagedInput);
-            }
-
-            //Try to limit query result if available
-            if (input is ILimitedResultRequest limitedInput)
-            {
-                return query.Take(limitedInput.MaxResultCount);
-            }
-
-            //No paging
-            return query;
-        }
-
-        /// <summary>
-        /// This method should create <see cref="IQueryable{TEntity}"/> based on given input.
-        /// It should filter query if needed, but should not do sorting or paging.
-        /// Sorting should be done in <see cref="ApplySorting"/> and paging should be done in <see cref="ApplyPaging"/>
-        /// methods.
-        /// </summary>
-        /// <param name="input">The input.</param>
-        protected virtual IQueryable<TEntity> CreateFilteredQuery(TGetListInput input)
-        {
-            return Repository;
-        }
-
-        /// <summary>
-        /// Maps <see cref="TEntity"/> to <see cref="TGetOutputDto"/>.
-        /// It uses <see cref="IObjectMapper"/> by default.
-        /// It can be overriden for custom mapping.
-        /// </summary>
-        protected virtual TGetOutputDto MapToGetOutputDto(TEntity entity)
-        {
-            return ObjectMapper.Map<TEntity, TGetOutputDto>(entity);
-        }
-
-        /// <summary>
-        /// Maps <see cref="TEntity"/> to <see cref="TGetListOutputDto"/>.
-        /// It uses <see cref="IObjectMapper"/> by default.
-        /// It can be overriden for custom mapping.
-        /// </summary>
-        protected virtual TGetListOutputDto MapToGetListOutputDto(TEntity entity)
-        {
-            return ObjectMapper.Map<TEntity, TGetListOutputDto>(entity);
-        }
-
-        /// <summary>
-        /// Maps <see cref="TCreateInput"/> to <see cref="TEntity"/> to create a new entity.
-        /// It uses <see cref="IObjectMapper"/> by default.
-        /// It can be overriden for custom mapping.
-        /// </summary>
-        protected virtual TEntity MapToEntity(TCreateInput createInput)
-        {
-            var entity = ObjectMapper.Map<TCreateInput, TEntity>(createInput);
-            SetIdForGuids(entity);
-            return entity;
-        }
-
-        /// <summary>
-        /// Sets Id value for the entity if <see cref="TKey"/> is <see cref="Guid"/>.
-        /// It's used while creating a new entity.
-        /// </summary>
-        protected virtual void SetIdForGuids(TEntity entity)
-        {
-            var entityWithGuidId = entity as IEntity<Guid>;
-
-            if (entityWithGuidId == null || entityWithGuidId.Id != Guid.Empty)
-            {
-                return;
-            }
-
-            EntityHelper.TrySetId(
-                entityWithGuidId,
-                () => GuidGenerator.Create(),
-                true
-            );
-        }
-
-        /// <summary>
-        /// Maps <see cref="TUpdateInput"/> to <see cref="TEntity"/> to update the entity.
-        /// It uses <see cref="IObjectMapper"/> by default.
-        /// It can be overriden for custom mapping.
-        /// </summary>
-        protected virtual void MapToEntity(TUpdateInput updateInput, TEntity entity)
-        {
-            if (updateInput is IEntityDto<TKey> entityDto)
-            {
-                entityDto.Id = entity.Id;
-            }
-
-            ObjectMapper.Map(updateInput, entity);
-        }
-
-        protected virtual void TryToSetTenantId(TEntity entity)
-        {
-            if (entity is IMultiTenant && HasTenantIdProperty(entity))
-            {
-                var tenantId = CurrentTenant.Id;
-
-                if (!tenantId.HasValue)
-                {
-                    return;
-                }
-
-                var propertyInfo = entity.GetType().GetProperty(nameof(IMultiTenant.TenantId));
-
-                if (propertyInfo == null || propertyInfo.GetSetMethod(true) == null)
-                {
-                    return;
-                }
-
-                propertyInfo.SetValue(entity, tenantId);
-            }
-        }
-
-        protected virtual bool HasTenantIdProperty(TEntity entity)
-        {
-            return entity.GetType().GetProperty(nameof(IMultiTenant.TenantId)) != null;
+            return MapToDto<TGetOutputDto>(entity);
         }
     }
+
+    public abstract class CrudAppService<TEntity, TGetOutputDto, TGetListOutputDto, TKey, TFind, TGetListInput, TCreateInput, TUpdateInput>
+       : BaseCrudAppService<TEntity, TGetOutputDto, TGetListOutputDto, TKey, TGetListInput, TCreateInput, TUpdateInput>,
+        ICrudAppService<TGetOutputDto, TGetListOutputDto, TKey, TFind, TGetListInput, TCreateInput, TUpdateInput>
+           where TEntity : class, IEntity
+        where TGetOutputDto : IEntityDto
+        where TGetListOutputDto : IEntityDto
+    {
+        protected CrudAppService(IRepository<TEntity> repository)
+            : base(repository) { }
+
+        public async Task<TGetOutputDto> GetFindAsync(TFind key)
+        {
+            await CheckGetPolicyAsync().ConfigureAwait(false);
+
+            var entity = await GetEntityByIdAsync(key).ConfigureAwait(false);
+
+            return MapToDto<TGetOutputDto>(entity);
+
+        }
+    }
+
 }

--- a/framework/src/Volo.Abp.Ddd.Application/Volo/Abp/Application/Services/CrudAppService.cs
+++ b/framework/src/Volo.Abp.Ddd.Application/Volo/Abp/Application/Services/CrudAppService.cs
@@ -84,25 +84,4 @@ namespace Volo.Abp.Application.Services
         }
     }
 
-    public abstract class CrudAppService<TEntity, TGetOutputDto, TGetListOutputDto, TKey, TFind, TGetListInput, TCreateInput, TUpdateInput>
-       : BaseCrudAppService<TEntity, TGetOutputDto, TGetListOutputDto, TKey, TGetListInput, TCreateInput, TUpdateInput>,
-        ICrudAppService<TGetOutputDto, TGetListOutputDto, TKey, TFind, TGetListInput, TCreateInput, TUpdateInput>
-           where TEntity : class, IEntity
-        where TGetOutputDto : IEntityDto
-        where TGetListOutputDto : IEntityDto
-    {
-        protected CrudAppService(IRepository<TEntity> repository)
-            : base(repository) { }
-
-        public async Task<TGetOutputDto> GetFindAsync(TFind key)
-        {
-            await CheckGetPolicyAsync().ConfigureAwait(false);
-
-            var entity = await GetEntityByIdAsync(key).ConfigureAwait(false);
-
-            return MapToDto<TGetOutputDto>(entity);
-
-        }
-    }
-
 }

--- a/framework/src/Volo.Abp.Ddd.Application/Volo/Abp/Application/Services/EntityWithCompositeKeyCrudAppService.cs
+++ b/framework/src/Volo.Abp.Ddd.Application/Volo/Abp/Application/Services/EntityWithCompositeKeyCrudAppService.cs
@@ -5,12 +5,11 @@ using Volo.Abp.Domain.Repositories;
 
 namespace Volo.Abp.Application.Services
 {
-    public abstract class EntityWithCompositeKeyCrudAppService<TEntity, TGetOutputDto, TGetListOutputDto, TKey, TGetListInput, TCreateInput, TUpdateInput>
-       : BaseCrudAppService<TEntity, TGetOutputDto, TGetListOutputDto, TKey, TGetListInput, TCreateInput, TUpdateInput>,
-        IEntityWithCompositeKeyCrudAppService<TGetOutputDto, TGetListOutputDto, TKey, TGetListInput, TCreateInput, TUpdateInput>
+    public abstract class EntityWithCompositeKeyCrudAppService<TEntity, TGetOutputDto, TKey, TGetListInput, TCreateInput, TUpdateInput>
+       : BaseCrudAppService<TEntity, TGetOutputDto, TKey, TGetListInput, TCreateInput, TUpdateInput>,
+        IEntityWithCompositeKeyCrudAppService<TGetOutputDto, TKey, TGetListInput, TCreateInput, TUpdateInput>
            where TEntity : class, IEntity
         where TGetOutputDto : IEntityDto
-        where TGetListOutputDto : IEntityDto
     {
         protected EntityWithCompositeKeyCrudAppService(IRepository<TEntity> repository)
             : base(repository) { }
@@ -24,21 +23,21 @@ namespace Volo.Abp.Application.Services
             return MapToDto<TGetOutputDto>(entity);
 
         }
-        [RemoteService(false)]//disable for http api
-        public override Task<TGetOutputDto> UpdateAsync(TKey id, TUpdateInput input)
+        [RemoteService(false)]//disable for http api,because of id is a object type,can't bind to url path
+        public override async Task<TGetOutputDto> UpdateAsync(TKey id, TUpdateInput input)
         {
-            return this.UpdateAsync(input);
+            return await base.UpdateAsync(id, input);
         }
 
         public virtual async Task<TGetOutputDto> UpdateAsync(TUpdateInput input)
         {
             var keys = ObjectMapper.Map<TUpdateInput, TKey>(input);
 
-            return await base.UpdateAsync(keys, input);
+            return await this.UpdateAsync(keys, input);
 
         }
 
-        public override async Task DeleteAsync(TKey input)
+        public override async Task DeleteAsync(TKey input)//Tkey is a object type,so change name from id to input 
         {
             await base.DeleteAsync(input);
         }

--- a/framework/src/Volo.Abp.Ddd.Application/Volo/Abp/Application/Services/EntityWithCompositeKeyCrudAppService.cs
+++ b/framework/src/Volo.Abp.Ddd.Application/Volo/Abp/Application/Services/EntityWithCompositeKeyCrudAppService.cs
@@ -1,0 +1,49 @@
+﻿using System.Threading.Tasks;
+using Volo.Abp.Application.Dtos;
+using Volo.Abp.Domain.Entities;
+using Volo.Abp.Domain.Repositories;
+
+namespace Volo.Abp.Application.Services
+{
+    public abstract class EntityWithCompositeKeyCrudAppService<TEntity, TGetOutputDto, TGetListOutputDto, TKey, TGetListInput, TCreateInput, TUpdateInput>
+       : BaseCrudAppService<TEntity, TGetOutputDto, TGetListOutputDto, TKey, TGetListInput, TCreateInput, TUpdateInput>,
+        IEntityWithCompositeKeyCrudAppService<TGetOutputDto, TGetListOutputDto, TKey, TGetListInput, TCreateInput, TUpdateInput>
+           where TEntity : class, IEntity
+        where TGetOutputDto : IEntityDto
+        where TGetListOutputDto : IEntityDto
+    {
+        protected EntityWithCompositeKeyCrudAppService(IRepository<TEntity> repository)
+            : base(repository) { }
+
+        public virtual async Task<TGetOutputDto> GetFindAsync(TKey key)
+        {
+            await CheckGetPolicyAsync().ConfigureAwait(false);
+
+            var entity = await GetEntityByIdAsync(key).ConfigureAwait(false);
+
+            return MapToDto<TGetOutputDto>(entity);
+
+        }
+        [RemoteService(false)]//disable for http api
+        public override Task<TGetOutputDto> UpdateAsync(TKey id, TUpdateInput input)
+        {
+            return this.UpdateAsync(input);
+        }
+
+        public virtual async Task<TGetOutputDto> UpdateAsync(TUpdateInput input)
+        {
+            var keys = ObjectMapper.Map<TUpdateInput, TKey>(input);
+
+            return await base.UpdateAsync(keys, input);
+
+        }
+
+        public override async Task DeleteAsync(TKey input)
+        {
+            await base.DeleteAsync(input);
+        }
+
+
+    }
+
+}

--- a/framework/src/Volo.Abp.Ddd.Application/Volo/Abp/Application/Services/EntityWithCompositeKeyCrudAppService.cs
+++ b/framework/src/Volo.Abp.Ddd.Application/Volo/Abp/Application/Services/EntityWithCompositeKeyCrudAppService.cs
@@ -26,20 +26,20 @@ namespace Volo.Abp.Application.Services
         [RemoteService(false)]//disable for http api,because of id is a object type,can't bind to url path
         public override async Task<TGetOutputDto> UpdateAsync(TKey id, TUpdateInput input)
         {
-            return await base.UpdateAsync(id, input);
+            return await base.UpdateAsync(id, input).ConfigureAwait(false);
         }
 
         public virtual async Task<TGetOutputDto> UpdateAsync(TUpdateInput input)
         {
             var keys = ObjectMapper.Map<TUpdateInput, TKey>(input);
 
-            return await this.UpdateAsync(keys, input);
+            return await this.UpdateAsync(keys, input).ConfigureAwait(false);
 
         }
 
         public override async Task DeleteAsync(TKey input)//Tkey is a object type,so change name from id to input 
         {
-            await base.DeleteAsync(input);
+            await base.DeleteAsync(input).ConfigureAwait(false);
         }
 
 


### PR DESCRIPTION
 Hi everyone: 
   Practically,we are very often using `CrudAppService` in begin,so on this pull request,I enhance some function for more flexibility and keep no breaking change.

## 1. `Replace Inheritance With Delegation` : 
add class [`PagedAndSortedOperation` ](https://github.com/yinchang0626/abp/blob/feature/Enhance_CrudAppService/framework/src/Volo.Abp.Ddd.Application/Volo/Abp/Application/PagedAndSortedOperation.cs),
 `Usage:` 
1. Inheritanced from CrudAppService still can override ApplySorting,ApplyPaging to replace method, 
2. Others AppService can reuse it by DI to list data with filter.sort.page...
## 2. `Extract Superclass`:
Original [`CrudAppService`](https://github.com/yinchang0626/abp/blob/eb14d8f01a8b80631755fc7391513162ecf736e0/framework/src/Volo.Abp.Ddd.Application/Volo/Abp/Application/Services/CrudAppService.cs#L62) move to [`BaseCrudAppService`](https://github.com/yinchang0626/abp/blob/feature/Enhance_CrudAppService/framework/src/Volo.Abp.Ddd.Application/Volo/Abp/Application/Services/BaseCrudAppService.cs) except GetAsync(TKey id) ,`BaseCrudAppService` is designed for `TEntity` and `TEntity<TKey>` but not limit in `TEntity<TKey>`.
Because in face legacy db schema,usually must be orm some entity with `Composite Key`,I know this doesn't make sense,but we need to handel  it without modifying primary key although it is a `aggregate root`.
So, I create a [`EntityWithCompositeKeyCrudAppService`](https://github.com/yinchang0626/abp/blob/feature/Enhance_CrudAppService/framework/src/Volo.Abp.Ddd.Application/Volo/Abp/Application/Services/EntityWithCompositeKeyCrudAppService.cs)(base on `BaseCrudAppService`) that without `GetAsync(TKey id)` but have `GetFindAsync(TKey key)` for Get an Entity By Key(like `DbSet.Find`).

 `Usage:` Just like Original `CrudAppService`,let AppService Inheritance `EntityWithCompositeKeyCrudAppService<TEntity, TGetOutputDto, TGetListOutputDto, TKey, TGetListInput, TCreateInput, TUpdateInput>`
note `TKey` is  Composite Key Type not for Entity<>
then you can do Create,Update,Delete,Find(get one by key) for IEntity with Composite Key

#### Known issues:
When use `CompositeKey`,avoid to implement `ISoftDelete`,I doesn't  test soft delete this entity and create the same `CompositeKey` will correct or not.

## 3. Modify `GetListAsync`
Change return type from `TGetListOutputDto`  to `TGetOutputDto`.
According to [best practices](https://github.com/abpframework/abp/blob/dev/docs/en/Best-Practices/Application-Services.md#getting-a-list-of-entities) ,so return a list of detailed DTOs.
and mark original `CrudAppService<TGetOutputDto, TGetListOutputDto, in TKey, in TGetListInput, in TCreateInput, in TUpdateInput>` as `Obsolete` because of no longer need `TGetListOutputDto` Type

If this Pull Request is accepted,I can write some unittest or doc in the future.
Thanks