### PR TITLE
refactor(theme-shared): create and use confirmation.status instead of toaster.status

### DIFF
--- a/npm/ng-packs/packages/theme-shared/src/lib/components/confirmation/confirmation.component.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/components/confirmation/confirmation.component.ts
@@ -2,7 +2,6 @@ import { Component } from '@angular/core';
 import { ConfirmationService } from '../../services/confirmation.service';
 import { Confirmation } from '../../models/confirmation';
 import { LocalizationService } from '@abp/ng.core';
-import { Toaster } from '../../models/toaster';
 
 @Component({
   selector: 'abp-confirmation',
@@ -10,9 +9,9 @@ import { Toaster } from '../../models/toaster';
   styleUrls: ['./confirmation.component.scss'],
 })
 export class ConfirmationComponent {
-  confirm = Toaster.Status.confirm;
-  reject = Toaster.Status.reject;
-  dismiss = Toaster.Status.dismiss;
+  confirm = Confirmation.Status.confirm;
+  reject = Confirmation.Status.reject;
+  dismiss = Confirmation.Status.dismiss;
 
   visible = false;
 
@@ -43,7 +42,7 @@ export class ConfirmationComponent {
     });
   }
 
-  close(status: Toaster.Status) {
+  close(status: Confirmation.Status) {
     this.confirmationService.clear(status);
   }
 }

--- a/npm/ng-packs/packages/theme-shared/src/lib/models/confirmation.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/models/confirmation.ts
@@ -20,4 +20,10 @@ export namespace Confirmation {
   }
 
   export type Severity = 'neutral' | 'success' | 'info' | 'warning' | 'error';
+
+  export enum Status {
+    confirm = 'confirm',
+    reject = 'reject',
+    dismiss = 'dismiss',
+  }
 }

--- a/npm/ng-packs/packages/theme-shared/src/lib/models/toaster.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/models/toaster.ts
@@ -21,6 +21,9 @@ export namespace Toaster {
 
   export type Severity = 'neutral' | 'success' | 'info' | 'warning' | 'error';
 
+  /**
+   * @deprecated Status will be removed from toaster model in v2.2
+   */
   export enum Status {
     confirm = 'confirm',
     reject = 'reject',

--- a/npm/ng-packs/packages/theme-shared/src/lib/services/confirmation.service.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/services/confirmation.service.ts
@@ -2,19 +2,18 @@ import { Injectable } from '@angular/core';
 import { Confirmation } from '../models/confirmation';
 import { fromEvent, Observable, Subject, ReplaySubject } from 'rxjs';
 import { takeUntil, debounceTime, filter } from 'rxjs/operators';
-import { Toaster } from '../models/toaster';
 import { Config } from '@abp/ng.core';
 
 @Injectable({ providedIn: 'root' })
 export class ConfirmationService {
-  status$: Subject<Toaster.Status>;
+  status$: Subject<Confirmation.Status>;
   confirmation$ = new ReplaySubject<Confirmation.DialogData>(1);
 
   info(
     message: Config.LocalizationParam,
     title: Config.LocalizationParam,
     options?: Partial<Confirmation.Options>,
-  ): Observable<Toaster.Status> {
+  ): Observable<Confirmation.Status> {
     return this.show(message, title, 'info', options);
   }
 
@@ -22,7 +21,7 @@ export class ConfirmationService {
     message: Config.LocalizationParam,
     title: Config.LocalizationParam,
     options?: Partial<Confirmation.Options>,
-  ): Observable<Toaster.Status> {
+  ): Observable<Confirmation.Status> {
     return this.show(message, title, 'success', options);
   }
 
@@ -30,7 +29,7 @@ export class ConfirmationService {
     message: Config.LocalizationParam,
     title: Config.LocalizationParam,
     options?: Partial<Confirmation.Options>,
-  ): Observable<Toaster.Status> {
+  ): Observable<Confirmation.Status> {
     return this.show(message, title, 'warning', options);
   }
 
@@ -38,16 +37,16 @@ export class ConfirmationService {
     message: Config.LocalizationParam,
     title: Config.LocalizationParam,
     options?: Partial<Confirmation.Options>,
-  ): Observable<Toaster.Status> {
+  ): Observable<Confirmation.Status> {
     return this.show(message, title, 'error', options);
   }
 
   show(
     message: Config.LocalizationParam,
     title: Config.LocalizationParam,
-    severity?: Toaster.Severity,
+    severity?: Confirmation.Severity,
     options?: Partial<Confirmation.Options>,
-  ): Observable<Toaster.Status> {
+  ): Observable<Confirmation.Status> {
     this.confirmation$.next({
       message,
       title,
@@ -59,9 +58,9 @@ export class ConfirmationService {
     return this.status$;
   }
 
-  clear(status?: Toaster.Status) {
+  clear(status?: Confirmation.Status) {
     this.confirmation$.next();
-    this.status$.next(status || Toaster.Status.dismiss);
+    this.status$.next(status || Confirmation.Status.dismiss);
   }
 
   listenToEscape() {


### PR DESCRIPTION
closes #2852 