### PR TITLE
Convert c# type to typescript type.

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/GenerateProxyCommand.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/GenerateProxyCommand.cs
@@ -13,6 +13,7 @@ using Volo.Abp.DependencyInjection;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using Volo.Abp.Reflection;
 
 namespace Volo.Abp.Cli.Commands
 {
@@ -516,7 +517,16 @@ namespace Volo.Abp.Cli.Commands
                         baseTypeKebabCase = "@abp/ng.core";
 
                         baseTypeName = baseType.Split("Volo.Abp.Application.Dtos")[1].Split("<")[0].TrimStart('.');
-                        customBaseTypeName = baseType.Split("Volo.Abp.Application.Dtos")[1].Replace("System.Guid", "string").TrimStart('.');
+                        customBaseTypeName = baseType.Split("Volo.Abp.Application.Dtos")[1].TrimStart('.');
+                        if (customBaseTypeName.Contains("<"))
+                        {
+                            var genericType = customBaseTypeName.Split("<")[1].TrimEnd('>');
+                            var customBaseType = Type.GetType(genericType);
+                            if (customBaseType != null)
+                            {
+                                customBaseTypeName = customBaseTypeName.Replace(genericType, TypeHelper.GetSimplifiedName(customBaseType));
+                            }
+                        }
                     }
 
                     if (baseTypeName.Contains("guid") || baseTypeName.Contains("Guid"))


### PR DESCRIPTION
Resolve #4051

I am confused about this code. Will it cause problems if a class contains `G/guid` replaced by `string`?

eg `public class MyGuidDto`

```c#
if (baseTypeName.Contains("guid") || baseTypeName.Contains("Guid"))
{
	baseTypeName = "string";
}
```
https://github.com/abpframework/abp/pull/4055/files#diff-ae62d3da26b0d94a192555bce181d5a7R532-R535