### PR TITLE
fix: return empty object from getSettings when keyword is not found

### DIFF
--- a/npm/ng-packs/packages/core/src/lib/states/config.state.ts
+++ b/npm/ng-packs/packages/core/src/lib/states/config.state.ts
@@ -1,11 +1,12 @@
+import { Injectable } from '@angular/core';
 import { Action, createSelector, Selector, State, StateContext, Store } from '@ngxs/store';
 import { of } from 'rxjs';
 import { switchMap, tap } from 'rxjs/operators';
 import snq from 'snq';
 import {
+  AddRoute,
   GetAppConfiguration,
   PatchRouteByName,
-  AddRoute,
   SetEnvironment,
 } from '../actions/config.actions';
 import { SetLanguage } from '../actions/session.actions';
@@ -14,7 +15,6 @@ import { Config } from '../models/config';
 import { ApplicationConfigurationService } from '../services/application-configuration.service';
 import { organizeRoutes } from '../utils/route-utils';
 import { SessionState } from './session.state';
-import { Injectable } from '@angular/core';
 
 @State<Config.State>({
   name: 'ConfigState',
@@ -88,28 +88,24 @@ export class ConfigState {
   }
 
   static getSetting(key: string) {
-    const selector = createSelector([ConfigState], (state: Config.State) => {
+    return createSelector([ConfigState], (state: Config.State) => {
       return snq(() => state.setting.values[key]);
     });
-    return selector;
   }
 
   static getSettings(keyword?: string) {
-    const selector = createSelector([ConfigState], (state: Config.State) => {
-      if (keyword) {
-        const keys = snq(
-          () => Object.keys(state.setting.values).filter(key => key.indexOf(keyword) > -1),
-          [],
-        );
+    return createSelector([ConfigState], (state: Config.State) => {
+      const settings = snq(() => state.setting.values, {});
 
-        if (keys.length) {
-          return keys.reduce((acc, key) => ({ ...acc, [key]: state.setting.values[key] }), {});
-        }
-      }
+      if (!keyword) return settings;
 
-      return snq(() => state.setting.values, {});
+      const keysFound = Object.keys(settings).filter(key => key.indexOf(keyword) > -1);
+
+      return keysFound.reduce((acc, key) => {
+        acc[key] = settings[key];
+        return acc;
+      }, {});
     });
-    return selector;
   }
 
   static getGrantedPolicy(key: string) {

--- a/npm/ng-packs/packages/core/src/lib/states/config.state.ts
+++ b/npm/ng-packs/packages/core/src/lib/states/config.state.ts
@@ -88,13 +88,15 @@ export class ConfigState {
   }
 
   static getSetting(key: string) {
-    return createSelector([ConfigState], (state: Config.State) => {
+    const selector = createSelector([ConfigState], (state: Config.State) => {
       return snq(() => state.setting.values[key]);
     });
+
+    return selector;
   }
 
   static getSettings(keyword?: string) {
-    return createSelector([ConfigState], (state: Config.State) => {
+    const selector = createSelector([ConfigState], (state: Config.State) => {
       const settings = snq(() => state.setting.values, {});
 
       if (!keyword) return settings;
@@ -106,6 +108,8 @@ export class ConfigState {
         return acc;
       }, {});
     });
+
+    return selector;
   }
 
   static getGrantedPolicy(key: string) {

--- a/npm/ng-packs/packages/core/src/lib/tests/config.state.spec.ts
+++ b/npm/ng-packs/packages/core/src/lib/tests/config.state.spec.ts
@@ -1,12 +1,12 @@
 import { createServiceFactory, SpectatorService, SpyObject } from '@ngneat/spectator/jest';
 import { Store } from '@ngxs/store';
-import { ReplaySubject, timer, Subject, of } from 'rxjs';
+import clone from 'just-clone';
+import { of, ReplaySubject, timer } from 'rxjs';
+import { AddRoute, PatchRouteByName, SetLanguage } from '../actions';
+import { ABP } from '../models';
 import { Config } from '../models/config';
 import { ApplicationConfigurationService, ConfigStateService } from '../services';
 import { ConfigState } from '../states';
-import { SetLanguage, PatchRouteByName, AddRoute } from '../actions';
-import clone from 'just-clone';
-import { ABP } from '../models';
 
 export const CONFIG_STATE_DATA = {
   environment: {
@@ -116,6 +116,7 @@ export const CONFIG_STATE_DATA = {
   },
   setting: {
     values: {
+      'Abp.Custom.SomeSetting': 'X',
       'Abp.Localization.DefaultLanguage': 'en',
     },
   },
@@ -218,14 +219,14 @@ describe('ConfigState', () => {
   });
 
   describe('#getSettings', () => {
-    it('should return settings', () => {
-      expect(ConfigState.getSettings('Localization')(CONFIG_STATE_DATA)).toEqual({
-        'Abp.Localization.DefaultLanguage': 'en',
-      });
-
-      expect(ConfigState.getSettings('AllSettings')(CONFIG_STATE_DATA)).toEqual(
-        CONFIG_STATE_DATA.setting.values,
-      );
+    test.each`
+      keyword           | expected
+      ${undefined}      | ${CONFIG_STATE_DATA.setting.values}
+      ${'Localization'} | ${{ 'Abp.Localization.DefaultLanguage': 'en' }}
+      ${'X'}            | ${{}}
+      ${'localization'} | ${{}}
+    `('should return $expected when keyword is given as $keyword', ({ keyword, expected }) => {
+      expect(ConfigState.getSettings(keyword)(CONFIG_STATE_DATA)).toEqual(expected);
     });
   });
 


### PR DESCRIPTION
Fixes #3095 