### PR TITLE
Add appsettings to enable/disable Redis as distributed cache

### DIFF
--- a/docs/en/Redis-Cache.md
+++ b/docs/en/Redis-Cache.md
@@ -25,9 +25,11 @@ Volo.Abp.Caching.StackExchangeRedis package automatically gets the redis [config
 
 ````js
 "Redis": { 
+ "IsEnabled": "true",
  "Configuration": "127.0.0.1"
 }
 ````
+The setting `IsEnabled` is optional and will be considered `true` if it is not set.
 
 Alternatively you can configure the standard [RedisCacheOptions](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.caching.stackexchangeredis.rediscacheoptions) [options](Options.md) class in the `ConfigureServices` method of your [module](Module-Development-Basics.md):
 

--- a/framework/src/Volo.Abp.Caching.StackExchangeRedis/Volo/Abp/Caching/StackExchangeRedis/AbpCachingStackExchangeRedisModule.cs
+++ b/framework/src/Volo.Abp.Caching.StackExchangeRedis/Volo/Abp/Caching/StackExchangeRedis/AbpCachingStackExchangeRedisModule.cs
@@ -14,17 +14,21 @@ namespace Volo.Abp.Caching.StackExchangeRedis
         public override void ConfigureServices(ServiceConfigurationContext context)
         {
             var configuration = context.Services.GetConfiguration();
-            
-            context.Services.AddStackExchangeRedisCache(options =>
-            {
-                var redisConfiguration = configuration["Redis:Configuration"];
-                if (!redisConfiguration.IsNullOrEmpty())
-                {
-                    options.Configuration = configuration["Redis:Configuration"];
-                }
-            });
 
-            context.Services.Replace(ServiceDescriptor.Singleton<IDistributedCache, AbpRedisCache>());
+            var redisEnabled = configuration["Redis:IsEnabled"];
+            if (redisEnabled.IsNullOrEmpty() || bool.Parse(redisEnabled))
+            {
+                context.Services.AddStackExchangeRedisCache(options =>
+                {
+                    var redisConfiguration = configuration["Redis:Configuration"];
+                    if (!redisConfiguration.IsNullOrEmpty())
+                    {
+                        options.Configuration = redisConfiguration;
+                    }
+                });
+
+                context.Services.Replace(ServiceDescriptor.Singleton<IDistributedCache, AbpRedisCache>());
+            }
         }
     }
 }


### PR DESCRIPTION
To allow switching between In-Memory and Redis as a distributed cache.
Background: sometimes we want to stop using Redis (on production) for some reason while don't want to rebuilt and redeploy the app.