### PR TITLE
Implemented the getting environment from remote URL

### DIFF
--- a/docs/en/UI/Angular/Localization.md
+++ b/docs/en/UI/Angular/Localization.md
@@ -199,7 +199,7 @@ Some of the culture names defined in .NET do not match Angular locales. In such 
 
 ![locale-error](./images/locale-error.png)
 
-If you see an error like this, you should pass the `cultureNameToLocaleFileNameMapping` property like below to CoreModule's forRoot static method.
+If you see an error like this, you should pass the `cultureNameLocaleFileMap` property like below to CoreModule's forRoot static method.
 
 ```js
 // app.module.ts
@@ -209,7 +209,7 @@ If you see an error like this, you should pass the `cultureNameToLocaleFileNameM
     // other imports
      CoreModule.forRoot({
       // other options
-      cultureNameToLocaleFileNameMapping: { 
+      cultureNameLocaleFileMap: { 
         "DotnetCultureName": "AngularLocaleFileName",
         "pt-BR": "pt"  // example
       }

--- a/docs/zh-Hans/UI/Angular/Localization.md
+++ b/docs/zh-Hans/UI/Angular/Localization.md
@@ -199,7 +199,7 @@ export class AppComponent {}
 
 ![locale-error](./images/locale-error.png)
 
-如果你看到这样的错误,你应该像下面这样传递 `cultureNameToLocaleFileNameMapping` 属性到CoreModule的forRoot静态方法.
+如果你看到这样的错误,你应该像下面这样传递 `cultureNameLocaleFileMap` 属性到CoreModule的forRoot静态方法.
 
 ```js
 // app.module.ts
@@ -209,7 +209,7 @@ export class AppComponent {}
     // other imports
      CoreModule.forRoot({
       // other options
-      cultureNameToLocaleFileNameMapping: { 
+      cultureNameLocaleFileMap: { 
         "DotnetCultureName": "AngularLocaleFileName",
         "pt-BR": "pt"  // example
       }

--- a/npm/ng-packs/packages/core/src/lib/models/common.ts
+++ b/npm/ng-packs/packages/core/src/lib/models/common.ts
@@ -9,7 +9,7 @@ export namespace ABP {
     environment: Partial<Config.Environment>;
     skipGetAppConfiguration?: boolean;
     sendNullsAsQueryParam?: boolean;
-    cultureNameToLocaleFileNameMapping?: Dictionary<string>;
+    cultureNameLocaleFileMap?: Dictionary<string>;
   }
 
   export interface Test {

--- a/npm/ng-packs/packages/core/src/lib/models/config.ts
+++ b/npm/ng-packs/packages/core/src/lib/models/config.ts
@@ -7,12 +7,13 @@ export namespace Config {
   export type State = ApplicationConfiguration.Response & ABP.Root & { environment: Environment };
 
   export interface Environment {
-    application: Application;
-    production: boolean;
-    hmr?: boolean;
-    oAuthConfig: AuthConfig;
     apis: Apis;
+    application: Application;
+    hmr?: boolean;
     localization?: { defaultResourceName?: string };
+    oAuthConfig: AuthConfig;
+    production: boolean;
+    remoteEnv?: RemoteEnv;
   }
 
   export interface Application {
@@ -41,4 +42,10 @@ export namespace Config {
   }
 
   export type LocalizationParam = string | LocalizationWithDefault;
+
+  export interface RemoteEnv {
+    url: string;
+    method?: string;
+    headers?: ABP.Dictionary<string>;
+  }
 }

--- a/npm/ng-packs/packages/core/src/lib/services/localization.service.ts
+++ b/npm/ng-packs/packages/core/src/lib/services/localization.service.ts
@@ -45,12 +45,12 @@ export class LocalizationService {
 
   registerLocale(locale: string) {
     const router = this.injector.get(Router);
-    const { cultureNameToLocaleFileNameMapping: localeNameMap } = this.injector.get(CORE_OPTIONS);
+    const { cultureNameToLocaleFileNameMapping } = this.injector.get(CORE_OPTIONS);
     const { shouldReuseRoute } = router.routeReuseStrategy;
     router.routeReuseStrategy.shouldReuseRoute = () => false;
     router.navigated = false;
 
-    return registerLocale(locale, localeNameMap).then(() => {
+    return registerLocale(locale, cultureNameToLocaleFileNameMapping).then(() => {
       this.ngZone.run(async () => {
         await router.navigateByUrl(router.url).catch(noop);
         router.routeReuseStrategy.shouldReuseRoute = shouldReuseRoute;

--- a/npm/ng-packs/packages/core/src/lib/services/localization.service.ts
+++ b/npm/ng-packs/packages/core/src/lib/services/localization.service.ts
@@ -45,12 +45,12 @@ export class LocalizationService {
 
   registerLocale(locale: string) {
     const router = this.injector.get(Router);
-    const { cultureNameToLocaleFileNameMapping } = this.injector.get(CORE_OPTIONS);
+    const { cultureNameLocaleFileMap } = this.injector.get(CORE_OPTIONS);
     const { shouldReuseRoute } = router.routeReuseStrategy;
     router.routeReuseStrategy.shouldReuseRoute = () => false;
     router.navigated = false;
 
-    return registerLocale(locale, cultureNameToLocaleFileNameMapping).then(() => {
+    return registerLocale(locale, cultureNameLocaleFileMap).then(() => {
       this.ngZone.run(async () => {
         await router.navigateByUrl(router.url).catch(noop);
         router.routeReuseStrategy.shouldReuseRoute = shouldReuseRoute;

--- a/npm/ng-packs/packages/core/src/lib/tests/environment-utils.spec.ts
+++ b/npm/ng-packs/packages/core/src/lib/tests/environment-utils.spec.ts
@@ -1,0 +1,71 @@
+import { HttpClient } from '@angular/common/http';
+import { Component, Injector } from '@angular/core';
+import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
+import { Store } from '@ngxs/store';
+import { BehaviorSubject, of } from 'rxjs';
+import { getRemoteEnv } from '../utils/environment-utils';
+import { SetEnvironment } from '../actions/config.actions';
+
+const environment = {
+  production: false,
+  hmr: false,
+  application: {
+    baseUrl: 'https://volosoft.com',
+    name: 'MyProjectName',
+    logoUrl: '',
+  },
+  oAuthConfig: {
+    issuer: 'https://api.volosoft.com',
+    clientId: 'MyProjectName_App',
+    dummyClientSecret: '1q2w3e*',
+    scope: 'MyProjectName',
+    oidc: false,
+    requireHttps: true,
+  },
+  apis: {
+    default: {
+      url: 'https://api.volosoft.com',
+    },
+  },
+};
+
+@Component({
+  selector: 'abp-dummy',
+  template: '',
+})
+export class DummyComponent {}
+
+describe('EnvironmentUtils', () => {
+  let spectator: Spectator<DummyComponent>;
+  const createComponent = createComponentFactory({
+    component: DummyComponent,
+    mocks: [Store, HttpClient],
+  });
+
+  beforeEach(() => (spectator = createComponent()));
+
+  describe('#getRemoteEnv', async () => {
+    test('should call the remoteEnv URL and dispatch the SetEnvironment action ', async () => {
+      const injector = spectator.inject(Injector);
+      const injectorSpy = jest.spyOn(injector, 'get');
+      const store = spectator.inject(Store);
+      const dispatchSpy = jest.spyOn(store, 'dispatch');
+      const http = spectator.inject(HttpClient);
+      const requestSpy = jest.spyOn(http, 'request');
+
+      injectorSpy.mockReturnValueOnce(http);
+      injectorSpy.mockReturnValueOnce(store);
+
+      requestSpy.mockReturnValue(new BehaviorSubject(environment));
+      dispatchSpy.mockReturnValue(of(true));
+
+      const partialEnv = { remoteEnv: { url: '/assets/appsettings.json' } };
+      getRemoteEnv(injector, partialEnv);
+
+      expect(requestSpy).toHaveBeenCalledWith('GET', '/assets/appsettings.json', { headers: {} });
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        new SetEnvironment({ ...environment, ...partialEnv }),
+      );
+    });
+  });
+});

--- a/npm/ng-packs/packages/core/src/lib/tests/initial-utils.spec.ts
+++ b/npm/ng-packs/packages/core/src/lib/tests/initial-utils.spec.ts
@@ -7,6 +7,7 @@ import { GetAppConfiguration } from '../actions';
 import { CORE_OPTIONS } from '../tokens/options.token';
 import { checkAccessToken, getInitialData, localeInitializer } from '../utils';
 import * as multiTenancyUtils from '../utils/multi-tenancy-utils';
+import * as environmentUtils from '../utils/environment-utils';
 
 @Component({
   selector: 'abp-dummy',
@@ -33,7 +34,9 @@ describe('InitialUtils', () => {
       const store = spectator.inject(Store);
       const dispatchSpy = jest.spyOn(store, 'dispatch');
       const parseTenantFromUrlSpy = jest.spyOn(multiTenancyUtils, 'parseTenantFromUrl');
+      const getRemoteEnvSpy = jest.spyOn(environmentUtils, 'getRemoteEnv');
       parseTenantFromUrlSpy.mockReturnValue(Promise.resolve());
+      getRemoteEnvSpy.mockReturnValue(Promise.resolve());
 
       injectorSpy.mockReturnValueOnce(store);
       injectorSpy.mockReturnValueOnce({ skipGetAppConfiguration: false });

--- a/npm/ng-packs/packages/core/src/lib/tests/initial-utils.spec.ts
+++ b/npm/ng-packs/packages/core/src/lib/tests/initial-utils.spec.ts
@@ -74,7 +74,7 @@ describe('InitialUtils', () => {
       const store = spectator.inject(Store);
       store.selectSnapshot.andCallFake(selector => selector({ SessionState: { language: 'tr' } }));
       injectorSpy.mockReturnValueOnce(store);
-      injectorSpy.mockReturnValueOnce({ cultureNameToLocaleFileNameMapping: {} });
+      injectorSpy.mockReturnValueOnce({ cultureNameLocaleFileMap: {} });
       expect(typeof localeInitializer(injector)).toBe('function');
       expect(await localeInitializer(injector)()).toBe('resolved');
     });

--- a/npm/ng-packs/packages/core/src/lib/tests/localization.service.spec.ts
+++ b/npm/ng-packs/packages/core/src/lib/tests/localization.service.spec.ts
@@ -16,7 +16,7 @@ describe('LocalizationService', () => {
     mocks: [Store, Router],
     providers: [
       { provide: Actions, useValue: new Subject() },
-      { provide: CORE_OPTIONS, useValue: { cultureNameToLocaleFileNameMapping: {} } },
+      { provide: CORE_OPTIONS, useValue: { cultureNameLocaleFileMap: {} } },
     ],
   });
 

--- a/npm/ng-packs/packages/core/src/lib/tokens/options.token.ts
+++ b/npm/ng-packs/packages/core/src/lib/tokens/options.token.ts
@@ -5,11 +5,11 @@ import differentLocales from '../constants/different-locales';
 export const CORE_OPTIONS = new InjectionToken<ABP.Root>('CORE_OPTIONS');
 
 export function coreOptionsFactory({
-  cultureNameToLocaleFileNameMapping: localeNameMap = {},
+  cultureNameLocaleFileMap: localeNameMap = {},
   ...options
 }: ABP.Root) {
   return {
     ...options,
-    cultureNameToLocaleFileNameMapping: { ...differentLocales, ...localeNameMap },
+    cultureNameLocaleFileMap: { ...differentLocales, ...localeNameMap },
   } as ABP.Root;
 }

--- a/npm/ng-packs/packages/core/src/lib/utils/environment-utils.ts
+++ b/npm/ng-packs/packages/core/src/lib/utils/environment-utils.ts
@@ -1,0 +1,21 @@
+import { HttpClient } from '@angular/common/http';
+import { Injector } from '@angular/core';
+import { Store } from '@ngxs/store';
+import { SetEnvironment } from '../actions/config.actions';
+import { Config } from '../models/config';
+
+export async function getRemoteEnv(injector: Injector, environment: Config.Environment) {
+  const { remoteEnv } = environment;
+  if (!remoteEnv?.url) return Promise.resolve();
+
+  const http = injector.get(HttpClient);
+  const store = injector.get(Store);
+
+  const env = await http
+    .request<Config.Environment>(remoteEnv.method || 'GET', remoteEnv.url, {
+      headers: remoteEnv.headers || {},
+    })
+    .toPromise();
+
+  return store.dispatch(new SetEnvironment({ ...environment, ...env })).toPromise();
+}

--- a/npm/ng-packs/packages/core/src/lib/utils/environment-utils.ts
+++ b/npm/ng-packs/packages/core/src/lib/utils/environment-utils.ts
@@ -1,21 +1,24 @@
 import { HttpClient } from '@angular/common/http';
 import { Injector } from '@angular/core';
 import { Store } from '@ngxs/store';
+import { of } from 'rxjs';
+import { catchError, switchMap } from 'rxjs/operators';
 import { SetEnvironment } from '../actions/config.actions';
 import { Config } from '../models/config';
 
-export async function getRemoteEnv(injector: Injector, environment: Config.Environment) {
+export function getRemoteEnv(injector: Injector, environment: Partial<Config.Environment>) {
   const { remoteEnv } = environment;
-  if (!remoteEnv?.url) return Promise.resolve();
+  const { headers = {}, method = 'GET', url } = remoteEnv || ({} as Config.RemoteEnv);
+  if (!url) return Promise.resolve();
 
   const http = injector.get(HttpClient);
   const store = injector.get(Store);
 
-  const env = await http
-    .request<Config.Environment>(remoteEnv.method || 'GET', remoteEnv.url, {
-      headers: remoteEnv.headers || {},
-    })
+  return http
+    .request<Config.Environment>(method, url, { headers })
+    .pipe(
+      catchError(() => of({} as Config.Environment)), // TODO: Handle error
+      switchMap(env => store.dispatch(new SetEnvironment({ ...environment, ...env }))),
+    )
     .toPromise();
-
-  return store.dispatch(new SetEnvironment({ ...environment, ...env })).toPromise();
 }

--- a/npm/ng-packs/packages/core/src/lib/utils/environment-utils.ts
+++ b/npm/ng-packs/packages/core/src/lib/utils/environment-utils.ts
@@ -1,10 +1,10 @@
 import { HttpClient } from '@angular/common/http';
 import { Injector } from '@angular/core';
 import { Store } from '@ngxs/store';
-import { of } from 'rxjs';
 import { catchError, switchMap } from 'rxjs/operators';
 import { SetEnvironment } from '../actions/config.actions';
 import { Config } from '../models/config';
+import { RestOccurError } from '../actions/rest.actions';
 
 export function getRemoteEnv(injector: Injector, environment: Partial<Config.Environment>) {
   const { remoteEnv } = environment;
@@ -17,7 +17,7 @@ export function getRemoteEnv(injector: Injector, environment: Partial<Config.Env
   return http
     .request<Config.Environment>(method, url, { headers })
     .pipe(
-      catchError(() => of({} as Config.Environment)), // TODO: Handle error
+      catchError(err => store.dispatch(new RestOccurError(err))), // TODO: Condiser get handle function from a provider
       switchMap(env => store.dispatch(new SetEnvironment({ ...environment, ...env }))),
     )
     .toPromise();

--- a/npm/ng-packs/packages/core/src/lib/utils/index.ts
+++ b/npm/ng-packs/packages/core/src/lib/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './array-utils';
 export * from './common-utils';
+export * from './environment-utils';
 export * from './factory-utils';
 export * from './form-utils';
 export * from './generator-utils';

--- a/npm/ng-packs/packages/core/src/lib/utils/initial-utils.ts
+++ b/npm/ng-packs/packages/core/src/lib/utils/initial-utils.ts
@@ -45,7 +45,7 @@ export function localeInitializer(injector: Injector) {
     const lang = store.selectSnapshot(state => state.SessionState.language) || 'en';
 
     return new Promise((resolve, reject) => {
-      registerLocale(lang, options.cultureNameToLocaleFileNameMapping).then(
+      registerLocale(lang, options.cultureNameLocaleFileMap).then(
         () => resolve('resolved'),
         reject,
       );

--- a/npm/ng-packs/packages/core/src/lib/utils/initial-utils.ts
+++ b/npm/ng-packs/packages/core/src/lib/utils/initial-utils.ts
@@ -7,16 +7,19 @@ import { GetAppConfiguration } from '../actions/config.actions';
 import { ABP } from '../models/common';
 import { ConfigState } from '../states/config.state';
 import { CORE_OPTIONS } from '../tokens/options.token';
+import { getRemoteEnv } from './environment-utils';
 import { parseTenantFromUrl } from './multi-tenancy-utils';
+import { Config } from '../models/config';
 
 export function getInitialData(injector: Injector) {
   const fn = async () => {
     const store: Store = injector.get(Store);
-    const { skipGetAppConfiguration } = injector.get(CORE_OPTIONS) as ABP.Root;
+    const options = injector.get(CORE_OPTIONS) as ABP.Root;
 
+    await getRemoteEnv(injector, options.environment as Config.Environment);
     await parseTenantFromUrl(injector);
 
-    if (skipGetAppConfiguration) return;
+    if (options.skipGetAppConfiguration) return;
 
     return store
       .dispatch(new GetAppConfiguration())

--- a/npm/ng-packs/packages/core/src/lib/utils/initial-utils.ts
+++ b/npm/ng-packs/packages/core/src/lib/utils/initial-utils.ts
@@ -9,14 +9,13 @@ import { ConfigState } from '../states/config.state';
 import { CORE_OPTIONS } from '../tokens/options.token';
 import { getRemoteEnv } from './environment-utils';
 import { parseTenantFromUrl } from './multi-tenancy-utils';
-import { Config } from '../models/config';
 
 export function getInitialData(injector: Injector) {
   const fn = async () => {
     const store: Store = injector.get(Store);
     const options = injector.get(CORE_OPTIONS) as ABP.Root;
 
-    await getRemoteEnv(injector, options.environment as Config.Environment);
+    await getRemoteEnv(injector, options.environment);
     await parseTenantFromUrl(injector);
 
     if (options.skipGetAppConfiguration) return;

--- a/npm/ng-packs/packages/core/src/lib/utils/multi-tenancy-utils.ts
+++ b/npm/ng-packs/packages/core/src/lib/utils/multi-tenancy-utils.ts
@@ -15,7 +15,7 @@ function getCurrentTenancyName(appBaseUrl: string): string {
 
   const parseTokens = createTokenParser(appBaseUrl);
   const token = tenancyPlaceholder.replace(/[}{]/g, '');
-  return parseTokens(window.location.href)[token][0];
+  return parseTokens(window.location.href)[token]?.[0];
 }
 
 export async function parseTenantFromUrl(injector: Injector) {

--- a/npm/ng-packs/yarn.lock
+++ b/npm/ng-packs/yarn.lock
@@ -273,9 +273,9 @@
     rxjs "6.4.0"
 
 "@angular/animations@~10.0.0":
-  version "10.0.7"
-  resolved "https://registry.yarnpkg.com/@angular/animations/-/animations-10.0.7.tgz#1896b76bee50abb5a199b335d447f9fcb195ab1b"
-  integrity sha512-lTF7wuhx16fc3WahmqcYE3Q6sHB5sUQZ6m4dKg38wuf49Hr9x8uQpOMypnOAp9qfKG06ZZ2arRs53JeHpzkMPw==
+  version "10.0.8"
+  resolved "https://registry.yarnpkg.com/@angular/animations/-/animations-10.0.8.tgz#f033a7043f41075fae128ea6e91bcdaec3a4df2f"
+  integrity sha512-vxJRNz6CbguuoLxZpKbaCRcJRFg+/UeXvrUjRlUxwJpAni5hFYkWZUjjXvHDszI97q8FkDNLpGDPcggGqPfo4w==
   dependencies:
     tslib "^2.0.0"
 
@@ -313,9 +313,9 @@
     uuid "8.1.0"
 
 "@angular/common@~10.0.0":
-  version "10.0.7"
-  resolved "https://registry.yarnpkg.com/@angular/common/-/common-10.0.7.tgz#16dc489ea2e53563fb972581e3b3de46ebd194b1"
-  integrity sha512-CPjmbjylbMG0eFLWz7TCaxONDcwuldcvEheEwaBGS3RloHVsa+ry/8r6/7YilQkscdNPUazhX8pIzzrxIf9cBQ==
+  version "10.0.8"
+  resolved "https://registry.yarnpkg.com/@angular/common/-/common-10.0.8.tgz#591263b42f8d03f3730e927251dae175e0d60669"
+  integrity sha512-Nzk5ckQ8y/qvTmqRdzpwUQELYD9N6DJC5yPWQw+remlkUTw24KX4KMUnt9Iy/2eFQC65MhZoTwostuKpjffrlQ==
   dependencies:
     tslib "^2.0.0"
 
@@ -346,28 +346,28 @@
     tslib "^2.0.0"
 
 "@angular/core@~10.0.0":
-  version "10.0.7"
-  resolved "https://registry.yarnpkg.com/@angular/core/-/core-10.0.7.tgz#297392ea4cf0764de28ac8efc7b4f041db507efc"
-  integrity sha512-h8R/2TCIFkagrFl6zmPN34gS5ZtQ1soYDI8dDeLj0+oQ+qH8HncoRgzYl+1+agFvUeYQ2pkwc5i635j/LwC++Q==
+  version "10.0.8"
+  resolved "https://registry.yarnpkg.com/@angular/core/-/core-10.0.8.tgz#dd8855e9faa3f2ba37268144d15402d346b1be57"
+  integrity sha512-52M1krR/TRZsV9WKPd+r7IPVT8c5Nh+Im1z3/ZY7rG0HmxXsV7YzuTuKV7oyHbWPg0WPJAwyH0+qxBK3kpvc8w==
   dependencies:
     tslib "^2.0.0"
 
 "@angular/forms@~10.0.0":
-  version "10.0.7"
-  resolved "https://registry.yarnpkg.com/@angular/forms/-/forms-10.0.7.tgz#571cbdc5ed213e10aedfdb9d660f4d55c71687a2"
-  integrity sha512-xSGPhidaUWLop3j9zPy4ZeO+/rwnusNWvwrDNey4W68lS068AExRXqf3yTuzobqBGdV2swDJaRabzgD7NS8yag==
+  version "10.0.8"
+  resolved "https://registry.yarnpkg.com/@angular/forms/-/forms-10.0.8.tgz#e491010a78be6997d4ac228565de661f5505dc2f"
+  integrity sha512-7aEF0iO8pwcCtVgY0uNN7njVvdXWzXCTygd0SfqOTJRpCQwZ5IgICmUkpjlo8soTrOUC/8VRUstEKVltNzj9gA==
   dependencies:
     tslib "^2.0.0"
 
 "@angular/language-service@~10.0.0":
-  version "10.0.7"
-  resolved "https://registry.yarnpkg.com/@angular/language-service/-/language-service-10.0.7.tgz#22a10d4ee4458b946aae376cf8d502c78b956a20"
-  integrity sha512-iD1It0GjQyn+1KKVh0IMTtrRw/HI0cXq69KYju2LXckngzSK0GXg+yvPP4sizwSBhJW2xeepV8qGkpGo9M+Wyw==
+  version "10.0.8"
+  resolved "https://registry.yarnpkg.com/@angular/language-service/-/language-service-10.0.8.tgz#2566f5ae48c54134c3f8a22c4f40ac4e2e039436"
+  integrity sha512-RO8KjO9yLrVaIxoArLPuO+Q63gNorJ6C8lerLBNIUvpAzf2Pa1wUOZ/Vrt7lBZADC9/FfYfGhIihFBZuZOVmpA==
 
 "@angular/localize@~10.0.0":
-  version "10.0.7"
-  resolved "https://registry.yarnpkg.com/@angular/localize/-/localize-10.0.7.tgz#ea99439ad94420cad73b23930f6d091c2e470c13"
-  integrity sha512-20PciUxCyVdIAkvopzGhmU5LA0bFRXmPFpfDqBccUn9tFv27PAOjNf70HbscdUKzEQW79kLjdV5qcbzXZqPnCg==
+  version "10.0.8"
+  resolved "https://registry.yarnpkg.com/@angular/localize/-/localize-10.0.8.tgz#167a1fed27ea11883247acfcfbdc264033172014"
+  integrity sha512-vtGLYHM1eguWqTNm037x15I24gx3YVbv6mbjG7AFh7nLRpXSn3wxiSSNlYzDJs0lne3qY4RBn3zSeMfRm8W+mg==
   dependencies:
     "@babel/core" "7.8.3"
     glob "7.1.2"
@@ -383,23 +383,23 @@
     yargs "15.3.0"
 
 "@angular/platform-browser-dynamic@~10.0.0":
-  version "10.0.7"
-  resolved "https://registry.yarnpkg.com/@angular/platform-browser-dynamic/-/platform-browser-dynamic-10.0.7.tgz#e419f25da20bdee5ac7c7c3b1907f4301cd7a363"
-  integrity sha512-ESn1hssKmgFbSSU8tI3KcP6QFEMKaxTvoKElkwULhAnCNkeXAhZaIkTdeqaa/vkO8s9nRbRwqcLuhw/mIQJbpQ==
+  version "10.0.8"
+  resolved "https://registry.yarnpkg.com/@angular/platform-browser-dynamic/-/platform-browser-dynamic-10.0.8.tgz#dd865d535a324a59a334a6f973bcd2d6333c2191"
+  integrity sha512-1hIourV0jF8188xwrweQnmP7QmcoRZu8D2wcy4EYyFU+i0mF6JXxJ97rfqVD3ueDr+Sd9VqXGZYFb0mO5G6MNg==
   dependencies:
     tslib "^2.0.0"
 
 "@angular/platform-browser@~10.0.0":
-  version "10.0.7"
-  resolved "https://registry.yarnpkg.com/@angular/platform-browser/-/platform-browser-10.0.7.tgz#c2328f2f5dad78da79c35fc8eb2bb6bacad81171"
-  integrity sha512-iACZDApTWTID+Dgpv9ztAlmP4OBIyCnqfmSrVWIpN30O/2pgalYS4hKS+jFXXjqG3IXrG6IpOAbFT9UubOWXKg==
+  version "10.0.8"
+  resolved "https://registry.yarnpkg.com/@angular/platform-browser/-/platform-browser-10.0.8.tgz#9d9880f090664fc1908f42e4be0a899d435681c8"
+  integrity sha512-x6ZJz6K+YvsgZFTTD5Rv/uwJAGVWzCqvYUspq25MjvkYTFAEOc6kQ9cfsqS/dTqhPBDoTTjGu6qhIxgm4ovGjA==
   dependencies:
     tslib "^2.0.0"
 
 "@angular/router@~10.0.0":
-  version "10.0.7"
-  resolved "https://registry.yarnpkg.com/@angular/router/-/router-10.0.7.tgz#8fe294f1054214a8aff9a3d982756a4b4dcf6284"
-  integrity sha512-uZAUTSQNuDvpkWGqF2qTkqr+btrNwg9USRB08lzhkWH351Myt1S/7ECVYOWNek6b/NmlAA+e3Kcyb94uDwMEew==
+  version "10.0.8"
+  resolved "https://registry.yarnpkg.com/@angular/router/-/router-10.0.8.tgz#8eec22a8c1050be4fb4003d177bee9e566df8aaf"
+  integrity sha512-Plub5gtfRv0Uk/e1Q66LVXRohzfMPqE9a4OqboFDjlWT5a94XSJaSHMgQHZ0esKoRidxijo3aRJOUSc/LAO9JQ==
   dependencies:
     tslib "^2.0.0"
 
@@ -477,15 +477,15 @@
     source-map "^0.5.0"
 
 "@babel/core@^7.1.0", "@babel/core@^7.7.5":
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.11.0.tgz#73b9c33f1658506887f767c26dae07798b30df76"
-  integrity sha512-mkLq8nwaXmDtFmRkQ8ED/eA2CnVw4zr7dCztKalZXBvdK5EeNUAesrrwUqjQEzFgomJssayzB0aqlOsP1vGLqg==
+  version "7.11.1"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.11.1.tgz#2c55b604e73a40dc21b0e52650b11c65cf276643"
+  integrity sha512-XqF7F6FWQdKGGWAzGELL+aCO1p+lRY5Tj5/tbT3St1G8NaH70jhhDIKknIZaDans0OQBG5wRAldROLHSt44BgQ==
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@babel/generator" "^7.11.0"
     "@babel/helper-module-transforms" "^7.11.0"
     "@babel/helpers" "^7.10.4"
-    "@babel/parser" "^7.11.0"
+    "@babel/parser" "^7.11.1"
     "@babel/template" "^7.10.4"
     "@babel/traverse" "^7.11.0"
     "@babel/types" "^7.11.0"
@@ -714,10 +714,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.10.4", "@babel/parser@^7.11.0", "@babel/parser@^7.8.3", "@babel/parser@^7.8.6", "@babel/parser@^7.9.6":
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.0.tgz#a9d7e11aead25d3b422d17b2c6502c8dddef6a5d"
-  integrity sha512-qvRvi4oI8xii8NllyEc4MDJjuZiNaRzyb7Y7lup1NqJV8TZHF4O27CcP+72WPn/k1zkgJ6WJfnIbk4jTsVAZHw==
+"@babel/parser@^7.1.0", "@babel/parser@^7.10.4", "@babel/parser@^7.11.0", "@babel/parser@^7.11.1", "@babel/parser@^7.8.3", "@babel/parser@^7.8.6", "@babel/parser@^7.9.6":
+  version "7.11.1"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.1.tgz#d91a387990b21e5d20047b336bb19b0553f02ff5"
+  integrity sha512-u9QMIRdKVF7hfEkb3nu2LgZDIzCQPv+yHD9Eg6ruoJLjkrQ9fFz4IBSlF/9XwoNri9+2F1IY+dYuOfZrXq8t3w==
 
 "@babel/plugin-proposal-async-generator-functions@^7.8.3":
   version "7.10.5"
@@ -909,9 +909,9 @@
     "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-transform-block-scoping@^7.8.3":
-  version "7.10.5"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.10.5.tgz#b81b8aafefbfe68f0f65f7ef397b9ece68a6037d"
-  integrity sha512-6Ycw3hjpQti0qssQcA6AMSFDHeNJ++R6dIMnpRqUjFeBBTmTDPa8zgF90OVfTvAo11mXZTlVUViY1g8ffrURLg==
+  version "7.11.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.11.1.tgz#5b7efe98852bef8d652c0b28144cd93a9e4b5215"
+  integrity sha512-00dYeDE0EVEHuuM+26+0w/SCL0BH2Qy7LwHuI4Hi4MH5gkC8/AqMN5uWFJIsoXZrAphiMm1iXzBw6L2T+eA0ew==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
@@ -1224,9 +1224,9 @@
     regenerator-runtime "^0.13.4"
 
 "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4":
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.0.tgz#f10245877042a815e07f7e693faff0ae9d3a2aac"
-  integrity sha512-qArkXsjJq7H+T86WrIFV0Fnu/tNOkZ4cgXmjkzAu3b/58D5mFIO8JH/y77t7C9q0OdDRdh9s7Ue5GasYssxtXw==
+  version "7.11.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.1.tgz#087afc57e7bf1073e792fe54f8fb3cfa752f9230"
+  integrity sha512-nH5y8fLvVl3HAb+ezbgcgwrH8QbClWo8xzkOu7+oyqngo3EVorwpWJQaqXPjGRpfj7mQvsJCl/S8knkfkPWqrw==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -2507,9 +2507,9 @@
     "@types/node" ">= 8"
 
 "@octokit/types@^5.0.0", "@octokit/types@^5.0.1":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-5.2.0.tgz#d075dc23bf293f540739250b6879e2c1be2fc20c"
-  integrity sha512-XjOk9y4m8xTLIKPe1NFxNWBdzA2/z3PFFA/bwf4EoH6oS8hM0Y46mEa4Cb+KCyj/tFDznJFahzQ0Aj3o1FYq4A==
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-5.2.1.tgz#c212f03b0492faf215fa2ae506d5ec18038c2a36"
+  integrity sha512-PugtgEw8u++zAyBpDpSkR8K1OsT2l8QWp3ECL6bZHFoq9PfHDoKeGFWSuX2Z+Ghy93k1fkKf8tsmqNBv+8dEfQ==
   dependencies:
     "@types/node" ">= 8"
 
@@ -3678,9 +3678,9 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
 bootstrap@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.5.0.tgz#97d9dbcb5a8972f8722c9962483543b907d9b9ec"
-  integrity sha512-Z93QoXvodoVslA+PWNdk23Hze4RBYIkpb5h8I2HY2Tu2h7A0LpAgLcyrhrSUyo2/Oxm2l1fRZPs1e5hnxnliXA==
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.5.1.tgz#f7322c7dd3e6376d430efc0c3f57e4d8005eb5b2"
+  integrity sha512-bxUooHBSbvefnIZfjD0LE8nfdPKrtiFy2sgrxQwUZ0UpFzpjVbVMUxaGIoo9XWT4B2LG1HX6UQg0UMOakT0prQ==
 
 boxen@^4.2.0:
   version "4.2.0"
@@ -3784,15 +3784,15 @@ browserify-rsa@^4.0.0, browserify-rsa@^4.0.1:
     randombytes "^2.0.1"
 
 browserify-sign@^4.0.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/browserify-sign/-/browserify-sign-4.2.0.tgz#545d0b1b07e6b2c99211082bf1b12cce7a0b0e11"
-  integrity sha512-hEZC1KEeYuoHRqhGhTy6gWrpJA3ZDjFWv0DE61643ZnOXAKJb3u7yWcrU0mMc9SwAqK1n7myPGndkp0dFG7NFA==
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/browserify-sign/-/browserify-sign-4.2.1.tgz#eaf4add46dd54be3bb3b36c0cf15abbeba7956c3"
+  integrity sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==
   dependencies:
     bn.js "^5.1.1"
     browserify-rsa "^4.0.1"
     create-hash "^1.2.0"
     create-hmac "^1.1.7"
-    elliptic "^6.5.2"
+    elliptic "^6.5.3"
     inherits "^2.0.4"
     parse-asn1 "^5.1.5"
     readable-stream "^3.6.0"
@@ -4096,9 +4096,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001032, caniuse-lite@^1.0.30001061, caniuse-lite@^1.0.30001093, caniuse-lite@^1.0.30001109:
-  version "1.0.30001110"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001110.tgz#9003e3c7f5a43ea6f1193d4d5acba0bfb152c71a"
-  integrity sha512-KqJWeat4rhSHF0ito4yz9q/JuZHkvn71SsBnxge4azjPDbowIjOUnS8i1xpKGxZxU6BFiPqO2hSV2eiCpFQVRw==
+  version "1.0.30001111"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001111.tgz#dd0ce822c70eb6c7c068e4a55c22e19ec1501298"
+  integrity sha512-xnDje2wchd/8mlJu8sXvWxOGvMgv+uT3iZ3bkIAynKOzToCssWCmkz/ZIkQBs/2pUB4uwnJKVORWQ31UkbVjOg==
 
 canonical-path@1.0.0:
   version "1.0.0"
@@ -4904,12 +4904,12 @@ cosmiconfig@^6.0.0:
     yaml "^1.7.2"
 
 create-ecdh@^4.0.0:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.3.tgz#c9111b6f33045c4697f144787f9254cdc77c45ff"
-  integrity sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.4.tgz#d6e7f4bffa66736085a0762fd3a632684dabcc4e"
+  integrity sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==
   dependencies:
     bn.js "^4.1.0"
-    elliptic "^6.0.0"
+    elliptic "^6.5.3"
 
 create-hash@^1.1.0, create-hash@^1.1.2, create-hash@^1.2.0:
   version "1.2.0"
@@ -5676,11 +5676,11 @@ ee-first@1.1.1:
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
 electron-to-chromium@^1.3.488:
-  version "1.3.518"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.518.tgz#c54ee9cf1a7bafd6e482a1a6cceac86448d941e8"
-  integrity sha512-IspiwXYDKZMxo+qc3Vof4WtwbG9BMDbJfati8PYj7uS4DJmJ67pwjCKZxlTBSAuCZSMcbRnj2Xz2H14uiKT7bQ==
+  version "1.3.520"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.520.tgz#dfda0a14a4aed785cbddfdb505ea122f75978392"
+  integrity sha512-q6H9E1sXDCjRHP+X06vcP+N0ki8ZvYoRPZfKnDuiRX10WWXxEHzKFVf4O9rBFMpuPtR3M+2KAdJnugJoBBp3Rw==
 
-elliptic@^6.0.0, elliptic@^6.5.2:
+elliptic@^6.5.3:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
   integrity sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==
@@ -7539,9 +7539,9 @@ is-directory@^0.3.1:
   integrity sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
 
 is-docker@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.1.0.tgz#25dc043e4fdc3cf969d622735e05a86ba9952e2b"
-  integrity sha512-mB2WygGsSeoXtLKpSYzP6sa0Z9DyU9ZyKlnvuZWxCociaI0qsF8u12sR72DFTX236g1u6oWSWYFuUk09nGQEjg==
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.1.1.tgz#4125a88e44e450d384e09047ede71adc2d144156"
+  integrity sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==
 
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
@@ -13092,9 +13092,9 @@ ts-pnp@^1.1.6:
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
 
 ts-toolbelt@^6.9.9:
-  version "6.13.39"
-  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-6.13.39.tgz#80541ce39b595a42be5ddd04e3e6df65597774f8"
-  integrity sha512-VD/rJ6+NGFA7AK2KWmGzLifrqA060M9o7+R2BxJtLBlwmfEaGdqGeyUPRDKhMZPMgpT/JMQ6+X+/ppaZNzuhvw==
+  version "6.14.0"
+  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-6.14.0.tgz#6f1082c5f59b39ff5d71ff427207bb92ffca4534"
+  integrity sha512-/EihMSk7AQn1n1zad6765tZNr7OCxAP75nS/VGzcZlWLlDa2izLJZV7SJSNDweSKusKuTDyHZhKFyUZW6UUnqg==
 
 tsickle@^0.38.1:
   version "0.38.1"


### PR DESCRIPTION
Resolves #4386

Remote environment configuration can be added to the environment like below:

```ts
import { Config } from '@abp/ng.core';

export const environment = {
  production: false,
  hmr: false,
  remoteEnv: {
    url: '/assets/appsettings.json',
    method: 'GET',
    headers: {}
  }
} as Config.Environment;

```