### PR TITLE
Tenant modals validation

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Components.WebAssembly/Volo/Abp/AspNetCore/Components/WebAssembly/AbpBlazorMessageLocalizerHelper.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Components.WebAssembly/Volo/Abp/AspNetCore/Components/WebAssembly/AbpBlazorMessageLocalizerHelper.cs
@@ -3,13 +3,13 @@ using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Extensions.Localization;
 
-namespace Volo.Abp.Identity.Blazor
+namespace Volo.Abp.AspNetCore.Components.WebAssembly
 {
-    public class AbpIdentityBlazorMessageLocalizerHelper<T>
+    public class AbpBlazorMessageLocalizerHelper<T>
     {
         private readonly IStringLocalizer<T> stringLocalizer;
 
-        public AbpIdentityBlazorMessageLocalizerHelper(IStringLocalizer<T> stringLocalizer)
+        public AbpBlazorMessageLocalizerHelper(IStringLocalizer<T> stringLocalizer)
         {
             this.stringLocalizer = stringLocalizer;
         }

--- a/framework/src/Volo.Abp.BlazoriseUI/AbpBlazoriseModule.cs
+++ b/framework/src/Volo.Abp.BlazoriseUI/AbpBlazoriseModule.cs
@@ -1,4 +1,5 @@
 ﻿using Blazorise;
+using Microsoft.Extensions.DependencyInjection;
 using Volo.Abp.AspNetCore.Components.WebAssembly;
 using Volo.Abp.Modularity;
 
@@ -18,6 +19,8 @@ namespace Volo.Abp.BlazoriseUI
         {
             context.Services
                 .AddBlazorise();
+
+            context.Services.AddSingleton(typeof(AbpBlazorMessageLocalizerHelper<>));
         }
     }
 }

--- a/modules/identity/src/Volo.Abp.Identity.Blazor/AbpIdentityBlazorModule.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Blazor/AbpIdentityBlazorModule.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Volo.Abp.AspNetCore.Components.WebAssembly.Theming.Routing;
 using Volo.Abp.AutoMapper;
+using Volo.Abp.BlazoriseUI;
 using Volo.Abp.Modularity;
 using Volo.Abp.PermissionManagement.Blazor;
 using Volo.Abp.UI.Navigation;
@@ -10,7 +11,8 @@ namespace Volo.Abp.Identity.Blazor
     [DependsOn(
         typeof(AbpIdentityHttpApiClientModule),
         typeof(AbpAutoMapperModule),
-        typeof(AbpPermissionManagementBlazorModule)
+        typeof(AbpPermissionManagementBlazorModule),
+        typeof(AbpBlazoriseUIModule)
         )]
     public class AbpIdentityBlazorModule : AbpModule
     {
@@ -32,8 +34,6 @@ namespace Volo.Abp.Identity.Blazor
             {
                 options.AdditionalAssemblies.Add(typeof(AbpIdentityBlazorModule).Assembly);
             });
-
-            context.Services.AddSingleton(typeof(AbpIdentityBlazorMessageLocalizerHelper<>));
         }
     }
 }

--- a/modules/identity/src/Volo.Abp.Identity.Blazor/Pages/Identity/RoleManagement.razor
+++ b/modules/identity/src/Volo.Abp.Identity.Blazor/Pages/Identity/RoleManagement.razor
@@ -6,10 +6,9 @@
 @using Volo.Abp.PermissionManagement.Blazor.Components
 @using Microsoft.Extensions.Localization
 @using Volo.Abp.Identity.Localization
-@inject AbpIdentityBlazorMessageLocalizerHelper<IdentityResource> LH
+@inject AbpBlazorMessageLocalizerHelper<IdentityResource> LH
 
 @inherits AbpCrudPageBase<IIdentityRoleAppService, IdentityRoleDto, Guid, GetIdentityRolesInput, IdentityRoleCreateDto, IdentityRoleUpdateDto>
-
 @* ************************* PAGE HEADER ************************* *@
 <Row>
     <Column ColumnSize="ColumnSize.Is6">

--- a/modules/identity/src/Volo.Abp.Identity.Blazor/Pages/Identity/UserManagement.razor
+++ b/modules/identity/src/Volo.Abp.Identity.Blazor/Pages/Identity/UserManagement.razor
@@ -186,7 +186,7 @@
                 <CloseButton Clicked="CloseEditModalAsync" />
             </ModalHeader>
             <ModalBody>
