### PR TITLE
Add details on the correct use of unit of work in event handlers

### DIFF
--- a/docs/en/Distributed-Event-Bus.md
+++ b/docs/en/Distributed-Event-Bus.md
@@ -178,7 +178,10 @@ That's all.
 
 You can inject any service and perform any required logic here. A single event handler class can **subscribe to multiple events** but implementing the `IDistributedEventHandler<TEvent>` interface for each event type.
 
+In your handler if you call a methods on a Repository you may find that you get an `ObjectDisposedException` being thrown.  This will be because the unit of work being used by the Repository has been disposed in another context e.g. an ASP.net controller action.  You will need to create a specific unit of work for your `HandleEventAsync` method.  You can either use the `IUnitOfWorkManager.Begin` method or use the `UnitOfWorkAttribute` on the method. See the [Unit of work document](Unit-of-work.md) for more details.
+
 > The handler class must be registered to the dependency injection (DI). The sample above uses the `ITransientDependency` to accomplish it. See the [DI document](Dependency-Injection.md) for more options.
+
 
 ## Pre-Defined Events
 


### PR DESCRIPTION
If you try to use Repository methods in EventHandlers you can get `ObjectDisposedException` this adds details on how to correctly use UnitOfWorkManger to avoid this issue. 

Raise in this issue https://github.com/abpframework/abp/issues/4721