### PR TITLE
Make ICurrentPrincipalAccessor changeable.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.SignalR/Volo/Abp/AspNetCore/SignalR/AbpSignalRUserIdProvider.cs
+++ b/framework/src/Volo.Abp.AspNetCore.SignalR/Volo/Abp/AspNetCore/SignalR/AbpSignalRUserIdProvider.cs
@@ -1,21 +1,28 @@
 ﻿using Microsoft.AspNetCore.SignalR;
 using Volo.Abp.DependencyInjection;
+using Volo.Abp.Security.Claims;
 using Volo.Abp.Users;
 
 namespace Volo.Abp.AspNetCore.SignalR
 {
     public class AbpSignalRUserIdProvider : IUserIdProvider, ITransientDependency
     {
-        public ICurrentUser CurrentUser { get; }
-        
-        public AbpSignalRUserIdProvider(ICurrentUser currentUser)
+        private readonly ICurrentPrincipalAccessor _currentPrincipalAccessor;
+
+        private readonly ICurrentUser _currentUser;
+
+        public AbpSignalRUserIdProvider(ICurrentPrincipalAccessor currentPrincipalAccessor, ICurrentUser currentUser)
         {
-            CurrentUser = currentUser;
+            _currentPrincipalAccessor = currentPrincipalAccessor;
+            _currentUser = currentUser;
         }
 
         public virtual string GetUserId(HubConnectionContext connection)
         {
-            return CurrentUser.Id?.ToString();
+            using (_currentPrincipalAccessor.Change(connection.User))
+            {
+                return _currentUser.Id?.ToString();
+            }
         }
     }
 }

--- a/framework/src/Volo.Abp.AspNetCore/Volo/Abp/AspNetCore/Security/Claims/HttpContextCurrentPrincipalAccessor.cs
+++ b/framework/src/Volo.Abp.AspNetCore/Volo/Abp/AspNetCore/Security/Claims/HttpContextCurrentPrincipalAccessor.cs
@@ -1,18 +1,13 @@
-﻿using System.Security.Claims;
-using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Http;
 using Volo.Abp.Security.Claims;
 
 namespace Volo.Abp.AspNetCore.Security.Claims
 {
     public class HttpContextCurrentPrincipalAccessor : ThreadCurrentPrincipalAccessor
     {
-        public override ClaimsPrincipal Principal => _httpContextAccessor.HttpContext?.User ?? base.Principal;
-
-        private readonly IHttpContextAccessor _httpContextAccessor;
-
         public HttpContextCurrentPrincipalAccessor(IHttpContextAccessor httpContextAccessor)
         {
-            _httpContextAccessor = httpContextAccessor;
+            CurrentScope.Value = () => httpContextAccessor.HttpContext?.User ?? GetThreadClaimsPrincipal();
         }
     }
 }

--- a/framework/src/Volo.Abp.AspNetCore/Volo/Abp/AspNetCore/Security/Claims/HttpContextCurrentPrincipalAccessor.cs
+++ b/framework/src/Volo.Abp.AspNetCore/Volo/Abp/AspNetCore/Security/Claims/HttpContextCurrentPrincipalAccessor.cs
@@ -13,7 +13,7 @@ namespace Volo.Abp.AspNetCore.Security.Claims
             _httpContextAccessor = httpContextAccessor;
         }
 
-        protected override ClaimsPrincipal GetClaimsPrincipal()
+        public override ClaimsPrincipal GetClaimsPrincipal()
         {
             return _httpContextAccessor.HttpContext?.User ?? base.GetClaimsPrincipal();
         }

