### PR TITLE
Add AbpStringToEnumConverter & AbpStringToBooleanConverter.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/Json/AbpJsonOptionsSetup.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/Json/AbpJsonOptionsSetup.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -23,6 +24,9 @@ namespace Volo.Abp.AspNetCore.Mvc.Json
 
             options.JsonSerializerOptions.Converters.Add(ServiceProvider.GetRequiredService<AbpDateTimeConverter>());
             options.JsonSerializerOptions.Converters.Add(ServiceProvider.GetRequiredService<AbpNullableDateTimeConverter>());
+
+            options.JsonSerializerOptions.Converters.Add(new AbpStringToEnumConverter());
+            options.JsonSerializerOptions.Converters.Add(new AbpStringToBooleanConverter());
         }
     }
 }

--- a/framework/src/Volo.Abp.Json/Volo/Abp/Json/SystemTextJson/AbpSystemTextJsonSerializerOptionsSetup.cs
+++ b/framework/src/Volo.Abp.Json/Volo/Abp/Json/SystemTextJson/AbpSystemTextJsonSerializerOptionsSetup.cs
@@ -1,10 +1,9 @@
 ﻿using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using Volo.Abp.Json.SystemTextJson;
 using Volo.Abp.Json.SystemTextJson.JsonConverters;
 
-namespace Volo.Abp.Json
+namespace Volo.Abp.Json.SystemTextJson
 {
     public class AbpSystemTextJsonSerializerOptionsSetup : IConfigureOptions<AbpSystemTextJsonSerializerOptions>
     {
@@ -19,6 +18,9 @@ namespace Volo.Abp.Json
         {
             options.JsonSerializerOptions.Converters.Add(ServiceProvider.GetRequiredService<AbpDateTimeConverter>());
             options.JsonSerializerOptions.Converters.Add(ServiceProvider.GetRequiredService<AbpNullableDateTimeConverter>());
+
+            options.JsonSerializerOptions.Converters.Add(new AbpStringToEnumConverter());
+            options.JsonSerializerOptions.Converters.Add(new AbpStringToBooleanConverter());
         }
     }
 }

--- a/framework/src/Volo.Abp.Json/Volo/Abp/Json/SystemTextJson/JsonConverters/AbpStringToBooleanConverter.cs
+++ b/framework/src/Volo.Abp.Json/Volo/Abp/Json/SystemTextJson/JsonConverters/AbpStringToBooleanConverter.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Buffers;
+using System.Buffers.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Volo.Abp.Json.SystemTextJson.JsonConverters
+{
+    public class AbpStringToBooleanConverter : JsonConverter<bool>
+    {
+        public override bool Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                var span = reader.HasValueSequence ? reader.ValueSequence.ToArray() : reader.ValueSpan;
+                if (Utf8Parser.TryParse(span, out bool b1, out var bytesConsumed) && span.Length == bytesConsumed)
+                {
+                    return b1;
+                }
+
+                if (bool.TryParse(reader.GetString(), out var b2))
+                {
+                    return b2;
+                }
+            }
+
+            return reader.GetBoolean();
+        }
+
+        public override void Write(Utf8JsonWriter writer, bool value, JsonSerializerOptions options)
+        {
+            var newOptions = new JsonSerializerOptions(options);
+            newOptions.Converters.Remove(this);
+            var entityConverter = (JsonConverter<bool>)newOptions.GetConverter(typeof(bool));
+            entityConverter.Write(writer, value, newOptions);
+        }
+    }
+}

--- a/framework/src/Volo.Abp.Json/Volo/Abp/Json/SystemTextJson/JsonConverters/AbpStringToEnumConverter.cs
+++ b/framework/src/Volo.Abp.Json/Volo/Abp/Json/SystemTextJson/JsonConverters/AbpStringToEnumConverter.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Volo.Abp.Json.SystemTextJson.JsonConverters
+{
+    public class AbpStringToEnumConverter : JsonConverter<object>
+    {
+        private readonly JsonStringEnumConverter _innerJsonStringEnumConverter;
+
+        public AbpStringToEnumConverter()
+            : this(namingPolicy: null, allowIntegerValues: true)
+        {
+        }
+
+        public AbpStringToEnumConverter(JsonNamingPolicy namingPolicy = null, bool allowIntegerValues = true)
+        {
+            _innerJsonStringEnumConverter = new JsonStringEnumConverter(namingPolicy, allowIntegerValues);
+        }
+
+        public override bool CanConvert(Type typeToConvert)
+        {
+            return typeToConvert.IsEnum;
+        }
+
+        public override object Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var newOptions = new JsonSerializerOptions(options);
+            newOptions.Converters.Remove(this);
+            newOptions.Converters.Add(_innerJsonStringEnumConverter.CreateConverter(typeToConvert, options));
+            return JsonSerializer.Deserialize(ref reader, typeToConvert, newOptions);
+        }
+
+        public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
+        {
+            var newOptions = new JsonSerializerOptions(options);
+            newOptions.Converters.Remove(this);
+            JsonSerializer.Serialize(writer, value, newOptions);
+        }
+    }
+}

--- a/framework/src/Volo.Abp.Json/Volo/Abp/Json/SystemTextJson/JsonConverters/AbpStringToEnumConverter.cs
+++ b/framework/src/Volo.Abp.Json/Volo/Abp/Json/SystemTextJson/JsonConverters/AbpStringToEnumConverter.cs
@@ -27,7 +27,7 @@ namespace Volo.Abp.Json.SystemTextJson.JsonConverters
         {
             var newOptions = new JsonSerializerOptions(options);
             newOptions.Converters.Remove(this);
-            newOptions.Converters.Add(_innerJsonStringEnumConverter.CreateConverter(typeToConvert, options));
+            newOptions.Converters.Add(_innerJsonStringEnumConverter.CreateConverter(typeToConvert, newOptions));
             return JsonSerializer.Deserialize(ref reader, typeToConvert, newOptions);
         }
 


### PR DESCRIPTION
Resolve #6092

The project may use **string** in JSON as the **enum and bool** values. We want to read them correctly, but we don’t want to   write **enum and bool** as **string** anymore.

BTW: Angular is using the **enum as int** now. 

Input:
```json
{
  "remember": "false",
  "day": "Monday",
}
```

output:
```json
{
  "remember": false,
  "day": 0
}
```