### PR TITLE
Consistent with aspnet core behavior of referencing static resources

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/AbpBundlingOptionsExtensions.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/AbpBundlingOptionsExtensions.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.Extensions.Hosting;
+
+namespace Volo.Abp.AspNetCore.Mvc.UI.Bundling
+{
+    public static class AbpBundlingOptionsExtensions
+    {
+        public static bool IsBundlingEnabled(this AbpBundlingOptions options, IHostEnvironment environment)
+        {
+            switch (options.Mode)
+            {
+                case BundlingMode.None:
+                    return false;
+                case BundlingMode.Bundle:
+                case BundlingMode.BundleAndMinify:
+                    return true;
+                case BundlingMode.Auto:
+                    return !environment.IsDevelopment();
+                default:
+                    throw new AbpException($"Unhandled {nameof(BundlingMode)}: {options.Mode}");
+            }
+        }
+
+        public static bool IsMinficationEnabled(this AbpBundlingOptions options, IHostEnvironment environment)
+        {
+            switch (options.Mode)
+            {
+                case BundlingMode.None:
+                case BundlingMode.Bundle:
+                    return false;
+                case BundlingMode.BundleAndMinify:
+                    return true;
+                case BundlingMode.Auto:
+                    return !environment.IsDevelopment();
+                default:
+                    throw new AbpException($"Unhandled {nameof(BundlingMode)}: {options.Mode}");
+            }
+        }
+    }
+}

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/BundleManager.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/BundleManager.cs
@@ -75,7 +75,7 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bundling
             var bundleFiles = RequestResources.TryAdd(await GetBundleFilesAsync(contributors));
             var dynamicResources = RequestResources.TryAdd(await GetDynamicResourcesAsync(contributors));
 
-            if (!IsBundlingEnabled())
+            if (!Options.IsBundlingEnabled(HostingEnvironment))
             {
                 return bundleFiles.Union(dynamicResources).ToImmutableList();
             }
@@ -99,7 +99,7 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bundling
                     new BundlerContext(
                         bundleRelativePath,
                         bundleFiles,
-                        IsMinficationEnabled()
+                        Options.IsMinficationEnabled(HostingEnvironment)
                     )
                 );
 
@@ -145,38 +145,6 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bundling
                     fileName
                 )
             );
-        }
-
-        protected virtual bool IsBundlingEnabled()
-        {
-            switch (Options.Mode)
-            {
-                case BundlingMode.None:
-                    return false;
-                case BundlingMode.Bundle:
-                case BundlingMode.BundleAndMinify:
-                    return true;
-                case BundlingMode.Auto:
-                    return !HostingEnvironment.IsDevelopment();
-                default:
-                    throw new AbpException($"Unhandled {nameof(BundlingMode)}: {Options.Mode}");
-            }
-        }
-
-        protected virtual bool IsMinficationEnabled()
-        {
-            switch (Options.Mode)
-            {
-                case BundlingMode.None:
-                case BundlingMode.Bundle:
-                    return false;
-                case BundlingMode.BundleAndMinify:
-                    return true;
-                case BundlingMode.Auto:
-                    return !HostingEnvironment.IsDevelopment();
-                default:
-                    throw new AbpException($"Unhandled {nameof(BundlingMode)}: {Options.Mode}");
-            }
         }
 
         protected async Task<List<string>> GetBundleFilesAsync(List<IBundleContributor> contributors)

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/TagHelpers/AbpBundleItemTagHelper.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/TagHelpers/AbpBundleItemTagHelper.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
 using Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers;
 
 namespace Volo.Abp.AspNetCore.Mvc.UI.Bundling.TagHelpers
@@ -16,6 +19,10 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bundling.TagHelpers
         /// A bundle contributor type.
         /// </summary>
         public Type Type { get; set; }
