### PR TITLE
Add ViewComponent to DynamicProxyIgnoreTypes.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AbpAspNetCoreMvcModule.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AbpAspNetCoreMvcModule.cs
@@ -55,6 +55,7 @@ namespace Volo.Abp.AspNetCore.Mvc
         {
             DynamicProxyIgnoreTypes.Add<ControllerBase>();
             DynamicProxyIgnoreTypes.Add<PageModel>();
+            DynamicProxyIgnoreTypes.Add<ViewComponent>();
 
             context.Services.AddConventionalRegistrar(new AbpAspNetCoreMvcConventionalRegistrar());
         }


### PR DESCRIPTION
Although **AbpViewComponent** does not use any interceptors, we need to avoid this situation.