### PR TITLE
Add multiple StaticWebAssetsFileProvider

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore/Volo/Abp/AspNetCore/VirtualFileSystem/WebContentFileProvider.cs
+++ b/framework/src/Volo.Abp.AspNetCore/Volo/Abp/AspNetCore/VirtualFileSystem/WebContentFileProvider.cs
@@ -99,17 +99,14 @@ namespace Volo.Abp.AspNetCore.VirtualFileSystem
                 _virtualFileProvider
             };
 
-            if (_hostingEnvironment.IsDevelopment() && 
+            if (_hostingEnvironment.IsDevelopment() &&
                 _hostingEnvironment.WebRootFileProvider is CompositeFileProvider compositeFileProvider)
             {
-                var staticWebAssetsFileProvider = compositeFileProvider
+                var staticWebAssetsFileProviders = compositeFileProvider
                     .FileProviders
-                    .FirstOrDefault(f => f.GetType().Name.Equals("StaticWebAssetsFileProvider"));
+                    .Where(f => f.GetType().Name.Equals("StaticWebAssetsFileProvider")).ToList();
 
-                if (staticWebAssetsFileProvider != null)
-                {
-                    fileProviders.Add(staticWebAssetsFileProvider);
-                }
+                fileProviders.AddRange(staticWebAssetsFileProviders);
             }
 
             return new CompositeFileProvider(


### PR DESCRIPTION
When using multiple Razor libraries, each library has its own `StaticWebAssetsFileProvider`. We should all add to `fileProviders`

![image](https://user-images.githubusercontent.com/16813853/81303087-d5448180-90ad-11ea-81cc-92825ec100e2.png)