+
+        [HtmlAttributeNotBound]
+        [ViewContext]
+        public ViewContext ViewContext { get; set; }
 
         protected AbpBundleItemTagHelper(TTagHelperService service)
             : base(service)

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/TagHelpers/AbpBundleItemTagHelperService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/TagHelpers/AbpBundleItemTagHelperService.cs
@@ -25,6 +25,7 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bundling.TagHelpers
             }
             else
             {
+                ResourceService.ViewContext = TagHelper.ViewContext;
                 await ResourceService.ProcessAsync(
                     context,
                     output,

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/TagHelpers/AbpBundleTagHelper.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/TagHelpers/AbpBundleTagHelper.cs
@@ -1,4 +1,7 @@
-﻿using Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers;
+﻿using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers;
 
 namespace Volo.Abp.AspNetCore.Mvc.UI.Bundling.TagHelpers
 {
@@ -7,6 +10,10 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bundling.TagHelpers
         where TService : class, IAbpTagHelperService<TTagHelper>
     {
         public string Name { get; set; }
+
+        [HtmlAttributeNotBound]
+        [ViewContext]
+        public ViewContext ViewContext { get; set; }
 
         protected AbpBundleTagHelper(TService service)
             : base(service)

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/TagHelpers/AbpBundleTagHelperService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/TagHelpers/AbpBundleTagHelperService.cs
@@ -17,6 +17,7 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bundling.TagHelpers
 
         public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {
+            ResourceService.ViewContext = TagHelper.ViewContext;
             await ResourceService.ProcessAsync(
                 context,
                 output,

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/TagHelpers/AbpTagHelperResourceService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/TagHelpers/AbpTagHelperResourceService.cs
@@ -5,6 +5,9 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -16,20 +19,24 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bundling.TagHelpers
     public abstract class AbpTagHelperResourceService : ITransientDependency
     {
         public ILogger<AbpTagHelperResourceService> Logger { get; set; }
+
+        protected IHttpContextAccessor HttpContextAccessor { get; }
         protected IBundleManager BundleManager { get; }
         protected IWebContentFileProvider WebContentFileProvider { get; }
         protected IWebHostEnvironment HostingEnvironment { get; }
         protected readonly AbpBundlingOptions Options;
-        
+
         protected AbpTagHelperResourceService(
             IBundleManager bundleManager,
             IWebContentFileProvider webContentFileProvider,
             IOptions<AbpBundlingOptions> options,
-            IWebHostEnvironment hostingEnvironment)
+            IWebHostEnvironment hostingEnvironment,
+            IHttpContextAccessor httpContextAccessor)
         {
             BundleManager = bundleManager;
             WebContentFileProvider = webContentFileProvider;
             HostingEnvironment = hostingEnvironment;
+            HttpContextAccessor = httpContextAccessor;
             Options = options.Value;
 
             Logger = NullLogger<AbpTagHelperResourceService>.Instance;
@@ -64,12 +71,12 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bundling.TagHelpers
             {
                 var file = WebContentFileProvider.GetFileInfo(bundleFile);
 
-                if (file == null || !file.Exists)
+                 if (file == null || !file.Exists)
                 {
                     throw new AbpException($"Could not find the bundle file '{bundleFile}' from {nameof(IWebContentFileProvider)}");
                 }
 
-                AddHtmlTag(context, output, bundleFile + "?_v=" + file.LastModified.UtcTicks);
+                AddHtmlTag(context, output, ResolveUrl(bundleFile) + "?_v=" + file.LastModified.UtcTicks);
             }
 
             stopwatch.Stop();
@@ -85,6 +92,20 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bundling.TagHelpers
         protected virtual string GenerateBundleName(List<BundleTagHelperItem> bundleItems)
         {
             return bundleItems.JoinAsString("|").ToMd5();
+        }
+
+        protected virtual string ResolveUrl(string contentPath)
+        {
+            if (contentPath[0] != '~' && !Options.IsBundlingEnabled(HostingEnvironment))
+            {
+                return contentPath;
+            }
+
+            var segment = new PathString(contentPath.TrimStart('~'));
+            var applicationPath = HttpContextAccessor.HttpContext.Request.PathBase;
+
+            return applicationPath.Add(segment).Value;
+
         }
     }
 }

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/TagHelpers/AbpTagHelperScriptService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/TagHelpers/AbpTagHelperScriptService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
@@ -16,12 +17,14 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bundling.TagHelpers
             IBundleManager bundleManager,
             IWebContentFileProvider webContentFileProvider,
             IOptions<AbpBundlingOptions> options,
-            IWebHostEnvironment hostingEnvironment
+            IWebHostEnvironment hostingEnvironment,
+            IHttpContextAccessor contextAccessor
             ) : base(
                 bundleManager,
                 webContentFileProvider,
                 options,
-                hostingEnvironment)
+                hostingEnvironment,
+                contextAccessor)
         {
         }
 

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/TagHelpers/AbpTagHelperScriptService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/TagHelpers/AbpTagHelperScriptService.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
@@ -18,13 +18,13 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bundling.TagHelpers
             IWebContentFileProvider webContentFileProvider,
             IOptions<AbpBundlingOptions> options,
             IWebHostEnvironment hostingEnvironment,
-            IHttpContextAccessor contextAccessor
+            IUrlHelperFactory urlHelperFactory
             ) : base(
                 bundleManager,
                 webContentFileProvider,
                 options,
                 hostingEnvironment,
-                contextAccessor)
+                urlHelperFactory)
         {
         }
 
@@ -44,7 +44,7 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bundling.TagHelpers
 
         protected override void AddHtmlTag(TagHelperContext context, TagHelperOutput output, string file)
         {
-            output.Content.AppendHtml($"<script src=\"{file}\"></script>{Environment.NewLine}");
+            output.Content.AppendHtml($"<script src=\"{ResolveUrl(file)}\"></script>{Environment.NewLine}");
         }
     }
 }

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/TagHelpers/AbpTagHelperStyleService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/TagHelpers/AbpTagHelperStyleService.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
@@ -18,14 +18,15 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bundling.TagHelpers
             IWebContentFileProvider webContentFileProvider,
             IOptions<AbpBundlingOptions> options,
             IWebHostEnvironment hostingEnvironment,
