### PR TITLE
Do not validate for primitive objects.

### DIFF
--- a/docs/en/Validation.md
+++ b/docs/en/Validation.md
@@ -112,6 +112,29 @@ namespace Acme.BookStore
 
 > ABP framework uses the [dynamic proxying / interception](Dynamic-Proxying-Interceptors.md) system to perform the validation. In order to make it working, your method should be **virtual** or your service should be injected and used over an **interface** (like `IMyService`).
 
+#### Enabling/Disabling Validation
+
+You can use the `[DisableValidation]` to disable it for methods, classs and properties.
+
+````csharp
+[DisableValidation]
+public Void MyMethod()
+{
+}
+
+[DisableValidation]
+public class InputClass
+{
+    public string MyProperty { get; set; }
+}
+
+public class InputClass
+{
+    [DisableValidation]
+    public string MyProperty { get; set; }
+}
+````
+
 ### AbpValidationException
 
 Once ABP determines a validation error, it throws an exception of type `AbpValidationException`. Your application code can throw `AbpValidationException`, but most of the times it is not needed.

--- a/framework/src/Volo.Abp.Validation/Volo/Abp/Validation/DataAnnotationObjectValidationContributor.cs
+++ b/framework/src/Volo.Abp.Validation/Volo/Abp/Validation/DataAnnotationObjectValidationContributor.cs
@@ -45,12 +45,18 @@ namespace Volo.Abp.Validation
             AddErrors(errors, validatingObject);
 
             //Validate items of enumerable
-            if (validatingObject is IEnumerable)
+            if (validatingObject is IEnumerable enumerable)
             {
-                if (!(validatingObject is IQueryable))
+                if (!(enumerable is IQueryable))
                 {
-                    foreach (var item in (validatingObject as IEnumerable))
+                    foreach (var item in enumerable)
                     {
+                        //Do not recursively validate for primitive objects
+                        if (TypeHelper.IsPrimitiveExtended(item.GetType()))
+                        {
+                            break;
+                        }
+
                         ValidateObjectRecursively(errors, item, currentDepth + 1);
                     }
                 }


### PR DESCRIPTION
**string** is also **IEnumerable**, so some performance problems are solved.

https://github.com/abpframework/abp/blob/5007709e234bdd52ae28d2b2c520e602a2ec1ba2/framework/src/Volo.Abp.Validation/Volo/Abp/Validation/DataAnnotationObjectValidationContributor.cs#L61-L67