### PR TITLE
The request method of RestService now gets apiName in config parameter for easy baseUrl

### DIFF
--- a/npm/ng-packs/packages/core/src/lib/models/config.ts
+++ b/npm/ng-packs/packages/core/src/lib/models/config.ts
@@ -24,15 +24,15 @@ export namespace Config {
     logoUrl?: string;
   }
 
-  export type ApiConfig = {
+  export interface ApiConfig {
     [key: string]: string;
     url: string;
-  };
+  }
 
-  export type Apis = {
+  export interface Apis {
     [key: string]: ApiConfig;
     default: ApiConfig;
-  };
+  }
 
   export interface Requirements {
     layouts: Type<any>[];

--- a/npm/ng-packs/packages/core/src/lib/models/config.ts
+++ b/npm/ng-packs/packages/core/src/lib/models/config.ts
@@ -1,5 +1,5 @@
-import { AuthConfig } from 'angular-oauth2-oidc';
 import { Type } from '@angular/core';
+import { AuthConfig } from 'angular-oauth2-oidc';
 import { ApplicationConfiguration } from './application-configuration';
 import { ABP } from './common';
 
@@ -13,6 +13,7 @@ export namespace Config {
   export interface Environment {
     application: Application;
     production: boolean;
+    hmr?: boolean;
     oAuthConfig: AuthConfig;
     apis: Apis;
     localization: { defaultResourceName: string };
@@ -23,9 +24,15 @@ export namespace Config {
     logoUrl?: string;
   }
 
-  export interface Apis {
-    [key: string]: { [key: string]: string };
-  }
+  export type ApiConfig = {
+    [key: string]: string;
+    url: string;
+  };
+
+  export type Apis = {
+    [key: string]: ApiConfig;
+    default: ApiConfig;
+  };
 
   export interface Requirements {
     layouts: Type<any>[];

--- a/npm/ng-packs/packages/core/src/lib/models/rest.ts
+++ b/npm/ng-packs/packages/core/src/lib/models/rest.ts
@@ -1,10 +1,11 @@
 import { HttpHeaders, HttpParams } from '@angular/common/http';
 
 export namespace Rest {
-  export interface Config {
-    skipHandleError?: boolean;
-    observe?: Observe;
-  }
+  export type Config = Partial<{
+    apiName: string;
+    skipHandleError: boolean;
+    observe: Observe;
+  }>;
 
   export const enum Observe {
     Body = 'body',

--- a/npm/ng-packs/packages/core/src/lib/services/rest.service.ts
+++ b/npm/ng-packs/packages/core/src/lib/services/rest.service.ts
@@ -19,10 +19,15 @@ export class RestService {
     return throwError(err);
   }
 
-  request<T, R>(request: HttpRequest<T> | Rest.Request<T>, config?: Rest.Config, api?: string): Observable<R> {
+  request<T, R>(
+    request: HttpRequest<T> | Rest.Request<T>,
+    config?: Rest.Config,
+    api?: string,
+  ): Observable<R> {
     config = config || ({} as Rest.Config);
     const { observe = Rest.Observe.Body, skipHandleError } = config;
-    const url = (api || this.store.selectSnapshot(ConfigState.getApiUrl())) + request.url;
+    const url =
+      (api || this.store.selectSnapshot(ConfigState.getApiUrl(config.apiName))) + request.url;
     const { method, params, ...options } = request;
 
     return this.http
@@ -32,7 +37,8 @@ export class RestService {
           params: Object.keys(params).reduce(
             (acc, key) => ({
               ...acc,
-              ...(typeof params[key] !== 'undefined' && params[key] !== '' && { [key]: params[key] }),
+              ...(typeof params[key] !== 'undefined' &&
+                params[key] !== '' && { [key]: params[key] }),
             }),
             {},
           ),


### PR DESCRIPTION
Added apiName to config parameter of request method of RestService

Fixes #3137 