-                <Validations @ref="@EditValidationsRef" Model="@NewEntity" ValidateOnLoad="false">
+                <Validations @ref="@EditValidationsRef" Model="@EditingEntity" ValidateOnLoad="false">
                     <input type="hidden" name="ConcurrencyStamp" @bind-value="EditingEntity.ConcurrencyStamp" />
 
                     <Tabs @bind-SelectedTab="@EditModalSelectedTab">

--- a/modules/identity/src/Volo.Abp.Identity.Blazor/Pages/Identity/UserManagement.razor
+++ b/modules/identity/src/Volo.Abp.Identity.Blazor/Pages/Identity/UserManagement.razor
@@ -1,14 +1,13 @@
 ﻿@page "/identity/users"
-@attribute [Authorize(IdentityPermissions.Users.Default)]
+@attribute [Authorize( IdentityPermissions.Users.Default )]
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Components.Forms
 @using Volo.Abp.PermissionManagement.Blazor.Components
 @using Microsoft.Extensions.Localization
 @using Volo.Abp.Identity.Localization
+@inject AbpBlazorMessageLocalizerHelper<IdentityResource> LH
 
 @inherits AbpCrudPageBase<IIdentityUserAppService, IdentityUserDto, Guid, GetIdentityUsersInput, IdentityUserCreateDto, IdentityUserUpdateDto>
-
-@inject AbpIdentityBlazorMessageLocalizerHelper<IdentityResource> LH
 @* ************************* PAGE HEADER ************************* *@
 <Row>
     <Column ColumnSize="ColumnSize.Is6">

--- a/modules/tenant-management/src/Volo.Abp.TenantManagement.Application.Contracts/Volo/Abp/TenantManagement/TenantCreateOrUpdateDtoBase.cs
+++ b/modules/tenant-management/src/Volo.Abp.TenantManagement.Application.Contracts/Volo/Abp/TenantManagement/TenantCreateOrUpdateDtoBase.cs
@@ -8,11 +8,12 @@ namespace Volo.Abp.TenantManagement
     {
         [Required]
         [DynamicStringLength(typeof(TenantConsts), nameof(TenantConsts.MaxNameLength))]
+        [Display(Name = "TenantName")]
         public string Name { get; set; }
 
         public TenantCreateOrUpdateDtoBase() : base(false)
         {
-            
+
         }
     }
 }

--- a/modules/tenant-management/src/Volo.Abp.TenantManagement.Blazor/Pages/TenantManagement/TenantManagement.razor
+++ b/modules/tenant-management/src/Volo.Abp.TenantManagement.Blazor/Pages/TenantManagement/TenantManagement.razor
@@ -1,15 +1,15 @@
 ﻿@page "/tenant-management/tenants"
-@attribute [Authorize(TenantManagementPermissions.Tenants.Default)]
+@attribute [Authorize( TenantManagementPermissions.Tenants.Default )]
 @using Microsoft.AspNetCore.Authorization
 @using Volo.Abp.FeatureManagement.Blazor.Components
 @using Microsoft.AspNetCore.Components.Forms
-
+@using Volo.Abp.TenantManagement.Localization
+@inject AbpBlazorMessageLocalizerHelper<AbpTenantManagementResource> LH
 @inherits AbpCrudPageBase<ITenantAppService, TenantDto, Guid, GetTenantsInput, TenantCreateDto, TenantUpdateDto>
-
 @* ************************* PAGE HEADER ************************* *@
 <Row>
     <Column ColumnSize="ColumnSize.Is6">
-        <h1>@L["Tenants"]</h1>
+        <Heading Size="HeadingSize.Is1">@L["Tenants"]</Heading>
     </Column>
     <Column ColumnSize="ColumnSize.Is6">
         @if (HasCreatePermission)