--- a/framework/src/Volo.Abp.AspNetCore/Volo/Abp/AspNetCore/Security/Claims/HttpContextCurrentPrincipalAccessor.cs
+++ b/framework/src/Volo.Abp.AspNetCore/Volo/Abp/AspNetCore/Security/Claims/HttpContextCurrentPrincipalAccessor.cs
@@ -1,13 +1,21 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
 using Volo.Abp.Security.Claims;
 
 namespace Volo.Abp.AspNetCore.Security.Claims
 {
     public class HttpContextCurrentPrincipalAccessor : ThreadCurrentPrincipalAccessor
     {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
         public HttpContextCurrentPrincipalAccessor(IHttpContextAccessor httpContextAccessor)
         {
-            CurrentScope.Value = () => httpContextAccessor.HttpContext?.User ?? GetThreadClaimsPrincipal();
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        protected override ClaimsPrincipal GetClaimsPrincipal()
+        {
+            return _httpContextAccessor.HttpContext?.User ?? base.GetClaimsPrincipal();
         }
     }
 }

--- a/framework/src/Volo.Abp.Security/Volo/Abp/Security/Claims/ICurrentPrincipalAccessor.cs
+++ b/framework/src/Volo.Abp.Security/Volo/Abp/Security/Claims/ICurrentPrincipalAccessor.cs
@@ -1,9 +1,12 @@
-﻿using System.Security.Claims;
+﻿using System;
+using System.Security.Claims;
 
 namespace Volo.Abp.Security.Claims
 {
     public interface ICurrentPrincipalAccessor
     {
         ClaimsPrincipal Principal { get; }
+
+        IDisposable Change(ClaimsPrincipal principal);
     }
 }

--- a/framework/src/Volo.Abp.Security/Volo/Abp/Security/Claims/ThreadCurrentPrincipalAccessor.cs
+++ b/framework/src/Volo.Abp.Security/Volo/Abp/Security/Claims/ThreadCurrentPrincipalAccessor.cs
@@ -1,11 +1,44 @@
-﻿using System.Security.Claims;
+﻿using System;
+using System.Security.Claims;
 using System.Threading;
+using System.Xml.Schema;
 using Volo.Abp.DependencyInjection;
 
 namespace Volo.Abp.Security.Claims
 {
     public class ThreadCurrentPrincipalAccessor : ICurrentPrincipalAccessor, ISingletonDependency
     {
-        public virtual ClaimsPrincipal Principal => Thread.CurrentPrincipal as ClaimsPrincipal;
+        public Guid Id = Guid.NewGuid();
+
+        public virtual ClaimsPrincipal Principal
+        {
+            get => CurrentScope.Value?.Invoke();
+            set => CurrentScope.Value = () => value;
+        }
+
+        protected readonly AsyncLocal<Func<ClaimsPrincipal>> CurrentScope;
+
+        public ThreadCurrentPrincipalAccessor()
+        {
+            CurrentScope = new AsyncLocal<Func<ClaimsPrincipal>>
+            {
+                Value = GetThreadClaimsPrincipal
+            };
+        }
+
+        protected ClaimsPrincipal GetThreadClaimsPrincipal()
+        {
+            return Thread.CurrentPrincipal as ClaimsPrincipal;
+        }
+
+        public virtual IDisposable Change(ClaimsPrincipal principal)
+        {
+            var parentScope = Principal;
+            Principal = principal;
+            return new DisposeAction(() =>
+            {
+                Principal = parentScope;
+            });
+        }
     }
 }

--- a/framework/src/Volo.Abp.Security/Volo/Abp/Security/Claims/ThreadCurrentPrincipalAccessor.cs
+++ b/framework/src/Volo.Abp.Security/Volo/Abp/Security/Claims/ThreadCurrentPrincipalAccessor.cs
@@ -11,7 +11,7 @@ namespace Volo.Abp.Security.Claims
 
         private readonly AsyncLocal<ClaimsPrincipal> _currentPrincipal = new AsyncLocal<ClaimsPrincipal>();
 
-        protected virtual ClaimsPrincipal GetClaimsPrincipal()
+        public virtual ClaimsPrincipal GetClaimsPrincipal()
         {
             return Thread.CurrentPrincipal as ClaimsPrincipal;
         }

--- a/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/Authorization/FakeAuthenticationMiddleware.cs
+++ b/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/Authorization/FakeAuthenticationMiddleware.cs
@@ -4,16 +4,19 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Volo.Abp.DependencyInjection;
+using Volo.Abp.Security.Claims;
 
 namespace Volo.Abp.AspNetCore.Mvc.Authorization
 {
     public class FakeAuthenticationMiddleware : IMiddleware, ITransientDependency
     {
         private readonly FakeUserClaims _fakeUserClaims;
+        private readonly ICurrentPrincipalAccessor _currentPrincipalAccessor;
 
-        public FakeAuthenticationMiddleware(FakeUserClaims fakeUserClaims)
+        public FakeAuthenticationMiddleware(FakeUserClaims fakeUserClaims, ICurrentPrincipalAccessor currentPrincipalAccessor)
         {
             _fakeUserClaims = fakeUserClaims;
+            _currentPrincipalAccessor = currentPrincipalAccessor;
         }
 
         public async Task InvokeAsync(HttpContext context, RequestDelegate next)
@@ -24,6 +27,8 @@ namespace Volo.Abp.AspNetCore.Mvc.Authorization
                 {
                     new ClaimsIdentity(_fakeUserClaims.Claims, "FakeSchema")
                 });
+
+                //_currentPrincipalAccessor.Change(context.User);
             }
 
             await next(context);

--- a/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/Authorization/FakeAuthenticationMiddleware.cs
+++ b/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/Authorization/FakeAuthenticationMiddleware.cs
@@ -27,8 +27,6 @@ namespace Volo.Abp.AspNetCore.Mvc.Authorization
                 {
                     new ClaimsIdentity(_fakeUserClaims.Claims, "FakeSchema")
                 });
