### PR TITLE
Build dictionary query string

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/ModelBinding/AbpExtraPropertiesDictionaryModelBinderProvider.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/ModelBinding/AbpExtraPropertiesDictionaryModelBinderProvider.cs
@@ -24,7 +24,7 @@ namespace Volo.Abp.AspNetCore.Mvc.ModelBinding
                 return null;
             }
 
-            if (!context.Metadata.ContainerType.IsAssignableTo<IHasExtraProperties>())
+            if (context.Metadata.ContainerType == null || !context.Metadata.ContainerType.IsAssignableTo<IHasExtraProperties>())
             {
                 return null;
             }

--- a/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/DynamicProxying/IObjectToQueryStringConverter.cs
+++ b/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/DynamicProxying/IObjectToQueryStringConverter.cs
@@ -1,0 +1,7 @@
+﻿namespace Volo.Abp.Http.Client.DynamicProxying
+{
+    public interface IObjectToQueryStringConverter
+    {
+        string ConvertObjectToQueryString(string name, object obj);
+    }
+}

--- a/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/DynamicProxying/ObjectToQueryStringConverter.cs
+++ b/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/DynamicProxying/ObjectToQueryStringConverter.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Reflection;
+using JetBrains.Annotations;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.Localization;
+using Volo.Abp.Reflection;
+
+namespace Volo.Abp.Http.Client.DynamicProxying
+{
+    public class ObjectToQueryStringConverter : IObjectToQueryStringConverter, ITransientDependency
+    {
+        public string ConvertObjectToQueryString(string name, object obj)
+        {
+            return SerializeToQueryString(obj, name);
+        }
+
+        private string SerializeToQueryString(object obj, string prefix)
+        {
+            var queryStrings = new List<string>();
+            var type = obj.GetType();
+
+            if (TypeHelper.IsPrimitiveExtended(type))
+            {
+                queryStrings.Add($"{prefix}={System.Net.WebUtility.UrlEncode(ConvertValueToString(obj))}");
+            }
+            else if (obj is IDictionary dict && type.IsGenericType && type.GetGenericTypeDefinition().IsAssignableFrom(typeof(Dictionary<,>)))
+            {
+                foreach (DictionaryEntry kv in dict)
+                {
+                    var value = kv.Value;
+                    if (value == null) continue;
+                    string name = $"{prefix}.{kv.Key}";
+                    AddQueryString(name, value, queryStrings);
+                }
+            }
+            else if (type.IsArray || type.IsGenericType && obj is IEnumerable)
+            {
+                var index = 0;
+                foreach (var value in (IEnumerable) obj)
+                {
+                    if (value == null) continue;
+                    string name = $"{prefix}[{index++}]";
+                    AddQueryString(name, value, queryStrings);
+                }
+            }
+            else
+            {
+                var props = type.GetProperties(BindingFlags.Instance | BindingFlags.Public);
+                foreach (var prop in props)
+                {
+                    var value = prop.GetValue(obj);
+                    if (value == null) continue;
+                    string name = $"{prefix}.{prop.Name}";
+                    AddQueryString(name, value, queryStrings);
+                }
+            }
+
+            return String.Join("&", queryStrings);
+        }
+
+        private void AddQueryString(string name, object value, ICollection<string> queryStrings)
+        {
+            string queryString = TypeHelper.IsPrimitiveExtended(value.GetType()) ? $"{name}={System.Net.WebUtility.UrlEncode(ConvertValueToString(value))}" : SerializeToQueryString(value, name);
+            queryStrings.Add(queryString);
+        }
+
+        private static string ConvertValueToString([NotNull] object value)
+        {
+            using (CultureHelper.Use(CultureInfo.InvariantCulture))
+            {
+                if (value is DateTime dateTimeValue)
+                {
+                    return dateTimeValue.ToUniversalTime().ToString("u");
+                }
+
+                return value.ToString();
+            }
+        }
+    }
+}

