### PR TITLE
 Save audit logs even if no action performed in the request.

### DIFF
--- a/framework/src/Volo.Abp.Auditing/Volo/Abp/Auditing/AuditingManager.cs
+++ b/framework/src/Volo.Abp.Auditing/Volo/Abp/Auditing/AuditingManager.cs
@@ -114,20 +114,7 @@ namespace Volo.Abp.Auditing
         {
             BeforeSave(saveHandle);
 
-            if (ShouldSave(saveHandle.AuditLog))
-            {
-                await _auditingStore.SaveAsync(saveHandle.AuditLog);
-            }
-        }
-
-        protected bool ShouldSave(AuditLogInfo auditLog)
-        {
-            if (!auditLog.Actions.Any() && !auditLog.EntityChanges.Any())
-            {
-                return false;
-            }
-
-            return true;
+            await _auditingStore.SaveAsync(saveHandle.AuditLog);
         }
 
         protected class DisposableSaveHandle : IAuditLogSaveHandle

--- a/framework/test/Volo.Abp.Auditing.Tests/Volo/Abp/Auditing/Auditing_Tests.cs
+++ b/framework/test/Volo.Abp.Auditing.Tests/Volo/Abp/Auditing/Auditing_Tests.cs
@@ -118,7 +118,7 @@ namespace Volo.Abp.Auditing
             }
 
 #pragma warning disable 4014
-            _auditingStore.DidNotReceive().SaveAsync(Arg.Any<AuditLogInfo>());
+            _auditingStore.Received().SaveAsync(Arg.Is<AuditLogInfo>(a => !a.EntityChanges.Any()));
 #pragma warning restore 4014
         }
 
@@ -172,7 +172,7 @@ namespace Volo.Abp.Auditing
 
 
         [Fact]
-        public virtual async Task Should_Not_Write_AuditLog_If_There_No_Action_And_No_EntityChanges()
+        public virtual async Task Should_Write_AuditLog_If_There_No_Action_And_No_EntityChanges()
         {
             using (var scope = _auditingManager.BeginScope())
             {
@@ -180,7 +180,7 @@ namespace Volo.Abp.Auditing
             }
 
 #pragma warning disable 4014
-            _auditingStore.DidNotReceive().SaveAsync(Arg.Any<AuditLogInfo>());
+            _auditingStore.Received().SaveAsync(Arg.Any<AuditLogInfo>());
 #pragma warning restore 4014
         }
 


### PR DESCRIPTION
Resolve #2820