### PR TITLE
Fix identity unit test.

### DIFF
--- a/modules/identity/test/Volo.Abp.Identity.TestBase/Volo/Abp/Identity/OrganizationUnitRepository_Tests.cs
+++ b/modules/identity/test/Volo.Abp.Identity.TestBase/Volo/Abp/Identity/OrganizationUnitRepository_Tests.cs
@@ -167,13 +167,21 @@ namespace Volo.Abp.Identity
         [Fact]
         public async Task RemoveAllRolesOfOrganizationUnit()
         {
-            OrganizationUnit ou = await _organizationUnitRepository.GetAsync("OU111", true);
-            var rolesCount = await _organizationUnitRepository.GetRolesCountAsync(ou);
-            rolesCount.ShouldBeGreaterThan(1);
+            using (var uow = _unitOfWorkManager.Begin())
+            {
+                OrganizationUnit ou = await _organizationUnitRepository.GetAsync("OU111", true);
+                var rolesCount = await _organizationUnitRepository.GetRolesCountAsync(ou);
+                rolesCount.ShouldBeGreaterThan(1);
 
-            await _organizationUnitRepository.RemoveAllRolesAsync(ou);
-            var newCount = await _organizationUnitRepository.GetRolesCountAsync(ou);
-            newCount.ShouldBe(0);
+                await _organizationUnitRepository.RemoveAllRolesAsync(ou);
+
+                await uow.SaveChangesAsync();
+
+                var newCount = await _organizationUnitRepository.GetRolesCountAsync(ou);
+                newCount.ShouldBe(0);
+
+                await uow.CompleteAsync();
+            }
         }
     }
 }


### PR DESCRIPTION
Resolve #4208

hi @gterdem 

Maybe we can consider using `OrganizationUnitId` instead of `OrganizationUnit `entity in `IOrganizationUnitRepository`. What do you think?