### PR TITLE
Added the ngxsStoragePluginOptions property to forRoot method options of CoreModule

### DIFF
--- a/npm/ng-packs/packages/core/src/lib/core.module.ts
+++ b/npm/ng-packs/packages/core/src/lib/core.module.ts
@@ -4,7 +4,11 @@ import { APP_INITIALIZER, Injector, ModuleWithProviders, NgModule } from '@angul
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { NgxsRouterPluginModule } from '@ngxs/router-plugin';
-import { NgxsStoragePluginModule } from '@ngxs/storage-plugin';
+import {
+  NgxsStoragePluginModule,
+  NGXS_STORAGE_PLUGIN_OPTIONS,
+  StorageOption,
+} from '@ngxs/storage-plugin';
 import { NgxsModule, NGXS_PLUGINS } from '@ngxs/store';
 import { OAuthModule, OAuthStorage } from 'angular-oauth2-oidc';
 import { AbstractNgModelComponent } from './abstracts/ng-model.component';
@@ -118,7 +122,7 @@ export class BaseCoreModule {}
     LocalizationModule,
     NgxsModule.forFeature([ReplaceableComponentsState, ProfileState, SessionState, ConfigState]),
     NgxsRouterPluginModule.forRoot(),
-    NgxsStoragePluginModule.forRoot({ key: ['SessionState'] }),
+    NgxsStoragePluginModule.forRoot(),
     OAuthModule.forRoot(),
   ],
 })
@@ -216,6 +220,18 @@ export class CoreModule {
           useFactory: noop,
         },
         { provide: OAuthStorage, useFactory: storageFactory },
+        {
+          provide: NGXS_STORAGE_PLUGIN_OPTIONS,
+          useValue: {
+            storage: StorageOption.LocalStorage,
+            serialize: JSON.stringify,
+            deserialize: JSON.parse,
+            beforeSerialize: obj => obj,
+            afterDeserialize: obj => obj,
+            ...options.ngxsStoragePluginOptions,
+            key: [...(options.ngxsStoragePluginOptions?.key || []), 'SessionState'],
+          },
+        },
       ],
     };
   }

--- a/npm/ng-packs/packages/core/src/lib/core.module.ts
+++ b/npm/ng-packs/packages/core/src/lib/core.module.ts
@@ -226,8 +226,8 @@ export class CoreModule {
             storage: StorageOption.LocalStorage,
             serialize: JSON.stringify,
             deserialize: JSON.parse,
-            beforeSerialize: obj => obj,
-            afterDeserialize: obj => obj,
+            beforeSerialize: ngxsStoragePluginSerialize,
+            afterDeserialize: ngxsStoragePluginSerialize,
             ...options.ngxsStoragePluginOptions,
             key: [...(options.ngxsStoragePluginOptions?.key || []), 'SessionState'],
           },
@@ -235,4 +235,8 @@ export class CoreModule {
       ],
     };
   }
+}
+
+export function ngxsStoragePluginSerialize(data) {
+  return data;
 }

--- a/npm/ng-packs/packages/core/src/lib/models/common.ts
+++ b/npm/ng-packs/packages/core/src/lib/models/common.ts
@@ -3,6 +3,7 @@ import { Router } from '@angular/router';
 import { Subject } from 'rxjs';
 import { eLayoutType } from '../enums/common';
 import { Config } from './config';