--- a/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/DynamicProxying/UrlBuilder.cs
+++ b/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/DynamicProxying/UrlBuilder.cs
@@ -111,6 +111,16 @@ namespace Volo.Abp.Http.Client.DynamicProxying
                 //remove & at the end of the urlBuilder.
                 urlBuilder.Remove(urlBuilder.Length - 1, 1);
             }
+
+            if (value is IDictionary dict && value.GetType().IsGenericType && value.GetType().GetGenericTypeDefinition().IsAssignableFrom(typeof(Dictionary<,>)))
+            {
+                foreach (DictionaryEntry kv in dict)
+                {
+                    urlBuilder.Append(name + "." + kv.Key + "=" + System.Net.WebUtility.UrlEncode(ConvertValueToString(kv.Value)) + "&");
+                }
+                //remove & at the end of the urlBuilder.
+                urlBuilder.Remove(urlBuilder.Length - 1, 1);
+            }
             else
             {
                 urlBuilder.Append(name + "=" + System.Net.WebUtility.UrlEncode(ConvertValueToString(value)));

--- a/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/DynamicProxying/UrlBuilder.cs
+++ b/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/DynamicProxying/UrlBuilder.cs
@@ -101,22 +101,21 @@ namespace Volo.Abp.Http.Client.DynamicProxying
         {
             urlBuilder.Append(isFirstParam ? "?" : "&");
 
-            if (value.GetType().IsArray || (value.GetType().IsGenericType && value is IEnumerable))
-            {
-                var index = 0;
-                foreach (var item in (IEnumerable) value)
-                {
-                    urlBuilder.Append(name + $"[{index++}]=" + System.Net.WebUtility.UrlEncode(ConvertValueToString(item)) + "&");
-                }
-                //remove & at the end of the urlBuilder.
-                urlBuilder.Remove(urlBuilder.Length - 1, 1);
-            }
-
             if (value is IDictionary dict && value.GetType().IsGenericType && value.GetType().GetGenericTypeDefinition().IsAssignableFrom(typeof(Dictionary<,>)))
             {
                 foreach (DictionaryEntry kv in dict)
                 {
                     urlBuilder.Append(name + "." + kv.Key + "=" + System.Net.WebUtility.UrlEncode(ConvertValueToString(kv.Value)) + "&");
+                }
+                //remove & at the end of the urlBuilder.
+                urlBuilder.Remove(urlBuilder.Length - 1, 1);
+            }
+            else if (value.GetType().IsArray || (value.GetType().IsGenericType && value is IEnumerable))
+            {
+                var index = 0;
+                foreach (var item in (IEnumerable) value)
+                {
+                    urlBuilder.Append(name + $"[{index++}]=" + System.Net.WebUtility.UrlEncode(ConvertValueToString(item)) + "&");
                 }
                 //remove & at the end of the urlBuilder.
                 urlBuilder.Remove(urlBuilder.Length - 1, 1);

--- a/framework/test/Volo.Abp.Http.Client.Tests/Volo/Abp/Http/DynamicProxying/PersonAppServiceClientProxy_Tests.cs
+++ b/framework/test/Volo.Abp.Http.Client.Tests/Volo/Abp/Http/DynamicProxying/PersonAppServiceClientProxy_Tests.cs
@@ -81,7 +81,7 @@ namespace Volo.Abp.Http.DynamicProxying
             @params.ShouldContain("Name:John");
             @params.ShouldContain("Age:36");
         }
-        
+
         [Fact]
         public async Task Delete()
         {
@@ -158,10 +158,7 @@ namespace Volo.Abp.Http.DynamicProxying
         [Fact]
         public async Task GetWithAuthorized()
         {
-            await Assert.ThrowsAnyAsync<Exception>(async () =>
-            {
-                await _peopleAppService.GetWithAuthorized();
-            });
+            await Assert.ThrowsAnyAsync<Exception>(async () => { await _peopleAppService.GetWithAuthorized(); });
         }
 
         [Fact]
@@ -176,8 +173,42 @@ namespace Volo.Abp.Http.DynamicProxying
                         Value2 = "value two",
                         Inner2 = new GetWithComplexTypeInput.GetWithComplexTypeInnerInner
                         {
-                            Value3 = "value three"
-                        }
+                            Value3 = "value three",
+                            Value4 = new Dictionary<string, string>
+                            {
+                                {"name", "john"},
+                                {"age", "36"},
+                            }
+                        },
+                    },
+                    ListInner = new List<GetWithComplexTypeInput.GetWithComplexTypeInner>
+                    {
+                        new GetWithComplexTypeInput.GetWithComplexTypeInner
+                        {
+                            Value2 = "list0 value two",
+                            Inner2 = new GetWithComplexTypeInput.GetWithComplexTypeInnerInner
+                            {
+                                Value3 = "list0 value three",
+                                Value4 = new Dictionary<string, string>
+                                {
+                                    {"name", "list0 john"},
+                                    {"age", "list0 36"},
+                                }
+                            },
+                        },
+                        new GetWithComplexTypeInput.GetWithComplexTypeInner
+                        {
+                            Value2 = "list1 value two",
+                            Inner2 = new GetWithComplexTypeInput.GetWithComplexTypeInnerInner
+                            {
+                                Value3 = "list1 value three",
+                                Value4 = new Dictionary<string, string>
+                                {
+                                    {"name", "list1 bob"},
+                                    {"age", "list1 42"},
+                                }
+                            },
+                        },
                     }
                 }
             );
