### PR TITLE
Fixed security issue in multi-tenancy docs

### DIFF
--- a/docs/en/Multi-Tenancy.md
+++ b/docs/en/Multi-Tenancy.md
@@ -302,7 +302,7 @@ TODO:...
 
 Volo.Abp.AspNetCore.MultiTenancy package adds following tenant resolvers to determine current tenant from current web request (ordered by priority). These resolvers are added and work out of the box:
 
-* **CurrentUserTenantResolveContributor**: Gets the tenant id from claims of the current user, if the current user has logged in. **This should always be stay as the first contributor for security**.
+* **CurrentUserTenantResolveContributor**: Gets the tenant id from claims of the current user, if the current user has logged in. **This should always be the first contributor for security**.
 * **QueryStringTenantResolver**: Tries to find current tenant id from query string parameter. Parameter name is "__tenant" by default.
 * **RouteTenantResolver**: Tries to find current tenant id from route (URL path). Variable name is "__tenant" by default. So, if you defined a route with this variable, then it can determine the current tenant from the route.
 * **HeaderTenantResolver**: Tries to find current tenant id from HTTP header. Header name is "__tenant" by default.
@@ -343,8 +343,10 @@ namespace MyCompany.MyProject
         {
             Configure<AbpTenantResolveOptions>(options =>
             {
-                //Subdomain format: {0}.mydomain.com (adding as the highest priority resolver)
-                options.TenantResolvers.Insert(0, new DomainTenantResolver("{0}.mydomain.com"));
+                //Subdomain format: {0}.mydomain.com 
+                //Adding as the second highest priority resolver after 'CurrentUserTenantResolveContributor' to
+                //ensure the user cannot impersonate a different tenant.
+                options.TenantResolvers.Insert(1, new DomainTenantResolver("{0}.mydomain.com"));
             });
 
             //...
@@ -355,7 +357,7 @@ namespace MyCompany.MyProject
 
 {0} is the the placeholder to determine current tenant's unique name.
 
-Instead of ``options.TenantResolvers.Insert(0, new DomainTenantResolver("{0}.mydomain.com"));`` you can use this shortcut:
+Instead of ``options.TenantResolvers.Insert(1, new DomainTenantResolver("{0}.mydomain.com"));`` you can use this shortcut:
 
 ````C#
 options.AddDomainTenantResolver("{0}.mydomain.com");

--- a/docs/zh-Hans/Multi-Tenancy.md
+++ b/docs/zh-Hans/Multi-Tenancy.md
@@ -343,8 +343,8 @@ namespace MyCompany.MyProject
         {
             Configure<AbpTenantResolveOptions>(options =>
             {
-                //子域名格式: {0}.mydomain.com (作为最高优先级解析器添加)
-                options.TenantResolvers.Insert(0, new DomainTenantResolver("{0}.mydomain.com"));
+                //子域名格式: {0}.mydomain.com (作为第二优先级解析器添加, 位于CurrentUserTenantResolveContributor之后)
+                options.TenantResolvers.Insert(1, new DomainTenantResolver("{0}.mydomain.com"));
             });
 
             //...
@@ -355,7 +355,7 @@ namespace MyCompany.MyProject
 
 {0}是用来确定当前租户唯一名称的占位符.
 
-你可以使用下面的方法,代替``options.TenantResolvers.Insert(0, new DomainTenantResolver("{0}.mydomain.com"));``:
+你可以使用下面的方法,代替``options.TenantResolvers.Insert(1, new DomainTenantResolver("{0}.mydomain.com"));``:
 
 ````C#
 options.AddDomainTenantResolver("{0}.mydomain.com");


### PR DESCRIPTION
`DomainTenantResolver` should appear after `CurrentUserTenantResolveContributor` but the docs say to insert it as the first contributor.