### PR TITLE
Wrong class name is fixed in documentation

### DIFF
--- a/docs/en/Background-Jobs.md
+++ b/docs/en/Background-Jobs.md
@@ -108,7 +108,7 @@ Enqueue method gets some optional arguments to control the background job:
 
 You may want to disable background job execution for your application. This is generally needed if you want to execute background jobs in another process and disable it for the current process.
 
-Use `BackgroundJobOptions` to configure the job execution:
+Use `AbpBackgroundJobOptions` to configure the job execution:
 
 ````csharp
 [DependsOn(typeof(AbpBackgroundJobsModule))]
@@ -116,7 +116,7 @@ public class MyModule : AbpModule
 {
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        Configure<BackgroundJobOptions>(options =>
+        Configure<AbpBackgroundJobOptions>(options =>
         {
             options.IsJobExecutionEnabled = false; //Disables job execution
         });

--- a/docs/en/Background-Jobs.md
+++ b/docs/en/Background-Jobs.md
@@ -140,7 +140,7 @@ ABP framework includes a simple `IBackgroundJobManager` implementation that;
 
 ### Configuration
 
-Use `BackgroundJobWorkerOptions` in your [module class](Module-Development-Basics.md) to configure the default background job manager. The example below changes the timeout duration for background jobs:
+Use `AbpBackgroundJobWorkerOptions` in your [module class](Module-Development-Basics.md) to configure the default background job manager. The example below changes the timeout duration for background jobs:
 
 ````csharp
 [DependsOn(typeof(AbpBackgroundJobsModule))]
@@ -148,7 +148,7 @@ public class MyModule : AbpModule
 {
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        Configure<BackgroundJobWorkerOptions>(options =>
+        Configure<AbpBackgroundJobWorkerOptions>(options =>
         {
             options.DefaultTimeout = 864000; //10 days (as seconds)
         });


### PR DESCRIPTION
'BackgroundJobOptions' is changed to 'AbpBackgroundJobOptions'