### PR TITLE
Fix build errors.

### DIFF
--- a/framework/src/Volo.Abp.IdentityModel/Volo/Abp/IdentityModel/AbpIdentityModelModule.cs
+++ b/framework/src/Volo.Abp.IdentityModel/Volo/Abp/IdentityModel/AbpIdentityModelModule.cs
@@ -13,8 +13,6 @@ namespace Volo.Abp.IdentityModel
         {
             var configuration = context.Services.GetConfiguration();
 
-            context.Services.AddHttpClient();
-
             Configure<AbpIdentityClientOptions>(configuration);
         }
     }


### PR DESCRIPTION
`AddHttpClient` needs to reference the [Microsoft.Extensions.Http](https://www.nuget.org/packages/Microsoft.Extensions.Http/) package.

But no related services(`IHttpClientFactory`) are used in `Volo.Abp.IdentityModel`.

