### PR TITLE
Provide a way to suppress the label generation for `abp-input` taghelper

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpInputTagHelper.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpInputTagHelper.cs
@@ -36,6 +36,8 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Form
 
         public string Value { get; set; }
 
+        public bool SuppressLabel { get; set; }
+
         public AbpInputTagHelper(AbpInputTagHelperService tagHelperService)
             : base(tagHelperService)
         {

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpInputTagHelperService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpInputTagHelperService.cs
@@ -247,7 +247,7 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Form
 
         protected virtual async Task<string> GetLabelAsHtmlAsync(TagHelperContext context, TagHelperOutput output, TagHelperOutput inputTag, bool isCheckbox)
         {
-            if (IsOutputHidden(inputTag) || ShouldSuppressLabel(inputTag))
+            if (IsOutputHidden(inputTag) || TagHelper.SuppressLabel)
             {
                 return "";
             }
@@ -431,11 +431,6 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Form
             var idAttr = inputTag.Attributes.FirstOrDefault(a => a.Name == "id");
 
             return idAttr != null ? "for=\"" + idAttr.Value + "\"" : "";
-        }
-
-        protected virtual bool ShouldSuppressLabel(TagHelperOutput inputTag)
-        {
-            return inputTag.Attributes.ContainsName("nolabel");
         }
 
         protected virtual void AddGroupToFormGroupContents(TagHelperContext context, string propertyName, string html, int order, out bool suppress)

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpInputTagHelperService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpInputTagHelperService.cs
@@ -247,7 +247,7 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Form
 
         protected virtual async Task<string> GetLabelAsHtmlAsync(TagHelperContext context, TagHelperOutput output, TagHelperOutput inputTag, bool isCheckbox)
         {
-            if (IsOutputHidden(inputTag))
+            if (IsOutputHidden(inputTag) || SuppressLabel(inputTag))
             {
                 return "";
             }
@@ -431,6 +431,11 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Form
             var idAttr = inputTag.Attributes.FirstOrDefault(a => a.Name == "id");
 
             return idAttr != null ? "for=\"" + idAttr.Value + "\"" : "";
+        }
+
+        protected virtual bool SuppressLabel(TagHelperOutput inputTag)
+        {
+            return inputTag.AllAttributes.ContainsName("nolabel");
         }
 
         protected virtual void AddGroupToFormGroupContents(TagHelperContext context, string propertyName, string html, int order, out bool suppress)

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpInputTagHelperService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpInputTagHelperService.cs
@@ -247,7 +247,7 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Form
 
         protected virtual async Task<string> GetLabelAsHtmlAsync(TagHelperContext context, TagHelperOutput output, TagHelperOutput inputTag, bool isCheckbox)
         {
-            if (IsOutputHidden(inputTag) || SuppressLabel(inputTag))
+            if (IsOutputHidden(inputTag) || ShouldSuppressLabel(inputTag))
             {
                 return "";
             }
@@ -433,7 +433,7 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Form
             return idAttr != null ? "for=\"" + idAttr.Value + "\"" : "";
         }
 
-        protected virtual bool SuppressLabel(TagHelperOutput inputTag)
+        protected virtual bool ShouldSuppressLabel(TagHelperOutput inputTag)
         {
             return inputTag.Attributes.ContainsName("nolabel");
         }

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpInputTagHelperService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpInputTagHelperService.cs
@@ -435,7 +435,7 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Form
 
         protected virtual bool SuppressLabel(TagHelperOutput inputTag)
         {
-            return inputTag.AllAttributes.ContainsName("nolabel");
+            return inputTag.Attributes.ContainsName("nolabel");
         }
 
         protected virtual void AddGroupToFormGroupContents(TagHelperContext context, string propertyName, string html, int order, out bool suppress)

--- a/framework/test/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.Demo/Pages/Components/FormElements.cshtml
+++ b/framework/test/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.Demo/Pages/Components/FormElements.cshtml
@@ -108,7 +108,7 @@
  public class FormElementsModel : PageModel
     {
         public SampleModel MyModel { get; set; }
-                    
+
         public List&lt;SelectListItem&gt; CityList { get; set; } = new List&lt;SelectListItem&gt;
         {
             new SelectListItem { Value = "NY", Text = "New York"},
@@ -260,7 +260,7 @@
         public class SampleModel
         {
             public string SampleInput0 { get; set; }
-                    
+
             public string SampleInput1 { get; set; }
 
             public string SampleInput2 { get; set; }
@@ -354,7 +354,7 @@
  public class FormElementsModel : PageModel
     {
         public SampleModel MyModel { get; set; }
-                    
+
         public List&quot;SelectListItem&quot; CityList { get; set; } = new List&quot;SelectListItem&quot;
         {
             new SelectListItem { Value = "NY", Text = "New York"},
@@ -458,6 +458,51 @@
          &lt;option value=&quot;3&quot;&gt;Coupe&lt;/option&gt;
      &lt;/select&gt;
  &lt;/div&gt;
+</code></pre>
+            </abp-tab>
+        </abp-tabs>
+    </div>
+</div>
+
+<h4>Suppress Label Generation</h4>
+
+<div class="demo-with-code">
+    <div class="demo-area">
+        <abp-input asp-for="@Model.MyModel.Name" suppress-label="true"/>
+    </div>
+    <div class="code-area">
+        <abp-tabs>
+            <abp-tab title="Modal Class">
+                <pre><code>
+ public class FormElementsModel : PageModel
+ {
+     public SampleModel MyModel { get; set; }
+
+     public void OnGet()
+     {
+         MyModel = new SampleModel();
+     }
+
+     public class SampleModel
+     {
+         [Required]
+         public string Name { get; set; }
+     }
+ }
+
+</code></pre>
+            </abp-tab>
+            <abp-tab title="Tag Helper" active="true">
+                <pre><code>
+&lt;abp-input asp-for=&quot;@@Model.MyModel.Name&quot; suppress-label=&quot;true&quot;/&gt;
+                </code></pre>
+            </abp-tab>
+            <abp-tab title="Rendered">
+                <pre><code>
+&lt;div class=&quot;form-group&quot;&gt;
+    &lt;input type=&quot;text&quot; id=&quot;MyModel_Name&quot; name=&quot;MyModel.Name&quot; value=&quot;&quot; class=&quot;form-control &quot;&gt;
+    &lt;span class=&quot;text-danger field-validation-valid&quot; data-valmsg-for=&quot;MyModel.Name&quot; data-valmsg-replace=&quot;true&quot;&gt;&lt;/span&gt;
+&lt;/div&gt;
 </code></pre>
             </abp-tab>
         </abp-tabs>


### PR DESCRIPTION
When using the `abp-input` taghelper, sometimes developers may not want to generate the label tag.

So this PR checks if there is a special attribute `nolabel` exists, if so, suppress the label tag generation:

``` html
<abp-input asp-for="Content" nolabel></abp-input>
```