### PR TITLE
Grammatical issues on Account en.json

### DIFF
--- a/modules/account/src/Volo.Abp.Account.Application.Contracts/Volo/Abp/Account/Localization/Resources/en.json
+++ b/modules/account/src/Volo.Abp.Account.Application.Contracts/Volo/Abp/Account/Localization/Resources/en.json
@@ -1,16 +1,16 @@
 {
   "culture": "en",
   "texts": {
-    "UserName": "User name",
+    "UserName": "Username",
     "EmailAddress": "Email address",
-    "UserNameOrEmailAddress": "User name or email address",
+    "UserNameOrEmailAddress": "Username or email address",
     "Password": "Password",
     "RememberMe": "Remember me",
     "UseAnotherServiceToLogin": "Use another service to log in",
     "UserLockedOutMessage": "The user account has been locked out due to invalid login attempts. Please wait a while and try again.",
     "InvalidUserNameOrPassword": "Invalid username or password!",
     "LoginIsNotAllowed": "You are not allowed to login! You need to confirm your email/phone number.",
-    "SelfRegistrationDisabledMessage": "Self user registration is disabled for this application. Contact to the application administrator to register a new user.",
+    "SelfRegistrationDisabledMessage": "Self-registration is disabled for this application. Please contact the application administrator to register a new user.",
     "Login": "Login",
     "Cancel": "Cancel",
     "Register": "Register",
@@ -23,7 +23,7 @@
     "DisplayName:NewPassword": "New password",
     "DisplayName:NewPasswordConfirm": "Confirm new password",
     "PasswordChangedMessage": "Your password has been changed successfully.",
-    "DisplayName:UserName": "User name",
+    "DisplayName:UserName": "Username",
     "DisplayName:Email": "Email",
     "DisplayName:Name": "Name",
     "DisplayName:Surname": "Surname",
@@ -39,6 +39,6 @@
     "DisplayName:Abp.Account.IsSelfRegistrationEnabled": "Is self-registration enabled",
     "Description:Abp.Account.IsSelfRegistrationEnabled": "Whether a user can register the account by him or herself.",
     "DisplayName:Abp.Account.EnableLocalLogin": "Authenticate with a local account",
-    "Description:Abp.Account.EnableLocalLogin": "Indicates if Server will allow users to authenticate with a local account."
+    "Description:Abp.Account.EnableLocalLogin": "Indicates if the server will allow users to authenticate with a local account."
   }
 }


### PR DESCRIPTION
Using "self-registration" rather than "self user registration" to align _DisplayName:Abp.Account.IsSelfRegistrationEnabled_ with _SelfRegistrationDisabledMessage_.