### PR TITLE
Output a warning if the command is not found.

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/HelpCommand.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/HelpCommand.cs
@@ -32,6 +32,13 @@ namespace Volo.Abp.Cli.Commands
                 return Task.CompletedTask;
             }
 
+            if (!AbpCliOptions.Commands.ContainsKey(commandLineArgs.Target))
+            {
+                Logger.LogWarning($"There is no command named {commandLineArgs.Target}.");
+                Logger.LogInformation(GetUsageInfo());
+                return Task.CompletedTask;
+            }
+
             var commandType = AbpCliOptions.Commands[commandLineArgs.Target];
 
             using (var scope = ServiceScopeFactory.CreateScope())


### PR DESCRIPTION
```
> abp help qwerty
[10:00:09 INF] ABP CLI (https://abp.io)
[10:00:10 INF] Version 2.0.0 (Stable channel)
[10:00:10 ERR] The given key 'qwerty' was not present in the dictionary.
System.Collections.Generic.KeyNotFoundException: The given key 'qwerty' was not present in the dictionary.
   at System.Collections.Generic.Dictionary`2.get_Item(TKey key)
   at Volo.Abp.Cli.Commands.HelpCommand.ExecuteAsync(CommandLineArgs commandLineArgs) in D:\Github\abp\framework\src\Volo.Abp.Cli.Core\Volo\Abp\Cli\Commands\HelpCommand.cs:line 35
   at Volo.Abp.Cli.CliService.RunAsync(String[] args) in D:\Github\abp\framework\src\Volo.Abp.Cli.Core\Volo\Abp\Cli\CliService.cs:line 55
```