### PR TITLE
correct docs wording of Principle to Principal

### DIFF
--- a/docs/en/CurrentUser.md
+++ b/docs/en/CurrentUser.md
@@ -1,4 +1,4 @@
-﻿# Current User
+# Current User
 
 It is very common to retrieve the information about the logged in user in a web application. The current user is the active user related to the current request in a web application.
 
@@ -86,7 +86,7 @@ Beside these standard methods, there are some extension methods:
 
 ## ICurrentPrincipalAccessor
 
-`ICurrentPrincipalAccessor` is the service that should be used (by the ABP Framework and your application code) whenever the current principle of the current user is needed.
+`ICurrentPrincipalAccessor` is the service that should be used (by the ABP Framework and your application code) whenever the current principal of the current user is needed.
 
 For a web application, it gets the `User` property of the current `HttpContext`. For a non-web application, it returns the `Thread.CurrentPrincipal`.
 
@@ -114,9 +114,9 @@ public class MyService : ITransientDependency
 }
 ````
 
-### Changing the Current Principle
+### Changing the Current Principal
 
-Current principle is not something you want to set or change, except at some advanced scenarios. If you need it, use the `Change` method of the `ICurrentPrincipalAccessor`. It takes a `ClaimsPrinciple` object and makes it "current" for a scope.
+Current principal is not something you want to set or change, except at some advanced scenarios. If you need it, use the `Change` method of the `ICurrentPrincipalAccessor`. It takes a `ClaimsPrincipal` object and makes it "current" for a scope.
 
 Example:
 
@@ -132,7 +132,7 @@ public class MyAppService : ApplicationService
 
     public void Foo()
     {
-        var newPrinciple = new ClaimsPrincipal(
+        var newPrincipal = new ClaimsPrincipal(
             new ClaimsIdentity(
                 new Claim[]
                 {
@@ -143,7 +143,7 @@ public class MyAppService : ApplicationService
             )
         );
 
-        using (_currentPrincipalAccessor.Change(newPrinciple))
+        using (_currentPrincipalAccessor.Change(newPrincipal))
         {
             var userName = CurrentUser.UserName; //returns "john"
             //...

--- a/docs/zh-Hans/CurrentUser.md
+++ b/docs/zh-Hans/CurrentUser.md
@@ -86,7 +86,7 @@ namespace AbpDemo
 
 ## ICurrentPrincipalAccessor
 
-`ICurrentPrincipalAccessor` 是当需要当前用户的principle时使用的服务(由ABP框架和你的应用程序代码使用).
+`ICurrentPrincipalAccessor` 是当需要当前用户的Principal时使用的服务(由ABP框架和你的应用程序代码使用).
 
 对于Web应用程序, 它获取当前 `HttpContext` 的 `User` 属性,对于非Web应用程序它将返回 `Thread.CurrentPrincipal`.
 
@@ -114,9 +114,9 @@ public class MyService : ITransientDependency
 }
 ````
 
-### 更改当前Principle
+### 更改当前Principal
 
-除了某些高级场景外,你不需要设置或更改当前principle. 如果需要可以使用 `ICurrentPrincipalAccessor` 的 `Change` 方法. 它接受一个 `ClaimsPrinciple` 对象并使其成为作用域的"当前"对象.
+除了某些高级场景外,你不需要设置或更改当前Principal. 如果需要可以使用 `ICurrentPrincipalAccessor` 的 `Change` 方法. 它接受一个 `ClaimsPrincipal` 对象并使其成为作用域的"当前"对象.
 
 示例:
 
@@ -132,7 +132,7 @@ public class MyAppService : ApplicationService
 
     public void Foo()
     {
-        var newPrinciple = new ClaimsPrincipal(
+        var newPrincipal = new ClaimsPrincipal(
             new ClaimsIdentity(
                 new Claim[]
                 {
@@ -143,7 +143,7 @@ public class MyAppService : ApplicationService
             )
         );
 
-        using (_currentPrincipalAccessor.Change(newPrinciple))
+        using (_currentPrincipalAccessor.Change(newPrincipal))
         {
             var userName = CurrentUser.UserName; //returns "john"
             //...


### PR DESCRIPTION
A "principle" is a guiding idea. The correct usage here is "principal" as in a chief actor or leader. See also the [ClaimsPrincipal class](https://docs.microsoft.com/en-us/dotnet/api/system.security.claims.claimsprincipal).