@@ -185,6 +216,17 @@ namespace Volo.Abp.Http.DynamicProxying
             result.Value1.ShouldBe("value one");
             result.Inner1.Value2.ShouldBe("value two");
             result.Inner1.Inner2.Value3.ShouldBe("value three");
+            result.Inner1.Inner2.Value4.ShouldContain(kv => kv.Key == "name" && kv.Value == "john");
+            result.Inner1.Inner2.Value4.ShouldContain(kv => kv.Key == "age" && kv.Value == "36");
+            result.ListInner.Count.ShouldBe(2);
+            result.ListInner[0].Value2.ShouldBe("list0 value two");
+            result.ListInner[0].Inner2.Value3.ShouldBe("list0 value three");
+            result.ListInner[0].Inner2.Value4.ShouldContain(kv => kv.Key == "name" && kv.Value == "list0 john");
+            result.ListInner[0].Inner2.Value4.ShouldContain(kv => kv.Key == "age" && kv.Value == "list0 36");
+            result.ListInner[1].Value2.ShouldBe("list1 value two");
+            result.ListInner[1].Inner2.Value3.ShouldBe("list1 value three");
+            result.ListInner[1].Inner2.Value4.ShouldContain(kv => kv.Key == "name" && kv.Value == "list1 bob");
+            result.ListInner[1].Inner2.Value4.ShouldContain(kv => kv.Key == "age" && kv.Value == "list1 42");
         }
     }
 }

--- a/framework/test/Volo.Abp.Http.Client.Tests/Volo/Abp/Http/DynamicProxying/PersonAppServiceClientProxy_Tests.cs
+++ b/framework/test/Volo.Abp.Http.Client.Tests/Volo/Abp/Http/DynamicProxying/PersonAppServiceClientProxy_Tests.cs
@@ -47,12 +47,12 @@ namespace Volo.Abp.Http.DynamicProxying
         }
 
         [Fact]
