### PR TITLE
Add permissions authorization for consuming framework tenant API endpoints

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.MultiTenancy/Pages/Abp/MultiTenancy/AbpTenantAppService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.MultiTenancy/Pages/Abp/MultiTenancy/AbpTenantAppService.cs
@@ -6,6 +6,7 @@ using Volo.Abp.MultiTenancy;
 
 namespace Pages.Abp.MultiTenancy
 {
+    [Authorize(TenantManagementPermissions.Tenants.Default)] //Psuedo as there might be no reference to the 'TenantManagementPermissions' class.
     public class AbpTenantAppService : ApplicationService, IAbpTenantAppService
     {
         protected ITenantStore TenantStore { get; }
@@ -15,6 +16,7 @@ namespace Pages.Abp.MultiTenancy
             TenantStore = tenantStore;
         }
 
+        [Authorize(TenantManagementPermissions.Tenants.View)]
         public async Task<FindTenantResultDto> FindTenantByNameAsync(string name)
         {
             var tenant = await TenantStore.FindAsync(name);
@@ -32,6 +34,8 @@ namespace Pages.Abp.MultiTenancy
             };
         }
         
+
+        [Authorize(TenantManagementPermissions.Tenants.View)]
         public async Task<FindTenantResultDto> FindTenantByIdAsync(Guid id)
         {
             var tenant = await TenantStore.FindAsync(id);


### PR DESCRIPTION
These API endpoints are available freely to access, without any permission management, and it's not documented how to hide these default endpoints or override these and add authentication.