### PR TITLE
Change tenant id when seed user,role and permission grant.

### DIFF
--- a/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/IdentityDataSeeder.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/IdentityDataSeeder.cs
@@ -16,7 +16,6 @@ namespace Volo.Abp.Identity
         protected ILookupNormalizer LookupNormalizer { get; }
         protected IdentityUserManager UserManager { get; }
         protected IdentityRoleManager RoleManager { get; }
-
         protected ICurrentTenant CurrentTenant { get; }
 
         public IdentityDataSeeder(

--- a/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/IdentityDataSeeder.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/IdentityDataSeeder.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Guids;
+using Volo.Abp.MultiTenancy;
 using Volo.Abp.Uow;
 
 namespace Volo.Abp.Identity
@@ -16,13 +17,16 @@ namespace Volo.Abp.Identity
         protected IdentityUserManager UserManager { get; }
         protected IdentityRoleManager RoleManager { get; }
 
+        protected ICurrentTenant CurrentTenant { get; }
+
         public IdentityDataSeeder(
             IGuidGenerator guidGenerator,
             IIdentityRoleRepository roleRepository,
             IIdentityUserRepository userRepository,
             ILookupNormalizer lookupNormalizer,
             IdentityUserManager userManager,
-            IdentityRoleManager roleManager)
+            IdentityRoleManager roleManager,
+            ICurrentTenant currentTenant)
         {
             GuidGenerator = guidGenerator;
             RoleRepository = roleRepository;
@@ -30,6 +34,7 @@ namespace Volo.Abp.Identity
             LookupNormalizer = lookupNormalizer;
             UserManager = userManager;
             RoleManager = roleManager;
+            CurrentTenant = currentTenant;
         }
 
         [UnitOfWork]
@@ -43,52 +48,55 @@ namespace Volo.Abp.Identity
 
             var result = new IdentityDataSeedResult();
 
-            //"admin" user
-            const string adminUserName = "admin";
-            var adminUser = await UserRepository.FindByNormalizedUserNameAsync(
-                LookupNormalizer.NormalizeName(adminUserName)
-            );
-
-            if (adminUser != null)
+            using (CurrentTenant.Change(tenantId))
             {
-                return result;
-            }
+                //"admin" user
+                const string adminUserName = "admin";
+                var adminUser = await UserRepository.FindByNormalizedUserNameAsync(
+                    LookupNormalizer.NormalizeName(adminUserName)
+                );
 
-            adminUser = new IdentityUser(
-                GuidGenerator.Create(),
-                adminUserName,
-                adminEmail,
-                tenantId
-            )
-            {
-                Name = adminUserName
-            };
+                if (adminUser != null)
+                {
+                    return result;
+                }
 
-            (await UserManager.CreateAsync(adminUser, adminPassword)).CheckErrors();
-            result.CreatedAdminUser = true;
-
-            //"admin" role
-            const string adminRoleName = "admin";
-            var adminRole = await RoleRepository.FindByNormalizedNameAsync(LookupNormalizer.NormalizeName(adminRoleName));
-            if (adminRole == null)
-            {
-                adminRole = new IdentityRole(
+                adminUser = new IdentityUser(
                     GuidGenerator.Create(),
-                    adminRoleName,
+                    adminUserName,
+                    adminEmail,
                     tenantId
                 )
                 {
-                    IsStatic = true,
-                    IsPublic = true
+                    Name = adminUserName
                 };
 
-                (await RoleManager.CreateAsync(adminRole)).CheckErrors();
-                result.CreatedAdminRole = true;
+                (await UserManager.CreateAsync(adminUser, adminPassword)).CheckErrors();
+                result.CreatedAdminUser = true;
+
+                //"admin" role
+                const string adminRoleName = "admin";
+                var adminRole = await RoleRepository.FindByNormalizedNameAsync(LookupNormalizer.NormalizeName(adminRoleName));
+                if (adminRole == null)
+                {
+                    adminRole = new IdentityRole(
+                        GuidGenerator.Create(),
+                        adminRoleName,
+                        tenantId
+                    )
+                    {
+                        IsStatic = true,
+                        IsPublic = true
+                    };
+
+                    (await RoleManager.CreateAsync(adminRole)).CheckErrors();
+                    result.CreatedAdminRole = true;
+                }
+
+                (await UserManager.AddToRoleAsync(adminUser, adminRoleName)).CheckErrors();
+
+                return result;
             }
-
-            (await UserManager.AddToRoleAsync(adminUser, adminRoleName)).CheckErrors();
-
-            return result;
         }
     }
 }

--- a/modules/identity/test/Volo.Abp.Identity.TestBase/Volo/Abp/Identity/IdentityDataSeeder_Tests.cs
+++ b/modules/identity/test/Volo.Abp.Identity.TestBase/Volo/Abp/Identity/IdentityDataSeeder_Tests.cs
@@ -1,7 +1,9 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
 using Shouldly;
 using Volo.Abp.Modularity;
+using Volo.Abp.MultiTenancy;
 using Xunit;
 
 namespace Volo.Abp.Identity
@@ -13,6 +15,7 @@ namespace Volo.Abp.Identity
         private readonly IIdentityUserRepository _userRepository;
         private readonly IIdentityRoleRepository _roleRepository;
         private readonly ILookupNormalizer _lookupNormalizer;
