### PR TITLE
Use `IHttpClientFactory` instead of manually creating a `HttpClient`

### DIFF
--- a/framework/src/Volo.Abp.IdentityModel/Volo.Abp.IdentityModel.csproj
+++ b/framework/src/Volo.Abp.IdentityModel/Volo.Abp.IdentityModel.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="IdentityModel" Version="4.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.2" />
     <ProjectReference Include="..\Volo.Abp.Threading\Volo.Abp.Threading.csproj" />
   </ItemGroup>
 

--- a/framework/src/Volo.Abp.IdentityModel/Volo/Abp/IdentityModel/IdentityModelAuthenticationService.cs
+++ b/framework/src/Volo.Abp.IdentityModel/Volo/Abp/IdentityModel/IdentityModelAuthenticationService.cs
@@ -21,12 +21,15 @@ namespace Volo.Abp.IdentityModel
         public ILogger<IdentityModelAuthenticationService> Logger { get; set; }
         protected AbpIdentityClientOptions ClientOptions { get; }
         protected ICancellationTokenProvider CancellationTokenProvider { get; }
+        protected IHttpClientFactory HttpClientFactory { get; }
 
         public IdentityModelAuthenticationService(
             IOptions<AbpIdentityClientOptions> options,
-            ICancellationTokenProvider cancellationTokenProvider)
+            ICancellationTokenProvider cancellationTokenProvider,
+            IHttpClientFactory httpClientFactory)
         {
             CancellationTokenProvider = cancellationTokenProvider;
+            HttpClientFactory = httpClientFactory;
             ClientOptions = options.Value;
             Logger = NullLogger<IdentityModelAuthenticationService>.Instance;
         }
@@ -95,7 +98,7 @@ namespace Volo.Abp.IdentityModel
         protected virtual async Task<DiscoveryDocumentResponse> GetDiscoveryResponse(
             IdentityClientConfiguration configuration)
         {
-            using (var httpClient = new HttpClient())
+            using (var httpClient = HttpClientFactory.CreateClient())
             {
                 return await httpClient.GetDiscoveryDocumentAsync(new DiscoveryDocumentRequest
                 {
@@ -109,10 +112,10 @@ namespace Volo.Abp.IdentityModel
         }
 
         protected virtual async Task<TokenResponse> GetTokenResponse(
-            DiscoveryDocumentResponse discoveryResponse, 
+            DiscoveryDocumentResponse discoveryResponse,
             IdentityClientConfiguration configuration)
         {
-            using (var httpClient = new HttpClient())
+            using (var httpClient = HttpClientFactory.CreateClient())
             {
                 switch (configuration.GrantType)
                 {
@@ -134,7 +137,7 @@ namespace Volo.Abp.IdentityModel
 
         protected virtual Task<PasswordTokenRequest> CreatePasswordTokenRequestAsync(DiscoveryDocumentResponse discoveryResponse, IdentityClientConfiguration configuration)
         {
-            var request =  new PasswordTokenRequest
+            var request = new PasswordTokenRequest
             {
                 Address = discoveryResponse.TokenEndpoint,
                 Scope = configuration.Scope,
@@ -149,11 +152,11 @@ namespace Volo.Abp.IdentityModel
             return Task.FromResult(request);
         }
 
-        protected virtual Task<ClientCredentialsTokenRequest>  CreateClientCredentialsTokenRequestAsync(
-            DiscoveryDocumentResponse discoveryResponse, 
+        protected virtual Task<ClientCredentialsTokenRequest> CreateClientCredentialsTokenRequestAsync(
+            DiscoveryDocumentResponse discoveryResponse,
             IdentityClientConfiguration configuration)
         {
-            var request =  new ClientCredentialsTokenRequest
+            var request = new ClientCredentialsTokenRequest
             {
                 Address = discoveryResponse.TokenEndpoint,
                 Scope = configuration.Scope,


### PR DESCRIPTION
This enables customization of the created client or it's handlers from outside of this module.

`IHttpClientFactory` provides different endpoints to customize the created clients. One of them would be to implement a custom `IHttpMessageHandlerBuilderFilter` and register it in the ioc framework.

My use case is a validation of self-signed certificates that aren't known to the clients or injecting a [WinHttpHandler](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.winhttphandler?view=dotnet-plat-ext-3.1) into the httpclient automatically to be used by .net-fx projects which use the `Volo.Abp.IdentityModel` package.