-            IHttpContextAccessor contextAccessor
+            IUrlHelperFactory urlHelperFactory
             ) : base(
                 bundleManager,
                 webContentFileProvider,
                 options,
                 hostingEnvironment,
-                contextAccessor)
+                urlHelperFactory)
         {
+
         }
 
         protected override void CreateBundle(string bundleName, List<BundleTagHelperItem> bundleItems)
@@ -44,7 +45,7 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bundling.TagHelpers
 
         protected override void AddHtmlTag(TagHelperContext context, TagHelperOutput output, string file)
         {
-            output.Content.AppendHtml($"<link rel=\"stylesheet\" href=\"{file}\" />{Environment.NewLine}");
+            output.Content.AppendHtml($"<link rel=\"stylesheet\" href=\"{ResolveUrl(file)}\" />{Environment.NewLine}");
         }
     }
 }

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/TagHelpers/AbpTagHelperStyleService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/TagHelpers/AbpTagHelperStyleService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
@@ -16,12 +17,14 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bundling.TagHelpers
             IBundleManager bundleManager,
             IWebContentFileProvider webContentFileProvider,
             IOptions<AbpBundlingOptions> options,
-            IWebHostEnvironment hostingEnvironment
+            IWebHostEnvironment hostingEnvironment,
+            IHttpContextAccessor contextAccessor
             ) : base(
                 bundleManager,
                 webContentFileProvider,
                 options,
-                hostingEnvironment)
+                hostingEnvironment,
+                contextAccessor)
         {
         }
 

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/TagHelpers/IBundleTagHelper.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/TagHelpers/IBundleTagHelper.cs
@@ -1,7 +1,11 @@
-﻿namespace Volo.Abp.AspNetCore.Mvc.UI.Bundling.TagHelpers
+﻿using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace Volo.Abp.AspNetCore.Mvc.UI.Bundling.TagHelpers
 {
     public interface IBundleTagHelper
     {
         string GetNameOrNull();
+
+        ViewContext ViewContext { get; set; }
     }
 }

--- a/framework/src/Volo.Abp.AspNetCore/Volo/Abp/AspNetCore/VirtualFileSystem/WebContentFileProvider.cs
+++ b/framework/src/Volo.Abp.AspNetCore/Volo/Abp/AspNetCore/VirtualFileSystem/WebContentFileProvider.cs
@@ -42,6 +42,8 @@ namespace Volo.Abp.AspNetCore.VirtualFileSystem
                 return new NotFoundFileInfo(subpath);
             }
 
+            subpath = NormalizePath(subpath);
+
             if (ExtraAllowedFolder(subpath) && ExtraAllowedExtension(subpath))
             {
                 var fileInfo = _fileProvider.GetFileInfo(subpath);
@@ -122,6 +124,13 @@ namespace Volo.Abp.AspNetCore.VirtualFileSystem
         protected virtual bool ExtraAllowedExtension(string path)
         {
             return Options.AllowedExtraWebContentFileExtensions.Any(e => path.EndsWith(e, StringComparison.OrdinalIgnoreCase));
+        }
+
+        protected virtual string NormalizePath(string subpath)
+        {
+            subpath = subpath.RemovePreFix(StringComparison.Ordinal, ".", "~");
+
+            return subpath.EnsureStartsWith('/');
         }
     }
 }


### PR DESCRIPTION
Resolve https://github.com/abpframework/abp/issues/3352

`~`  in aspnet core will be converted into subpath (if using iis sub-application deployment).I added 
 support sub-application deployment way for the bundling system.

Example :

![image](https://user-images.githubusercontent.com/16813853/82810448-1cf64600-9ec1-11ea-93dc-3d16ad67a8fa.png)