+import { NgxsStoragePluginOptions } from '@ngxs/storage-plugin';
 
 export namespace ABP {
   export interface Root {
@@ -10,6 +11,7 @@ export namespace ABP {
     skipGetAppConfiguration?: boolean;
     sendNullsAsQueryParam?: boolean;
     cultureNameLocaleFileMap?: Dictionary<string>;
+    ngxsStoragePluginOptions?: NgxsStoragePluginOptions & { key?: string[] };
   }
 
   export interface Test {

--- a/npm/ng-packs/packages/core/src/lib/strategies/auth-flow.strategy.ts
+++ b/npm/ng-packs/packages/core/src/lib/strategies/auth-flow.strategy.ts
@@ -3,7 +3,7 @@ import { Router } from '@angular/router';
 import { Store } from '@ngxs/store';
 import { AuthConfig, OAuthService } from 'angular-oauth2-oidc';
 import { Observable, of } from 'rxjs';
-import { switchMap } from 'rxjs/operators';
+import { switchMap, tap } from 'rxjs/operators';
 import { GetAppConfiguration } from '../actions/config.actions';
 import { RestOccurError } from '../actions/rest.actions';
 import { RestService } from '../services/rest.service';
@@ -87,10 +87,8 @@ export class AuthPasswordFlowStrategy extends AuthFlowStrategy {
         issuer,
       )
       .pipe(
-        switchMap(() => {
-          this.oAuthService.logOut();
-          return this.store.dispatch(new GetAppConfiguration());
-        }),
+        tap(() => this.oAuthService.logOut()),
+        switchMap(() =>  this.store.dispatch(new GetAppConfiguration())),
       );
   }
 

--- a/npm/ng-packs/packages/core/src/lib/strategies/auth-flow.strategy.ts
+++ b/npm/ng-packs/packages/core/src/lib/strategies/auth-flow.strategy.ts
@@ -12,6 +12,7 @@ import { GetAppConfiguration } from '../actions/config.actions';
 export abstract class AuthFlowStrategy {
   abstract readonly isInternalAuth: boolean;
 
+  protected store: Store;
   protected oAuthService: OAuthService;
   protected oAuthConfig: AuthConfig;
   abstract checkIfInternalAuth(): boolean;
@@ -20,12 +21,13 @@ export abstract class AuthFlowStrategy {
   abstract destroy(): void;
 
   private catchError = err => {
-    // TODO: handle the error
+    return this.store.dispatch(new RestOccurError(err));
   };
 
   constructor(protected injector: Injector) {
     this.oAuthService = injector.get(OAuthService);
     this.oAuthConfig = injector.get(CORE_OPTIONS).environment.oAuthConfig;
+    this.store = injector.get(Store);
   }
 
   async init(): Promise<any> {

--- a/npm/ng-packs/packages/core/src/lib/strategies/auth-flow.strategy.ts
+++ b/npm/ng-packs/packages/core/src/lib/strategies/auth-flow.strategy.ts
@@ -20,9 +20,7 @@ export abstract class AuthFlowStrategy {
   abstract logout(): Observable<any>;
   abstract destroy(): void;
 
-  private catchError = err => {
-    return this.store.dispatch(new RestOccurError(err));
-  };
+  private catchError = err => this.store.dispatch(new RestOccurError(err));
 
   constructor(protected injector: Injector) {
     this.store = injector.get(Store);

--- a/npm/ng-packs/packages/core/src/lib/tokens/options.token.ts
+++ b/npm/ng-packs/packages/core/src/lib/tokens/options.token.ts
@@ -1,15 +1,12 @@
 import { InjectionToken } from '@angular/core';
-import { ABP } from '../models/common';
 import differentLocales from '../constants/different-locales';
+import { ABP } from '../models/common';
 
 export const CORE_OPTIONS = new InjectionToken<ABP.Root>('CORE_OPTIONS');
 
-export function coreOptionsFactory({
-  cultureNameLocaleFileMap: localeNameMap = {},
-  ...options
-}: ABP.Root) {
+export function coreOptionsFactory({ cultureNameLocaleFileMap = {}, ...options }: ABP.Root) {
   return {
     ...options,
-    cultureNameLocaleFileMap: { ...differentLocales, ...localeNameMap },
+    cultureNameLocaleFileMap: { ...differentLocales, ...cultureNameLocaleFileMap },
   } as ABP.Root;
 }


### PR DESCRIPTION
You can pass custom [`NgxsStoragePlugin`](https://www.ngxs.io/plugins/storage) options to `forRoot` method of `CoreModule`:

```ts
// app.module.ts

@NgModule({
  imports: [
    //...other imports,
    CoreModule.forRoot({
      //...other options
      ngxsStoragePluginOptions: {key: ['MyStateName'] as string[]}
    })
  ]
})
```

**Important Note:** Please do not import the `NgxsStoragePluginModule` to any module. It is already imported to `CoreModule`

Resolves #4839