### PR TITLE
Use user-defined menus in Blazor's LoginDisplay.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Components.WebAssembly.BasicTheme/Themes/Basic/LoginDisplay.razor
+++ b/framework/src/Volo.Abp.AspNetCore.Components.WebAssembly.BasicTheme/Themes/Basic/LoginDisplay.razor
@@ -25,7 +25,7 @@
                 {
                     @foreach (var menuItem in Menu.Items)
                     {
-                        <DropdownItem Clicked="@(() => NavigateToAsync(menuItem.Url, menuItem.Target))">@menuItem.DisplayName</DropdownItem>
+                        <DropdownItem Clicked="@(() => NavigateTo(menuItem.Url))">@menuItem.DisplayName</DropdownItem>
                     }
                 }
                 <DropdownDivider />
@@ -39,21 +39,14 @@
 </AuthorizeView>
 @code{
 
-    private async Task NavigateToAsync(string uri, string target = "_self")
+    private void NavigateTo(string uri, string target = "_self")
     {
-        if (target == "_blank")
-        {
-            await JsRuntime.InvokeVoidAsync("open", uri, "_blank");
-        }
-        else
-        {
-            Navigation.NavigateTo(uri);
-        }
+        Navigation.NavigateTo(uri);
     }
 
     private async Task BeginSignOut()
     {
         await SignOutManager.SetSignOutState();
-        await NavigateToAsync("authentication/logout");
+        NavigateTo("authentication/logout");
     }
 }

--- a/framework/src/Volo.Abp.AspNetCore.Components.WebAssembly.BasicTheme/Themes/Basic/LoginDisplay.razor
+++ b/framework/src/Volo.Abp.AspNetCore.Components.WebAssembly.BasicTheme/Themes/Basic/LoginDisplay.razor
@@ -1,6 +1,8 @@
 ﻿@using Microsoft.AspNetCore.Components.WebAssembly.Authentication
 @using Volo.Abp.Users
 @using Volo.Abp.MultiTenancy
+@using Volo.Abp.UI.Navigation
+@inject IJSRuntime JsRuntime
 @inject ICurrentUser CurrentUser
 @inject ICurrentTenant CurrentTenant
 @inject NavigationManager Navigation
@@ -23,12 +25,9 @@
                 {
                     @foreach (var menuItem in Menu.Items)
                     {
-                        <DropdownItem Clicked="@(() => NavigateTo(menuItem.Url))">@menuItem.DisplayName</DropdownItem>
+                        <DropdownItem Clicked="@(() => NavigateToAsync(menuItem.Url, menuItem.Target))">@menuItem.DisplayName</DropdownItem>
                     }
                 }
-                <a class="dropdown-item" href="@ServerAccountUrl">
-                    @UiLocalizer["ManageYourAccount"]
-                </a>
                 <DropdownDivider />
                 <DropdownItem Clicked="BeginSignOut">Logout</DropdownItem>
             </DropdownMenu>
@@ -40,14 +39,21 @@
 </AuthorizeView>
 @code{
 
-    private void NavigateTo(string uri)
+    private async Task NavigateToAsync(string uri, string target = "_self")
     {
-        Navigation.NavigateTo(uri);
+        if (target == "_blank")
+        {
+            await JsRuntime.InvokeVoidAsync("open", uri, "_blank");
+        }
+        else
+        {
+            Navigation.NavigateTo(uri);
+        }
     }
 
     private async Task BeginSignOut()
     {
         await SignOutManager.SetSignOutState();
-        NavigateTo("authentication/logout");
+        await NavigateToAsync("authentication/logout");
     }
 }

--- a/framework/src/Volo.Abp.AspNetCore.Components.WebAssembly.BasicTheme/Themes/Basic/LoginDisplay.razor
+++ b/framework/src/Volo.Abp.AspNetCore.Components.WebAssembly.BasicTheme/Themes/Basic/LoginDisplay.razor
@@ -1,8 +1,6 @@
 ﻿@using Microsoft.AspNetCore.Components.WebAssembly.Authentication
 @using Volo.Abp.Users
 @using Volo.Abp.MultiTenancy
-@using Volo.Abp.UI.Navigation
-@inject IJSRuntime JsRuntime
 @inject ICurrentUser CurrentUser
 @inject ICurrentTenant CurrentTenant
 @inject NavigationManager Navigation