-        public async Task GetParams()
+        public async Task GetEnumerableParams()
         {
             var id1 = Guid.NewGuid();
             var id2 = Guid.NewGuid();
 
-            var @params = await _peopleAppService.GetParams(new List<Guid>
+            var @params = await _peopleAppService.GetEnumerableParams(new List<Guid>
             {
                 id1,
                 id2
@@ -64,6 +64,24 @@ namespace Volo.Abp.Http.DynamicProxying
             @params.ShouldContain("name2");
         }
 
+
+        [Fact]
+        public async Task GetDictionaryParams()
+        {
+            var id = Guid.NewGuid();
+
+            var @params = await _peopleAppService.GetDictionaryParams(new Dictionary<string, string>
+            {
+                {"Id", id.ToString()},
+                {"Name", "John"},
+                {"Age", 36.ToString()},
+            });
+
+            @params.ShouldContain($"Id:{id}");
+            @params.ShouldContain("Name:John");
+            @params.ShouldContain("Age:36");
+        }
+        
         [Fact]
         public async Task Delete()
         {

--- a/framework/test/Volo.Abp.TestApp/Volo/Abp/TestApp/Application/Dto/GetWithComplexTypeInput.cs
+++ b/framework/test/Volo.Abp.TestApp/Volo/Abp/TestApp/Application/Dto/GetWithComplexTypeInput.cs
@@ -1,4 +1,6 @@
-﻿namespace Volo.Abp.TestApp.Application.Dto
+﻿using System.Collections.Generic;
+
+namespace Volo.Abp.TestApp.Application.Dto
 {
     public class GetWithComplexTypeInput
     {
@@ -6,15 +8,20 @@
 
         public GetWithComplexTypeInner Inner1 { get; set; }
 
+        public List<GetWithComplexTypeInner> ListInner { get; set; }
+
         public class GetWithComplexTypeInner
         {
             public string Value2 { get; set; }
             public GetWithComplexTypeInnerInner Inner2 { get; set; }
+
         }
 
         public class GetWithComplexTypeInnerInner
         {
             public string Value3 { get; set; }
+
+            public IDictionary<string, string> Value4 { get; set; }
         }
     }
 }

--- a/framework/test/Volo.Abp.TestApp/Volo/Abp/TestApp/Application/IPeopleAppService.cs
+++ b/framework/test/Volo.Abp.TestApp/Volo/Abp/TestApp/Application/IPeopleAppService.cs
@@ -11,8 +11,10 @@ namespace Volo.Abp.TestApp.Application
     {
         Task<ListResultDto<PhoneDto>> GetPhones(Guid id, GetPersonPhonesFilter filter);
 
-        Task<List<string>> GetParams(IEnumerable<Guid> ids, string[] names);
+        Task<List<string>> GetEnumerableParams(IEnumerable<Guid> ids, string[] names);
 
+        Task<List<string>> GetDictionaryParams(Dictionary<string, string> filters);
+        
         Task<PhoneDto> AddPhone(Guid id, PhoneDto phoneDto);
 
         Task RemovePhone(Guid id, string number);

--- a/framework/test/Volo.Abp.TestApp/Volo/Abp/TestApp/Application/PeopleAppService.cs
+++ b/framework/test/Volo.Abp.TestApp/Volo/Abp/TestApp/Application/PeopleAppService.cs
@@ -30,13 +30,20 @@ namespace Volo.Abp.TestApp.Application
             );
         }
 
-        public Task<List<string>> GetParams(IEnumerable<Guid> ids, string[] names)
+        public Task<List<string>> GetEnumerableParams(IEnumerable<Guid> ids, string[] names)
         {
             var @params = ids.Select(id => id.ToString("N")).ToList();
             @params.AddRange(names);
             return Task.FromResult(@params.ToList());
         }
 
+ 
+        public Task<List<string>> GetDictionaryParams(Dictionary<string, string> filters)
+        {
+            var @params = filters.Select(kv => $"{kv.Key}:{kv.Value}");
+            return Task.FromResult(@params.ToList());
+        }
+        
         public async Task<PhoneDto> AddPhone(Guid id, PhoneDto phoneDto)
         {
             var person = await GetEntityByIdAsync(id);
@@ -64,5 +71,7 @@ namespace Volo.Abp.TestApp.Application
         {
             return Task.FromResult(input);
         }
+        
+        // public Task<string> GetParams
     }
 }

--- a/npm/packs/core/src/abp.js
+++ b/npm/packs/core/src/abp.js
@@ -153,7 +153,7 @@ var abp = abp || {};
 
         for (var i = 0; i < packageMap.length; i++) {
             var map = packageMap[i];
-            if (map.name === language){
+            if (map.name === language) {
                 return map.value;
             }
         }
@@ -595,29 +595,42 @@ var abp = abp || {};
 
             if (parameterInfo.value.toJSON && typeof parameterInfo.value.toJSON === "function") {
                 qs = qs + parameterInfo.name + '=' + encodeURIComponent(parameterInfo.value.toJSON());
-            } else if (Array.isArray(parameterInfo.value) && parameterInfo.value.length) {
-                for (var j = 0; j < parameterInfo.value.length; j++) {
-                    if (j > 0) {
-                        addSeperator();
-                    }
-
-                    qs = qs + parameterInfo.name + '[' + j + ']=' + encodeURIComponent(parameterInfo.value[j]);
-                }
-            } else if (typeof parameterInfo.value === 'object' && parameterInfo.value !== null) {
-                var index = 0;
-                for (var propertyName in parameterInfo.value) {
-                    if (index > 0) {
-                        addSeperator();
-                    }
-                    qs = qs + parameterInfo.name + '.' + propertyName + '=' + encodeURIComponent(parameterInfo.value[propertyName]);
-                    index++;
-                }
+            } else if (typeof parameterInfo.value === 'object') {
+                qs = qs + abp.utils.serializeToQueryString(parameterInfo.value, parameterInfo.name);
             } else {
                 qs = qs + parameterInfo.name + '=' + encodeURIComponent(parameterInfo.value);
             }
         }
 
         return qs;
+    }
+
+    /**
+     * Serialize any object to a query string
+     * @param obj
+     * @param prefix
+     */
+    abp.utils.serializeToQueryString = function (obj, prefix) {
+        var str = [];
+        for (var prop in obj) {
+            if (obj.hasOwnProperty(prop)) {
+                var name;
+                if (prefix) {
+                    if (Array.isArray(obj)) {
+                        name = prefix + "[" + prop + "]";
+                    } else {
+                        name = prefix + "." + prop;
+                    }
+                } else {
+                    name = prop;
+                }
+                var value = obj[prop];
+                str.push((value !== null && typeof value === "object") ?
+                    abp.utils.serializeToQueryString(value, name) :
+                    encodeURIComponent(name) + "=" + encodeURIComponent(value));
+            }
+        }
+        return str.join("&");
     }
 
     /**

--- a/npm/packs/core/src/abp.js
+++ b/npm/packs/core/src/abp.js
@@ -603,6 +603,15 @@ var abp = abp || {};
 
                     qs = qs + parameterInfo.name + '[' + j + ']=' + encodeURIComponent(parameterInfo.value[j]);
                 }
+            } else if (typeof parameterInfo.value === 'object' && parameterInfo.value !== null) {
+                var index = 0;
+                for (var propertyName in parameterInfo.value) {
+                    if (index > 0) {
+                        addSeperator();
+                    }
+                    qs = qs + parameterInfo.name + '.' + propertyName + '=' + encodeURIComponent(parameterInfo.value[propertyName]);
+                    index++;
+                }
             } else {
                 qs = qs + parameterInfo.name + '=' + encodeURIComponent(parameterInfo.value);
             }


### PR DESCRIPTION
This PR handled object type of the `parameterInfo.value` in `abp.utils.buildQueryString`, in order to pass parameters as dictionary-compatible from JS to DTO.

For example, given a DTO defined:

``` csharp
public class GetListInput 
{
    public Dictionary<string, object> Filters { get; set; }
}
```

You can pass values to `Filters` from JS like this:
``` javascript
ajax: abp.libs.datatables.createAjax(myService.getList, function () {
                    return {
                        filters: {
                            name: "John",
                            age: 36
                        }
                    }
                }),
```

will generate the query string: `myService?filters.name=John&filters.age=36...`
