### PR TITLE
Allow replace & delete BundleContributor.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Packages/Volo/Abp/AspNetCore/Mvc/UI/Packages/BootstrapDatepicker/BootstrapDatepickerScriptContributor.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Packages/Volo/Abp/AspNetCore/Mvc/UI/Packages/BootstrapDatepicker/BootstrapDatepickerScriptContributor.cs
@@ -21,7 +21,7 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Packages.Timeago
                 ? "en"
                 : CultureInfo.CurrentUICulture.Name;
 
-            if (TryAddCultureFile(context, cultureName))
+            if (TryAddCultureFile(context, MapCultureName(cultureName)))
             {
                 return;
             }
@@ -38,6 +38,11 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Packages.Timeago
 
             context.Files.AddIfNotContains(filePath);
             return true;
+        }
+        
+        protected virtual string MapCultureName(string cultureName)
+        {
+            return cultureName;
         }
     }
 }

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Packages/Volo/Abp/AspNetCore/Mvc/UI/Packages/JQueryValidation/JQueryValidationScriptContributor.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Packages/Volo/Abp/AspNetCore/Mvc/UI/Packages/JQueryValidation/JQueryValidationScriptContributor.cs
@@ -25,7 +25,7 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Packages.JQueryValidation
 
             var cultureName = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName.Replace('-', '_');
 
-            if (TryAddCultureFile(context, cultureName))
+            if (TryAddCultureFile(context, MapCultureName(cultureName)))
             {
                 return;
             }
@@ -35,7 +35,7 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Packages.JQueryValidation
                 return;
             }
 
-            TryAddCultureFile(context, cultureName.Substring(0, cultureName.IndexOf('_')));
+            TryAddCultureFile(context, MapCultureName(cultureName.Substring(0, cultureName.IndexOf('_'))));
         }
 
         protected virtual bool TryAddCultureFile(BundleConfigurationContext context, string cultureName)
@@ -50,6 +50,11 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Packages.JQueryValidation
 
             context.Files.AddIfNotContains(filePath);
             return true;
+        }
+        
+        protected virtual string MapCultureName(string cultureName)
+        {
+            return cultureName;
         }
     }
 }


### PR DESCRIPTION
A js library may have many localization files, but their file names may be different from the culture name.

such as:
```
zh-Hans: zh-cn
pt-BR: ptBr
es-MX: es
```

We should allow developers to map them manually.
``` c#
public class MyBootstrapDatepickerScriptContributor : BootstrapDatepickerScriptContributor
{
    protected override string MapCultureName(string cultureName)
    {
        return cultureName == "zh-Hans" ? "zh-CN" : base.MapCultureName(cultureName);
    }
}

Configure<AbpBundlingOptions>(options =>
{
	options.ScriptBundles.Get(StandardBundles.Scripts.Global).Contributors
		.Replace<BootstrapDatepickerScriptContributor, MyBootstrapDatepickerScriptContributor>();
});
```