### PR TITLE
Backgroundworkerbase logger properties use concrete types as generic parameters

### DIFF
--- a/framework/src/Volo.Abp.BackgroundWorkers/Volo/Abp/BackgroundWorkers/BackgroundWorkerBase.cs
+++ b/framework/src/Volo.Abp.BackgroundWorkers/Volo/Abp/BackgroundWorkers/BackgroundWorkerBase.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -11,14 +13,34 @@ namespace Volo.Abp.BackgroundWorkers
     public abstract class BackgroundWorkerBase : IBackgroundWorker
     {
         //TODO: Add UOW, Localization and other useful properties..?
+        public IServiceProvider ServiceProvider { get; set; }
+        protected readonly object ServiceProviderLock = new object();
 
-        public ILogger<BackgroundWorkerBase> Logger { protected get; set; }
+        protected TService LazyGetRequiredService<TService>(ref TService reference)
+            => LazyGetRequiredService(typeof(TService), ref reference);
 
-        protected BackgroundWorkerBase()
+        protected TRef LazyGetRequiredService<TRef>(Type serviceType, ref TRef reference)
         {
-            Logger = NullLogger<BackgroundWorkerBase>.Instance;
+            if (reference == null)
+            {
+                lock (ServiceProviderLock)
+                {
+                    if (reference == null)
+                    {
+                        reference = (TRef)ServiceProvider.GetRequiredService(serviceType);
+                    }
+                }
+            }
+
+            return reference;
         }
-        
+
+        public ILoggerFactory LoggerFactory => LazyGetRequiredService(ref _loggerFactory);
+        private ILoggerFactory _loggerFactory;
+
+        protected ILogger Logger => _lazyLogger.Value;
+        private Lazy<ILogger> _lazyLogger => new Lazy<ILogger>(() => LoggerFactory?.CreateLogger(GetType().FullName) ?? NullLogger.Instance, true);
+
         public virtual Task StartAsync(CancellationToken cancellationToken = default)
         {
             Logger.LogDebug("Started background worker: " + ToString());


### PR DESCRIPTION
Resolved : https://github.com/abpframework/abp/issues/3100