### PR TITLE
Unify route format: checkPassword -> check-password.

### DIFF
--- a/modules/account/src/Volo.Abp.Account.Web/Areas/Account/Controllers/AccountController.cs
+++ b/modules/account/src/Volo.Abp.Account.Web/Areas/Account/Controllers/AccountController.cs
@@ -83,6 +83,14 @@ namespace Volo.Abp.Account.Web.Areas.Account.Controllers
 
         [HttpPost]
         [Route("checkPassword")]
+        [ApiExplorerSettings(IgnoreApi = true)]
+        public virtual Task<AbpLoginResult> CheckPasswordCompatible(UserLoginInfo login)
+        {
+            return CheckPassword(login);
+        }
+
+        [HttpPost]
+        [Route("check-password")]
         public virtual async Task<AbpLoginResult> CheckPassword(UserLoginInfo login)
         {
             ValidateLoginInfo(login);


### PR DESCRIPTION
I found abp usually uses dash-separated route format. Such as:
- /api/abp/api-definition
- /api/abp/application-configuration
- /api/abp/multi-tenancy/tenants/by-name/{name}
- /api/identity/my-profile/change-password

But there is a exception that uses camelCase:
- /api/account/checkPassword

I want to unify them and keep the old route for compatible. Please check the changes.