### PR TITLE
Add AbpAspNetCoreMvcModule to microservices host module dependencies

### DIFF
--- a/samples/MicroserviceDemo/microservices/BloggingService.Host/BloggingServiceHostModule.cs
+++ b/samples/MicroserviceDemo/microservices/BloggingService.Host/BloggingServiceHostModule.cs
@@ -13,6 +13,7 @@ using MsDemo.Shared;
 using Swashbuckle.AspNetCore.Swagger;
 using Volo.Abp;
 using Volo.Abp.AspNetCore.MultiTenancy;
+using Volo.Abp.AspNetCore.Mvc;
 using Volo.Abp.Auditing;
 using Volo.Abp.AuditLogging.EntityFrameworkCore;
 using Volo.Abp.Autofac;
@@ -40,6 +41,7 @@ namespace BloggingService.Host
 {
     [DependsOn(
         typeof(AbpAutofacModule),
+        typeof(AbpAspNetCoreMvcModule),
         typeof(AbpEventBusRabbitMqModule),
         typeof(AbpEntityFrameworkCoreSqlServerModule),
         typeof(AbpAuditLoggingEntityFrameworkCoreModule),

--- a/samples/MicroserviceDemo/microservices/IdentityService.Host/IdentityServiceHostModule.cs
+++ b/samples/MicroserviceDemo/microservices/IdentityService.Host/IdentityServiceHostModule.cs
@@ -9,6 +9,7 @@ using Microsoft.OpenApi.Models;
 using MsDemo.Shared;
 using Volo.Abp;
 using Volo.Abp.AspNetCore.MultiTenancy;
+using Volo.Abp.AspNetCore.Mvc;
 using Volo.Abp.Auditing;
 using Volo.Abp.AuditLogging.EntityFrameworkCore;
 using Volo.Abp.Autofac;
@@ -29,6 +30,7 @@ namespace IdentityService.Host
 {
     [DependsOn(
         typeof(AbpAutofacModule),
+        typeof(AbpAspNetCoreMvcModule),
         typeof(AbpEventBusRabbitMqModule),
         typeof(AbpEntityFrameworkCoreSqlServerModule),
         typeof(AbpAuditLoggingEntityFrameworkCoreModule),

--- a/samples/MicroserviceDemo/microservices/ProductService.Host/ProductServiceHostModule.cs
+++ b/samples/MicroserviceDemo/microservices/ProductService.Host/ProductServiceHostModule.cs
@@ -12,6 +12,7 @@ using MsDemo.Shared;
 using Swashbuckle.AspNetCore.Swagger;
 using Volo.Abp;
 using Volo.Abp.AspNetCore.MultiTenancy;
+using Volo.Abp.AspNetCore.Mvc;
 using Volo.Abp.Auditing;
 using Volo.Abp.AuditLogging.EntityFrameworkCore;
 using Volo.Abp.Autofac;
@@ -32,6 +33,7 @@ namespace ProductService.Host
 {
     [DependsOn(
         typeof(AbpAutofacModule),
+        typeof(AbpAspNetCoreMvcModule),
         typeof(AbpEventBusRabbitMqModule),
         typeof(AbpEntityFrameworkCoreSqlServerModule),
         typeof(AbpAuditLoggingEntityFrameworkCoreModule),

--- a/samples/MicroserviceDemo/microservices/TenantManagementService.Host/TenantManagementServiceHostModule.cs
+++ b/samples/MicroserviceDemo/microservices/TenantManagementService.Host/TenantManagementServiceHostModule.cs
@@ -9,6 +9,7 @@ using MsDemo.Shared;
 using StackExchange.Redis;
 using Volo.Abp;
 using Volo.Abp.AspNetCore.MultiTenancy;
+using Volo.Abp.AspNetCore.Mvc;
 using Volo.Abp.Auditing;
 using Volo.Abp.AuditLogging.EntityFrameworkCore;
 using Volo.Abp.Autofac;
@@ -29,6 +30,7 @@ namespace TenantManagementService.Host
 {
     [DependsOn(
         typeof(AbpAutofacModule),
+        typeof(AbpAspNetCoreMvcModule),
         typeof(AbpEventBusRabbitMqModule),
         typeof(AbpEntityFrameworkCoreSqlServerModule),
         typeof(AbpAuditLoggingEntityFrameworkCoreModule),


### PR DESCRIPTION
The endpoints cannot be configured correctly since lack of the AbpAspNetCoreMvcModule dependency.