### PR TITLE
Explicitly define @Injectable() decoration requirement.

### DIFF
--- a/docs/en/Tutorials/Part-1.md
+++ b/docs/en/Tutorials/Part-1.md
@@ -970,6 +970,7 @@ export class BooksState {
 }
 ```
 * We added the book property to BooksStateModel model.
+* We added `@Injectable()` decorator to BookState class (Regquired for Ivy to work properly).
 * We added the `GetBooks` action that retrieves the books data via `BooksService` that generated via ABP CLI and patches the state.
 * `NGXS` requires to return the observable without subscribing it in the get function.
 


### PR DESCRIPTION
From the documentation, it was not obvious to add `@Injectable()` decorator, So I had to do some googling to realize it.
I think this change could save some time for other developers.