### PR TITLE
Make proxy script support [FromForm] model binding.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AspNetCoreApiDescriptionModelProvider.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AspNetCoreApiDescriptionModelProvider.cs
@@ -175,7 +175,10 @@ namespace Volo.Abp.AspNetCore.Mvc
                         parameterDescription.RouteInfo?.IsOptional ?? false,
                         parameterDescription.RouteInfo?.DefaultValue,
                         parameterDescription.RouteInfo?.Constraints?.Select(c => c.GetType().Name).ToArray(),
-                        parameterDescription.Source.Id
+                        parameterDescription.Source.Id,
+                        parameterDescription.ModelMetadata.ContainerType != null
+                            ? parameterDescription.ParameterDescriptor.Name
+                            : string.Empty
                     )
                 );
             }

--- a/framework/src/Volo.Abp.Http/Volo/Abp/Http/Modeling/ParameterApiDescriptionModel.cs
+++ b/framework/src/Volo.Abp.Http/Volo/Abp/Http/Modeling/ParameterApiDescriptionModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Volo.Abp.Http.Modeling
 {
@@ -19,12 +19,14 @@ namespace Volo.Abp.Http.Modeling
 
         public string BindingSourceId { get; set; }
 
+        public string DescriptorName { get; set; }
+
         private ParameterApiDescriptionModel()
         {
             
         }
 
-        public static ParameterApiDescriptionModel Create(string name, string nameOnMethod, Type type, bool isOptional = false, object defaultValue = null, string[] constraintTypes = null, string bindingSourceId = null)
+        public static ParameterApiDescriptionModel Create(string name, string nameOnMethod, Type type, bool isOptional = false, object defaultValue = null, string[] constraintTypes = null, string bindingSourceId = null, string descriptorName = null)
         {
             return new ParameterApiDescriptionModel
             {
@@ -34,7 +36,8 @@ namespace Volo.Abp.Http.Modeling
                 IsOptional = isOptional,
                 DefaultValue = defaultValue,
                 ConstraintTypes = constraintTypes,
-                BindingSourceId = bindingSourceId
+                BindingSourceId = bindingSourceId,
+                DescriptorName = descriptorName
             };
         }
     }

--- a/framework/src/Volo.Abp.Http/Volo/Abp/Http/ProxyScripting/Generators/JQuery/JQueryProxyScriptGenerator.cs
+++ b/framework/src/Volo.Abp.Http/Volo/Abp/Http/ProxyScripting/Generators/JQuery/JQueryProxyScriptGenerator.cs
@@ -96,7 +96,11 @@ namespace Volo.Abp.Http.ProxyScripting.Generators.JQuery
 
             AddAjaxCallParameters(script, action);
 
-            script.AppendLine("      }, ajaxParams));;");
+            var ajaxParamsIsFromForm = action.Parameters.Any(x => x.BindingSourceId == ParameterBindingSources.Form);
+            script.AppendLine(ajaxParamsIsFromForm
+                ? "      }, $.extend(true, {}, ajaxParams, { contentType: 'application/x-www-form-urlencoded; charset=UTF-8' })));"
+                : "      }, ajaxParams));");
+
             script.AppendLine("    };");
         }
 

--- a/framework/src/Volo.Abp.Http/Volo/Abp/Http/ProxyScripting/Generators/ProxyScriptingHelper.cs
+++ b/framework/src/Volo.Abp.Http/Volo/Abp/Http/ProxyScripting/Generators/ProxyScriptingHelper.cs
@@ -66,7 +66,7 @@ namespace Volo.Abp.Http.ProxyScripting.Generators
                 return null;
             }
 
-            return ProxyScriptingJsFuncHelper.CreateJsObjectLiteral(parameters, indent);
+            return ProxyScriptingJsFuncHelper.CreateJsFormPostData(parameters, indent);
         }
 
         private static string ReplacePathVariables(string url, IList<ParameterApiDescriptionModel> actionParameters)


### PR DESCRIPTION
Resolve #2744

```c#
public Task MyMethod([FromQuery]string a, [FromForm]string b, [FromForm]TestModel input, [FromForm]TestModel input2)
{
	return Task.CompletedTask;
}
```
Generated script:
```js
function(a, b, inputName, inputBirthDate, input2Name, input2BirthDate, ajaxParams) {
  return abp.ajax($.extend(true, {
	url: abp.appPath + 'api/test' + abp.utils.buildQueryString([{ name: 'a', value: a }]) + '',
	type: 'POST',
	dataType: null,
	data: 'b=' + b + '&' + 'input.Name=' + inputName + '&' + 'input.BirthDate=' + inputBirthDate + '&' + 'input2.Name=' + input2Name + '&' + 'input2.BirthDate=' + input2BirthDate
  }, $.extend(true, {}, ajaxParams, { contentType: 'application/x-www-form-urlencoded; charset=UTF-8' })));
};
```