### PR TITLE
Invalid links on Quartz background worker docs

### DIFF
--- a/docs/en/Background-Workers-Quartz.md
+++ b/docs/en/Background-Workers-Quartz.md
@@ -38,7 +38,7 @@ public class YourModule : AbpModule
 
 ### Configuration
 
-See [Configuration](Background-Jobs-Quartz.md#Configuration).
+See [Configuration](Background-Jobs-Quartz#Configuration).
 
 ### Create a Background Worker
 
@@ -61,7 +61,7 @@ public class MyLogWorker : QuartzBackgroundWorkerBase
 }
 ````
 
-We simply implemented the Execute method to write a log. The background worker is a **singleton by default**. If you want, you can also implement a [dependency interface](Dependency-Injection.md#DependencyInterfaces) to register it as another life cycle.
+We simply implemented the Execute method to write a log. The background worker is a **singleton by default**. If you want, you can also implement a [dependency interface](Dependency-Injection#DependencyInterfaces) to register it as another life cycle.
 
 ### More
 


### PR DESCRIPTION
This might be due to the way the markdown is rendered or requests are routed? Links without the hash are fine to include '.md' file extension.