### PR TITLE
Dynamic C# proxying enhancements for culture sensitive types.

### DIFF
--- a/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/DynamicProxying/DynamicHttpProxyInterceptor.cs
+++ b/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/DynamicProxying/DynamicHttpProxyInterceptor.cs
@@ -111,7 +111,7 @@ namespace Volo.Abp.Http.Client.DynamicProxying
             {
                 return (T)Convert.ChangeType(responseAsString, typeof(T));
             }
-            
+
             return JsonSerializer.Deserialize<T>(responseAsString);
         }
 

--- a/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/DynamicProxying/DynamicHttpProxyInterceptor.cs
+++ b/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/DynamicProxying/DynamicHttpProxyInterceptor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -106,20 +106,12 @@ namespace Volo.Abp.Http.Client.DynamicProxying
         private async Task<T> MakeRequestAndGetResultAsync<T>(IAbpMethodInvocation invocation)
         {
             var responseAsString = await MakeRequestAsync(invocation);
-
-            //TODO: Think on that
-            if (TypeHelper.IsPrimitiveExtended(typeof(T), true))
+            
+            if (typeof(T) == typeof(string))
             {
-                if (typeof(DateTime).IsAssignableFrom(typeof(T)))
-                {
-                    return (T)(object)DateTime.Parse(responseAsString.Trim('\"'), CultureInfo.InvariantCulture);
-                }
-                else
-                {
-                    return (T)Convert.ChangeType(responseAsString, typeof(T));
-                }
+                responseAsString = responseAsString.EnsureStartsWith('"').EnsureEndsWith('"');
             }
-
+            
             return JsonSerializer.Deserialize<T>(responseAsString);
         }
 

--- a/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/DynamicProxying/DynamicHttpProxyInterceptor.cs
+++ b/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/DynamicProxying/DynamicHttpProxyInterceptor.cs
@@ -109,7 +109,7 @@ namespace Volo.Abp.Http.Client.DynamicProxying
             
             if (typeof(T) == typeof(string))
             {
-                responseAsString = responseAsString.EnsureStartsWith('"').EnsureEndsWith('"');
+                return (T)Convert.ChangeType(responseAsString, typeof(T));
             }
             
             return JsonSerializer.Deserialize<T>(responseAsString);

--- a/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/DynamicProxying/UrlBuilder.cs
+++ b/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/DynamicProxying/UrlBuilder.cs
@@ -6,6 +6,7 @@ using System.Text;
 using JetBrains.Annotations;
 using Volo.Abp.Http.Modeling;
 using Volo.Abp.Http.ProxyScripting.Generators;
+using Volo.Abp.Localization;
 using Volo.Abp.Reflection;
 
 namespace Volo.Abp.Http.Client.DynamicProxying
@@ -104,12 +105,15 @@ namespace Volo.Abp.Http.Client.DynamicProxying
 
         private static string ConvertValueToString([NotNull] object value)
         {
-            if (value is DateTime dateTimeValue)
+            using (CultureHelper.Use(CultureInfo.InvariantCulture))
             {
-                return dateTimeValue.ToUniversalTime().ToString("u");
-            }
+                if (value is DateTime dateTimeValue)
+                {
+                    return dateTimeValue.ToUniversalTime().ToString("u");
+                }
 
-            return value.ToString();
+                return value.ToString();
+            }
         }
     }
 }


### PR DESCRIPTION
Resolve #3472

For any return value except `string`, it can be json deserialized.

Mvc's `QueryStringValueProvider `uses `InvariantCulture `to get parameters. So we should also use `InvariantCulture `to convert `object to string.` Of course the `DateTime` needs to be converted to utc format.
