### PR TITLE
Invalidate cache on setting update, allow UnitOfWork re-reads

### DIFF
--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain/Volo/Abp/SettingManagement/SettingManagementStore.cs
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain/Volo/Abp/SettingManagement/SettingManagementStore.cs
@@ -42,6 +42,10 @@ namespace Volo.Abp.SettingManagement
             {
                 setting.Value = value;
                 await SettingRepository.UpdateAsync(setting);
+                
+                /* Re-set on cache */
+                var cacheKey = CalculateCacheKey(name, providerName, providerKey);
+                await Cache.RemoveAsync(cacheKey);
             }
         }
 


### PR DESCRIPTION
Invalidate cache on setting `Set` (references #4040).

There are still some problems with this approach: mainly, if we do a: `get (creates cache) -> set (invalidates cache) -> get (creates cache with updated setting) -> unit of work fails saving`, the cache is kept in inconsistent state.

This is just a first approach, extra thinking should be taken to maintain consistent cache state in all scenarios (mainly UOW scenarios), which would probably require tracking the cache changes and rolling back the changes in case the UnitOfWork fails committing/saving changes.