@@ -65,31 +65,52 @@
 {
     <Modal @ref="CreateModal">
         <ModalBackdrop />
-        <ModalContent IsCentered="true">
-            <ModalHeader>
-                <ModalTitle>@L["NewTenant"]</ModalTitle>
-                <CloseButton Clicked="CloseCreateModalAsync" />
-            </ModalHeader>
-            <ModalBody>
-                <EditForm id="TenantCreateForm" Model="@NewEntity" OnValidSubmit="CreateEntityAsync">
-                    <Field>
-                        <FieldLabel>@L["TenantName"]</FieldLabel>
-                        <TextEdit @bind-text="@NewEntity.Name" />
-                    </Field>
-                    <Field>
-                        <FieldLabel>@L["DisplayName:AdminEmailAddress"]</FieldLabel>
-                        <TextEdit Role="@TextRole.Email" @bind-text="@NewEntity.AdminEmailAddress" />
-                    </Field>
-                    <Field>
-                        <FieldLabel>@L["DisplayName:AdminPassword"]</FieldLabel>
-                        <TextEdit Role="@TextRole.Password" @bind-text="@NewEntity.AdminPassword" />
-                    </Field>
-                </EditForm>
-            </ModalBody>
-            <ModalFooter>
-                <Button Color="Color.Secondary" Clicked="CloseCreateModalAsync">@L["Cancel"]</Button>
-                <Button form="TenantCreateForm" Color="Color.Primary" Clicked="CreateEntityAsync">@L["Save"]</Button>
-            </ModalFooter>
+        <ModalContent Centered="true">
+            <Form id="TenantCreateForm">
+                <ModalHeader>
+                    <ModalTitle>@L["NewTenant"]</ModalTitle>
+                    <CloseButton Clicked="CloseCreateModalAsync" />
+                </ModalHeader>
+                <ModalBody>
+
+                    <Validations @ref="@CreateValidationsRef" Model="@NewEntity" ValidateOnLoad="false">
+                        <Validation MessageLocalizer="@LH.Localize">
+                            <Field>
+                                <FieldLabel>@L["TenantName"]</FieldLabel>
+                                <TextEdit @bind-Text="@NewEntity.Name">
+                                    <Feedback>
+                                        <ValidationError />
+                                    </Feedback>
+                                </TextEdit>
+                            </Field>
+                        </Validation>
+                        <Validation MessageLocalizer="@LH.Localize">
+                            <Field>
+                                <FieldLabel>@L["DisplayName:AdminEmailAddress"]</FieldLabel>
+                                <TextEdit Role="@TextRole.Email" @bind-Text="@NewEntity.AdminEmailAddress">
+                                    <Feedback>
+                                        <ValidationError />
+                                    </Feedback>
+                                </TextEdit>
+                            </Field>
+                        </Validation>
+                        <Validation MessageLocalizer="@LH.Localize">
+                            <Field>
+                                <FieldLabel>@L["DisplayName:AdminPassword"]</FieldLabel>
+                                <TextEdit Role="@TextRole.Password" @bind-Text="@NewEntity.AdminPassword">
+                                    <Feedback>
+                                        <ValidationError />
+                                    </Feedback>
+                                </TextEdit>
+                            </Field>
+                        </Validation>
+                    </Validations>
+                </ModalBody>
+                <ModalFooter>
+                    <Button Color="Color.Secondary" Clicked="CloseCreateModalAsync">@L["Cancel"]</Button>
+                    <Button form="TenantCreateForm" Type="ButtonType.Submit" PreventDefaultOnSubmit="true" Color="Color.Primary" Clicked="CreateEntityAsync">@L["Save"]</Button>
+                </ModalFooter>
+            </Form>
         </ModalContent>
     </Modal>
 }
@@ -99,23 +120,31 @@
 {
     <Modal @ref="EditModal">
         <ModalBackdrop />
-        <ModalContent IsCentered="true">
-            <ModalHeader>
-                <ModalTitle>@L["Edit"]</ModalTitle>
-                <CloseButton Clicked="CloseEditModalAsync" />
-            </ModalHeader>
-            <ModalBody>
-                <EditForm id="TenantEditForm" Model="@EditingEntity" OnValidSubmit="UpdateEntityAsync">
-                    <Field>
-                        <FieldLabel>@L["TenantName"]</FieldLabel>
-                        <TextEdit @bind-text="@EditingEntity.Name" />
-                    </Field>
-                </EditForm>
-            </ModalBody>
-            <ModalFooter>
-                <Button Color="Color.Secondary" Clicked="CloseEditModalAsync">@L["Cancel"]</Button>
-                <Button form="TenantEditForm" Color="Color.Primary" Clicked="UpdateEntityAsync">@L["Save"]</Button>
-            </ModalFooter>
+        <ModalContent Centered="true">
+            <Form id="TenantEditForm">
+                <ModalHeader>
+                    <ModalTitle>@L["Edit"]</ModalTitle>
+                    <CloseButton Clicked="CloseEditModalAsync" />
+                </ModalHeader>
+                <ModalBody>
+                    <Validations @ref="@EditValidationsRef" Model="@EditingEntity" ValidateOnLoad="false">
+                        <Validation MessageLocalizer="@LH.Localize">
+                            <Field>
+                                <FieldLabel>@L["TenantName"]</FieldLabel>
+                                <TextEdit @bind-Text="@EditingEntity.Name">
+                                    <Feedback>
+                                        <ValidationError />
+                                    </Feedback>
+                                </TextEdit>
+                            </Field>
+                        </Validation>
+                    </Validations>
+                </ModalBody>
+                <ModalFooter>
+                    <Button Color="Color.Secondary" Clicked="CloseEditModalAsync">@L["Cancel"]</Button>
+                    <Button form="TenantEditForm" Type="ButtonType.Submit" PreventDefaultOnSubmit="true" Color="Color.Primary" Clicked="UpdateEntityAsync">@L["Save"]</Button>
+                </ModalFooter>
+            </Form>
         </ModalContent>
     </Modal>
 }
