### PR TITLE
Revert "Use `IHttpClientFactory` instead of manually creating a `HttpClient`"

### DIFF
--- a/framework/src/Volo.Abp.IdentityModel/Volo.Abp.IdentityModel.csproj
+++ b/framework/src/Volo.Abp.IdentityModel/Volo.Abp.IdentityModel.csproj
@@ -16,7 +16,6 @@
 
   <ItemGroup>
     <PackageReference Include="IdentityModel" Version="4.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.2" />
     <ProjectReference Include="..\Volo.Abp.Threading\Volo.Abp.Threading.csproj" />
   </ItemGroup>
 

--- a/framework/src/Volo.Abp.IdentityModel/Volo/Abp/IdentityModel/IdentityModelAuthenticationService.cs
+++ b/framework/src/Volo.Abp.IdentityModel/Volo/Abp/IdentityModel/IdentityModelAuthenticationService.cs
@@ -21,15 +21,12 @@ namespace Volo.Abp.IdentityModel
         public ILogger<IdentityModelAuthenticationService> Logger { get; set; }
         protected AbpIdentityClientOptions ClientOptions { get; }
         protected ICancellationTokenProvider CancellationTokenProvider { get; }
-        protected IHttpClientFactory HttpClientFactory { get; }
 
         public IdentityModelAuthenticationService(
             IOptions<AbpIdentityClientOptions> options,
-            ICancellationTokenProvider cancellationTokenProvider,
-            IHttpClientFactory httpClientFactory)
+            ICancellationTokenProvider cancellationTokenProvider)
         {
             CancellationTokenProvider = cancellationTokenProvider;
-            HttpClientFactory = httpClientFactory;
             ClientOptions = options.Value;
             Logger = NullLogger<IdentityModelAuthenticationService>.Instance;
         }
@@ -98,7 +95,7 @@ namespace Volo.Abp.IdentityModel
         protected virtual async Task<DiscoveryDocumentResponse> GetDiscoveryResponse(
             IdentityClientConfiguration configuration)
         {
-            using (var httpClient = HttpClientFactory.CreateClient())
+            using (var httpClient = new HttpClient())
             {
                 return await httpClient.GetDiscoveryDocumentAsync(new DiscoveryDocumentRequest
                 {
@@ -112,10 +109,10 @@ namespace Volo.Abp.IdentityModel
         }
 
         protected virtual async Task<TokenResponse> GetTokenResponse(
-            DiscoveryDocumentResponse discoveryResponse,
+            DiscoveryDocumentResponse discoveryResponse, 
             IdentityClientConfiguration configuration)
         {
-            using (var httpClient = HttpClientFactory.CreateClient())
+            using (var httpClient = new HttpClient())
             {
                 switch (configuration.GrantType)
                 {
@@ -137,7 +134,7 @@ namespace Volo.Abp.IdentityModel
 
         protected virtual Task<PasswordTokenRequest> CreatePasswordTokenRequestAsync(DiscoveryDocumentResponse discoveryResponse, IdentityClientConfiguration configuration)
         {
-            var request = new PasswordTokenRequest
+            var request =  new PasswordTokenRequest
             {
                 Address = discoveryResponse.TokenEndpoint,
                 Scope = configuration.Scope,
@@ -152,11 +149,11 @@ namespace Volo.Abp.IdentityModel
             return Task.FromResult(request);
         }
 
-        protected virtual Task<ClientCredentialsTokenRequest> CreateClientCredentialsTokenRequestAsync(
-            DiscoveryDocumentResponse discoveryResponse,
+        protected virtual Task<ClientCredentialsTokenRequest>  CreateClientCredentialsTokenRequestAsync(
+            DiscoveryDocumentResponse discoveryResponse, 
             IdentityClientConfiguration configuration)
         {
-            var request = new ClientCredentialsTokenRequest
+            var request =  new ClientCredentialsTokenRequest
             {
                 Address = discoveryResponse.TokenEndpoint,
                 Scope = configuration.Scope,


### PR DESCRIPTION
Reverts abpframework/abp#2937

Since there is no `AddHttpClient `method to register `IHttpClientFactory`. It will cause dependency injection problems.

![image](https://user-images.githubusercontent.com/6908465/75731024-8125c580-5d29-11ea-8b6f-61cfb1d72375.png)