--- a/framework/src/Volo.Abp.AspNetCore.Components.WebAssembly.BasicTheme/Themes/Basic/LoginDisplay.razor
+++ b/framework/src/Volo.Abp.AspNetCore.Components.WebAssembly.BasicTheme/Themes/Basic/LoginDisplay.razor
@@ -39,7 +39,7 @@
 </AuthorizeView>
 @code{
 
-    private void NavigateTo(string uri, string target = "_self")
+    private void NavigateTo(string uri)
     {
         Navigation.NavigateTo(uri);
     }

--- a/framework/src/Volo.Abp.AspNetCore.Components.WebAssembly.BasicTheme/Themes/Basic/LoginDisplay.razor.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Components.WebAssembly.BasicTheme/Themes/Basic/LoginDisplay.razor.cs
@@ -12,36 +12,29 @@ namespace Volo.Abp.AspNetCore.Components.WebAssembly.BasicTheme.Themes.Basic
 {
     public partial class LoginDisplay : IDisposable
     {
-        [Inject] 
+        [Inject]
         protected IMenuManager MenuManager { get; set; }
-        
+
         [Inject]
         protected IStringLocalizer<AbpUiResource> UiLocalizer { get; set; }
-        
+
         [Inject]
         protected IOptions<AbpRemoteServiceOptions> RemoteServiceOptions { get; set; }
-        
-        protected ApplicationMenu Menu { get; set; }
 
-        protected string ServerUrl { get; set; }
-        protected string ServerAccountUrl { get; set; }
+        protected ApplicationMenu Menu { get; set; }
 
         protected override async Task OnInitializedAsync()
         {
             Menu = await MenuManager.GetAsync(StandardMenus.User);
-            
-            ServerUrl = RemoteServiceOptions.Value.RemoteServices.Default?.BaseUrl?.TrimEnd('/');
-            ServerAccountUrl = ServerUrl + "/Account/Manage?returnUrl=" + Navigation.Uri;
-            
+
             Navigation.LocationChanged += OnLocationChanged;
         }
 
         protected virtual void OnLocationChanged(object sender, LocationChangedEventArgs e)
         {
-            ServerAccountUrl = ServerUrl + "/Account/Manage?returnUrl=" + Navigation.Uri;
             StateHasChanged();
         }
-        
+
         public void Dispose()
         {
             Navigation.LocationChanged -= OnLocationChanged;

--- a/framework/src/Volo.Abp.AspNetCore.Components.WebAssembly.BasicTheme/Themes/Basic/LoginDisplay.razor.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Components.WebAssembly.BasicTheme/Themes/Basic/LoginDisplay.razor.cs
@@ -1,11 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Localization.Resources.AbpUi;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Routing;
-using Microsoft.Extensions.Localization;
-using Microsoft.Extensions.Options;
-using Volo.Abp.Http.Client;
 using Volo.Abp.UI.Navigation;
 
 namespace Volo.Abp.AspNetCore.Components.WebAssembly.BasicTheme.Themes.Basic

--- a/framework/src/Volo.Abp.AspNetCore.Components.WebAssembly.BasicTheme/Themes/Basic/LoginDisplay.razor.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Components.WebAssembly.BasicTheme/Themes/Basic/LoginDisplay.razor.cs
@@ -15,12 +15,6 @@ namespace Volo.Abp.AspNetCore.Components.WebAssembly.BasicTheme.Themes.Basic
         [Inject]
         protected IMenuManager MenuManager { get; set; }
 
-        [Inject]
-        protected IStringLocalizer<AbpUiResource> UiLocalizer { get; set; }
-
-        [Inject]
-        protected IOptions<AbpRemoteServiceOptions> RemoteServiceOptions { get; set; }
-
         protected ApplicationMenu Menu { get; set; }
 
         protected override async Task OnInitializedAsync()

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor/MyProjectNameBlazorModule.cs
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor/MyProjectNameBlazorModule.cs
@@ -55,7 +55,7 @@ namespace MyCompanyName.MyProjectName.Blazor
         {
             Configure<AbpNavigationOptions>(options =>
             {
-                options.MenuContributors.Add(new MyProjectNameMenuContributor());
+                options.MenuContributors.Add(new MyProjectNameMenuContributor(context.Services.GetConfiguration()));
             });
         }
 

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor/MyProjectNameMenuContributor.cs
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor/MyProjectNameMenuContributor.cs
@@ -1,18 +1,37 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using MyCompanyName.MyProjectName.Localization;
+using Volo.Abp.Account.Localization;
 using Volo.Abp.UI.Navigation;
+using Volo.Abp.Users;
 
 namespace MyCompanyName.MyProjectName.Blazor
 {
     public class MyProjectNameMenuContributor : IMenuContributor
     {
-        public Task ConfigureMenuAsync(MenuConfigurationContext context)
-        {
-            if(context.Menu.DisplayName != StandardMenus.Main)
-            {
-                return Task.CompletedTask;
-            }
+        private readonly IConfiguration _configuration;
 
+        public MyProjectNameMenuContributor(IConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        public async Task ConfigureMenuAsync(MenuConfigurationContext context)
+        {
+            if (context.Menu.Name == StandardMenus.Main)
+            {
+                await ConfigureMainMenuAsync(context);
+            }
+            else if (context.Menu.Name == StandardMenus.User)
+            {
+                await ConfigureUserMenuAsync(context);
+            }
+        }
+
+        private Task ConfigureMainMenuAsync(MenuConfigurationContext context)
+        {
             var l = context.GetLocalizer<MyProjectNameResource>();
 
             context.Menu.Items.Insert(
@@ -24,6 +43,28 @@ namespace MyCompanyName.MyProjectName.Blazor
                     icon: "fas fa-home"
                 )
             );
+
+            return Task.CompletedTask;
+        }
+
+        private Task ConfigureUserMenuAsync(MenuConfigurationContext context)
+        {
+            var accountStringLocalizer = context.GetLocalizer<AccountResource>();
+            var currentUser = context.ServiceProvider.GetRequiredService<ICurrentUser>();
+
+            var identityServerUrl = _configuration["AuthServer:Authority"] ?? "";
+
+            if (currentUser.IsAuthenticated)
+            {
+                context.Menu.AddItem(new ApplicationMenuItem(
+                    "Account.Manage",
+                    accountStringLocalizer["ManageYourProfile"],
+                    $"{identityServerUrl.EnsureEndsWith('/')}Account/Manage",
+                    icon: "fa fa-cog",
+                    order: 1000,
+                    null,
+                    "_blank"));
+            }
 
             return Task.CompletedTask;
         }


### PR DESCRIPTION
Fix #5970

`InvokeVoidAsync` caused an exception, and I did find a solution. ,
```cs
await JsRuntime.InvokeVoidAsync("open", uri, "_blank");
```
```cs
blazor.webassembly.js:1 Uncaught (in promise) TypeError: Converting circular structure to JSON
    --> starting at object with constructor 'Window'
    --- property 'window' closes the circle
    at JSON.stringify (<anonymous>)
    at blazor.webassembly.js:1
```