+        private readonly ICurrentTenant _currentTenant;
 
         protected IdentityDataSeeder_Tests()
         {
@@ -20,6 +23,7 @@ namespace Volo.Abp.Identity
             _userRepository = GetRequiredService<IIdentityUserRepository>();
             _roleRepository = GetRequiredService<IIdentityRoleRepository>();
             _lookupNormalizer = GetRequiredService<ILookupNormalizer>();
+            _currentTenant = GetRequiredService<ICurrentTenant>();
         }
 
         [Fact]
@@ -30,6 +34,26 @@ namespace Volo.Abp.Identity
             (await _userRepository.FindByNormalizedUserNameAsync(_lookupNormalizer.NormalizeName("admin"))).ShouldNotBeNull();
             (await _userRepository.FindByNormalizedUserNameAsync(_lookupNormalizer.NormalizeName("admin"))).Name.ShouldBe("admin");
             (await _roleRepository.FindByNormalizedNameAsync(_lookupNormalizer.NormalizeName("admin"))).ShouldNotBeNull();
+        }
+
+        [Fact]
+        public async Task Should_Create_Admin_User_And_Role_With_TenantId()
+        {
+            var tenantId = Guid.NewGuid();
+
+            await _identityDataSeeder.SeedAsync("admin@tenant.abp.io", "1q2w3E*", tenantId);
+
+            (await _userRepository.FindByNormalizedEmailAsync(_lookupNormalizer.NormalizeEmail("admin@tenant.abp.io"))).ShouldBeNull();
+
+            using (_currentTenant.Change(tenantId))
+            {
+                (await _userRepository.FindByNormalizedUserNameAsync(_lookupNormalizer.NormalizeName("admin"))).ShouldNotBeNull();
+                (await _userRepository.FindByNormalizedUserNameAsync(_lookupNormalizer.NormalizeName("admin"))).Name.ShouldBe("admin");
+                (await _userRepository.FindByNormalizedUserNameAsync(_lookupNormalizer.NormalizeName("admin"))).TenantId.ShouldBe(tenantId);
+
+                (await _roleRepository.FindByNormalizedNameAsync(_lookupNormalizer.NormalizeName("admin"))).ShouldNotBeNull();
+                (await _roleRepository.FindByNormalizedNameAsync(_lookupNormalizer.NormalizeName("admin"))).TenantId.ShouldBe(tenantId);
+            }
         }
     }
 }

--- a/modules/permission-management/test/Volo.Abp.PermissionManagement.Domain.Tests/Volo/Abp/PermissionManagement/PermissionDataSeeder_Tests.cs
+++ b/modules/permission-management/test/Volo.Abp.PermissionManagement.Domain.Tests/Volo/Abp/PermissionManagement/PermissionDataSeeder_Tests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 using Shouldly;
+using Volo.Abp.MultiTenancy;
 using Xunit;
 
 namespace Volo.Abp.PermissionManagement
@@ -11,11 +12,13 @@ namespace Volo.Abp.PermissionManagement
     {
         private readonly IPermissionDataSeeder _permissionDataSeeder;
         private readonly IPermissionGrantRepository _grantpermissionGrantRepository;
+        private readonly ICurrentTenant _currentTenant;
 
         public PermissionDataSeeder_Tests()
         {
             _permissionDataSeeder = GetRequiredService<IPermissionDataSeeder>();
             _grantpermissionGrantRepository = GetRequiredService<IPermissionGrantRepository>();
+            _currentTenant = GetRequiredService<ICurrentTenant>();
         }
 
         [Fact]
@@ -32,7 +35,37 @@ namespace Volo.Abp.PermissionManagement
 
             (await _grantpermissionGrantRepository.FindAsync("MyPermission1", "Test", "Test")).ShouldNotBeNull();
             (await _grantpermissionGrantRepository.FindAsync("MyPermission2", "Test", "Test")).ShouldNotBeNull();
+        }
 
+        [Fact]
+        public async Task Seed_With_TenantId()
+        {
+            //Seed without tenant
+            await _permissionDataSeeder.SeedAsync("Test", "Test", new List<string>()
+            {
+                "MyPermission1",
+                "MyPermission2"
+            });
+
+            var tenantId = Guid.NewGuid();
+
+            using (_currentTenant.Change(tenantId))
+            {
+                (await _grantpermissionGrantRepository.FindAsync("MyPermission1", "Test", "Test")).ShouldBeNull();
+                (await _grantpermissionGrantRepository.FindAsync("MyPermission2", "Test", "Test")).ShouldBeNull();
+            }
+
+            await _permissionDataSeeder.SeedAsync("Test", "Test", new List<string>()
+            {
+                "MyPermission1",
+                "MyPermission2"
+            }, tenantId);
+
+            using (_currentTenant.Change(tenantId))
+            {
+                (await _grantpermissionGrantRepository.FindAsync("MyPermission1", "Test", "Test")).ShouldNotBeNull();
+                (await _grantpermissionGrantRepository.FindAsync("MyPermission2", "Test", "Test")).ShouldNotBeNull();
+            }
         }
     }
 }


### PR DESCRIPTION
Any `IDataSeedContributor `should consider the `TenantId `of the `DataSeedContext`.