### PR TITLE
Improve EFCoreRepositoryExtensions.

### DIFF
--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/Domain/Repositories/EfCoreRepositoryExtensions.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/Domain/Repositories/EfCoreRepositoryExtensions.cs
@@ -9,28 +9,27 @@ namespace Volo.Abp.Domain.Repositories
 
     public static class EfCoreRepositoryExtensions
     {
-        public static DbContext GetDbContext<TEntity, TKey>(this IReadOnlyBasicRepository<TEntity, TKey> repository)
-            where TEntity : class, IEntity<TKey>
+        public static DbContext GetDbContext<TEntity>(this IReadOnlyBasicRepository<TEntity> repository)
+            where TEntity : class, IEntity
         {
             return repository.ToEfCoreRepository().DbContext;
         }
 
-        public static DbSet<TEntity> GetDbSet<TEntity, TKey>(this IReadOnlyBasicRepository<TEntity, TKey> repository)
-            where TEntity : class, IEntity<TKey>
+        public static DbSet<TEntity> GetDbSet<TEntity>(this IReadOnlyBasicRepository<TEntity> repository)
+            where TEntity : class, IEntity
         {
             return repository.ToEfCoreRepository().DbSet;
         }
 
-        public static IEfCoreRepository<TEntity, TKey> ToEfCoreRepository<TEntity, TKey>(this IReadOnlyBasicRepository<TEntity, TKey> repository)
-            where TEntity : class, IEntity<TKey>
+        public static IEfCoreRepository<TEntity> ToEfCoreRepository<TEntity>(this IReadOnlyBasicRepository<TEntity> repository)
+            where TEntity : class, IEntity
         {
-            var efCoreRepository = repository as IEfCoreRepository<TEntity, TKey>;
-            if (efCoreRepository == null)
+            if (repository is IEfCoreRepository<TEntity> efCoreRepository)
             {
-                throw new ArgumentException("Given repository does not implement " + typeof(IEfCoreRepository<TEntity, TKey>).AssemblyQualifiedName, nameof(repository));
+                return efCoreRepository;
             }
 
-            return efCoreRepository;
+            throw new ArgumentException("Given repository does not implement " + typeof(IEfCoreRepository<TEntity>).AssemblyQualifiedName, nameof(repository));
         }
     }
 }

--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/Domain/Repositories/EfCoreRepositoryExtensions.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/Domain/Repositories/EfCoreRepositoryExtensions.cs
@@ -5,8 +5,6 @@ using Volo.Abp.Domain.Repositories.EntityFrameworkCore;
 
 namespace Volo.Abp.Domain.Repositories
 {
-    //TODO: Should work for any IRepository implementation
-
     public static class EfCoreRepositoryExtensions
     {
         public static DbContext GetDbContext<TEntity>(this IReadOnlyBasicRepository<TEntity> repository)


### PR DESCRIPTION
A simple improvement, please reference changed files.

The `IReadOnlyBasicRepository<TEntity, TKey>` is a subclass of `IReadOnlyBasicRepository<TEntity>`.
as well as,
`IEFCoreRepository<TEntity, TKey>` inherit of `IEFCoreRepository<TEntity>`.
`IEntity<TKey>` inherit of `IEntity`.

So we can make them all be super class/interface for more general.