### PR TITLE
fix: MySqlConnector issues between ABP and Quartz

### DIFF
--- a/framework/src/Volo.Abp.Quartz/Volo/Abp/Quartz/AbpQuartzModule.cs
+++ b/framework/src/Volo.Abp.Quartz/Volo/Abp/Quartz/AbpQuartzModule.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Quartz;
+using Quartz.Impl;
 using Quartz.Impl.AdoJobStore.Common;
 using Volo.Abp.Modularity;
 using Volo.Abp.Threading;
@@ -15,37 +16,35 @@ namespace Volo.Abp.Quartz
         {
             var options = context.Services.ExecutePreConfiguredActions<AbpQuartzOptions>();
 
-            // todo: Remove this once Pomelo update MySqlConnector to >= 1.0.0 : https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/pull/1103
-            var mySqlAvailable = System.Type.GetType("MySql.Data.MySqlClient.MySqlConnection, MySqlConnector") != null;
-            if (mySqlAvailable)
-            {
-                // Overriding the default 'MySqlConnector' provider to use the old 'MySql.Data' namespace found in MySqlConnector < 1.0.0
-                DbProvider.RegisterDbMetadata("MySqlConnector", new DbMetadata()
-                {
-                    ProductName = "MySQL, MySqlConnector provider",
-                    AssemblyName = "MySqlConnector",
-                    ConnectionType = System.Type.GetType("MySql.Data.MySqlClient.MySqlConnection, MySqlConnector"),
-                    CommandType = System.Type.GetType("MySql.Data.MySqlClient.MySqlCommand, MySqlConnector"),
-                    ParameterType = System.Type.GetType("MySql.Data.MySqlClient.MySqlParameter, MySqlConnector"),
-                    ParameterDbType = System.Type.GetType("MySql.Data.MySqlClient.MySqlDbType, MySqlConnector"),
-                    ParameterDbTypePropertyName = "MySqlDbType",
-                    ParameterNamePrefix = "?",
-                    ExceptionType = System.Type.GetType("MySql.Data.MySqlClient.MySqlException, MySqlConnector"),
-                    BindByName = true,
-                    DbBinaryTypeName = "Blob"
-                });
-            }
+            // TODO: Remove this once Pomelo update MySqlConnector to >= 1.0.0 : https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/pull/1103
+            AdaptMysqlConnector();
 
             context.Services.AddQuartz(options.Properties, build =>
             {
-                build.UseMicrosoftDependencyInjectionScopedJobFactory();
                 // these are the defaults
-                build.UseSimpleTypeLoader();
-                build.UseInMemoryStore();
-                build.UseDefaultThreadPool(tp =>
+                if (options.Properties[StdSchedulerFactory.PropertySchedulerJobFactoryType] == null)
                 {
-                    tp.MaxConcurrency = 10;
-                });
+                    build.UseMicrosoftDependencyInjectionScopedJobFactory();
+                }
+
+                if (options.Properties[StdSchedulerFactory.PropertySchedulerTypeLoadHelperType] == null)
+                {
+                    build.UseSimpleTypeLoader();
+                }
+
+                if (options.Properties[StdSchedulerFactory.PropertyJobStoreType] == null)
+                {
+                    build.UseInMemoryStore();
+                }
+
+                if (options.Properties[StdSchedulerFactory.PropertyThreadPoolType] == null)
+                {
+                    build.UseDefaultThreadPool(tp =>
+                    {
+                        tp.MaxConcurrency = 10;
+                    });
+                }
+
                 options.Configurator?.Invoke(build);
             });
 
@@ -75,6 +74,29 @@ namespace Volo.Abp.Quartz
             if (_scheduler.IsStarted)
             {
                 AsyncHelper.RunSync(() => _scheduler.Shutdown());
+            }
+        }
+
+        private void AdaptMysqlConnector()
+        {
+            var mySqlAvailable = System.Type.GetType("MySql.Data.MySqlClient.MySqlConnection, MySqlConnector") != null;
+            if (mySqlAvailable)
+            {
+                // Overriding the default 'MySqlConnector' provider to use the old 'MySql.Data' namespace found in MySqlConnector < 1.0.0
+                DbProvider.RegisterDbMetadata("MySqlConnector", new DbMetadata()
+                {
+                    ProductName = "MySQL, MySqlConnector provider",
+                    AssemblyName = "MySqlConnector",
+                    ConnectionType = System.Type.GetType("MySql.Data.MySqlClient.MySqlConnection, MySqlConnector"),
+                    CommandType = System.Type.GetType("MySql.Data.MySqlClient.MySqlCommand, MySqlConnector"),
+                    ParameterType = System.Type.GetType("MySql.Data.MySqlClient.MySqlParameter, MySqlConnector"),
+                    ParameterDbType = System.Type.GetType("MySql.Data.MySqlClient.MySqlDbType, MySqlConnector"),
+                    ParameterDbTypePropertyName = "MySqlDbType",
+                    ParameterNamePrefix = "?",
+                    ExceptionType = System.Type.GetType("MySql.Data.MySqlClient.MySqlException, MySqlConnector"),
+                    BindByName = true,
+                    DbBinaryTypeName = "Blob"
+                });
             }
         }
     }


### PR DESCRIPTION
After a lot of playing around, I managed to fix the MySqlConnector compatibility issues between ABP and Quartz when using MySql (as [mentioned here](https://github.com/abpframework/abp/issues/4775#issuecomment-674979973)). Original advice to create a custom provider came from the developer of Quartz.net ([see here](https://github.com/quartznet/quartznet/issues/902#issuecomment-663678704))

This overrides the `MySqlConnector` provider to revert the provider namespace back to pre 1.0.0 ([see here](https://github.com/quartznet/quartznet/blob/effbc3ee162e429ea6f198cc67927cdf01747c55/src/Quartz/Impl/AdoJobStore/Common/dbproviders.properties#L88-L100))

This change will allow you to remove this hotfix from the framework without any changes for users of ABP after Pomelo update their MySqlConnector dependency >= 1.0.0 (which will be after the .NET 5 release - [see here](https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/pull/1103#issuecomment-643736104))

Alternatively we can use a custom provider name like `AbpMySqlConnector` instead of overriding the default `MySqlConnector` but my testing shows that it is working fine as it is and users of ABP won't need to update their config when it is removed either.

Feel free to amend :)