### PR TITLE
Change the ErrorMessage of StringLengthAttribute according to the situation.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/Validation/ValidationAttributeHelper.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/Validation/ValidationAttributeHelper.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using System.Reflection;
-using System.Text;
 
 namespace Volo.Abp.AspNetCore.Mvc.Validation
 {
@@ -11,10 +8,25 @@ namespace Volo.Abp.AspNetCore.Mvc.Validation
         private static readonly PropertyInfo ValidationAttributeErrorMessageStringProperty = typeof(ValidationAttribute)
             .GetProperty("ErrorMessageString", BindingFlags.Instance | BindingFlags.NonPublic);
 
+        private static readonly PropertyInfo ValidationAttributeCustomErrorMessageSetProperty = typeof(ValidationAttribute)
+            .GetProperty("CustomErrorMessageSet", BindingFlags.Instance | BindingFlags.NonPublic);
+
         public static void SetDefaultErrorMessage(ValidationAttribute validationAttribute)
         {
-            validationAttribute.ErrorMessage =
-                ValidationAttributeErrorMessageStringProperty.GetValue(validationAttribute) as string;
+            if (validationAttribute is StringLengthAttribute stringLength && stringLength.MinimumLength != 0)
+            {
+                var customErrorMessageSet = ValidationAttributeCustomErrorMessageSetProperty.GetValue(validationAttribute) as bool?;
+                if (customErrorMessageSet != true)
+                {
+                    validationAttribute.ErrorMessage =
+                        "The field {0} must be a string with a minimum length of {2} and a maximum length of {1}.";
+                }
+            }
+            else
+            {
+                validationAttribute.ErrorMessage =
+                    ValidationAttributeErrorMessageStringProperty.GetValue(validationAttribute) as string;
+            }
         }
     }
 }

--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/Validation/ValidationAttributeHelper.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/Validation/ValidationAttributeHelper.cs
@@ -20,13 +20,12 @@ namespace Volo.Abp.AspNetCore.Mvc.Validation
                 {
                     validationAttribute.ErrorMessage =
                         "The field {0} must be a string with a minimum length of {2} and a maximum length of {1}.";
+                    return;
                 }
             }
-            else
-            {
-                validationAttribute.ErrorMessage =
-                    ValidationAttributeErrorMessageStringProperty.GetValue(validationAttribute) as string;
-            }
+
+            validationAttribute.ErrorMessage =
+                ValidationAttributeErrorMessageStringProperty.GetValue(validationAttribute) as string;
         }
     }
 }

--- a/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/Validation/ValidationTestController.cs
+++ b/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/Validation/ValidationTestController.cs
@@ -35,7 +35,7 @@ namespace Volo.Abp.AspNetCore.Mvc.Validation
         public class ValidationTest1Model
         {
             [Required]
-            [MinLength(2)]
+            [StringLength(5, MinimumLength = 2)]
             public string Value1 { get; set; }
         }
 

--- a/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/Validation/ValidationTestController_Tests.cs
+++ b/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/Validation/ValidationTestController_Tests.cs
@@ -30,7 +30,7 @@ namespace Volo.Abp.AspNetCore.Mvc.Validation
             {
                 var result = await GetResponseAsObjectAsync<RemoteServiceErrorResponse>("/api/validation-test/object-result-action?value1=a", HttpStatusCode.BadRequest); //value1 has min length of 2 chars.
                 result.Error.ValidationErrors.Length.ShouldBeGreaterThan(0);
-                result.Error.ValidationErrors[0].Message.ShouldBe("Değer Bir alanı en az '2' uzunluğunda bir metin ya da dizi olmalıdır.");
+                result.Error.ValidationErrors[0].Message.ShouldBe("Değer Bir alanı en az 2, en fazla 5 uzunluğunda bir metin olmalıdır.");
             }
         }
 


### PR DESCRIPTION
Resolve #4094

It seems that only `StringLengthAttribute `is special, so we can change its `ErrorMessage`.