### PR TITLE
Remove ITransientDependency interface from the DeviceFlowStore class.

### DIFF
--- a/modules/identityserver/src/Volo.Abp.IdentityServer.Domain/Volo/Abp/IdentityServer/Devices/DeviceFlowStore.cs
+++ b/modules/identityserver/src/Volo.Abp.IdentityServer.Domain/Volo/Abp/IdentityServer/Devices/DeviceFlowStore.cs
@@ -5,20 +5,19 @@ using IdentityServer4.Models;
 using IdentityServer4.Stores;
 using IdentityServer4.Stores.Serialization;
 using JetBrains.Annotations;
-using Volo.Abp.DependencyInjection;
 using Volo.Abp.Guids;
 
 namespace Volo.Abp.IdentityServer.Devices
 {
-    public class DeviceFlowStore : IDeviceFlowStore, ITransientDependency
+    public class DeviceFlowStore : IDeviceFlowStore
     {
         protected IDeviceFlowCodesRepository DeviceFlowCodesRepository { get; }
         protected IGuidGenerator GuidGenerator { get; }
         protected IPersistentGrantSerializer PersistentGrantSerializer { get; }
 
         public DeviceFlowStore(
-            IDeviceFlowCodesRepository deviceFlowCodesRepository, 
-            IGuidGenerator guidGenerator, 
+            IDeviceFlowCodesRepository deviceFlowCodesRepository,
+            IGuidGenerator guidGenerator,
             IPersistentGrantSerializer persistentGrantSerializer)
         {
             DeviceFlowCodesRepository = deviceFlowCodesRepository;
@@ -46,7 +45,7 @@ namespace Volo.Abp.IdentityServer.Devices
                     }
                 );
         }
-        
+
         public virtual async Task<DeviceCode> FindByUserCodeAsync(string userCode)
         {
             Check.NotNull(userCode, nameof(userCode));
@@ -70,7 +69,7 @@ namespace Volo.Abp.IdentityServer.Devices
             var deviceCodes = await DeviceFlowCodesRepository
                 .FindByDeviceCodeAsync(deviceCode)
                 ;
-            
+
             if (deviceCodes == null)
             {
                 return null;


### PR DESCRIPTION
Resolve #4883

https://github.com/abpframework/abp/blob/02724445e1dbdd7eab23f8ea6cb0d0d0f7e8de2e/modules/identityserver/src/Volo.Abp.IdentityServer.Domain/Volo/Abp/IdentityServer/IdentityServerBuilderExtensions.cs#L11-L21