-
-                //_currentPrincipalAccessor.Change(context.User);
             }
 
             await next(context);

--- a/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/Authorization/FakeAuthenticationMiddleware.cs
+++ b/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/Authorization/FakeAuthenticationMiddleware.cs
@@ -4,19 +4,16 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Volo.Abp.DependencyInjection;
-using Volo.Abp.Security.Claims;
 
 namespace Volo.Abp.AspNetCore.Mvc.Authorization
 {
     public class FakeAuthenticationMiddleware : IMiddleware, ITransientDependency
     {
         private readonly FakeUserClaims _fakeUserClaims;
-        private readonly ICurrentPrincipalAccessor _currentPrincipalAccessor;
 
-        public FakeAuthenticationMiddleware(FakeUserClaims fakeUserClaims, ICurrentPrincipalAccessor currentPrincipalAccessor)
+        public FakeAuthenticationMiddleware(FakeUserClaims fakeUserClaims)
         {
             _fakeUserClaims = fakeUserClaims;
-            _currentPrincipalAccessor = currentPrincipalAccessor;
         }
 
         public async Task InvokeAsync(HttpContext context, RequestDelegate next)

--- a/framework/test/Volo.Abp.Security.Tests/Volo/Abp/Security/Claims/CurrentPrincipalAccessor_Test.cs
+++ b/framework/test/Volo.Abp.Security.Tests/Volo/Abp/Security/Claims/CurrentPrincipalAccessor_Test.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using System.Security.Claims;
+using Shouldly;
+using Volo.Abp.Testing;
+using Xunit;
+
+namespace Volo.Abp.Security.Claims
+{
+    public class CurrentPrincipalAccessor_Test : AbpIntegratedTest<AbpSecurityTestModule>
+    {
+        private readonly ICurrentPrincipalAccessor _currentPrincipalAccessor;
+
+        public CurrentPrincipalAccessor_Test()
+        {
+            _currentPrincipalAccessor = GetRequiredService<ICurrentPrincipalAccessor>();
+        }
+
+        [Fact]
+        public void Should_Get_Changed_Principal_If()
+        {
+            var claimsPrincipal = new ClaimsPrincipal(new ClaimsIdentity(new List<Claim>
+            {
+                new Claim(ClaimTypes.Name,"bob"),
+                new Claim(ClaimTypes.NameIdentifier,"123456")
+            }));
+
+            var claimsPrincipal2 = new ClaimsPrincipal(new ClaimsIdentity(new List<Claim>
+            {
+                new Claim(ClaimTypes.Name,"lee"),
+                new Claim(ClaimTypes.NameIdentifier,"654321")
+            }));
+
+
+            _currentPrincipalAccessor.Principal.ShouldBe(null);
+
+            using (_currentPrincipalAccessor.Change(claimsPrincipal))
+            {
+                _currentPrincipalAccessor.Principal.ShouldBe(claimsPrincipal);
+
+                using (_currentPrincipalAccessor.Change(claimsPrincipal2))
+                {
+                    _currentPrincipalAccessor.Principal.ShouldBe(claimsPrincipal2);
+                }
+
+                _currentPrincipalAccessor.Principal.ShouldBe(claimsPrincipal);
+            }
+            _currentPrincipalAccessor.Principal.ShouldBeNull();
+        }
+    }
+}

--- a/templates/app/aspnet-core/test/MyCompanyName.MyProjectName.TestBase/Security/FakeCurrentPrincipalAccessor.cs
+++ b/templates/app/aspnet-core/test/MyCompanyName.MyProjectName.TestBase/Security/FakeCurrentPrincipalAccessor.cs
@@ -6,9 +6,13 @@ using Volo.Abp.Security.Claims;
 namespace MyCompanyName.MyProjectName.Security
 {
     [Dependency(ReplaceServices = true)]
-    public class FakeCurrentPrincipalAccessor : ICurrentPrincipalAccessor, ISingletonDependency
+    public class FakeCurrentPrincipalAccessor : ThreadCurrentPrincipalAccessor
     {
-        public ClaimsPrincipal Principal => GetPrincipal();
+        protected override ClaimsPrincipal GetClaimsPrincipal()
+        {
+            return GetPrincipal();
+        }
+
         private ClaimsPrincipal _principal;
 
         private ClaimsPrincipal GetPrincipal()

--- a/templates/app/aspnet-core/test/MyCompanyName.MyProjectName.TestBase/Security/FakeCurrentPrincipalAccessor.cs
+++ b/templates/app/aspnet-core/test/MyCompanyName.MyProjectName.TestBase/Security/FakeCurrentPrincipalAccessor.cs
@@ -8,7 +8,7 @@ namespace MyCompanyName.MyProjectName.Security
     [Dependency(ReplaceServices = true)]
     public class FakeCurrentPrincipalAccessor : ThreadCurrentPrincipalAccessor
     {
-        protected override ClaimsPrincipal GetClaimsPrincipal()
+        public override ClaimsPrincipal GetClaimsPrincipal()
         {
             return GetPrincipal();
         }

--- a/templates/module/aspnet-core/test/MyCompanyName.MyProjectName.TestBase/Security/FakeCurrentPrincipalAccessor.cs
+++ b/templates/module/aspnet-core/test/MyCompanyName.MyProjectName.TestBase/Security/FakeCurrentPrincipalAccessor.cs
@@ -6,9 +6,13 @@ using Volo.Abp.Security.Claims;
 namespace MyCompanyName.MyProjectName.Security
 {
     [Dependency(ReplaceServices = true)]
-    public class FakeCurrentPrincipalAccessor : ICurrentPrincipalAccessor, ISingletonDependency
+    public class FakeCurrentPrincipalAccessor : ThreadCurrentPrincipalAccessor
     {
-        public ClaimsPrincipal Principal => GetPrincipal();
+        protected override ClaimsPrincipal GetClaimsPrincipal()
+        {
+            return GetPrincipal();
+        }
+
         private ClaimsPrincipal _principal;
 
         private ClaimsPrincipal GetPrincipal()

--- a/templates/module/aspnet-core/test/MyCompanyName.MyProjectName.TestBase/Security/FakeCurrentPrincipalAccessor.cs
+++ b/templates/module/aspnet-core/test/MyCompanyName.MyProjectName.TestBase/Security/FakeCurrentPrincipalAccessor.cs
@@ -8,7 +8,7 @@ namespace MyCompanyName.MyProjectName.Security
     [Dependency(ReplaceServices = true)]
     public class FakeCurrentPrincipalAccessor : ThreadCurrentPrincipalAccessor
     {
-        protected override ClaimsPrincipal GetClaimsPrincipal()
+        public override ClaimsPrincipal GetClaimsPrincipal()
         {
             return GetPrincipal();
         }


### PR DESCRIPTION
Resolve #3913

This way we can replace `ClaimsPrincipal` with `HubCallerContext.User` in signalr.

Because many services are using `ICurrentPrincipalAccessor`. Developers may call these methods, we must ensure that `ClaimsPrincipal `is always obtained correctly.
