### PR TITLE
use InvariantCulture when normalizing container name.

### DIFF
--- a/framework/src/Volo.Abp.BlobStoring.Aliyun/Volo/Abp/BlobStoring/Aliyun/AliyunBlobNamingNormalizer.cs
+++ b/framework/src/Volo.Abp.BlobStoring.Aliyun/Volo/Abp/BlobStoring/Aliyun/AliyunBlobNamingNormalizer.cs
@@ -1,47 +1,51 @@
 ﻿using System.Globalization;
 using System.Text.RegularExpressions;
 using Volo.Abp.DependencyInjection;
+using Volo.Abp.Localization;
 
 namespace Volo.Abp.BlobStoring.Aliyun
 {
     public class AliyunBlobNamingNormalizer : IBlobNamingNormalizer, ITransientDependency
     {
         /// <summary>
-        /// Container names can contain only letters, numbers, and the dash (-) character 
-        /// they can't start or end with the dash (-) character 
+        /// Container names can contain only letters, numbers, and the dash (-) character
+        /// they can't start or end with the dash (-) character
         /// Container names must be from 3 through 63 characters long
         /// </summary>
         public virtual string NormalizeContainerName(string containerName)
         {
-            // All letters in a container name must be lowercase.
-            containerName = containerName.ToLowerInvariant();
-
-            // Container names can contain only letters, numbers, and the dash (-) character.
-            containerName = Regex.Replace(containerName, "[^a-z0-9-]", string.Empty);
-
-            // Every dash (-) character must be immediately preceded and followed by a letter or number;
-            // consecutive dashes are not permitted in container names.
-            // Container names must start or end with a letter or number
-            containerName = Regex.Replace(containerName, "-{2,}", "-");
-            containerName = Regex.Replace(containerName, "^-", string.Empty);
-            containerName = Regex.Replace(containerName, "-$", string.Empty);
-
-            // Container names must be from 3 through 63 characters long.
-            if (containerName.Length < 3)
+            using (CultureHelper.Use(CultureInfo.InvariantCulture))
             {
-                var length = containerName.Length;
-                for (var i = 0; i < 3 - length; i++)
+                // All letters in a container name must be lowercase.
+                containerName = containerName.ToLower();
+
+                // Container names can contain only letters, numbers, and the dash (-) character.
+                containerName = Regex.Replace(containerName, "[^a-z0-9-]", string.Empty);
+
+                // Every dash (-) character must be immediately preceded and followed by a letter or number;
+                // consecutive dashes are not permitted in container names.
+                // Container names must start or end with a letter or number
+                containerName = Regex.Replace(containerName, "-{2,}", "-");
+                containerName = Regex.Replace(containerName, "^-", string.Empty);
+                containerName = Regex.Replace(containerName, "-$", string.Empty);
+
+                // Container names must be from 3 through 63 characters long.
+                if (containerName.Length < 3)
                 {
-                    containerName += "0";
+                    var length = containerName.Length;
+                    for (var i = 0; i < 3 - length; i++)
+                    {
+                        containerName += "0";
+                    }
                 }
-            }
 
-            if (containerName.Length > 63)
-            {
-                containerName = containerName.Substring(0, 63);
-            }
+                if (containerName.Length > 63)
+                {
+                    containerName = containerName.Substring(0, 63);
+                }
 
-            return containerName;
+                return containerName;
+            }
         }
 
         public virtual string NormalizeBlobName(string blobName)

--- a/framework/src/Volo.Abp.BlobStoring.Aliyun/Volo/Abp/BlobStoring/Aliyun/AliyunBlobNamingNormalizer.cs
+++ b/framework/src/Volo.Abp.BlobStoring.Aliyun/Volo/Abp/BlobStoring/Aliyun/AliyunBlobNamingNormalizer.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Globalization;
+using System.Text.RegularExpressions;
 using Volo.Abp.DependencyInjection;
 
 namespace Volo.Abp.BlobStoring.Aliyun
@@ -13,7 +14,7 @@ namespace Volo.Abp.BlobStoring.Aliyun
         public virtual string NormalizeContainerName(string containerName)
         {
             // All letters in a container name must be lowercase.
-            containerName = containerName.ToLower();
+            containerName = containerName.ToLowerInvariant();
 
             // Container names can contain only letters, numbers, and the dash (-) character.
             containerName = Regex.Replace(containerName, "[^a-z0-9-]", string.Empty);

--- a/framework/src/Volo.Abp.BlobStoring.Aws/Volo/Abp/BlobStoring/Aws/AwsBlobNamingNormalizer.cs
+++ b/framework/src/Volo.Abp.BlobStoring.Aws/Volo/Abp/BlobStoring/Aws/AwsBlobNamingNormalizer.cs
@@ -1,5 +1,7 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Globalization;
+using System.Text.RegularExpressions;
 using Volo.Abp.DependencyInjection;
+using Volo.Abp.Localization;
 
 namespace Volo.Abp.BlobStoring.Aws
 {
@@ -10,35 +12,38 @@ namespace Volo.Abp.BlobStoring.Aws
         /// </summary>
         public virtual string NormalizeContainerName(string containerName)
         {
-            // All letters in a container name must be lowercase.
-            containerName = containerName.ToLowerInvariant();
-
-            // Container names can contain only letters, numbers, and the dash (-) character.
-            containerName = Regex.Replace(containerName, "[^a-z0-9-]", string.Empty);
-
-            // Every dash (-) character must be immediately preceded and followed by a letter or number;
-            // consecutive dashes are not permitted in container names.
-            // Container names must start or end with a letter or number
-            containerName = Regex.Replace(containerName, "-{2,}", "-");
-            containerName = Regex.Replace(containerName, "^-", string.Empty);
-            containerName = Regex.Replace(containerName, "-$", string.Empty);
-
-            // Container names must be from 3 through 63 characters long.
-            if (containerName.Length < 3)
+            using (CultureHelper.Use(CultureInfo.InvariantCulture))
             {
-                var length = containerName.Length;
-                for (var i = 0; i < 3 - length; i++)
+                // All letters in a container name must be lowercase.
+                containerName = containerName.ToLower();
+
+                // Container names can contain only letters, numbers, and the dash (-) character.
+                containerName = Regex.Replace(containerName, "[^a-z0-9-]", string.Empty);
+
+                // Every dash (-) character must be immediately preceded and followed by a letter or number;
+                // consecutive dashes are not permitted in container names.
+                // Container names must start or end with a letter or number
+                containerName = Regex.Replace(containerName, "-{2,}", "-");
+                containerName = Regex.Replace(containerName, "^-", string.Empty);
+                containerName = Regex.Replace(containerName, "-$", string.Empty);
+
+                // Container names must be from 3 through 63 characters long.
+                if (containerName.Length < 3)
                 {
-                    containerName += "0";
+                    var length = containerName.Length;
+                    for (var i = 0; i < 3 - length; i++)
+                    {
+                        containerName += "0";
+                    }
                 }
-            }
 
-            if (containerName.Length > 63)
-            {
-                containerName = containerName.Substring(0, 63);
-            }
+                if (containerName.Length > 63)
+                {
+                    containerName = containerName.Substring(0, 63);
+                }
 
-            return containerName;
+                return containerName;
+            }
         }
 
         /// <summary>

--- a/framework/src/Volo.Abp.BlobStoring.Aws/Volo/Abp/BlobStoring/Aws/AwsBlobNamingNormalizer.cs
+++ b/framework/src/Volo.Abp.BlobStoring.Aws/Volo/Abp/BlobStoring/Aws/AwsBlobNamingNormalizer.cs
@@ -11,7 +11,7 @@ namespace Volo.Abp.BlobStoring.Aws
         public virtual string NormalizeContainerName(string containerName)
         {
             // All letters in a container name must be lowercase.
-            containerName = containerName.ToLower();
+            containerName = containerName.ToLowerInvariant();
 
             // Container names can contain only letters, numbers, and the dash (-) character.
             containerName = Regex.Replace(containerName, "[^a-z0-9-]", string.Empty);

--- a/framework/src/Volo.Abp.BlobStoring.Azure/Volo/Abp/BlobStoring/Azure/AzureBlobNamingNormalizer.cs
+++ b/framework/src/Volo.Abp.BlobStoring.Azure/Volo/Abp/BlobStoring/Azure/AzureBlobNamingNormalizer.cs
@@ -1,5 +1,7 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Globalization;
+using System.Text.RegularExpressions;
 using Volo.Abp.DependencyInjection;
+using Volo.Abp.Localization;
 
 namespace Volo.Abp.BlobStoring.Azure
 {
@@ -10,35 +12,38 @@ namespace Volo.Abp.BlobStoring.Azure
         /// </summary>
         public virtual string NormalizeContainerName(string containerName)
         {
-            // All letters in a container name must be lowercase.
-            containerName = containerName.ToLowerInvariant();
-
-            // Container names can contain only letters, numbers, and the dash (-) character.
-            containerName = Regex.Replace(containerName, "[^a-z0-9-]", string.Empty);
-
-            // Every dash (-) character must be immediately preceded and followed by a letter or number;
-            // consecutive dashes are not permitted in container names.
-            // Container names must start or end with a letter or number
-            containerName = Regex.Replace(containerName, "-{2,}", "-");
-            containerName = Regex.Replace(containerName, "^-", string.Empty);
-            containerName = Regex.Replace(containerName, "-$", string.Empty);
-
-            // Container names must be from 3 through 63 characters long.
-            if (containerName.Length < 3)
+            using (CultureHelper.Use(CultureInfo.InvariantCulture))
             {
-                var length = containerName.Length;
-                for (var i = 0; i < 3 - length; i++)
+                // All letters in a container name must be lowercase.
+                containerName = containerName.ToLower();
+
+                // Container names can contain only letters, numbers, and the dash (-) character.
+                containerName = Regex.Replace(containerName, "[^a-z0-9-]", string.Empty);
+
+                // Every dash (-) character must be immediately preceded and followed by a letter or number;
+                // consecutive dashes are not permitted in container names.
+                // Container names must start or end with a letter or number
+                containerName = Regex.Replace(containerName, "-{2,}", "-");
+                containerName = Regex.Replace(containerName, "^-", string.Empty);
+                containerName = Regex.Replace(containerName, "-$", string.Empty);
+
+                // Container names must be from 3 through 63 characters long.
+                if (containerName.Length < 3)
                 {
-                    containerName += "0";
+                    var length = containerName.Length;
+                    for (var i = 0; i < 3 - length; i++)
+                    {
+                        containerName += "0";
+                    }
                 }
-            }
 
-            if (containerName.Length > 63)
-            {
-                containerName = containerName.Substring(0, 63);
-            }
+                if (containerName.Length > 63)
+                {
+                    containerName = containerName.Substring(0, 63);
+                }
 
-            return containerName;
+                return containerName;
+            }
         }
 
         /// <summary>

--- a/framework/src/Volo.Abp.BlobStoring.Azure/Volo/Abp/BlobStoring/Azure/AzureBlobNamingNormalizer.cs
+++ b/framework/src/Volo.Abp.BlobStoring.Azure/Volo/Abp/BlobStoring/Azure/AzureBlobNamingNormalizer.cs
@@ -11,7 +11,7 @@ namespace Volo.Abp.BlobStoring.Azure
         public virtual string NormalizeContainerName(string containerName)
         {
             // All letters in a container name must be lowercase.
-            containerName = containerName.ToLower();
+            containerName = containerName.ToLowerInvariant();
 
             // Container names can contain only letters, numbers, and the dash (-) character.
             containerName = Regex.Replace(containerName, "[^a-z0-9-]", string.Empty);

--- a/framework/src/Volo.Abp.BlobStoring.FileSystem/Volo/Abp/BlobStoring/FileSystem/FileSystemBlobNamingNormalizer.cs
+++ b/framework/src/Volo.Abp.BlobStoring.FileSystem/Volo/Abp/BlobStoring/FileSystem/FileSystemBlobNamingNormalizer.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Globalization;
 using System.Runtime;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using Volo.Abp.DependencyInjection;
+using Volo.Abp.Localization;
 
 namespace Volo.Abp.BlobStoring.FileSystem
 {
@@ -27,15 +29,18 @@ namespace Volo.Abp.BlobStoring.FileSystem
 
         protected virtual string Normalize(string fileName)
         {
-            var os = _iosPlatformProvider.GetCurrentOSPlatform();
-            if (os == OSPlatform.Windows)
+            using (CultureHelper.Use(CultureInfo.InvariantCulture))
             {
-                // A filename cannot contain any of the following characters: \ / : * ? " < > |
-                // In order to support the directory included in the blob name, remove / and \
-                fileName = Regex.Replace(fileName, "[:\\*\\?\"<>\\|]", string.Empty);
-            }
+                var os = _iosPlatformProvider.GetCurrentOSPlatform();
+                if (os == OSPlatform.Windows)
+                {
+                    // A filename cannot contain any of the following characters: \ / : * ? " < > |
+                    // In order to support the directory included in the blob name, remove / and \
+                    fileName = Regex.Replace(fileName, "[:\\*\\?\"<>\\|]", string.Empty);
+                }
 
-            return fileName;
+                return fileName;
+            }
         }
     }
 }

--- a/framework/src/Volo.Abp.BlobStoring.Minio/Volo/Abp/BlobStoring/Minio/MinioBlobNamingNormalizer.cs
+++ b/framework/src/Volo.Abp.BlobStoring.Minio/Volo/Abp/BlobStoring/Minio/MinioBlobNamingNormalizer.cs
@@ -1,5 +1,7 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Globalization;
+using System.Text.RegularExpressions;
 using Volo.Abp.DependencyInjection;
+using Volo.Abp.Localization;
 
 namespace Volo.Abp.BlobStoring.Minio
 {
@@ -10,35 +12,38 @@ namespace Volo.Abp.BlobStoring.Minio
         /// </summary>
         public virtual string NormalizeContainerName(string containerName)
         {
-            // All letters in a container name must be lowercase.
-            containerName = containerName.ToLowerInvariant();
-
-            // Container names can contain only letters, numbers, and the dash (-) character.
-            containerName = Regex.Replace(containerName, "[^a-z0-9-]", string.Empty);
-
-            // Every dash (-) character must be immediately preceded and followed by a letter or number;
-            // consecutive dashes are not permitted in container names.
-            // Container names must start or end with a letter or number
-            containerName = Regex.Replace(containerName, "-{2,}", "-");
-            containerName = Regex.Replace(containerName, "^-", string.Empty);
-            containerName = Regex.Replace(containerName, "-$", string.Empty);
-
-            // Container names must be from 3 through 63 characters long.
-            if (containerName.Length < 3)
+            using (CultureHelper.Use(CultureInfo.InvariantCulture))
             {
-                var length = containerName.Length;
-                for (var i = 0; i < 3 - length; i++)
+                // All letters in a container name must be lowercase.
+                containerName = containerName.ToLower();
+
+                // Container names can contain only letters, numbers, and the dash (-) character.
+                containerName = Regex.Replace(containerName, "[^a-z0-9-]", string.Empty);
+
+                // Every dash (-) character must be immediately preceded and followed by a letter or number;
+                // consecutive dashes are not permitted in container names.
+                // Container names must start or end with a letter or number
+                containerName = Regex.Replace(containerName, "-{2,}", "-");
+                containerName = Regex.Replace(containerName, "^-", string.Empty);
+                containerName = Regex.Replace(containerName, "-$", string.Empty);
+
+                // Container names must be from 3 through 63 characters long.
+                if (containerName.Length < 3)
                 {
-                    containerName += "0";
+                    var length = containerName.Length;
+                    for (var i = 0; i < 3 - length; i++)
+                    {
+                        containerName += "0";
+                    }
                 }
-            }
 
-            if (containerName.Length > 63)
-            {
-                containerName = containerName.Substring(0, 63);
-            }
+                if (containerName.Length > 63)
+                {
+                    containerName = containerName.Substring(0, 63);
+                }
 
-            return containerName;
+                return containerName;
+            }
         }
 
         /// <summary>

--- a/framework/src/Volo.Abp.BlobStoring.Minio/Volo/Abp/BlobStoring/Minio/MinioBlobNamingNormalizer.cs
+++ b/framework/src/Volo.Abp.BlobStoring.Minio/Volo/Abp/BlobStoring/Minio/MinioBlobNamingNormalizer.cs
@@ -11,7 +11,7 @@ namespace Volo.Abp.BlobStoring.Minio
         public virtual string NormalizeContainerName(string containerName)
         {
             // All letters in a container name must be lowercase.
-            containerName = containerName.ToLower();
+            containerName = containerName.ToLowerInvariant();
 
             // Container names can contain only letters, numbers, and the dash (-) character.
             containerName = Regex.Replace(containerName, "[^a-z0-9-]", string.Empty);


### PR DESCRIPTION
Otherwise, it will fail on machines with specific cultures (like for lowering I to i in TR culture). 