### PR TITLE
Solve that IdentityModelHttpRequestMessageOptions is not configured.

### DIFF
--- a/framework/src/Volo.Abp.IdentityModel/Volo/Abp/IdentityModel/IdentityModelAuthenticationService.cs
+++ b/framework/src/Volo.Abp.IdentityModel/Volo/Abp/IdentityModel/IdentityModelAuthenticationService.cs
@@ -123,7 +123,7 @@ namespace Volo.Abp.IdentityModel
                         RequireHttps = configuration.RequireHttps
                     }
                 };
-                IdentityModelHttpRequestMessageOptions.ConfigureHttpRequestMessage(request);
+                IdentityModelHttpRequestMessageOptions.ConfigureHttpRequestMessage?.Invoke(request);
                 return await httpClient.GetDiscoveryDocumentAsync(request);
             }
         }
@@ -165,7 +165,7 @@ namespace Volo.Abp.IdentityModel
                 UserName = configuration.UserName,
                 Password = configuration.UserPassword
             };
-            IdentityModelHttpRequestMessageOptions.ConfigureHttpRequestMessage(request);
+            IdentityModelHttpRequestMessageOptions.ConfigureHttpRequestMessage?.Invoke(request);
 
             AddParametersToRequestAsync(configuration, request);
 
@@ -183,7 +183,7 @@ namespace Volo.Abp.IdentityModel
                 ClientId = configuration.ClientId,
                 ClientSecret = configuration.ClientSecret
             };
-            IdentityModelHttpRequestMessageOptions.ConfigureHttpRequestMessage(request);
+            IdentityModelHttpRequestMessageOptions.ConfigureHttpRequestMessage?.Invoke(request);
 
             AddParametersToRequestAsync(configuration, request);
 


### PR DESCRIPTION
Solutions before the new version.

```cs
public override void ConfigureServices(ServiceConfigurationContext context)
{
	Configure<IdentityModelHttpRequestMessageOptions>(options =>
	{
		options.ConfigureHttpRequestMessage = request => {};
	});
}
```