### PR TITLE
Configure IdentityModel request message & configure all http clients.

### DIFF
--- a/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/AbpHttpClientModule.cs
+++ b/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/AbpHttpClientModule.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http;
 using Volo.Abp.Castle;
 using Volo.Abp.Modularity;
 using Volo.Abp.MultiTenancy;
@@ -20,6 +22,25 @@ namespace Volo.Abp.Http.Client
         {
             var configuration = context.Services.GetConfiguration();
             Configure<AbpRemoteServiceOptions>(configuration);
+        }
+
+        public override void PostConfigureServices(ServiceConfigurationContext context)
+        {
+            Configure<AbpHttpClientOptions>(options =>
+            {
+                if (options.HttpClientActions.Any())
+                {
+                    var httpClientNames = options.HttpClientProxies.Select(x => x.Value.RemoteServiceName);
+                    foreach (var httpClientName in httpClientNames)
+                    {
+                        foreach (var httpClientAction in options.HttpClientActions)
+                        {
+                            context.Services.Configure<HttpClientFactoryOptions>(httpClientName,
+                                x => x.HttpClientActions.Add(httpClientAction.Invoke(httpClientName)));
+                        }
+                    }
+                }
+            });
         }
     }
 }

--- a/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/AbpHttpClientOptions.cs
+++ b/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/AbpHttpClientOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using Volo.Abp.Http.Client.DynamicProxying;
 
 namespace Volo.Abp.Http.Client
@@ -8,9 +9,12 @@ namespace Volo.Abp.Http.Client
     {
         public Dictionary<Type, DynamicHttpClientProxyConfig> HttpClientProxies { get; set; }
 
+        public List<Func<string, Action<HttpClient>>> HttpClientActions { get; }
+
         public AbpHttpClientOptions()
         {
             HttpClientProxies = new Dictionary<Type, DynamicHttpClientProxyConfig>();
+            HttpClientActions = new List<Func<string, Action<HttpClient>>>();
         }
     }
 }

--- a/framework/src/Volo.Abp.IdentityModel/Volo/Abp/IdentityModel/IdentityModelHttpRequestMessageOptions.cs
+++ b/framework/src/Volo.Abp.IdentityModel/Volo/Abp/IdentityModel/IdentityModelHttpRequestMessageOptions.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Net.Http;
+
+namespace Volo.Abp.IdentityModel
+{
+    public class IdentityModelHttpRequestMessageOptions
+    {
+        public Action<HttpRequestMessage> ConfigureHttpRequestMessage { get; set; }
+    }
+}


### PR DESCRIPTION
Related #4062

This allow configure all the dynamic http client and configure the request message of the IdentityModel extension method. It can make httpclient support `http 2`.

example:
```cs
Configure<AbpHttpClientOptions>(options =>
{
	options.HttpClientActions.Add(clientName =>
	{
		if (clientName == "MyClient")
		{
			return c => c.DefaultRequestVersion = HttpVersion.Version10;
		}

		return c => c.DefaultRequestVersion = HttpVersion.Version20;
	});
}

Configure<IdentityModelHttpRequestMessageOptions>(options =>
{
	options.ConfigureHttpRequestMessage = request => request.Version = HttpVersion.Version20;
});
```