@@ -125,30 +154,36 @@
 {
     <Modal @ref="@ManageConnectionStringModal">
         <ModalBackdrop />
-        <ModalContent IsCentered="true">
-            <ModalHeader>
-                <ModalTitle>@L["ConnectionStrings"]</ModalTitle>
-                <CloseButton Clicked="CloseEditConnectionStringModal" />
-            </ModalHeader>
-            <ModalBody>
-                <EditForm id="ConnectionStringEditForm" Model="@TenantInfo" OnValidSubmit="UpdateConnectionStringAsync">
-                    <Field>
-                        <FieldLabel>@L["DisplayName:DefaultConnectionString"]</FieldLabel>
-                        <Check TValue="bool" @bind-Checked="@TenantInfo.UseSharedDatabase" Cursor="@Cursor.Pointer" />
-                    </Field>
-                    @if (!TenantInfo.UseSharedDatabase)
-                    {
-                        <Field>
-                            <FieldLabel>@L["DisplayName:DefaultConnectionString"]</FieldLabel>
-                            <TextEdit @bind-text="@TenantInfo.DefaultConnectionString" />
-                        </Field>
-                    }
-                </EditForm>
-            </ModalBody>
-            <ModalFooter>
-                <Button Color="Color.Secondary" Clicked="CloseEditConnectionStringModal">@L["Cancel"]</Button>
-                <Button form="ConnectionStringEditForm" Color="Color.Primary" Clicked="UpdateConnectionStringAsync">@L["Save"]</Button>
-            </ModalFooter>
+        <ModalContent Centered="true">
+            <Form id="ConnectionStringEditForm">
+                <ModalHeader>
+                    <ModalTitle>@L["ConnectionStrings"]</ModalTitle>
+                    <CloseButton Clicked="CloseEditConnectionStringModal" />
+                </ModalHeader>
+                <ModalBody>
+                    <Validations @ref="@ManageConnectionStringValidations" Model="@TenantInfo" ValidateOnLoad="false">
+                        <Validation MessageLocalizer="@LH.Localize">
+                            <Field>
+                                <FieldLabel>@L["DisplayName:DefaultConnectionString"]</FieldLabel>
+                                <Check TValue="bool" @bind-Checked="@TenantInfo.UseSharedDatabase" Cursor="@Cursor.Pointer" />
+                            </Field>
+                        </Validation>
+                        @if (!TenantInfo.UseSharedDatabase)
+                        {
+                            <Validation MessageLocalizer="@LH.Localize">
+                                <Field>
+                                    <FieldLabel>@L["DisplayName:DefaultConnectionString"]</FieldLabel>
+                                    <TextEdit @bind-Text="@TenantInfo.DefaultConnectionString" />
+                                </Field>
+                            </Validation>
+                        }
+                    </Validations>
+                </ModalBody>
+                <ModalFooter>
+                    <Button Color="Color.Secondary" Clicked="CloseEditConnectionStringModal">@L["Cancel"]</Button>
+                    <Button form="ConnectionStringEditForm" Type="ButtonType.Submit" PreventDefaultOnSubmit="true" Color="Color.Primary" Clicked="UpdateConnectionStringAsync">@L["Save"]</Button>
+                </ModalFooter>
+            </Form>
         </ModalContent>
     </Modal>
 }


### PR DESCRIPTION
resolve #6026

- Blazorise validation for create, edit and connection string modals
- Fixed display name localization for tenant model
- modal can be submitted with enter key
- Fixed user edit modal