### PR TITLE
Make sure the script is executed before the callback method.

### DIFF
--- a/npm/packs/jquery/src/abp.jquery.js
+++ b/npm/packs/jquery/src/abp.jquery.js
@@ -364,7 +364,7 @@
                     dataType: 'text'
                 })
                 .done(function (script) {
-                    jQuery.globalEval(script);
+                    $.globalEval(script);
                     urlInfo.succeed();
                 })
                 .fail(function () {

--- a/npm/packs/jquery/src/abp.jquery.js
+++ b/npm/packs/jquery/src/abp.jquery.js
@@ -359,13 +359,17 @@
 
         var _loadScript = function (url, loadCallback, failCallback) {
             _loadFromUrl(url, loadCallback, failCallback, function (urlInfo) {
-                $.getScript(url)
-                    .done(function () {
-                        urlInfo.succeed();
-                    })
-                    .fail(function () {
-                        urlInfo.failed();
-                    });
+                $.get({
+                    url: url,
+                    dataType: 'text'
+                })
+                .done(function (script) {
+                    jQuery.globalEval(script);
+                    urlInfo.succeed();
+                })
+                .fail(function () {
+                    urlInfo.failed();
+                });
             });
         };
 


### PR DESCRIPTION
`$.getScript` 
The callback is fired once the script has been loaded **but not necessarily executed**.