### PR TITLE
Restore the sourceFile variable.

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/NugetPackageToLocalReferenceConverter.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/NugetPackageToLocalReferenceConverter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -52,6 +52,7 @@ namespace Volo.Abp.Cli.ProjectModification
 
             foreach (XmlNode oldNode in nodes)
             {
+                var tempSourceFile = sourceFile;
                 var oldNodeIncludeValue = oldNode?.Attributes?["Include"]?.Value;
 
                 var moduleName = nugetPackageList.FirstOrDefault(n => n.NugetPackage.Name == oldNodeIncludeValue)?.ModuleName;
@@ -67,11 +68,11 @@ namespace Volo.Abp.Cli.ProjectModification
                         if (oldNodeIncludeValue.EndsWith(".test", StringComparison.InvariantCultureIgnoreCase) ||
                             oldNodeIncludeValue.EndsWith(".tests", StringComparison.InvariantCultureIgnoreCase))
                         {
-                            sourceFile = "test";
+                            tempSourceFile = "test";
                         }
                         else
                         {
-                            sourceFile = "src";
+                            tempSourceFile = "src";
                         }
                     }
                     else
@@ -81,7 +82,7 @@ namespace Volo.Abp.Cli.ProjectModification
                 }
 
                 var referenceProjectPath =
-                    $"{localPathPrefix}{moduleName}\\{sourceFile}\\{oldNodeIncludeValue}\\{oldNodeIncludeValue}.csproj";
+                    $"{localPathPrefix}{moduleName}\\{tempSourceFile}\\{oldNodeIncludeValue}\\{oldNodeIncludeValue}.csproj";
 
                 XmlNode newNode = GetNewReferenceNode(doc, referenceProjectPath);
 


### PR DESCRIPTION
Related: https://github.com/abpframework/abp/issues/3054

hi @yekalkan 
Volo.Identity's `masterModules `include `Volo.Account`. Should it be reversed?

![image](https://user-images.githubusercontent.com/6908465/76313391-ce003200-630f-11ea-90e5-ba1e8e8b450d.png)
