### PR TITLE
Proxy Generator: Enable optional string properties in models

### DIFF
--- a/npm/ng-packs/packages/schematics/src/mocks/api-definition.json
+++ b/npm/ng-packs/packages/schematics/src/mocks/api-definition.json
@@ -1,5 +1,1019 @@
 ﻿{
   "modules": {
+    "identityServer": {
+      "rootPath": "identityServer",
+      "remoteServiceName": "AbpIdentityServer",
+      "controllers": {
+        "Volo.Abp.IdentityServer.ApiResourcesController": {
+          "controllerName": "ApiResources",
+          "type": "Volo.Abp.IdentityServer.ApiResourcesController",
+          "interfaces": [
+            {
+              "type": "Volo.Abp.IdentityServer.ApiResource.IApiResourceAppService"
+            }
+          ],
+          "actions": {
+            "GetListAsyncByInput": {
+              "uniqueName": "GetListAsyncByInput",
+              "name": "GetListAsync",
+              "httpMethod": "GET",
+              "url": "api/identity-server/api-resources",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Abp.IdentityServer.ApiResource.Dtos.GetApiResourceListInput, Volo.Abp.IdentityServer.Application.Contracts",
+                  "type": "Volo.Abp.IdentityServer.ApiResource.Dtos.GetApiResourceListInput",
+                  "typeSimple": "Volo.Abp.IdentityServer.ApiResource.Dtos.GetApiResourceListInput",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "input",
+                  "name": "Filter",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "Sorting",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "SkipCount",
+                  "type": "System.Int32",
+                  "typeSimple": "number",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "MaxResultCount",
+                  "type": "System.Int32",
+                  "typeSimple": "number",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.Application.Dtos.PagedResultDto<Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceWithDetailsDto>",
+                "typeSimple": "Volo.Abp.Application.Dtos.PagedResultDto<Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceWithDetailsDto>"
+              }
+            },
+            "GetAllListAsync": {
+              "uniqueName": "GetAllListAsync",
+              "name": "GetAllListAsync",
+              "httpMethod": "GET",
+              "url": "api/identity-server/api-resources/all",
+              "supportedVersions": [],
+              "parametersOnMethod": [],
+              "parameters": [],
+              "returnValue": {
+                "type": "System.Collections.Generic.List<Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceWithDetailsDto>",
+                "typeSimple": "[Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceWithDetailsDto]"
+              }
+            },
+            "GetAsyncById": {
+              "uniqueName": "GetAsyncById",
+              "name": "GetAsync",
+              "httpMethod": "GET",
+              "url": "api/identity-server/api-resources/{id}",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "id",
+                  "typeAsString": "System.Guid, System.Private.CoreLib",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "id",
+                  "name": "id",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceWithDetailsDto",
+                "typeSimple": "Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceWithDetailsDto"
+              }
+            },
+            "CreateAsyncByInput": {
+              "uniqueName": "CreateAsyncByInput",
+              "name": "CreateAsync",
+              "httpMethod": "POST",
+              "url": "api/identity-server/api-resources",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Abp.IdentityServer.ApiResource.Dtos.CreateApiResourceDto, Volo.Abp.IdentityServer.Application.Contracts",
+                  "type": "Volo.Abp.IdentityServer.ApiResource.Dtos.CreateApiResourceDto",
+                  "typeSimple": "Volo.Abp.IdentityServer.ApiResource.Dtos.CreateApiResourceDto",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "input",
+                  "name": "input",
+                  "type": "Volo.Abp.IdentityServer.ApiResource.Dtos.CreateApiResourceDto",
+                  "typeSimple": "Volo.Abp.IdentityServer.ApiResource.Dtos.CreateApiResourceDto",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "Body",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceWithDetailsDto",
+                "typeSimple": "Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceWithDetailsDto"
+              }
+            },
+            "UpdateAsyncByIdAndInput": {
+              "uniqueName": "UpdateAsyncByIdAndInput",
+              "name": "UpdateAsync",
+              "httpMethod": "PUT",
+              "url": "api/identity-server/api-resources/{id}",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "id",
+                  "typeAsString": "System.Guid, System.Private.CoreLib",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                },
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Abp.IdentityServer.ApiResource.Dtos.UpdateApiResourceDto, Volo.Abp.IdentityServer.Application.Contracts",
+                  "type": "Volo.Abp.IdentityServer.ApiResource.Dtos.UpdateApiResourceDto",
+                  "typeSimple": "Volo.Abp.IdentityServer.ApiResource.Dtos.UpdateApiResourceDto",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "id",
+                  "name": "id",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "input",
+                  "type": "Volo.Abp.IdentityServer.ApiResource.Dtos.UpdateApiResourceDto",
+                  "typeSimple": "Volo.Abp.IdentityServer.ApiResource.Dtos.UpdateApiResourceDto",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "Body",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceWithDetailsDto",
+                "typeSimple": "Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceWithDetailsDto"
+              }
+            },
+            "DeleteAsyncById": {
+              "uniqueName": "DeleteAsyncById",
+              "name": "DeleteAsync",
+              "httpMethod": "DELETE",
+              "url": "api/identity-server/api-resources",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "id",
+                  "typeAsString": "System.Guid, System.Private.CoreLib",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "id",
+                  "name": "id",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "System.Void",
+                "typeSimple": "System.Void"
+              }
+            }
+          }
+        },
+        "Volo.Abp.IdentityServer.ApiScopesController": {
+          "controllerName": "ApiScopes",
+          "type": "Volo.Abp.IdentityServer.ApiScopesController",
+          "interfaces": [
+            {
+              "type": "Volo.Abp.IdentityServer.ApiScope.IApiScopeAppService"
+            }
+          ],
+          "actions": {
+            "GetListAsyncByInput": {
+              "uniqueName": "GetListAsyncByInput",
+              "name": "GetListAsync",
+              "httpMethod": "GET",
+              "url": "api/identity-server/apiScopes",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Abp.IdentityServer.ApiScope.Dtos.GetApiScopeListInput, Volo.Abp.IdentityServer.Application.Contracts",
+                  "type": "Volo.Abp.IdentityServer.ApiScope.Dtos.GetApiScopeListInput",
+                  "typeSimple": "Volo.Abp.IdentityServer.ApiScope.Dtos.GetApiScopeListInput",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "input",
+                  "name": "Filter",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "Sorting",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "SkipCount",
+                  "type": "System.Int32",
+                  "typeSimple": "number",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "MaxResultCount",
+                  "type": "System.Int32",
+                  "typeSimple": "number",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.Application.Dtos.PagedResultDto<Volo.Abp.IdentityServer.ApiScope.Dtos.ApiScopeWithDetailsDto>",
+                "typeSimple": "Volo.Abp.Application.Dtos.PagedResultDto<Volo.Abp.IdentityServer.ApiScope.Dtos.ApiScopeWithDetailsDto>"
+              }
+            },
+            "GetAllListAsync": {
+              "uniqueName": "GetAllListAsync",
+              "name": "GetAllListAsync",
+              "httpMethod": "GET",
+              "url": "api/identity-server/apiScopes/all",
+              "supportedVersions": [],
+              "parametersOnMethod": [],
+              "parameters": [],
+              "returnValue": {
+                "type": "System.Collections.Generic.List<Volo.Abp.IdentityServer.ApiScope.Dtos.ApiScopeWithDetailsDto>",
+                "typeSimple": "[Volo.Abp.IdentityServer.ApiScope.Dtos.ApiScopeWithDetailsDto]"
+              }
+            },
+            "GetAsyncById": {
+              "uniqueName": "GetAsyncById",
+              "name": "GetAsync",
+              "httpMethod": "GET",
+              "url": "api/identity-server/apiScopes/{id}",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "id",
+                  "typeAsString": "System.Guid, System.Private.CoreLib",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "id",
+                  "name": "id",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.IdentityServer.ApiScope.Dtos.ApiScopeWithDetailsDto",
+                "typeSimple": "Volo.Abp.IdentityServer.ApiScope.Dtos.ApiScopeWithDetailsDto"
+              }
+            },
+            "CreateAsyncByInput": {
+              "uniqueName": "CreateAsyncByInput",
+              "name": "CreateAsync",
+              "httpMethod": "POST",
+              "url": "api/identity-server/apiScopes",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Abp.IdentityServer.ApiScope.Dtos.CreateApiScopeDto, Volo.Abp.IdentityServer.Application.Contracts",
+                  "type": "Volo.Abp.IdentityServer.ApiScope.Dtos.CreateApiScopeDto",
+                  "typeSimple": "Volo.Abp.IdentityServer.ApiScope.Dtos.CreateApiScopeDto",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "input",
+                  "name": "input",
+                  "type": "Volo.Abp.IdentityServer.ApiScope.Dtos.CreateApiScopeDto",
+                  "typeSimple": "Volo.Abp.IdentityServer.ApiScope.Dtos.CreateApiScopeDto",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "Body",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.IdentityServer.ApiScope.Dtos.ApiScopeWithDetailsDto",
+                "typeSimple": "Volo.Abp.IdentityServer.ApiScope.Dtos.ApiScopeWithDetailsDto"
+              }
+            },
+            "UpdateAsyncByIdAndInput": {
+              "uniqueName": "UpdateAsyncByIdAndInput",
+              "name": "UpdateAsync",
+              "httpMethod": "PUT",
+              "url": "api/identity-server/apiScopes/{id}",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "id",
+                  "typeAsString": "System.Guid, System.Private.CoreLib",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                },
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Abp.IdentityServer.ApiScope.Dtos.UpdateApiScopeDto, Volo.Abp.IdentityServer.Application.Contracts",
+                  "type": "Volo.Abp.IdentityServer.ApiScope.Dtos.UpdateApiScopeDto",
+                  "typeSimple": "Volo.Abp.IdentityServer.ApiScope.Dtos.UpdateApiScopeDto",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "id",
+                  "name": "id",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "input",
+                  "type": "Volo.Abp.IdentityServer.ApiScope.Dtos.UpdateApiScopeDto",
+                  "typeSimple": "Volo.Abp.IdentityServer.ApiScope.Dtos.UpdateApiScopeDto",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "Body",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.IdentityServer.ApiScope.Dtos.ApiScopeWithDetailsDto",
+                "typeSimple": "Volo.Abp.IdentityServer.ApiScope.Dtos.ApiScopeWithDetailsDto"
+              }
+            },
+            "DeleteAsyncById": {
+              "uniqueName": "DeleteAsyncById",
+              "name": "DeleteAsync",
+              "httpMethod": "DELETE",
+              "url": "api/identity-server/apiScopes",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "id",
+                  "typeAsString": "System.Guid, System.Private.CoreLib",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "id",
+                  "name": "id",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "System.Void",
+                "typeSimple": "System.Void"
+              }
+            }
+          }
+        },
+        "Volo.Abp.IdentityServer.ClientsController": {
+          "controllerName": "Clients",
+          "type": "Volo.Abp.IdentityServer.ClientsController",
+          "interfaces": [
+            {
+              "type": "Volo.Abp.IdentityServer.Client.IClientAppService"
+            }
+          ],
+          "actions": {
+            "GetListAsyncByInput": {
+              "uniqueName": "GetListAsyncByInput",
+              "name": "GetListAsync",
+              "httpMethod": "GET",
+              "url": "api/identity-server/clients",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Abp.IdentityServer.Client.Dtos.GetClientListInput, Volo.Abp.IdentityServer.Application.Contracts",
+                  "type": "Volo.Abp.IdentityServer.Client.Dtos.GetClientListInput",
+                  "typeSimple": "Volo.Abp.IdentityServer.Client.Dtos.GetClientListInput",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "input",
+                  "name": "Filter",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "Sorting",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "SkipCount",
+                  "type": "System.Int32",
+                  "typeSimple": "number",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "MaxResultCount",
+                  "type": "System.Int32",
+                  "typeSimple": "number",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.Application.Dtos.PagedResultDto<Volo.Abp.IdentityServer.Client.Dtos.ClientWithDetailsDto>",
+                "typeSimple": "Volo.Abp.Application.Dtos.PagedResultDto<Volo.Abp.IdentityServer.Client.Dtos.ClientWithDetailsDto>"
+              }
+            },
+            "GetAsyncById": {
+              "uniqueName": "GetAsyncById",
+              "name": "GetAsync",
+              "httpMethod": "GET",
+              "url": "api/identity-server/clients/{id}",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "id",
+                  "typeAsString": "System.Guid, System.Private.CoreLib",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "id",
+                  "name": "id",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.IdentityServer.Client.Dtos.ClientWithDetailsDto",
+                "typeSimple": "Volo.Abp.IdentityServer.Client.Dtos.ClientWithDetailsDto"
+              }
+            },
+            "CreateAsyncByInput": {
+              "uniqueName": "CreateAsyncByInput",
+              "name": "CreateAsync",
+              "httpMethod": "POST",
+              "url": "api/identity-server/clients",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Abp.IdentityServer.Client.Dtos.CreateClientDto, Volo.Abp.IdentityServer.Application.Contracts",
+                  "type": "Volo.Abp.IdentityServer.Client.Dtos.CreateClientDto",
+                  "typeSimple": "Volo.Abp.IdentityServer.Client.Dtos.CreateClientDto",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "input",
+                  "name": "input",
+                  "type": "Volo.Abp.IdentityServer.Client.Dtos.CreateClientDto",
+                  "typeSimple": "Volo.Abp.IdentityServer.Client.Dtos.CreateClientDto",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "Body",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.IdentityServer.Client.Dtos.ClientWithDetailsDto",
+                "typeSimple": "Volo.Abp.IdentityServer.Client.Dtos.ClientWithDetailsDto"
+              }
+            },
+            "UpdateAsyncByIdAndInput": {
+              "uniqueName": "UpdateAsyncByIdAndInput",
+              "name": "UpdateAsync",
+              "httpMethod": "PUT",
+              "url": "api/identity-server/clients/{id}",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "id",
+                  "typeAsString": "System.Guid, System.Private.CoreLib",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                },
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Abp.IdentityServer.Client.Dtos.UpdateClientDto, Volo.Abp.IdentityServer.Application.Contracts",
+                  "type": "Volo.Abp.IdentityServer.Client.Dtos.UpdateClientDto",
+                  "typeSimple": "Volo.Abp.IdentityServer.Client.Dtos.UpdateClientDto",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "id",
+                  "name": "id",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "input",
+                  "type": "Volo.Abp.IdentityServer.Client.Dtos.UpdateClientDto",
+                  "typeSimple": "Volo.Abp.IdentityServer.Client.Dtos.UpdateClientDto",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "Body",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.IdentityServer.Client.Dtos.ClientWithDetailsDto",
+                "typeSimple": "Volo.Abp.IdentityServer.Client.Dtos.ClientWithDetailsDto"
+              }
+            },
+            "DeleteAsyncById": {
+              "uniqueName": "DeleteAsyncById",
+              "name": "DeleteAsync",
+              "httpMethod": "DELETE",
+              "url": "api/identity-server/clients",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "id",
+                  "typeAsString": "System.Guid, System.Private.CoreLib",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "id",
+                  "name": "id",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "System.Void",
+                "typeSimple": "System.Void"
+              }
+            }
+          }
+        },
+        "Volo.Abp.IdentityServer.IdentityResourcesController": {
+          "controllerName": "IdentityResources",
+          "type": "Volo.Abp.IdentityServer.IdentityResourcesController",
+          "interfaces": [
+            {
+              "type": "Volo.Abp.IdentityServer.IdentityResource.IIdentityResourceAppService"
+            }
+          ],
+          "actions": {
+            "GetListAsyncByInput": {
+              "uniqueName": "GetListAsyncByInput",
+              "name": "GetListAsync",
+              "httpMethod": "GET",
+              "url": "api/identity-server/identity-resources",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Abp.IdentityServer.IdentityResource.Dtos.GetIdentityResourceListInput, Volo.Abp.IdentityServer.Application.Contracts",
+                  "type": "Volo.Abp.IdentityServer.IdentityResource.Dtos.GetIdentityResourceListInput",
+                  "typeSimple": "Volo.Abp.IdentityServer.IdentityResource.Dtos.GetIdentityResourceListInput",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "input",
+                  "name": "Filter",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "Sorting",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "SkipCount",
+                  "type": "System.Int32",
+                  "typeSimple": "number",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "MaxResultCount",
+                  "type": "System.Int32",
+                  "typeSimple": "number",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.Application.Dtos.PagedResultDto<Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityResourceWithDetailsDto>",
+                "typeSimple": "Volo.Abp.Application.Dtos.PagedResultDto<Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityResourceWithDetailsDto>"
+              }
+            },
+            "GetAllListAsync": {
+              "uniqueName": "GetAllListAsync",
+              "name": "GetAllListAsync",
+              "httpMethod": "GET",
+              "url": "api/identity-server/identity-resources/all",
+              "supportedVersions": [],
+              "parametersOnMethod": [],
+              "parameters": [],
+              "returnValue": {
+                "type": "System.Collections.Generic.List<Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityResourceWithDetailsDto>",
+                "typeSimple": "[Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityResourceWithDetailsDto]"
+              }
+            },
+            "GetAsyncById": {
+              "uniqueName": "GetAsyncById",
+              "name": "GetAsync",
+              "httpMethod": "GET",
+              "url": "api/identity-server/identity-resources/{id}",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "id",
+                  "typeAsString": "System.Guid, System.Private.CoreLib",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "id",
+                  "name": "id",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityResourceWithDetailsDto",
+                "typeSimple": "Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityResourceWithDetailsDto"
+              }
+            },
+            "CreateAsyncByInput": {
+              "uniqueName": "CreateAsyncByInput",
+              "name": "CreateAsync",
+              "httpMethod": "POST",
+              "url": "api/identity-server/identity-resources",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Abp.IdentityServer.IdentityResource.Dtos.CreateIdentityResourceDto, Volo.Abp.IdentityServer.Application.Contracts",
+                  "type": "Volo.Abp.IdentityServer.IdentityResource.Dtos.CreateIdentityResourceDto",
+                  "typeSimple": "Volo.Abp.IdentityServer.IdentityResource.Dtos.CreateIdentityResourceDto",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "input",
+                  "name": "input",
+                  "type": "Volo.Abp.IdentityServer.IdentityResource.Dtos.CreateIdentityResourceDto",
+                  "typeSimple": "Volo.Abp.IdentityServer.IdentityResource.Dtos.CreateIdentityResourceDto",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "Body",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityResourceWithDetailsDto",
+                "typeSimple": "Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityResourceWithDetailsDto"
+              }
+            },
+            "UpdateAsyncByIdAndInput": {
+              "uniqueName": "UpdateAsyncByIdAndInput",
+              "name": "UpdateAsync",
+              "httpMethod": "PUT",
+              "url": "api/identity-server/identity-resources/{id}",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "id",
+                  "typeAsString": "System.Guid, System.Private.CoreLib",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                },
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Abp.IdentityServer.IdentityResource.Dtos.UpdateIdentityResourceDto, Volo.Abp.IdentityServer.Application.Contracts",
+                  "type": "Volo.Abp.IdentityServer.IdentityResource.Dtos.UpdateIdentityResourceDto",
+                  "typeSimple": "Volo.Abp.IdentityServer.IdentityResource.Dtos.UpdateIdentityResourceDto",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "id",
+                  "name": "id",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "input",
+                  "type": "Volo.Abp.IdentityServer.IdentityResource.Dtos.UpdateIdentityResourceDto",
+                  "typeSimple": "Volo.Abp.IdentityServer.IdentityResource.Dtos.UpdateIdentityResourceDto",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "Body",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityResourceWithDetailsDto",
+                "typeSimple": "Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityResourceWithDetailsDto"
+              }
+            },
+            "DeleteAsyncById": {
+              "uniqueName": "DeleteAsyncById",
+              "name": "DeleteAsync",
+              "httpMethod": "DELETE",
+              "url": "api/identity-server/identity-resources",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "id",
+                  "typeAsString": "System.Guid, System.Private.CoreLib",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "id",
+                  "name": "id",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "System.Void",
+                "typeSimple": "System.Void"
+              }
+            },
+            "CreateStandardResourcesAsync": {
+              "uniqueName": "CreateStandardResourcesAsync",
+              "name": "CreateStandardResourcesAsync",
+              "httpMethod": "POST",
+              "url": "api/identity-server/identity-resources/create-standard-resources",
+              "supportedVersions": [],
+              "parametersOnMethod": [],
+              "parameters": [],
+              "returnValue": {
+                "type": "System.Void",
+                "typeSimple": "System.Void"
+              }
+            }
+          }
+        },
+        "Volo.Abp.IdentityServer.IdentityServerClaimTypesController": {
+          "controllerName": "IdentityServerClaimTypes",
+          "type": "Volo.Abp.IdentityServer.IdentityServerClaimTypesController",
+          "interfaces": [
+            {
+              "type": "Volo.Abp.IdentityServer.ClaimType.IIdentityServerClaimTypeAppService"
+            }
+          ],
+          "actions": {
+            "GetListAsync": {
+              "uniqueName": "GetListAsync",
+              "name": "GetListAsync",
+              "httpMethod": "GET",
+              "url": "api/identity-server/claim-types",
+              "supportedVersions": [],
+              "parametersOnMethod": [],
+              "parameters": [],
+              "returnValue": {
+                "type": "System.Collections.Generic.List<Volo.Abp.IdentityServer.ClaimType.Dtos.IdentityClaimTypeDto>",
+                "typeSimple": "[Volo.Abp.IdentityServer.ClaimType.Dtos.IdentityClaimTypeDto]"
+              }
+            }
+          }
+        }
+      }
+    },
     "leptonThemeManagement": {
       "rootPath": "leptonThemeManagement",
       "remoteServiceName": "LeptonThemeManagement",
@@ -48,6 +1062,1394 @@
                   "name": "input",
                   "type": "Volo.Abp.LeptonTheme.Management.UpdateLeptonThemeSettingsDto",
                   "typeSimple": "Volo.Abp.LeptonTheme.Management.UpdateLeptonThemeSettingsDto",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "Body",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "System.Void",
+                "typeSimple": "System.Void"
+              }
+            }
+          }
+        }
+      }
+    },
+    "account": {
+      "rootPath": "account",
+      "remoteServiceName": "AbpAccountPublic",
+      "controllers": {
+        "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.AccountController": {
+          "controllerName": "Account",
+          "type": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.AccountController",
+          "interfaces": [],
+          "actions": {
+            "LoginByLogin": {
+              "uniqueName": "LoginByLogin",
+              "name": "Login",
+              "httpMethod": "POST",
+              "url": "api/account/login",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "login",
+                  "typeAsString": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.UserLoginInfo, Volo.Abp.Account.Pro.Public.Web",
+                  "type": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.UserLoginInfo",
+                  "typeSimple": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.UserLoginInfo",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "login",
+                  "name": "login",
+                  "type": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.UserLoginInfo",
+                  "typeSimple": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.UserLoginInfo",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "Body",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.AbpLoginResult",
+                "typeSimple": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.AbpLoginResult"
+              }
+            },
+            "LinkLoginByLogin": {
+              "uniqueName": "LinkLoginByLogin",
+              "name": "LinkLogin",
+              "httpMethod": "POST",
+              "url": "api/account/linkLogin",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "login",
+                  "typeAsString": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.LinkUserLoginInfo, Volo.Abp.Account.Pro.Public.Web",
+                  "type": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.LinkUserLoginInfo",
+                  "typeSimple": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.LinkUserLoginInfo",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "login",
+                  "name": "login",
+                  "type": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.LinkUserLoginInfo",
+                  "typeSimple": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.LinkUserLoginInfo",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "Body",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.AbpLoginResult",
+                "typeSimple": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.AbpLoginResult"
+              }
+            },
+            "Logout": {
+              "uniqueName": "Logout",
+              "name": "Logout",
+              "httpMethod": "GET",
+              "url": "api/account/logout",
+              "supportedVersions": [],
+              "parametersOnMethod": [],
+              "parameters": [],
+              "returnValue": {
+                "type": "System.Void",
+                "typeSimple": "System.Void"
+              }
+            },
+            "CheckPasswordByLogin": {
+              "uniqueName": "CheckPasswordByLogin",
+              "name": "CheckPassword",
+              "httpMethod": "POST",
+              "url": "api/account/checkPassword",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "login",
+                  "typeAsString": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.UserLoginInfo, Volo.Abp.Account.Pro.Public.Web",
+                  "type": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.UserLoginInfo",
+                  "typeSimple": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.UserLoginInfo",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "login",
+                  "name": "login",
+                  "type": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.UserLoginInfo",
+                  "typeSimple": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.UserLoginInfo",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "Body",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.AbpLoginResult",
+                "typeSimple": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.AbpLoginResult"
+              }
+            }
+          }
+        },
+        "Volo.Abp.Account.AccountController": {
+          "controllerName": "Account",
+          "type": "Volo.Abp.Account.AccountController",
+          "interfaces": [
+            {
+              "type": "Volo.Abp.Account.IAccountAppService"
+            }
+          ],
+          "actions": {
+            "RegisterAsyncByInput": {
+              "uniqueName": "RegisterAsyncByInput",
+              "name": "RegisterAsync",
+              "httpMethod": "POST",
+              "url": "api/account/register",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Abp.Account.RegisterDto, Volo.Abp.Account.Pro.Public.Application.Contracts",
+                  "type": "Volo.Abp.Account.RegisterDto",
+                  "typeSimple": "Volo.Abp.Account.RegisterDto",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "input",
+                  "name": "input",
+                  "type": "Volo.Abp.Account.RegisterDto",
+                  "typeSimple": "Volo.Abp.Account.RegisterDto",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "Body",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.Identity.IdentityUserDto",
+                "typeSimple": "Volo.Abp.Identity.IdentityUserDto"
+              }
+            },
+            "SendPasswordResetCodeAsyncByInput": {
+              "uniqueName": "SendPasswordResetCodeAsyncByInput",
+              "name": "SendPasswordResetCodeAsync",
+              "httpMethod": "POST",
+              "url": "api/account/send-password-reset-code",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Abp.Account.SendPasswordResetCodeDto, Volo.Abp.Account.Pro.Public.Application.Contracts",
+                  "type": "Volo.Abp.Account.SendPasswordResetCodeDto",
+                  "typeSimple": "Volo.Abp.Account.SendPasswordResetCodeDto",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "input",
+                  "name": "input",
+                  "type": "Volo.Abp.Account.SendPasswordResetCodeDto",
+                  "typeSimple": "Volo.Abp.Account.SendPasswordResetCodeDto",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "Body",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "System.Void",
+                "typeSimple": "System.Void"
+              }
+            },
+            "ResetPasswordAsyncByInput": {
+              "uniqueName": "ResetPasswordAsyncByInput",
+              "name": "ResetPasswordAsync",
+              "httpMethod": "POST",
+              "url": "api/account/reset-password",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Abp.Account.ResetPasswordDto, Volo.Abp.Account.Pro.Public.Application.Contracts",
+                  "type": "Volo.Abp.Account.ResetPasswordDto",
+                  "typeSimple": "Volo.Abp.Account.ResetPasswordDto",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "input",
+                  "name": "input",
+                  "type": "Volo.Abp.Account.ResetPasswordDto",
+                  "typeSimple": "Volo.Abp.Account.ResetPasswordDto",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "Body",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "System.Void",
+                "typeSimple": "System.Void"
+              }
+            },
+            "SendPhoneNumberConfirmationTokenAsync": {
+              "uniqueName": "SendPhoneNumberConfirmationTokenAsync",
+              "name": "SendPhoneNumberConfirmationTokenAsync",
+              "httpMethod": "POST",
+              "url": "api/account/send-phone-number-confirmation-token",
+              "supportedVersions": [],
+              "parametersOnMethod": [],
+              "parameters": [],
+              "returnValue": {
+                "type": "System.Void",
+                "typeSimple": "System.Void"
+              }
+            },
+            "SendEmailConfirmationTokenAsyncByInput": {
+              "uniqueName": "SendEmailConfirmationTokenAsyncByInput",
+              "name": "SendEmailConfirmationTokenAsync",
+              "httpMethod": "POST",
+              "url": "api/account/send-email-confirmation-token",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Abp.Account.SendEmailConfirmationTokenDto, Volo.Abp.Account.Pro.Public.Application.Contracts",
+                  "type": "Volo.Abp.Account.SendEmailConfirmationTokenDto",
+                  "typeSimple": "Volo.Abp.Account.SendEmailConfirmationTokenDto",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "input",
+                  "name": "input",
+                  "type": "Volo.Abp.Account.SendEmailConfirmationTokenDto",
+                  "typeSimple": "Volo.Abp.Account.SendEmailConfirmationTokenDto",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "Body",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "System.Void",
+                "typeSimple": "System.Void"
+              }
+            },
+            "ConfirmPhoneNumberAsyncByInput": {
+              "uniqueName": "ConfirmPhoneNumberAsyncByInput",
+              "name": "ConfirmPhoneNumberAsync",
+              "httpMethod": "POST",
+              "url": "api/account/confirm-phone-number",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Abp.Account.ConfirmPhoneNumberInput, Volo.Abp.Account.Pro.Public.Application.Contracts",
+                  "type": "Volo.Abp.Account.ConfirmPhoneNumberInput",
+                  "typeSimple": "Volo.Abp.Account.ConfirmPhoneNumberInput",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "input",
+                  "name": "input",
+                  "type": "Volo.Abp.Account.ConfirmPhoneNumberInput",
+                  "typeSimple": "Volo.Abp.Account.ConfirmPhoneNumberInput",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "Body",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "System.Void",
+                "typeSimple": "System.Void"
+              }
+            },
+            "ConfirmEmailAsyncByInput": {
+              "uniqueName": "ConfirmEmailAsyncByInput",
+              "name": "ConfirmEmailAsync",
+              "httpMethod": "POST",
+              "url": "api/account/confirm-email",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Abp.Account.ConfirmEmailInput, Volo.Abp.Account.Pro.Public.Application.Contracts",
+                  "type": "Volo.Abp.Account.ConfirmEmailInput",
+                  "typeSimple": "Volo.Abp.Account.ConfirmEmailInput",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "input",
+                  "name": "input",
+                  "type": "Volo.Abp.Account.ConfirmEmailInput",
+                  "typeSimple": "Volo.Abp.Account.ConfirmEmailInput",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "Body",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "System.Void",
+                "typeSimple": "System.Void"
+              }
+            },
+            "SetProfilePictureAsyncByInput": {
+              "uniqueName": "SetProfilePictureAsyncByInput",
+              "name": "SetProfilePictureAsync",
+              "httpMethod": "POST",
+              "url": "api/account/profile-picture",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Abp.Account.ProfilePictureInput, Volo.Abp.Account.Pro.Public.Application.Contracts",
+                  "type": "Volo.Abp.Account.ProfilePictureInput",
+                  "typeSimple": "Volo.Abp.Account.ProfilePictureInput",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "input",
+                  "name": "input",
+                  "type": "Volo.Abp.Account.ProfilePictureInput",
+                  "typeSimple": "Volo.Abp.Account.ProfilePictureInput",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "Body",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "System.Void",
+                "typeSimple": "System.Void"
+              }
+            },
+            "GetProfilePictureAsyncById": {
+              "uniqueName": "GetProfilePictureAsyncById",
+              "name": "GetProfilePictureAsync",
+              "httpMethod": "GET",
+              "url": "api/account/profile-picture/{id}",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "id",
+                  "typeAsString": "System.Guid, System.Private.CoreLib",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "id",
+                  "name": "id",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.Account.ProfilePictureSourceDto",
+                "typeSimple": "Volo.Abp.Account.ProfilePictureSourceDto"
+              }
+            },
+            "UploadProfilePictureFileAsyncByImage": {
+              "uniqueName": "UploadProfilePictureFileAsyncByImage",
+              "name": "UploadProfilePictureFileAsync",
+              "httpMethod": "POST",
+              "url": "api/account/profile-picture-file",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "image",
+                  "typeAsString": "Microsoft.AspNetCore.Http.IFormFile, Microsoft.AspNetCore.Http.Features",
+                  "type": "Microsoft.AspNetCore.Http.IFormFile",
+                  "typeSimple": "Microsoft.AspNetCore.Http.IFormFile",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "image",
+                  "name": "image",
+                  "type": "Microsoft.AspNetCore.Http.IFormFile",
+                  "typeSimple": "Microsoft.AspNetCore.Http.IFormFile",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "FormFile",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "Microsoft.AspNetCore.Mvc.IActionResult",
+                "typeSimple": "Microsoft.AspNetCore.Mvc.IActionResult"
+              }
+            },
+            "GetProfilePictureFileAsyncById": {
+              "uniqueName": "GetProfilePictureFileAsyncById",
+              "name": "GetProfilePictureFileAsync",
+              "httpMethod": "GET",
+              "url": "api/account/profile-picture-file/{id}",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "id",
+                  "typeAsString": "System.Guid, System.Private.CoreLib",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "id",
+                  "name": "id",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "Microsoft.AspNetCore.Mvc.IActionResult",
+                "typeSimple": "Microsoft.AspNetCore.Mvc.IActionResult"
+              }
+            }
+          }
+        },
+        "Volo.Abp.Account.AccountExternalProviderController": {
+          "controllerName": "AccountExternalProvider",
+          "type": "Volo.Abp.Account.AccountExternalProviderController",
+          "interfaces": [
+            {
+              "type": "Volo.Abp.Account.ExternalProviders.IAccountExternalProviderAppService"
+            }
+          ],
+          "actions": {
+            "GetAllAsync": {
+              "uniqueName": "GetAllAsync",
+              "name": "GetAllAsync",
+              "httpMethod": "GET",
+              "url": "api/account/external-provider",
+              "supportedVersions": [],
+              "parametersOnMethod": [],
+              "parameters": [],
+              "returnValue": {
+                "type": "Volo.Abp.Account.ExternalProviders.ExternalProviderDto",
+                "typeSimple": "Volo.Abp.Account.ExternalProviders.ExternalProviderDto"
+              }
+            },
+            "GetByNameAsyncByInput": {
+              "uniqueName": "GetByNameAsyncByInput",
+              "name": "GetByNameAsync",
+              "httpMethod": "GET",
+              "url": "api/account/external-provider/by-name",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Abp.Account.ExternalProviders.GetByNameInput, Volo.Abp.Account.Pro.Public.Application.Contracts",
+                  "type": "Volo.Abp.Account.ExternalProviders.GetByNameInput",
+                  "typeSimple": "Volo.Abp.Account.ExternalProviders.GetByNameInput",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "input",
+                  "name": "TenantId",
+                  "type": "System.Guid?",
+                  "typeSimple": "string?",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "Name",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.Account.ExternalProviders.ExternalProviderItemWithSecretDto",
+                "typeSimple": "Volo.Abp.Account.ExternalProviders.ExternalProviderItemWithSecretDto"
+              }
+            }
+          }
+        }
+      }
+    },
+    "app": {
+      "rootPath": "app",
+      "remoteServiceName": "Default",
+      "controllers": {
+        "MyCompanyName.MyProjectName.BookAppService": {
+          "controllerName": "Book",
+          "type": "MyCompanyName.MyProjectName.BookAppService",
+          "interfaces": [
+            {
+              "type": "Volo.Abp.Validation.IValidationEnabled"
+            },
+            {
+              "type": "Volo.Abp.Auditing.IAuditingEnabled"
+            },
+            {
+              "type": "MyCompanyName.MyProjectName.IBookAppService"
+            }
+          ],
+          "actions": {
+            "GetListAsyncByInput": {
+              "uniqueName": "GetListAsyncByInput",
+              "name": "GetListAsync",
+              "httpMethod": "GET",
+              "url": "api/app/book",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "input",
+                  "typeAsString": "MyCompanyName.MyProjectName.BookListFilterDto, MyCompanyName.MyProjectName.Application.Contracts",
+                  "type": "MyCompanyName.MyProjectName.BookListFilterDto",
+                  "typeSimple": "MyCompanyName.MyProjectName.BookListFilterDto",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "input",
+                  "name": "RequiredStr",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "NonRequiredStr",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                }
+              ],
+              "returnValue": {
+                "type": "System.Collections.Generic.List<MyCompanyName.MyProjectName.BookDto>",
+                "typeSimple": "[MyCompanyName.MyProjectName.BookDto]"
+              }
+            }
+          }
+        }
+      }
+    },
+    "saas": {
+      "rootPath": "saas",
+      "remoteServiceName": "SaasHost",
+      "controllers": {
+        "Volo.Saas.Host.EditionController": {
+          "controllerName": "Edition",
+          "type": "Volo.Saas.Host.EditionController",
+          "interfaces": [
+            {
+              "type": "Volo.Saas.Host.IEditionAppService"
+            }
+          ],
+          "actions": {
+            "GetAsyncById": {
+              "uniqueName": "GetAsyncById",
+              "name": "GetAsync",
+              "httpMethod": "GET",
+              "url": "api/saas/editions/{id}",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "id",
+                  "typeAsString": "System.Guid, System.Private.CoreLib",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "id",
+                  "name": "id",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Saas.Host.Dtos.EditionDto",
+                "typeSimple": "Volo.Saas.Host.Dtos.EditionDto"
+              }
+            },
+            "GetListAsyncByInput": {
+              "uniqueName": "GetListAsyncByInput",
+              "name": "GetListAsync",
+              "httpMethod": "GET",
+              "url": "api/saas/editions",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Saas.Host.Dtos.GetEditionsInput, Volo.Saas.Host.Application.Contracts",
+                  "type": "Volo.Saas.Host.Dtos.GetEditionsInput",
+                  "typeSimple": "Volo.Saas.Host.Dtos.GetEditionsInput",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "input",
+                  "name": "Filter",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "Sorting",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "SkipCount",
+                  "type": "System.Int32",
+                  "typeSimple": "number",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "MaxResultCount",
+                  "type": "System.Int32",
+                  "typeSimple": "number",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.Application.Dtos.PagedResultDto<Volo.Saas.Host.Dtos.EditionDto>",
+                "typeSimple": "Volo.Abp.Application.Dtos.PagedResultDto<Volo.Saas.Host.Dtos.EditionDto>"
+              }
+            },
+            "CreateAsyncByInput": {
+              "uniqueName": "CreateAsyncByInput",
+              "name": "CreateAsync",
+              "httpMethod": "POST",
+              "url": "api/saas/editions",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Saas.Host.Dtos.EditionCreateDto, Volo.Saas.Host.Application.Contracts",
+                  "type": "Volo.Saas.Host.Dtos.EditionCreateDto",
+                  "typeSimple": "Volo.Saas.Host.Dtos.EditionCreateDto",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "input",
+                  "name": "input",
+                  "type": "Volo.Saas.Host.Dtos.EditionCreateDto",
+                  "typeSimple": "Volo.Saas.Host.Dtos.EditionCreateDto",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "Body",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Saas.Host.Dtos.EditionDto",
+                "typeSimple": "Volo.Saas.Host.Dtos.EditionDto"
+              }
+            },
+            "UpdateAsyncByIdAndInput": {
+              "uniqueName": "UpdateAsyncByIdAndInput",
+              "name": "UpdateAsync",
+              "httpMethod": "PUT",
+              "url": "api/saas/editions/{id}",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "id",
+                  "typeAsString": "System.Guid, System.Private.CoreLib",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                },
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Saas.Host.Dtos.EditionUpdateDto, Volo.Saas.Host.Application.Contracts",
+                  "type": "Volo.Saas.Host.Dtos.EditionUpdateDto",
+                  "typeSimple": "Volo.Saas.Host.Dtos.EditionUpdateDto",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "id",
+                  "name": "id",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "input",
+                  "type": "Volo.Saas.Host.Dtos.EditionUpdateDto",
+                  "typeSimple": "Volo.Saas.Host.Dtos.EditionUpdateDto",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "Body",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Saas.Host.Dtos.EditionDto",
+                "typeSimple": "Volo.Saas.Host.Dtos.EditionDto"
+              }
+            },
+            "DeleteAsyncById": {
+              "uniqueName": "DeleteAsyncById",
+              "name": "DeleteAsync",
+              "httpMethod": "DELETE",
+              "url": "api/saas/editions/{id}",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "id",
+                  "typeAsString": "System.Guid, System.Private.CoreLib",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "id",
+                  "name": "id",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "System.Void",
+                "typeSimple": "System.Void"
+              }
+            },
+            "GetUsageStatistics": {
+              "uniqueName": "GetUsageStatistics",
+              "name": "GetUsageStatistics",
+              "httpMethod": "GET",
+              "url": "api/saas/editions/statistics/usage-statistic",
+              "supportedVersions": [],
+              "parametersOnMethod": [],
+              "parameters": [],
+              "returnValue": {
+                "type": "Volo.Saas.Host.GetEditionUsageStatisticsResult",
+                "typeSimple": "Volo.Saas.Host.GetEditionUsageStatisticsResult"
+              }
+            }
+          }
+        },
+        "Volo.Saas.Host.TenantController": {
+          "controllerName": "Tenant",
+          "type": "Volo.Saas.Host.TenantController",
+          "interfaces": [
+            {
+              "type": "Volo.Saas.Host.ITenantAppService"
+            }
+          ],
+          "actions": {
+            "GetAsyncById": {
+              "uniqueName": "GetAsyncById",
+              "name": "GetAsync",
+              "httpMethod": "GET",
+              "url": "api/saas/tenants/{id}",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "id",
+                  "typeAsString": "System.Guid, System.Private.CoreLib",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "id",
+                  "name": "id",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Saas.Host.Dtos.SaasTenantDto",
+                "typeSimple": "Volo.Saas.Host.Dtos.SaasTenantDto"
+              }
+            },
+            "GetListAsyncByInput": {
+              "uniqueName": "GetListAsyncByInput",
+              "name": "GetListAsync",
+              "httpMethod": "GET",
+              "url": "api/saas/tenants",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Saas.Host.Dtos.GetTenantsInput, Volo.Saas.Host.Application.Contracts",
+                  "type": "Volo.Saas.Host.Dtos.GetTenantsInput",
+                  "typeSimple": "Volo.Saas.Host.Dtos.GetTenantsInput",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "input",
+                  "name": "Filter",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "GetEditionNames",
+                  "type": "System.Boolean",
+                  "typeSimple": "boolean",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "Sorting",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "SkipCount",
+                  "type": "System.Int32",
+                  "typeSimple": "number",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "MaxResultCount",
+                  "type": "System.Int32",
+                  "typeSimple": "number",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.Application.Dtos.PagedResultDto<Volo.Saas.Host.Dtos.SaasTenantDto>",
+                "typeSimple": "Volo.Abp.Application.Dtos.PagedResultDto<Volo.Saas.Host.Dtos.SaasTenantDto>"
+              }
+            },
+            "CreateAsyncByInput": {
+              "uniqueName": "CreateAsyncByInput",
+              "name": "CreateAsync",
+              "httpMethod": "POST",
+              "url": "api/saas/tenants",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Saas.Host.Dtos.SaasTenantCreateDto, Volo.Saas.Host.Application.Contracts",
+                  "type": "Volo.Saas.Host.Dtos.SaasTenantCreateDto",
+                  "typeSimple": "Volo.Saas.Host.Dtos.SaasTenantCreateDto",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "input",
+                  "name": "input",
+                  "type": "Volo.Saas.Host.Dtos.SaasTenantCreateDto",
+                  "typeSimple": "Volo.Saas.Host.Dtos.SaasTenantCreateDto",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "Body",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Saas.Host.Dtos.SaasTenantDto",
+                "typeSimple": "Volo.Saas.Host.Dtos.SaasTenantDto"
+              }
+            },
+            "UpdateAsyncByIdAndInput": {
+              "uniqueName": "UpdateAsyncByIdAndInput",
+              "name": "UpdateAsync",
+              "httpMethod": "PUT",
+              "url": "api/saas/tenants/{id}",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "id",
+                  "typeAsString": "System.Guid, System.Private.CoreLib",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                },
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Saas.Host.Dtos.SaasTenantUpdateDto, Volo.Saas.Host.Application.Contracts",
+                  "type": "Volo.Saas.Host.Dtos.SaasTenantUpdateDto",
+                  "typeSimple": "Volo.Saas.Host.Dtos.SaasTenantUpdateDto",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "id",
+                  "name": "id",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "input",
+                  "type": "Volo.Saas.Host.Dtos.SaasTenantUpdateDto",
+                  "typeSimple": "Volo.Saas.Host.Dtos.SaasTenantUpdateDto",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "Body",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Saas.Host.Dtos.SaasTenantDto",
+                "typeSimple": "Volo.Saas.Host.Dtos.SaasTenantDto"
+              }
+            },
+            "DeleteAsyncById": {
+              "uniqueName": "DeleteAsyncById",
+              "name": "DeleteAsync",
+              "httpMethod": "DELETE",
+              "url": "api/saas/tenants/{id}",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "id",
+                  "typeAsString": "System.Guid, System.Private.CoreLib",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "id",
+                  "name": "id",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "System.Void",
+                "typeSimple": "System.Void"
+              }
+            },
+            "GetDefaultConnectionStringAsyncById": {
+              "uniqueName": "GetDefaultConnectionStringAsyncById",
+              "name": "GetDefaultConnectionStringAsync",
+              "httpMethod": "GET",
+              "url": "api/saas/tenants/{id}/default-connection-string",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "id",
+                  "typeAsString": "System.Guid, System.Private.CoreLib",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "id",
+                  "name": "id",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "System.String",
+                "typeSimple": "string"
+              }
+            },
+            "UpdateDefaultConnectionStringAsyncByIdAndDefaultConnectionString": {
+              "uniqueName": "UpdateDefaultConnectionStringAsyncByIdAndDefaultConnectionString",
+              "name": "UpdateDefaultConnectionStringAsync",
+              "httpMethod": "PUT",
+              "url": "api/saas/tenants/{id}/default-connection-string",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "id",
+                  "typeAsString": "System.Guid, System.Private.CoreLib",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                },
+                {
+                  "name": "defaultConnectionString",
+                  "typeAsString": "System.String, System.Private.CoreLib",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "id",
+                  "name": "id",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                },
+                {
+                  "nameOnMethod": "defaultConnectionString",
+                  "name": "defaultConnectionString",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "System.Void",
+                "typeSimple": "System.Void"
+              }
+            },
+            "DeleteDefaultConnectionStringAsyncById": {
+              "uniqueName": "DeleteDefaultConnectionStringAsyncById",
+              "name": "DeleteDefaultConnectionStringAsync",
+              "httpMethod": "DELETE",
+              "url": "api/saas/tenants/{id}/default-connection-string",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "id",
+                  "typeAsString": "System.Guid, System.Private.CoreLib",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "id",
+                  "name": "id",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "System.Void",
+                "typeSimple": "System.Void"
+              }
+            }
+          }
+        }
+      }
+    },
+    "permissionManagement": {
+      "rootPath": "permissionManagement",
+      "remoteServiceName": "AbpPermissionManagement",
+      "controllers": {
+        "Volo.Abp.PermissionManagement.PermissionsController": {
+          "controllerName": "Permissions",
+          "type": "Volo.Abp.PermissionManagement.PermissionsController",
+          "interfaces": [
+            {
+              "type": "Volo.Abp.PermissionManagement.IPermissionAppService"
+            }
+          ],
+          "actions": {
+            "GetAsyncByProviderNameAndProviderKey": {
+              "uniqueName": "GetAsyncByProviderNameAndProviderKey",
+              "name": "GetAsync",
+              "httpMethod": "GET",
+              "url": "api/permission-management/permissions",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "providerName",
+                  "typeAsString": "System.String, System.Private.CoreLib",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                },
+                {
+                  "name": "providerKey",
+                  "typeAsString": "System.String, System.Private.CoreLib",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "providerName",
+                  "name": "providerName",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": ""
+                },
+                {
+                  "nameOnMethod": "providerKey",
+                  "name": "providerKey",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.PermissionManagement.GetPermissionListResultDto",
+                "typeSimple": "Volo.Abp.PermissionManagement.GetPermissionListResultDto"
+              }
+            },
+            "UpdateAsyncByProviderNameAndProviderKeyAndInput": {
+              "uniqueName": "UpdateAsyncByProviderNameAndProviderKeyAndInput",
+              "name": "UpdateAsync",
+              "httpMethod": "PUT",
+              "url": "api/permission-management/permissions",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "providerName",
+                  "typeAsString": "System.String, System.Private.CoreLib",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                },
+                {
+                  "name": "providerKey",
+                  "typeAsString": "System.String, System.Private.CoreLib",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                },
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Abp.PermissionManagement.UpdatePermissionsDto, Volo.Abp.PermissionManagement.Application.Contracts",
+                  "type": "Volo.Abp.PermissionManagement.UpdatePermissionsDto",
+                  "typeSimple": "Volo.Abp.PermissionManagement.UpdatePermissionsDto",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "providerName",
+                  "name": "providerName",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": ""
+                },
+                {
+                  "nameOnMethod": "providerKey",
+                  "name": "providerKey",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": ""
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "input",
+                  "type": "Volo.Abp.PermissionManagement.UpdatePermissionsDto",
+                  "typeSimple": "Volo.Abp.PermissionManagement.UpdatePermissionsDto",
                   "isOptional": false,
                   "defaultValue": null,
                   "constraintTypes": null,
@@ -595,6 +2997,1153 @@
         }
       }
     },
+    "languageManagement": {
+      "rootPath": "languageManagement",
+      "remoteServiceName": "LanguageManagement",
+      "controllers": {
+        "Volo.Abp.LanguageManagement.LanguageController": {
+          "controllerName": "Language",
+          "type": "Volo.Abp.LanguageManagement.LanguageController",
+          "interfaces": [
+            {
+              "type": "Volo.Abp.LanguageManagement.ILanguageAppService"
+            }
+          ],
+          "actions": {
+            "GetAllListAsync": {
+              "uniqueName": "GetAllListAsync",
+              "name": "GetAllListAsync",
+              "httpMethod": "GET",
+              "url": "api/language-management/languages/all",
+              "supportedVersions": [],
+              "parametersOnMethod": [],
+              "parameters": [],
+              "returnValue": {
+                "type": "Volo.Abp.Application.Dtos.ListResultDto<Volo.Abp.LanguageManagement.Dto.LanguageDto>",
+                "typeSimple": "Volo.Abp.Application.Dtos.ListResultDto<Volo.Abp.LanguageManagement.Dto.LanguageDto>"
+              }
+            },
+            "GetListAsyncByInput": {
+              "uniqueName": "GetListAsyncByInput",
+              "name": "GetListAsync",
+              "httpMethod": "GET",
+              "url": "api/language-management/languages",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Abp.LanguageManagement.Dto.GetLanguagesTextsInput, Volo.Abp.LanguageManagement.Application.Contracts",
+                  "type": "Volo.Abp.LanguageManagement.Dto.GetLanguagesTextsInput",
+                  "typeSimple": "Volo.Abp.LanguageManagement.Dto.GetLanguagesTextsInput",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "input",
+                  "name": "Filter",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "ResourceName",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "BaseCultureName",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "TargetCultureName",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "GetOnlyEmptyValues",
+                  "type": "System.Boolean",
+                  "typeSimple": "boolean",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "Sorting",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "SkipCount",
+                  "type": "System.Int32",
+                  "typeSimple": "number",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "MaxResultCount",
+                  "type": "System.Int32",
+                  "typeSimple": "number",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.Application.Dtos.PagedResultDto<Volo.Abp.LanguageManagement.Dto.LanguageDto>",
+                "typeSimple": "Volo.Abp.Application.Dtos.PagedResultDto<Volo.Abp.LanguageManagement.Dto.LanguageDto>"
+              }
+            },
+            "GetAsyncById": {
+              "uniqueName": "GetAsyncById",
+              "name": "GetAsync",
+              "httpMethod": "GET",
+              "url": "api/language-management/languages/{id}",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "id",
+                  "typeAsString": "System.Guid, System.Private.CoreLib",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "id",
+                  "name": "id",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.LanguageManagement.Dto.LanguageDto",
+                "typeSimple": "Volo.Abp.LanguageManagement.Dto.LanguageDto"
+              }
+            },
+            "CreateAsyncByInput": {
+              "uniqueName": "CreateAsyncByInput",
+              "name": "CreateAsync",
+              "httpMethod": "POST",
+              "url": "api/language-management/languages",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Abp.LanguageManagement.Dto.CreateLanguageDto, Volo.Abp.LanguageManagement.Application.Contracts",
+                  "type": "Volo.Abp.LanguageManagement.Dto.CreateLanguageDto",
+                  "typeSimple": "Volo.Abp.LanguageManagement.Dto.CreateLanguageDto",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "input",
+                  "name": "input",
+                  "type": "Volo.Abp.LanguageManagement.Dto.CreateLanguageDto",
+                  "typeSimple": "Volo.Abp.LanguageManagement.Dto.CreateLanguageDto",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "Body",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.LanguageManagement.Dto.LanguageDto",
+                "typeSimple": "Volo.Abp.LanguageManagement.Dto.LanguageDto"
+              }
+            },
+            "UpdateAsyncByIdAndInput": {
+              "uniqueName": "UpdateAsyncByIdAndInput",
+              "name": "UpdateAsync",
+              "httpMethod": "PUT",
+              "url": "api/language-management/languages/{id}",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "id",
+                  "typeAsString": "System.Guid, System.Private.CoreLib",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                },
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Abp.LanguageManagement.Dto.UpdateLanguageDto, Volo.Abp.LanguageManagement.Application.Contracts",
+                  "type": "Volo.Abp.LanguageManagement.Dto.UpdateLanguageDto",
+                  "typeSimple": "Volo.Abp.LanguageManagement.Dto.UpdateLanguageDto",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "id",
+                  "name": "id",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "input",
+                  "type": "Volo.Abp.LanguageManagement.Dto.UpdateLanguageDto",
+                  "typeSimple": "Volo.Abp.LanguageManagement.Dto.UpdateLanguageDto",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "Body",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.LanguageManagement.Dto.LanguageDto",
+                "typeSimple": "Volo.Abp.LanguageManagement.Dto.LanguageDto"
+              }
+            },
+            "DeleteAsyncById": {
+              "uniqueName": "DeleteAsyncById",
+              "name": "DeleteAsync",
+              "httpMethod": "DELETE",
+              "url": "api/language-management/languages/{id}",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "id",
+                  "typeAsString": "System.Guid, System.Private.CoreLib",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "id",
+                  "name": "id",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "System.Void",
+                "typeSimple": "System.Void"
+              }
+            },
+            "SetAsDefaultAsyncById": {
+              "uniqueName": "SetAsDefaultAsyncById",
+              "name": "SetAsDefaultAsync",
+              "httpMethod": "PUT",
+              "url": "api/language-management/languages/{id}/set-as-default",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "id",
+                  "typeAsString": "System.Guid, System.Private.CoreLib",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "id",
+                  "name": "id",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "System.Void",
+                "typeSimple": "System.Void"
+              }
+            },
+            "GetResourcesAsync": {
+              "uniqueName": "GetResourcesAsync",
+              "name": "GetResourcesAsync",
+              "httpMethod": "GET",
+              "url": "api/language-management/languages/resources",
+              "supportedVersions": [],
+              "parametersOnMethod": [],
+              "parameters": [],
+              "returnValue": {
+                "type": "System.Collections.Generic.List<Volo.Abp.LanguageManagement.Dto.LanguageResourceDto>",
+                "typeSimple": "[Volo.Abp.LanguageManagement.Dto.LanguageResourceDto]"
+              }
+            },
+            "GetCulturelistAsync": {
+              "uniqueName": "GetCulturelistAsync",
+              "name": "GetCulturelistAsync",
+              "httpMethod": "GET",
+              "url": "api/language-management/languages/culture-list",
+              "supportedVersions": [],
+              "parametersOnMethod": [],
+              "parameters": [],
+              "returnValue": {
+                "type": "System.Collections.Generic.List<Volo.Abp.LanguageManagement.Dto.CultureInfoDto>",
+                "typeSimple": "[Volo.Abp.LanguageManagement.Dto.CultureInfoDto]"
+              }
+            },
+            "GetFlagListAsync": {
+              "uniqueName": "GetFlagListAsync",
+              "name": "GetFlagListAsync",
+              "httpMethod": "GET",
+              "url": "api/language-management/languages/flag-list",
+              "supportedVersions": [],
+              "parametersOnMethod": [],
+              "parameters": [],
+              "returnValue": {
+                "type": "System.Collections.Generic.List<System.String>",
+                "typeSimple": "[string]"
+              }
+            }
+          }
+        },
+        "Volo.Abp.LanguageManagement.LanguageTextController": {
+          "controllerName": "LanguageText",
+          "type": "Volo.Abp.LanguageManagement.LanguageTextController",
+          "interfaces": [
+            {
+              "type": "Volo.Abp.LanguageManagement.ILanguageTextAppService"
+            }
+          ],
+          "actions": {
+            "GetListAsyncByInput": {
+              "uniqueName": "GetListAsyncByInput",
+              "name": "GetListAsync",
+              "httpMethod": "GET",
+              "url": "api/language-management/language-texts",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Abp.LanguageManagement.Dto.GetLanguagesTextsInput, Volo.Abp.LanguageManagement.Application.Contracts",
+                  "type": "Volo.Abp.LanguageManagement.Dto.GetLanguagesTextsInput",
+                  "typeSimple": "Volo.Abp.LanguageManagement.Dto.GetLanguagesTextsInput",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "input",
+                  "name": "Filter",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "ResourceName",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "BaseCultureName",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "TargetCultureName",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "GetOnlyEmptyValues",
+                  "type": "System.Boolean",
+                  "typeSimple": "boolean",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "Sorting",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "SkipCount",
+                  "type": "System.Int32",
+                  "typeSimple": "number",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "MaxResultCount",
+                  "type": "System.Int32",
+                  "typeSimple": "number",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.Application.Dtos.PagedResultDto<Volo.Abp.LanguageManagement.Dto.LanguageTextDto>",
+                "typeSimple": "Volo.Abp.Application.Dtos.PagedResultDto<Volo.Abp.LanguageManagement.Dto.LanguageTextDto>"
+              }
+            },
+            "GetAsyncByResourceNameAndCultureNameAndNameAndBaseCultureName": {
+              "uniqueName": "GetAsyncByResourceNameAndCultureNameAndNameAndBaseCultureName",
+              "name": "GetAsync",
+              "httpMethod": "GET",
+              "url": "api/language-management/language-texts/{resourceName}/{cultureName}/{name}",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "resourceName",
+                  "typeAsString": "System.String, System.Private.CoreLib",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                },
+                {
+                  "name": "cultureName",
+                  "typeAsString": "System.String, System.Private.CoreLib",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                },
+                {
+                  "name": "name",
+                  "typeAsString": "System.String, System.Private.CoreLib",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                },
+                {
+                  "name": "baseCultureName",
+                  "typeAsString": "System.String, System.Private.CoreLib",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "resourceName",
+                  "name": "resourceName",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                },
+                {
+                  "nameOnMethod": "cultureName",
+                  "name": "cultureName",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                },
+                {
+                  "nameOnMethod": "name",
+                  "name": "name",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                },
+                {
+                  "nameOnMethod": "baseCultureName",
+                  "name": "baseCultureName",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.LanguageManagement.Dto.LanguageTextDto",
+                "typeSimple": "Volo.Abp.LanguageManagement.Dto.LanguageTextDto"
+              }
+            },
+            "UpdateAsyncByResourceNameAndCultureNameAndNameAndValue": {
+              "uniqueName": "UpdateAsyncByResourceNameAndCultureNameAndNameAndValue",
+              "name": "UpdateAsync",
+              "httpMethod": "PUT",
+              "url": "api/language-management/language-texts/{resourceName}/{cultureName}/{name}",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "resourceName",
+                  "typeAsString": "System.String, System.Private.CoreLib",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                },
+                {
+                  "name": "cultureName",
+                  "typeAsString": "System.String, System.Private.CoreLib",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                },
+                {
+                  "name": "name",
+                  "typeAsString": "System.String, System.Private.CoreLib",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                },
+                {
+                  "name": "value",
+                  "typeAsString": "System.String, System.Private.CoreLib",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "resourceName",
+                  "name": "resourceName",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                },
+                {
+                  "nameOnMethod": "cultureName",
+                  "name": "cultureName",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                },
+                {
+                  "nameOnMethod": "name",
+                  "name": "name",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                },
+                {
+                  "nameOnMethod": "value",
+                  "name": "value",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "System.Void",
+                "typeSimple": "System.Void"
+              }
+            },
+            "RestoreToDefaultAsyncByResourceNameAndCultureNameAndName": {
+              "uniqueName": "RestoreToDefaultAsyncByResourceNameAndCultureNameAndName",
+              "name": "RestoreToDefaultAsync",
+              "httpMethod": "PUT",
+              "url": "api/language-management/language-texts/{resourceName}/{cultureName}/{name}/restore",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "resourceName",
+                  "typeAsString": "System.String, System.Private.CoreLib",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                },
+                {
+                  "name": "cultureName",
+                  "typeAsString": "System.String, System.Private.CoreLib",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                },
+                {
+                  "name": "name",
+                  "typeAsString": "System.String, System.Private.CoreLib",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "resourceName",
+                  "name": "resourceName",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                },
+                {
+                  "nameOnMethod": "cultureName",
+                  "name": "cultureName",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                },
+                {
+                  "nameOnMethod": "name",
+                  "name": "name",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "System.Void",
+                "typeSimple": "System.Void"
+              }
+            }
+          }
+        }
+      }
+    },
+    "accountAdmin": {
+      "rootPath": "accountAdmin",
+      "remoteServiceName": "AbpAccountAdmin",
+      "controllers": {
+        "Volo.Abp.Account.AccountSettingsController": {
+          "controllerName": "AccountSettings",
+          "type": "Volo.Abp.Account.AccountSettingsController",
+          "interfaces": [
+            {
+              "type": "Volo.Abp.Account.IAccountSettingsAppService"
+            }
+          ],
+          "actions": {
+            "GetAsync": {
+              "uniqueName": "GetAsync",
+              "name": "GetAsync",
+              "httpMethod": "GET",
+              "url": "api/account-admin/settings",
+              "supportedVersions": [],
+              "parametersOnMethod": [],
+              "parameters": [],
+              "returnValue": {
+                "type": "Volo.Abp.Account.AccountSettingsDto",
+                "typeSimple": "Volo.Abp.Account.AccountSettingsDto"
+              }
+            },
+            "UpdateAsyncByInput": {
+              "uniqueName": "UpdateAsyncByInput",
+              "name": "UpdateAsync",
+              "httpMethod": "PUT",
+              "url": "api/account-admin/settings",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Abp.Account.AccountSettingsDto, Volo.Abp.Account.Pro.Admin.Application.Contracts",
+                  "type": "Volo.Abp.Account.AccountSettingsDto",
+                  "typeSimple": "Volo.Abp.Account.AccountSettingsDto",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "input",
+                  "name": "input",
+                  "type": "Volo.Abp.Account.AccountSettingsDto",
+                  "typeSimple": "Volo.Abp.Account.AccountSettingsDto",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "Body",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "System.Void",
+                "typeSimple": "System.Void"
+              }
+            },
+            "GetLdapAsync": {
+              "uniqueName": "GetLdapAsync",
+              "name": "GetLdapAsync",
+              "httpMethod": "GET",
+              "url": "api/account-admin/settings/ldap",
+              "supportedVersions": [],
+              "parametersOnMethod": [],
+              "parameters": [],
+              "returnValue": {
+                "type": "Volo.Abp.Account.AccountLdapSettingsDto",
+                "typeSimple": "Volo.Abp.Account.AccountLdapSettingsDto"
+              }
+            },
+            "UpdateLdapAsyncByInput": {
+              "uniqueName": "UpdateLdapAsyncByInput",
+              "name": "UpdateLdapAsync",
+              "httpMethod": "PUT",
+              "url": "api/account-admin/settings/ldap",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Abp.Account.AccountLdapSettingsDto, Volo.Abp.Account.Pro.Admin.Application.Contracts",
+                  "type": "Volo.Abp.Account.AccountLdapSettingsDto",
+                  "typeSimple": "Volo.Abp.Account.AccountLdapSettingsDto",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "input",
+                  "name": "input",
+                  "type": "Volo.Abp.Account.AccountLdapSettingsDto",
+                  "typeSimple": "Volo.Abp.Account.AccountLdapSettingsDto",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "Body",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "System.Void",
+                "typeSimple": "System.Void"
+              }
+            },
+            "GetTwoFactorAsync": {
+              "uniqueName": "GetTwoFactorAsync",
+              "name": "GetTwoFactorAsync",
+              "httpMethod": "GET",
+              "url": "api/account-admin/settings/two-factor",
+              "supportedVersions": [],
+              "parametersOnMethod": [],
+              "parameters": [],
+              "returnValue": {
+                "type": "Volo.Abp.Account.AccountTwoFactorSettingsDto",
+                "typeSimple": "Volo.Abp.Account.AccountTwoFactorSettingsDto"
+              }
+            },
+            "UpdateTwoFactorAsyncByInput": {
+              "uniqueName": "UpdateTwoFactorAsyncByInput",
+              "name": "UpdateTwoFactorAsync",
+              "httpMethod": "PUT",
+              "url": "api/account-admin/settings/two-factor",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Abp.Account.AccountTwoFactorSettingsDto, Volo.Abp.Account.Pro.Admin.Application.Contracts",
+                  "type": "Volo.Abp.Account.AccountTwoFactorSettingsDto",
+                  "typeSimple": "Volo.Abp.Account.AccountTwoFactorSettingsDto",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "input",
+                  "name": "input",
+                  "type": "Volo.Abp.Account.AccountTwoFactorSettingsDto",
+                  "typeSimple": "Volo.Abp.Account.AccountTwoFactorSettingsDto",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "Body",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "System.Void",
+                "typeSimple": "System.Void"
+              }
+            },
+            "GetRecaptchaAsync": {
+              "uniqueName": "GetRecaptchaAsync",
+              "name": "GetRecaptchaAsync",
+              "httpMethod": "GET",
+              "url": "api/account-admin/settings/recaptcha",
+              "supportedVersions": [],
+              "parametersOnMethod": [],
+              "parameters": [],
+              "returnValue": {
+                "type": "Volo.Abp.Account.AccountRecaptchaSettingsDto",
+                "typeSimple": "Volo.Abp.Account.AccountRecaptchaSettingsDto"
+              }
+            },
+            "UpdateRecaptchaAsyncByInput": {
+              "uniqueName": "UpdateRecaptchaAsyncByInput",
+              "name": "UpdateRecaptchaAsync",
+              "httpMethod": "PUT",
+              "url": "api/account-admin/settings/recaptcha",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Abp.Account.AccountRecaptchaSettingsDto, Volo.Abp.Account.Pro.Admin.Application.Contracts",
+                  "type": "Volo.Abp.Account.AccountRecaptchaSettingsDto",
+                  "typeSimple": "Volo.Abp.Account.AccountRecaptchaSettingsDto",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "input",
+                  "name": "input",
+                  "type": "Volo.Abp.Account.AccountRecaptchaSettingsDto",
+                  "typeSimple": "Volo.Abp.Account.AccountRecaptchaSettingsDto",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "Body",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "System.Void",
+                "typeSimple": "System.Void"
+              }
+            },
+            "GetExternalProviderAsync": {
+              "uniqueName": "GetExternalProviderAsync",
+              "name": "GetExternalProviderAsync",
+              "httpMethod": "GET",
+              "url": "api/account-admin/settings/external-provider",
+              "supportedVersions": [],
+              "parametersOnMethod": [],
+              "parameters": [],
+              "returnValue": {
+                "type": "Volo.Abp.Account.AccountExternalProviderSettingsDto",
+                "typeSimple": "Volo.Abp.Account.AccountExternalProviderSettingsDto"
+              }
+            },
+            "UpdateExternalProviderAsyncByInput": {
+              "uniqueName": "UpdateExternalProviderAsyncByInput",
+              "name": "UpdateExternalProviderAsync",
+              "httpMethod": "PUT",
+              "url": "api/account-admin/settings/external-provider",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "input",
+                  "typeAsString": "System.Collections.Generic.List`1[[Volo.Abp.Account.UpdateExternalProviderDto, Volo.Abp.Account.Pro.Admin.Application.Contracts, Version=4.0.0.0, Culture=neutral, PublicKeyToken=null]], System.Private.CoreLib",
+                  "type": "System.Collections.Generic.List<Volo.Abp.Account.UpdateExternalProviderDto>",
+                  "typeSimple": "[Volo.Abp.Account.UpdateExternalProviderDto]",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "input",
+                  "name": "input",
+                  "type": "System.Collections.Generic.List<Volo.Abp.Account.UpdateExternalProviderDto>",
+                  "typeSimple": "[Volo.Abp.Account.UpdateExternalProviderDto]",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "Body",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "System.Void",
+                "typeSimple": "System.Void"
+              }
+            }
+          }
+        }
+      }
+    },
+    "abp": {
+      "rootPath": "abp",
+      "remoteServiceName": "abp",
+      "controllers": {
+        "Pages.Abp.MultiTenancy.AbpTenantController": {
+          "controllerName": "AbpTenant",
+          "type": "Pages.Abp.MultiTenancy.AbpTenantController",
+          "interfaces": [
+            {
+              "type": "Volo.Abp.AspNetCore.Mvc.MultiTenancy.IAbpTenantAppService"
+            }
+          ],
+          "actions": {
+            "FindTenantByNameAsyncByName": {
+              "uniqueName": "FindTenantByNameAsyncByName",
+              "name": "FindTenantByNameAsync",
+              "httpMethod": "GET",
+              "url": "api/abp/multi-tenancy/tenants/by-name/{name}",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "name",
+                  "typeAsString": "System.String, System.Private.CoreLib",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "name",
+                  "name": "name",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.AspNetCore.Mvc.MultiTenancy.FindTenantResultDto",
+                "typeSimple": "Volo.Abp.AspNetCore.Mvc.MultiTenancy.FindTenantResultDto"
+              }
+            },
+            "FindTenantByIdAsyncById": {
+              "uniqueName": "FindTenantByIdAsyncById",
+              "name": "FindTenantByIdAsync",
+              "httpMethod": "GET",
+              "url": "api/abp/multi-tenancy/tenants/by-id/{id}",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "id",
+                  "typeAsString": "System.Guid, System.Private.CoreLib",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "id",
+                  "name": "id",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.AspNetCore.Mvc.MultiTenancy.FindTenantResultDto",
+                "typeSimple": "Volo.Abp.AspNetCore.Mvc.MultiTenancy.FindTenantResultDto"
+              }
+            }
+          }
+        },
+        "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.AbpApplicationConfigurationController": {
+          "controllerName": "AbpApplicationConfiguration",
+          "type": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.AbpApplicationConfigurationController",
+          "interfaces": [
+            {
+              "type": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.IAbpApplicationConfigurationAppService"
+            }
+          ],
+          "actions": {
+            "GetAsync": {
+              "uniqueName": "GetAsync",
+              "name": "GetAsync",
+              "httpMethod": "GET",
+              "url": "api/abp/application-configuration",
+              "supportedVersions": [],
+              "parametersOnMethod": [],
+              "parameters": [],
+              "returnValue": {
+                "type": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ApplicationConfigurationDto",
+                "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ApplicationConfigurationDto"
+              }
+            }
+          }
+        },
+        "Volo.Abp.AspNetCore.Mvc.ApiExploring.AbpApiDefinitionController": {
+          "controllerName": "AbpApiDefinition",
+          "type": "Volo.Abp.AspNetCore.Mvc.ApiExploring.AbpApiDefinitionController",
+          "interfaces": [],
+          "actions": {
+            "GetByModel": {
+              "uniqueName": "GetByModel",
+              "name": "Get",
+              "httpMethod": "GET",
+              "url": "api/abp/api-definition",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "model",
+                  "typeAsString": "Volo.Abp.Http.Modeling.ApplicationApiDescriptionModelRequestDto, Volo.Abp.Http",
+                  "type": "Volo.Abp.Http.Modeling.ApplicationApiDescriptionModelRequestDto",
+                  "typeSimple": "Volo.Abp.Http.Modeling.ApplicationApiDescriptionModelRequestDto",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "model",
+                  "name": "IncludeTypes",
+                  "type": "System.Boolean",
+                  "typeSimple": "boolean",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "model"
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.Http.Modeling.ApplicationApiDescriptionModel",
+                "typeSimple": "Volo.Abp.Http.Modeling.ApplicationApiDescriptionModel"
+              }
+            }
+          }
+        }
+      }
+    },
     "identity": {
       "rootPath": "identity",
       "remoteServiceName": "AbpIdentity",
@@ -828,6 +4377,179 @@
               "returnValue": {
                 "type": "System.Void",
                 "typeSimple": "System.Void"
+              }
+            }
+          }
+        },
+        "Volo.Abp.Identity.IdentityLinkUserController": {
+          "controllerName": "IdentityLinkUser",
+          "type": "Volo.Abp.Identity.IdentityLinkUserController",
+          "interfaces": [
+            {
+              "type": "Volo.Abp.Identity.IIdentityLinkUserAppService"
+            }
+          ],
+          "actions": {
+            "LinkAsyncByInput": {
+              "uniqueName": "LinkAsyncByInput",
+              "name": "LinkAsync",
+              "httpMethod": "POST",
+              "url": "api/identity/link-user/link",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Abp.Identity.LinkUserInput, Volo.Abp.Identity.Pro.Application.Contracts",
+                  "type": "Volo.Abp.Identity.LinkUserInput",
+                  "typeSimple": "Volo.Abp.Identity.LinkUserInput",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "input",
+                  "name": "input",
+                  "type": "Volo.Abp.Identity.LinkUserInput",
+                  "typeSimple": "Volo.Abp.Identity.LinkUserInput",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "Body",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "System.Void",
+                "typeSimple": "System.Void"
+              }
+            },
+            "UnlinkAsyncByInput": {
+              "uniqueName": "UnlinkAsyncByInput",
+              "name": "UnlinkAsync",
+              "httpMethod": "POST",
+              "url": "api/identity/link-user/unlink",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Abp.Identity.UnLinkUserInput, Volo.Abp.Identity.Pro.Application.Contracts",
+                  "type": "Volo.Abp.Identity.UnLinkUserInput",
+                  "typeSimple": "Volo.Abp.Identity.UnLinkUserInput",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "input",
+                  "name": "input",
+                  "type": "Volo.Abp.Identity.UnLinkUserInput",
+                  "typeSimple": "Volo.Abp.Identity.UnLinkUserInput",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "Body",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "System.Void",
+                "typeSimple": "System.Void"
+              }
+            },
+            "IsLinkedAsyncByInput": {
+              "uniqueName": "IsLinkedAsyncByInput",
+              "name": "IsLinkedAsync",
+              "httpMethod": "POST",
+              "url": "api/identity/link-user/is-linked",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Abp.Identity.IsLinkedInput, Volo.Abp.Identity.Pro.Application.Contracts",
+                  "type": "Volo.Abp.Identity.IsLinkedInput",
+                  "typeSimple": "Volo.Abp.Identity.IsLinkedInput",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "input",
+                  "name": "input",
+                  "type": "Volo.Abp.Identity.IsLinkedInput",
+                  "typeSimple": "Volo.Abp.Identity.IsLinkedInput",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "Body",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "System.Boolean",
+                "typeSimple": "boolean"
+              }
+            },
+            "GenerateLinkTokenAsync": {
+              "uniqueName": "GenerateLinkTokenAsync",
+              "name": "GenerateLinkTokenAsync",
+              "httpMethod": "POST",
+              "url": "api/identity/link-user/generate-link-token",
+              "supportedVersions": [],
+              "parametersOnMethod": [],
+              "parameters": [],
+              "returnValue": {
+                "type": "System.String",
+                "typeSimple": "string"
+              }
+            },
+            "VerifyLinkTokenAsyncByToken": {
+              "uniqueName": "VerifyLinkTokenAsyncByToken",
+              "name": "VerifyLinkTokenAsync",
+              "httpMethod": "POST",
+              "url": "api/identity/link-user/verify-link-token",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "token",
+                  "typeAsString": "Volo.Abp.Identity.VerifyLinkTokenInput, Volo.Abp.Identity.Pro.Application.Contracts",
+                  "type": "Volo.Abp.Identity.VerifyLinkTokenInput",
+                  "typeSimple": "Volo.Abp.Identity.VerifyLinkTokenInput",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "token",
+                  "name": "token",
+                  "type": "Volo.Abp.Identity.VerifyLinkTokenInput",
+                  "typeSimple": "Volo.Abp.Identity.VerifyLinkTokenInput",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "Body",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "System.Boolean",
+                "typeSimple": "boolean"
+              }
+            },
+            "GetAllListAsync": {
+              "uniqueName": "GetAllListAsync",
+              "name": "GetAllListAsync",
+              "httpMethod": "GET",
+              "url": "api/identity/link-user",
+              "supportedVersions": [],
+              "parametersOnMethod": [],
+              "parameters": [],
+              "returnValue": {
+                "type": "Volo.Abp.Application.Dtos.ListResultDto<Volo.Abp.Identity.LinkUserDto>",
+                "typeSimple": "Volo.Abp.Application.Dtos.ListResultDto<Volo.Abp.Identity.LinkUserDto>"
               }
             }
           }
@@ -1093,7 +4815,7 @@
                 },
                 {
                   "name": "input",
-                  "typeAsString": "System.Collections.Generic.List`1[[Volo.Abp.Identity.IdentityRoleClaimDto, Volo.Abp.Identity.Pro.Application.Contracts, Version=3.1.0.0, Culture=neutral, PublicKeyToken=null]], System.Private.CoreLib",
+                  "typeAsString": "System.Collections.Generic.List`1[[Volo.Abp.Identity.IdentityRoleClaimDto, Volo.Abp.Identity.Pro.Application.Contracts, Version=4.0.0.0, Culture=neutral, PublicKeyToken=null]], System.Private.CoreLib",
                   "type": "System.Collections.Generic.List<Volo.Abp.Identity.IdentityRoleClaimDto>",
                   "typeSimple": "[Volo.Abp.Identity.IdentityRoleClaimDto]",
                   "isOptional": false,
@@ -2045,7 +5767,7 @@
                 },
                 {
                   "name": "input",
-                  "typeAsString": "System.Collections.Generic.List`1[[Volo.Abp.Identity.IdentityUserClaimDto, Volo.Abp.Identity.Pro.Application.Contracts, Version=3.1.0.0, Culture=neutral, PublicKeyToken=null]], System.Private.CoreLib",
+                  "typeAsString": "System.Collections.Generic.List`1[[Volo.Abp.Identity.IdentityUserClaimDto, Volo.Abp.Identity.Pro.Application.Contracts, Version=4.0.0.0, Culture=neutral, PublicKeyToken=null]], System.Private.CoreLib",
                   "type": "System.Collections.Generic.List<Volo.Abp.Identity.IdentityUserClaimDto>",
                   "typeSimple": "[Volo.Abp.Identity.IdentityUserClaimDto]",
                   "isOptional": false,
@@ -2073,6 +5795,59 @@
                   "defaultValue": null,
                   "constraintTypes": null,
                   "bindingSourceId": "Body",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "System.Void",
+                "typeSimple": "System.Void"
+              }
+            },
+            "LockAsyncByIdAndLockoutDuration": {
+              "uniqueName": "LockAsyncByIdAndLockoutDuration",
+              "name": "LockAsync",
+              "httpMethod": "PUT",
+              "url": "api/identity/users/{id}/lock/{lockoutDuration}",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "id",
+                  "typeAsString": "System.Guid, System.Private.CoreLib",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                },
+                {
+                  "name": "lockoutDuration",
+                  "typeAsString": "System.Int32, System.Private.CoreLib",
+                  "type": "System.Int32",
+                  "typeSimple": "number",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "id",
+                  "name": "id",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                },
+                {
+                  "nameOnMethod": "lockoutDuration",
+                  "name": "lockoutDuration",
+                  "type": "System.Int32",
+                  "typeSimple": "number",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
                   "descriptorName": ""
                 }
               ],
@@ -2181,6 +5956,93 @@
               "returnValue": {
                 "type": "Volo.Abp.Identity.IdentityUserDto",
                 "typeSimple": "Volo.Abp.Identity.IdentityUserDto"
+              }
+            },
+            "GetTwoFactorEnabledAsyncById": {
+              "uniqueName": "GetTwoFactorEnabledAsyncById",
+              "name": "GetTwoFactorEnabledAsync",
+              "httpMethod": "GET",
+              "url": "api/identity/users/{id}/two-factor-enabled",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "id",
+                  "typeAsString": "System.Guid, System.Private.CoreLib",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "id",
+                  "name": "id",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "System.Boolean",
+                "typeSimple": "boolean"
+              }
+            },
+            "SetTwoFactorEnabledAsyncByIdAndEnabled": {
+              "uniqueName": "SetTwoFactorEnabledAsyncByIdAndEnabled",
+              "name": "SetTwoFactorEnabledAsync",
+              "httpMethod": "PUT",
+              "url": "api/identity/users/{id}/two-factor/{enabled}",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "id",
+                  "typeAsString": "System.Guid, System.Private.CoreLib",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                },
+                {
+                  "name": "enabled",
+                  "typeAsString": "System.Boolean, System.Private.CoreLib",
+                  "type": "System.Boolean",
+                  "typeSimple": "boolean",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "id",
+                  "name": "id",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                },
+                {
+                  "nameOnMethod": "enabled",
+                  "name": "enabled",
+                  "type": "System.Boolean",
+                  "typeSimple": "boolean",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "System.Void",
+                "typeSimple": "System.Void"
               }
             },
             "UpdatePasswordAsyncByIdAndInput": {
@@ -2929,6 +6791,162 @@
                 "typeSimple": "System.Void"
               }
             },
+            "GetAvailableUsersAsyncByInput": {
+              "uniqueName": "GetAvailableUsersAsyncByInput",
+              "name": "GetAvailableUsersAsync",
+              "httpMethod": "GET",
+              "url": "api/identity/organization-units/available-users",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Abp.Identity.GetAvailableUsersInput, Volo.Abp.Identity.Pro.Application.Contracts",
+                  "type": "Volo.Abp.Identity.GetAvailableUsersInput",
+                  "typeSimple": "Volo.Abp.Identity.GetAvailableUsersInput",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "input",
+                  "name": "Filter",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "Id",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "Sorting",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "SkipCount",
+                  "type": "System.Int32",
+                  "typeSimple": "number",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "MaxResultCount",
+                  "type": "System.Int32",
+                  "typeSimple": "number",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.Application.Dtos.PagedResultDto<Volo.Abp.Identity.IdentityUserDto>",
+                "typeSimple": "Volo.Abp.Application.Dtos.PagedResultDto<Volo.Abp.Identity.IdentityUserDto>"
+              }
+            },
+            "GetAvailableRolesAsyncByInput": {
+              "uniqueName": "GetAvailableRolesAsyncByInput",
+              "name": "GetAvailableRolesAsync",
+              "httpMethod": "GET",
+              "url": "api/identity/organization-units/available-roles",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "input",
+                  "typeAsString": "Volo.Abp.Identity.GetAvailableRolesInput, Volo.Abp.Identity.Pro.Application.Contracts",
+                  "type": "Volo.Abp.Identity.GetAvailableRolesInput",
+                  "typeSimple": "Volo.Abp.Identity.GetAvailableRolesInput",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "input",
+                  "name": "Filter",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "Id",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "Sorting",
+                  "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "SkipCount",
+                  "type": "System.Int32",
+                  "typeSimple": "number",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                },
+                {
+                  "nameOnMethod": "input",
+                  "name": "MaxResultCount",
+                  "type": "System.Int32",
+                  "typeSimple": "number",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": null,
+                  "bindingSourceId": "ModelBinding",
+                  "descriptorName": "input"
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.Application.Dtos.PagedResultDto<Volo.Abp.Identity.IdentityRoleDto>",
+                "typeSimple": "Volo.Abp.Application.Dtos.PagedResultDto<Volo.Abp.Identity.IdentityRoleDto>"
+              }
+            },
             "UpdateAsyncByIdAndInput": {
               "uniqueName": "UpdateAsyncByIdAndInput",
               "name": "UpdateAsync",
@@ -3179,287 +7197,46 @@
                 "type": "System.Void",
                 "typeSimple": "System.Void"
               }
-            }
-          }
-        }
-      }
-    },
-    "account": {
-      "rootPath": "account",
-      "remoteServiceName": "AbpAccountPublic",
-      "controllers": {
-        "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.AccountController": {
-          "controllerName": "Account",
-          "type": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.AccountController",
-          "interfaces": [],
-          "actions": {
-            "LoginByLogin": {
-              "uniqueName": "LoginByLogin",
-              "name": "Login",
-              "httpMethod": "POST",
-              "url": "api/account/login",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "login",
-                  "typeAsString": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.UserLoginInfo, Volo.Abp.Account.Pro.Public.Web",
-                  "type": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.UserLoginInfo",
-                  "typeSimple": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.UserLoginInfo",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "login",
-                  "name": "login",
-                  "type": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.UserLoginInfo",
-                  "typeSimple": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.UserLoginInfo",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "Body",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.AbpLoginResult",
-                "typeSimple": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.AbpLoginResult"
-              }
             },
-            "Logout": {
-              "uniqueName": "Logout",
-              "name": "Logout",
+            "GetTwoFactorEnabledAsync": {
+              "uniqueName": "GetTwoFactorEnabledAsync",
+              "name": "GetTwoFactorEnabledAsync",
               "httpMethod": "GET",
-              "url": "api/account/logout",
+              "url": "api/identity/my-profile/two-factor-enabled",
               "supportedVersions": [],
               "parametersOnMethod": [],
               "parameters": [],
               "returnValue": {
-                "type": "System.Void",
-                "typeSimple": "System.Void"
+                "type": "System.Boolean",
+                "typeSimple": "boolean"
               }
             },
-            "CheckPasswordByLogin": {
-              "uniqueName": "CheckPasswordByLogin",
-              "name": "CheckPassword",
+            "SetTwoFactorEnabledAsyncByEnabled": {
+              "uniqueName": "SetTwoFactorEnabledAsyncByEnabled",
+              "name": "SetTwoFactorEnabledAsync",
               "httpMethod": "POST",
-              "url": "api/account/checkPassword",
+              "url": "api/identity/my-profile/set-two-factor-enabled",
               "supportedVersions": [],
               "parametersOnMethod": [
                 {
-                  "name": "login",
-                  "typeAsString": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.UserLoginInfo, Volo.Abp.Account.Pro.Public.Web",
-                  "type": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.UserLoginInfo",
-                  "typeSimple": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.UserLoginInfo",
+                  "name": "enabled",
+                  "typeAsString": "System.Boolean, System.Private.CoreLib",
+                  "type": "System.Boolean",
+                  "typeSimple": "boolean",
                   "isOptional": false,
                   "defaultValue": null
                 }
               ],
               "parameters": [
                 {
-                  "nameOnMethod": "login",
-                  "name": "login",
-                  "type": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.UserLoginInfo",
-                  "typeSimple": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.UserLoginInfo",
+                  "nameOnMethod": "enabled",
+                  "name": "enabled",
+                  "type": "System.Boolean",
+                  "typeSimple": "boolean",
                   "isOptional": false,
                   "defaultValue": null,
                   "constraintTypes": null,
-                  "bindingSourceId": "Body",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.AbpLoginResult",
-                "typeSimple": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.AbpLoginResult"
-              }
-            }
-          }
-        },
-        "Volo.Abp.Account.AccountController": {
-          "controllerName": "Account",
-          "type": "Volo.Abp.Account.AccountController",
-          "interfaces": [
-            {
-              "type": "Volo.Abp.Account.IAccountAppService"
-            }
-          ],
-          "actions": {
-            "RegisterAsyncByInput": {
-              "uniqueName": "RegisterAsyncByInput",
-              "name": "RegisterAsync",
-              "httpMethod": "POST",
-              "url": "api/account/register",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "input",
-                  "typeAsString": "Volo.Abp.Account.RegisterDto, Volo.Abp.Account.Pro.Public.Application.Contracts",
-                  "type": "Volo.Abp.Account.RegisterDto",
-                  "typeSimple": "Volo.Abp.Account.RegisterDto",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "input",
-                  "name": "input",
-                  "type": "Volo.Abp.Account.RegisterDto",
-                  "typeSimple": "Volo.Abp.Account.RegisterDto",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "Body",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "Volo.Abp.Identity.IdentityUserDto",
-                "typeSimple": "Volo.Abp.Identity.IdentityUserDto"
-              }
-            },
-            "SendPasswordResetCodeAsyncByInput": {
-              "uniqueName": "SendPasswordResetCodeAsyncByInput",
-              "name": "SendPasswordResetCodeAsync",
-              "httpMethod": "POST",
-              "url": "api/account/send-password-reset-code",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "input",
-                  "typeAsString": "Volo.Abp.Account.SendPasswordResetCodeDto, Volo.Abp.Account.Pro.Public.Application.Contracts",
-                  "type": "Volo.Abp.Account.SendPasswordResetCodeDto",
-                  "typeSimple": "Volo.Abp.Account.SendPasswordResetCodeDto",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "input",
-                  "name": "input",
-                  "type": "Volo.Abp.Account.SendPasswordResetCodeDto",
-                  "typeSimple": "Volo.Abp.Account.SendPasswordResetCodeDto",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "Body",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "System.Void",
-                "typeSimple": "System.Void"
-              }
-            },
-            "ResetPasswordAsyncByInput": {
-              "uniqueName": "ResetPasswordAsyncByInput",
-              "name": "ResetPasswordAsync",
-              "httpMethod": "POST",
-              "url": "api/account/reset-password",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "input",
-                  "typeAsString": "Volo.Abp.Account.ResetPasswordDto, Volo.Abp.Account.Pro.Public.Application.Contracts",
-                  "type": "Volo.Abp.Account.ResetPasswordDto",
-                  "typeSimple": "Volo.Abp.Account.ResetPasswordDto",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "input",
-                  "name": "input",
-                  "type": "Volo.Abp.Account.ResetPasswordDto",
-                  "typeSimple": "Volo.Abp.Account.ResetPasswordDto",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "Body",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "System.Void",
-                "typeSimple": "System.Void"
-              }
-            },
-            "SendPhoneNumberConfirmationTokenAsync": {
-              "uniqueName": "SendPhoneNumberConfirmationTokenAsync",
-              "name": "SendPhoneNumberConfirmationTokenAsync",
-              "httpMethod": "POST",
-              "url": "api/account/send-phone-number-confirmation-token",
-              "supportedVersions": [],
-              "parametersOnMethod": [],
-              "parameters": [],
-              "returnValue": {
-                "type": "System.Void",
-                "typeSimple": "System.Void"
-              }
-            },
-            "ConfirmPhoneNumberAsyncByInput": {
-              "uniqueName": "ConfirmPhoneNumberAsyncByInput",
-              "name": "ConfirmPhoneNumberAsync",
-              "httpMethod": "POST",
-              "url": "api/account/confirm-phone-number",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "input",
-                  "typeAsString": "Volo.Abp.Account.ConfirmPhoneNumberInput, Volo.Abp.Account.Pro.Public.Application.Contracts",
-                  "type": "Volo.Abp.Account.ConfirmPhoneNumberInput",
-                  "typeSimple": "Volo.Abp.Account.ConfirmPhoneNumberInput",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "input",
-                  "name": "input",
-                  "type": "Volo.Abp.Account.ConfirmPhoneNumberInput",
-                  "typeSimple": "Volo.Abp.Account.ConfirmPhoneNumberInput",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "Body",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "System.Void",
-                "typeSimple": "System.Void"
-              }
-            },
-            "ConfirmEmailAsyncByInput": {
-              "uniqueName": "ConfirmEmailAsyncByInput",
-              "name": "ConfirmEmailAsync",
-              "httpMethod": "POST",
-              "url": "api/account/confirm-email",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "input",
-                  "typeAsString": "Volo.Abp.Account.ConfirmEmailInput, Volo.Abp.Account.Pro.Public.Application.Contracts",
-                  "type": "Volo.Abp.Account.ConfirmEmailInput",
-                  "typeSimple": "Volo.Abp.Account.ConfirmEmailInput",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "input",
-                  "name": "input",
-                  "type": "Volo.Abp.Account.ConfirmEmailInput",
-                  "typeSimple": "Volo.Abp.Account.ConfirmEmailInput",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "Body",
+                  "bindingSourceId": "ModelBinding",
                   "descriptorName": ""
                 }
               ],
@@ -3534,8 +7311,8 @@
                 }
               ],
               "returnValue": {
-                "type": "Volo.Abp.FeatureManagement.FeatureListDto",
-                "typeSimple": "Volo.Abp.FeatureManagement.FeatureListDto"
+                "type": "Volo.Abp.FeatureManagement.GetFeatureListResultDto",
+                "typeSimple": "Volo.Abp.FeatureManagement.GetFeatureListResultDto"
               }
             },
             "UpdateAsyncByProviderNameAndProviderKeyAndInput": {
@@ -3855,2479 +7632,6 @@
           }
         }
       }
-    },
-    "languageManagement": {
-      "rootPath": "languageManagement",
-      "remoteServiceName": "LanguageManagement",
-      "controllers": {
-        "Volo.Abp.LanguageManagement.LanguageController": {
-          "controllerName": "Language",
-          "type": "Volo.Abp.LanguageManagement.LanguageController",
-          "interfaces": [
-            {
-              "type": "Volo.Abp.LanguageManagement.ILanguageAppService"
-            }
-          ],
-          "actions": {
-            "GetAllListAsync": {
-              "uniqueName": "GetAllListAsync",
-              "name": "GetAllListAsync",
-              "httpMethod": "GET",
-              "url": "api/language-management/languages/all",
-              "supportedVersions": [],
-              "parametersOnMethod": [],
-              "parameters": [],
-              "returnValue": {
-                "type": "Volo.Abp.Application.Dtos.ListResultDto<Volo.Abp.LanguageManagement.Dto.LanguageDto>",
-                "typeSimple": "Volo.Abp.Application.Dtos.ListResultDto<Volo.Abp.LanguageManagement.Dto.LanguageDto>"
-              }
-            },
-            "GetListAsyncByInput": {
-              "uniqueName": "GetListAsyncByInput",
-              "name": "GetListAsync",
-              "httpMethod": "GET",
-              "url": "api/language-management/languages",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "input",
-                  "typeAsString": "Volo.Abp.LanguageManagement.Dto.GetLanguagesTextsInput, Volo.Abp.LanguageManagement.Application.Contracts",
-                  "type": "Volo.Abp.LanguageManagement.Dto.GetLanguagesTextsInput",
-                  "typeSimple": "Volo.Abp.LanguageManagement.Dto.GetLanguagesTextsInput",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "input",
-                  "name": "Filter",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "ResourceName",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "BaseCultureName",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "TargetCultureName",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "GetOnlyEmptyValues",
-                  "type": "System.Boolean",
-                  "typeSimple": "boolean",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "Sorting",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "SkipCount",
-                  "type": "System.Int32",
-                  "typeSimple": "number",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "MaxResultCount",
-                  "type": "System.Int32",
-                  "typeSimple": "number",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                }
-              ],
-              "returnValue": {
-                "type": "Volo.Abp.Application.Dtos.ListResultDto<Volo.Abp.LanguageManagement.Dto.LanguageDto>",
-                "typeSimple": "Volo.Abp.Application.Dtos.ListResultDto<Volo.Abp.LanguageManagement.Dto.LanguageDto>"
-              }
-            },
-            "GetAsyncById": {
-              "uniqueName": "GetAsyncById",
-              "name": "GetAsync",
-              "httpMethod": "GET",
-              "url": "api/language-management/languages/{id}",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "id",
-                  "typeAsString": "System.Guid, System.Private.CoreLib",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "id",
-                  "name": "id",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": [],
-                  "bindingSourceId": "Path",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "Volo.Abp.LanguageManagement.Dto.LanguageDto",
-                "typeSimple": "Volo.Abp.LanguageManagement.Dto.LanguageDto"
-              }
-            },
-            "CreateAsyncByInput": {
-              "uniqueName": "CreateAsyncByInput",
-              "name": "CreateAsync",
-              "httpMethod": "POST",
-              "url": "api/language-management/languages",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "input",
-                  "typeAsString": "Volo.Abp.LanguageManagement.Dto.CreateLanguageDto, Volo.Abp.LanguageManagement.Application.Contracts",
-                  "type": "Volo.Abp.LanguageManagement.Dto.CreateLanguageDto",
-                  "typeSimple": "Volo.Abp.LanguageManagement.Dto.CreateLanguageDto",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "input",
-                  "name": "input",
-                  "type": "Volo.Abp.LanguageManagement.Dto.CreateLanguageDto",
-                  "typeSimple": "Volo.Abp.LanguageManagement.Dto.CreateLanguageDto",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "Body",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "Volo.Abp.LanguageManagement.Dto.LanguageDto",
-                "typeSimple": "Volo.Abp.LanguageManagement.Dto.LanguageDto"
-              }
-            },
-            "UpdateAsyncByIdAndInput": {
-              "uniqueName": "UpdateAsyncByIdAndInput",
-              "name": "UpdateAsync",
-              "httpMethod": "PUT",
-              "url": "api/language-management/languages/{id}",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "id",
-                  "typeAsString": "System.Guid, System.Private.CoreLib",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                },
-                {
-                  "name": "input",
-                  "typeAsString": "Volo.Abp.LanguageManagement.Dto.UpdateLanguageDto, Volo.Abp.LanguageManagement.Application.Contracts",
-                  "type": "Volo.Abp.LanguageManagement.Dto.UpdateLanguageDto",
-                  "typeSimple": "Volo.Abp.LanguageManagement.Dto.UpdateLanguageDto",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "id",
-                  "name": "id",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": [],
-                  "bindingSourceId": "Path",
-                  "descriptorName": ""
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "input",
-                  "type": "Volo.Abp.LanguageManagement.Dto.UpdateLanguageDto",
-                  "typeSimple": "Volo.Abp.LanguageManagement.Dto.UpdateLanguageDto",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "Body",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "Volo.Abp.LanguageManagement.Dto.LanguageDto",
-                "typeSimple": "Volo.Abp.LanguageManagement.Dto.LanguageDto"
-              }
-            },
-            "DeleteAsyncById": {
-              "uniqueName": "DeleteAsyncById",
-              "name": "DeleteAsync",
-              "httpMethod": "DELETE",
-              "url": "api/language-management/languages/{id}",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "id",
-                  "typeAsString": "System.Guid, System.Private.CoreLib",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "id",
-                  "name": "id",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": [],
-                  "bindingSourceId": "Path",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "System.Void",
-                "typeSimple": "System.Void"
-              }
-            },
-            "SetAsDefaultAsyncById": {
-              "uniqueName": "SetAsDefaultAsyncById",
-              "name": "SetAsDefaultAsync",
-              "httpMethod": "PUT",
-              "url": "api/language-management/languages/{id}/set-as-default",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "id",
-                  "typeAsString": "System.Guid, System.Private.CoreLib",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "id",
-                  "name": "id",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": [],
-                  "bindingSourceId": "Path",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "System.Void",
-                "typeSimple": "System.Void"
-              }
-            },
-            "GetResourcesAsync": {
-              "uniqueName": "GetResourcesAsync",
-              "name": "GetResourcesAsync",
-              "httpMethod": "GET",
-              "url": "api/language-management/languages/resources",
-              "supportedVersions": [],
-              "parametersOnMethod": [],
-              "parameters": [],
-              "returnValue": {
-                "type": "System.Collections.Generic.List<Volo.Abp.LanguageManagement.Dto.LanguageResourceDto>",
-                "typeSimple": "[Volo.Abp.LanguageManagement.Dto.LanguageResourceDto]"
-              }
-            },
-            "GetCulturelistAsync": {
-              "uniqueName": "GetCulturelistAsync",
-              "name": "GetCulturelistAsync",
-              "httpMethod": "GET",
-              "url": "api/language-management/languages/culture-list",
-              "supportedVersions": [],
-              "parametersOnMethod": [],
-              "parameters": [],
-              "returnValue": {
-                "type": "System.Collections.Generic.List<Volo.Abp.LanguageManagement.Dto.CultureInfoDto>",
-                "typeSimple": "[Volo.Abp.LanguageManagement.Dto.CultureInfoDto]"
-              }
-            }
-          }
-        },
-        "Volo.Abp.LanguageManagement.LanguageTextController": {
-          "controllerName": "LanguageText",
-          "type": "Volo.Abp.LanguageManagement.LanguageTextController",
-          "interfaces": [
-            {
-              "type": "Volo.Abp.LanguageManagement.ILanguageTextAppService"
-            }
-          ],
-          "actions": {
-            "GetListAsyncByInput": {
-              "uniqueName": "GetListAsyncByInput",
-              "name": "GetListAsync",
-              "httpMethod": "GET",
-              "url": "api/language-management/language-texts",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "input",
-                  "typeAsString": "Volo.Abp.LanguageManagement.Dto.GetLanguagesTextsInput, Volo.Abp.LanguageManagement.Application.Contracts",
-                  "type": "Volo.Abp.LanguageManagement.Dto.GetLanguagesTextsInput",
-                  "typeSimple": "Volo.Abp.LanguageManagement.Dto.GetLanguagesTextsInput",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "input",
-                  "name": "Filter",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "ResourceName",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "BaseCultureName",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "TargetCultureName",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "GetOnlyEmptyValues",
-                  "type": "System.Boolean",
-                  "typeSimple": "boolean",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "Sorting",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "SkipCount",
-                  "type": "System.Int32",
-                  "typeSimple": "number",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "MaxResultCount",
-                  "type": "System.Int32",
-                  "typeSimple": "number",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                }
-              ],
-              "returnValue": {
-                "type": "Volo.Abp.Application.Dtos.PagedResultDto<Volo.Abp.LanguageManagement.Dto.LanguageTextDto>",
-                "typeSimple": "Volo.Abp.Application.Dtos.PagedResultDto<Volo.Abp.LanguageManagement.Dto.LanguageTextDto>"
-              }
-            },
-            "GetAsyncByResourceNameAndCultureNameAndNameAndBaseCultureName": {
-              "uniqueName": "GetAsyncByResourceNameAndCultureNameAndNameAndBaseCultureName",
-              "name": "GetAsync",
-              "httpMethod": "GET",
-              "url": "api/language-management/language-texts/{resourceName}/{cultureName}/{name}",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "resourceName",
-                  "typeAsString": "System.String, System.Private.CoreLib",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                },
-                {
-                  "name": "cultureName",
-                  "typeAsString": "System.String, System.Private.CoreLib",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                },
-                {
-                  "name": "name",
-                  "typeAsString": "System.String, System.Private.CoreLib",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                },
-                {
-                  "name": "baseCultureName",
-                  "typeAsString": "System.String, System.Private.CoreLib",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "resourceName",
-                  "name": "resourceName",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": [],
-                  "bindingSourceId": "Path",
-                  "descriptorName": ""
-                },
-                {
-                  "nameOnMethod": "cultureName",
-                  "name": "cultureName",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": [],
-                  "bindingSourceId": "Path",
-                  "descriptorName": ""
-                },
-                {
-                  "nameOnMethod": "name",
-                  "name": "name",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": [],
-                  "bindingSourceId": "Path",
-                  "descriptorName": ""
-                },
-                {
-                  "nameOnMethod": "baseCultureName",
-                  "name": "baseCultureName",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "Volo.Abp.LanguageManagement.Dto.LanguageTextDto",
-                "typeSimple": "Volo.Abp.LanguageManagement.Dto.LanguageTextDto"
-              }
-            },
-            "UpdateAsyncByResourceNameAndCultureNameAndNameAndValue": {
-              "uniqueName": "UpdateAsyncByResourceNameAndCultureNameAndNameAndValue",
-              "name": "UpdateAsync",
-              "httpMethod": "PUT",
-              "url": "api/language-management/language-texts/{resourceName}/{cultureName}/{name}",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "resourceName",
-                  "typeAsString": "System.String, System.Private.CoreLib",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                },
-                {
-                  "name": "cultureName",
-                  "typeAsString": "System.String, System.Private.CoreLib",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                },
-                {
-                  "name": "name",
-                  "typeAsString": "System.String, System.Private.CoreLib",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                },
-                {
-                  "name": "value",
-                  "typeAsString": "System.String, System.Private.CoreLib",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "resourceName",
-                  "name": "resourceName",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": [],
-                  "bindingSourceId": "Path",
-                  "descriptorName": ""
-                },
-                {
-                  "nameOnMethod": "cultureName",
-                  "name": "cultureName",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": [],
-                  "bindingSourceId": "Path",
-                  "descriptorName": ""
-                },
-                {
-                  "nameOnMethod": "name",
-                  "name": "name",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": [],
-                  "bindingSourceId": "Path",
-                  "descriptorName": ""
-                },
-                {
-                  "nameOnMethod": "value",
-                  "name": "value",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "System.Void",
-                "typeSimple": "System.Void"
-              }
-            },
-            "RestoreToDefaultAsyncByResourceNameAndCultureNameAndName": {
-              "uniqueName": "RestoreToDefaultAsyncByResourceNameAndCultureNameAndName",
-              "name": "RestoreToDefaultAsync",
-              "httpMethod": "PUT",
-              "url": "api/language-management/language-texts/{resourceName}/{cultureName}/{name}/restore",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "resourceName",
-                  "typeAsString": "System.String, System.Private.CoreLib",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                },
-                {
-                  "name": "cultureName",
-                  "typeAsString": "System.String, System.Private.CoreLib",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                },
-                {
-                  "name": "name",
-                  "typeAsString": "System.String, System.Private.CoreLib",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "resourceName",
-                  "name": "resourceName",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": [],
-                  "bindingSourceId": "Path",
-                  "descriptorName": ""
-                },
-                {
-                  "nameOnMethod": "cultureName",
-                  "name": "cultureName",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": [],
-                  "bindingSourceId": "Path",
-                  "descriptorName": ""
-                },
-                {
-                  "nameOnMethod": "name",
-                  "name": "name",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": [],
-                  "bindingSourceId": "Path",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "System.Void",
-                "typeSimple": "System.Void"
-              }
-            }
-          }
-        }
-      }
-    },
-    "saas": {
-      "rootPath": "saas",
-      "remoteServiceName": "SaasHost",
-      "controllers": {
-        "Volo.Saas.Host.EditionController": {
-          "controllerName": "Edition",
-          "type": "Volo.Saas.Host.EditionController",
-          "interfaces": [
-            {
-              "type": "Volo.Saas.Host.IEditionAppService"
-            }
-          ],
-          "actions": {
-            "GetAsyncById": {
-              "uniqueName": "GetAsyncById",
-              "name": "GetAsync",
-              "httpMethod": "GET",
-              "url": "api/saas/editions/{id}",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "id",
-                  "typeAsString": "System.Guid, System.Private.CoreLib",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "id",
-                  "name": "id",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": [],
-                  "bindingSourceId": "Path",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "Volo.Saas.Host.Dtos.EditionDto",
-                "typeSimple": "Volo.Saas.Host.Dtos.EditionDto"
-              }
-            },
-            "GetListAsyncByInput": {
-              "uniqueName": "GetListAsyncByInput",
-              "name": "GetListAsync",
-              "httpMethod": "GET",
-              "url": "api/saas/editions",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "input",
-                  "typeAsString": "Volo.Saas.Host.Dtos.GetEditionsInput, Volo.Saas.Host.Application.Contracts",
-                  "type": "Volo.Saas.Host.Dtos.GetEditionsInput",
-                  "typeSimple": "Volo.Saas.Host.Dtos.GetEditionsInput",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "input",
-                  "name": "Filter",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "Sorting",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "SkipCount",
-                  "type": "System.Int32",
-                  "typeSimple": "number",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "MaxResultCount",
-                  "type": "System.Int32",
-                  "typeSimple": "number",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                }
-              ],
-              "returnValue": {
-                "type": "Volo.Abp.Application.Dtos.PagedResultDto<Volo.Saas.Host.Dtos.EditionDto>",
-                "typeSimple": "Volo.Abp.Application.Dtos.PagedResultDto<Volo.Saas.Host.Dtos.EditionDto>"
-              }
-            },
-            "CreateAsyncByInput": {
-              "uniqueName": "CreateAsyncByInput",
-              "name": "CreateAsync",
-              "httpMethod": "POST",
-              "url": "api/saas/editions",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "input",
-                  "typeAsString": "Volo.Saas.Host.Dtos.EditionCreateDto, Volo.Saas.Host.Application.Contracts",
-                  "type": "Volo.Saas.Host.Dtos.EditionCreateDto",
-                  "typeSimple": "Volo.Saas.Host.Dtos.EditionCreateDto",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "input",
-                  "name": "input",
-                  "type": "Volo.Saas.Host.Dtos.EditionCreateDto",
-                  "typeSimple": "Volo.Saas.Host.Dtos.EditionCreateDto",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "Body",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "Volo.Saas.Host.Dtos.EditionDto",
-                "typeSimple": "Volo.Saas.Host.Dtos.EditionDto"
-              }
-            },
-            "UpdateAsyncByIdAndInput": {
-              "uniqueName": "UpdateAsyncByIdAndInput",
-              "name": "UpdateAsync",
-              "httpMethod": "PUT",
-              "url": "api/saas/editions/{id}",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "id",
-                  "typeAsString": "System.Guid, System.Private.CoreLib",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                },
-                {
-                  "name": "input",
-                  "typeAsString": "Volo.Saas.Host.Dtos.EditionUpdateDto, Volo.Saas.Host.Application.Contracts",
-                  "type": "Volo.Saas.Host.Dtos.EditionUpdateDto",
-                  "typeSimple": "Volo.Saas.Host.Dtos.EditionUpdateDto",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "id",
-                  "name": "id",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": [],
-                  "bindingSourceId": "Path",
-                  "descriptorName": ""
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "input",
-                  "type": "Volo.Saas.Host.Dtos.EditionUpdateDto",
-                  "typeSimple": "Volo.Saas.Host.Dtos.EditionUpdateDto",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "Body",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "Volo.Saas.Host.Dtos.EditionDto",
-                "typeSimple": "Volo.Saas.Host.Dtos.EditionDto"
-              }
-            },
-            "DeleteAsyncById": {
-              "uniqueName": "DeleteAsyncById",
-              "name": "DeleteAsync",
-              "httpMethod": "DELETE",
-              "url": "api/saas/editions/{id}",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "id",
-                  "typeAsString": "System.Guid, System.Private.CoreLib",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "id",
-                  "name": "id",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": [],
-                  "bindingSourceId": "Path",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "System.Void",
-                "typeSimple": "System.Void"
-              }
-            },
-            "GetUsageStatistics": {
-              "uniqueName": "GetUsageStatistics",
-              "name": "GetUsageStatistics",
-              "httpMethod": "GET",
-              "url": "api/saas/editions/statistics/usage-statistic",
-              "supportedVersions": [],
-              "parametersOnMethod": [],
-              "parameters": [],
-              "returnValue": {
-                "type": "Volo.Saas.Host.GetEditionUsageStatisticsResult",
-                "typeSimple": "Volo.Saas.Host.GetEditionUsageStatisticsResult"
-              }
-            }
-          }
-        },
-        "Volo.Saas.Host.TenantController": {
-          "controllerName": "Tenant",
-          "type": "Volo.Saas.Host.TenantController",
-          "interfaces": [
-            {
-              "type": "Volo.Saas.Host.ITenantAppService"
-            }
-          ],
-          "actions": {
-            "GetAsyncById": {
-              "uniqueName": "GetAsyncById",
-              "name": "GetAsync",
-              "httpMethod": "GET",
-              "url": "api/saas/tenants/{id}",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "id",
-                  "typeAsString": "System.Guid, System.Private.CoreLib",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "id",
-                  "name": "id",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": [],
-                  "bindingSourceId": "Path",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "Volo.Saas.Host.Dtos.SaasTenantDto",
-                "typeSimple": "Volo.Saas.Host.Dtos.SaasTenantDto"
-              }
-            },
-            "GetListAsyncByInput": {
-              "uniqueName": "GetListAsyncByInput",
-              "name": "GetListAsync",
-              "httpMethod": "GET",
-              "url": "api/saas/tenants",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "input",
-                  "typeAsString": "Volo.Saas.Host.Dtos.GetTenantsInput, Volo.Saas.Host.Application.Contracts",
-                  "type": "Volo.Saas.Host.Dtos.GetTenantsInput",
-                  "typeSimple": "Volo.Saas.Host.Dtos.GetTenantsInput",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "input",
-                  "name": "Filter",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "GetEditionNames",
-                  "type": "System.Boolean",
-                  "typeSimple": "boolean",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "Sorting",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "SkipCount",
-                  "type": "System.Int32",
-                  "typeSimple": "number",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "MaxResultCount",
-                  "type": "System.Int32",
-                  "typeSimple": "number",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                }
-              ],
-              "returnValue": {
-                "type": "Volo.Abp.Application.Dtos.PagedResultDto<Volo.Saas.Host.Dtos.SaasTenantDto>",
-                "typeSimple": "Volo.Abp.Application.Dtos.PagedResultDto<Volo.Saas.Host.Dtos.SaasTenantDto>"
-              }
-            },
-            "CreateAsyncByInput": {
-              "uniqueName": "CreateAsyncByInput",
-              "name": "CreateAsync",
-              "httpMethod": "POST",
-              "url": "api/saas/tenants",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "input",
-                  "typeAsString": "Volo.Saas.Host.Dtos.SaasTenantCreateDto, Volo.Saas.Host.Application.Contracts",
-                  "type": "Volo.Saas.Host.Dtos.SaasTenantCreateDto",
-                  "typeSimple": "Volo.Saas.Host.Dtos.SaasTenantCreateDto",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "input",
-                  "name": "input",
-                  "type": "Volo.Saas.Host.Dtos.SaasTenantCreateDto",
-                  "typeSimple": "Volo.Saas.Host.Dtos.SaasTenantCreateDto",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "Body",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "Volo.Saas.Host.Dtos.SaasTenantDto",
-                "typeSimple": "Volo.Saas.Host.Dtos.SaasTenantDto"
-              }
-            },
-            "UpdateAsyncByIdAndInput": {
-              "uniqueName": "UpdateAsyncByIdAndInput",
-              "name": "UpdateAsync",
-              "httpMethod": "PUT",
-              "url": "api/saas/tenants/{id}",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "id",
-                  "typeAsString": "System.Guid, System.Private.CoreLib",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                },
-                {
-                  "name": "input",
-                  "typeAsString": "Volo.Saas.Host.Dtos.SaasTenantUpdateDto, Volo.Saas.Host.Application.Contracts",
-                  "type": "Volo.Saas.Host.Dtos.SaasTenantUpdateDto",
-                  "typeSimple": "Volo.Saas.Host.Dtos.SaasTenantUpdateDto",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "id",
-                  "name": "id",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": [],
-                  "bindingSourceId": "Path",
-                  "descriptorName": ""
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "input",
-                  "type": "Volo.Saas.Host.Dtos.SaasTenantUpdateDto",
-                  "typeSimple": "Volo.Saas.Host.Dtos.SaasTenantUpdateDto",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "Body",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "Volo.Saas.Host.Dtos.SaasTenantDto",
-                "typeSimple": "Volo.Saas.Host.Dtos.SaasTenantDto"
-              }
-            },
-            "DeleteAsyncById": {
-              "uniqueName": "DeleteAsyncById",
-              "name": "DeleteAsync",
-              "httpMethod": "DELETE",
-              "url": "api/saas/tenants/{id}",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "id",
-                  "typeAsString": "System.Guid, System.Private.CoreLib",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "id",
-                  "name": "id",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": [],
-                  "bindingSourceId": "Path",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "System.Void",
-                "typeSimple": "System.Void"
-              }
-            },
-            "GetDefaultConnectionStringAsyncById": {
-              "uniqueName": "GetDefaultConnectionStringAsyncById",
-              "name": "GetDefaultConnectionStringAsync",
-              "httpMethod": "GET",
-              "url": "api/saas/tenants/{id}/default-connection-string",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "id",
-                  "typeAsString": "System.Guid, System.Private.CoreLib",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "id",
-                  "name": "id",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": [],
-                  "bindingSourceId": "Path",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "System.String",
-                "typeSimple": "string"
-              }
-            },
-            "UpdateDefaultConnectionStringAsyncByIdAndDefaultConnectionString": {
-              "uniqueName": "UpdateDefaultConnectionStringAsyncByIdAndDefaultConnectionString",
-              "name": "UpdateDefaultConnectionStringAsync",
-              "httpMethod": "PUT",
-              "url": "api/saas/tenants/{id}/default-connection-string",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "id",
-                  "typeAsString": "System.Guid, System.Private.CoreLib",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                },
-                {
-                  "name": "defaultConnectionString",
-                  "typeAsString": "System.String, System.Private.CoreLib",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "id",
-                  "name": "id",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": [],
-                  "bindingSourceId": "Path",
-                  "descriptorName": ""
-                },
-                {
-                  "nameOnMethod": "defaultConnectionString",
-                  "name": "defaultConnectionString",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "System.Void",
-                "typeSimple": "System.Void"
-              }
-            },
-            "DeleteDefaultConnectionStringAsyncById": {
-              "uniqueName": "DeleteDefaultConnectionStringAsyncById",
-              "name": "DeleteDefaultConnectionStringAsync",
-              "httpMethod": "DELETE",
-              "url": "api/saas/tenants/{id}/default-connection-string",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "id",
-                  "typeAsString": "System.Guid, System.Private.CoreLib",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "id",
-                  "name": "id",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": [],
-                  "bindingSourceId": "Path",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "System.Void",
-                "typeSimple": "System.Void"
-              }
-            }
-          }
-        }
-      }
-    },
-    "abp": {
-      "rootPath": "abp",
-      "remoteServiceName": "abp",
-      "controllers": {
-        "Pages.Abp.MultiTenancy.AbpTenantController": {
-          "controllerName": "AbpTenant",
-          "type": "Pages.Abp.MultiTenancy.AbpTenantController",
-          "interfaces": [
-            {
-              "type": "Volo.Abp.AspNetCore.Mvc.MultiTenancy.IAbpTenantAppService"
-            }
-          ],
-          "actions": {
-            "FindTenantByNameAsyncByName": {
-              "uniqueName": "FindTenantByNameAsyncByName",
-              "name": "FindTenantByNameAsync",
-              "httpMethod": "GET",
-              "url": "api/abp/multi-tenancy/tenants/by-name/{name}",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "name",
-                  "typeAsString": "System.String, System.Private.CoreLib",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "name",
-                  "name": "name",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": [],
-                  "bindingSourceId": "Path",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "Volo.Abp.AspNetCore.Mvc.MultiTenancy.FindTenantResultDto",
-                "typeSimple": "Volo.Abp.AspNetCore.Mvc.MultiTenancy.FindTenantResultDto"
-              }
-            },
-            "FindTenantByIdAsyncById": {
-              "uniqueName": "FindTenantByIdAsyncById",
-              "name": "FindTenantByIdAsync",
-              "httpMethod": "GET",
-              "url": "api/abp/multi-tenancy/tenants/by-id/{id}",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "id",
-                  "typeAsString": "System.Guid, System.Private.CoreLib",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "id",
-                  "name": "id",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": [],
-                  "bindingSourceId": "Path",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "Volo.Abp.AspNetCore.Mvc.MultiTenancy.FindTenantResultDto",
-                "typeSimple": "Volo.Abp.AspNetCore.Mvc.MultiTenancy.FindTenantResultDto"
-              }
-            }
-          }
-        },
-        "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.AbpApplicationConfigurationController": {
-          "controllerName": "AbpApplicationConfiguration",
-          "type": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.AbpApplicationConfigurationController",
-          "interfaces": [
-            {
-              "type": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.IAbpApplicationConfigurationAppService"
-            }
-          ],
-          "actions": {
-            "GetAsync": {
-              "uniqueName": "GetAsync",
-              "name": "GetAsync",
-              "httpMethod": "GET",
-              "url": "api/abp/application-configuration",
-              "supportedVersions": [],
-              "parametersOnMethod": [],
-              "parameters": [],
-              "returnValue": {
-                "type": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ApplicationConfigurationDto",
-                "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ApplicationConfigurationDto"
-              }
-            }
-          }
-        },
-        "Volo.Abp.AspNetCore.Mvc.ApiExploring.AbpApiDefinitionController": {
-          "controllerName": "AbpApiDefinition",
-          "type": "Volo.Abp.AspNetCore.Mvc.ApiExploring.AbpApiDefinitionController",
-          "interfaces": [],
-          "actions": {
-            "GetByModel": {
-              "uniqueName": "GetByModel",
-              "name": "Get",
-              "httpMethod": "GET",
-              "url": "api/abp/api-definition",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "model",
-                  "typeAsString": "Volo.Abp.Http.Modeling.ApplicationApiDescriptionModelRequestDto, Volo.Abp.Http",
-                  "type": "Volo.Abp.Http.Modeling.ApplicationApiDescriptionModelRequestDto",
-                  "typeSimple": "Volo.Abp.Http.Modeling.ApplicationApiDescriptionModelRequestDto",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "model",
-                  "name": "IncludeTypes",
-                  "type": "System.Boolean",
-                  "typeSimple": "boolean",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "model"
-                }
-              ],
-              "returnValue": {
-                "type": "Volo.Abp.Http.Modeling.ApplicationApiDescriptionModel",
-                "typeSimple": "Volo.Abp.Http.Modeling.ApplicationApiDescriptionModel"
-              }
-            }
-          }
-        }
-      }
-    },
-    "identityServer": {
-      "rootPath": "identityServer",
-      "remoteServiceName": "AbpIdentityServer",
-      "controllers": {
-        "Volo.Abp.IdentityServer.ApiResourcesController": {
-          "controllerName": "ApiResources",
-          "type": "Volo.Abp.IdentityServer.ApiResourcesController",
-          "interfaces": [
-            {
-              "type": "Volo.Abp.IdentityServer.ApiResource.IApiResourceAppService"
-            }
-          ],
-          "actions": {
-            "GetListAsyncByInput": {
-              "uniqueName": "GetListAsyncByInput",
-              "name": "GetListAsync",
-              "httpMethod": "GET",
-              "url": "api/identity-server/api-resources",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "input",
-                  "typeAsString": "Volo.Abp.IdentityServer.ApiResource.Dtos.GetApiResourceListInput, Volo.Abp.IdentityServer.Application.Contracts",
-                  "type": "Volo.Abp.IdentityServer.ApiResource.Dtos.GetApiResourceListInput",
-                  "typeSimple": "Volo.Abp.IdentityServer.ApiResource.Dtos.GetApiResourceListInput",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "input",
-                  "name": "Filter",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "Sorting",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "SkipCount",
-                  "type": "System.Int32",
-                  "typeSimple": "number",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "MaxResultCount",
-                  "type": "System.Int32",
-                  "typeSimple": "number",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                }
-              ],
-              "returnValue": {
-                "type": "Volo.Abp.Application.Dtos.PagedResultDto<Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceWithDetailsDto>",
-                "typeSimple": "Volo.Abp.Application.Dtos.PagedResultDto<Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceWithDetailsDto>"
-              }
-            },
-            "GetAllListAsync": {
-              "uniqueName": "GetAllListAsync",
-              "name": "GetAllListAsync",
-              "httpMethod": "GET",
-              "url": "api/identity-server/api-resources/all",
-              "supportedVersions": [],
-              "parametersOnMethod": [],
-              "parameters": [],
-              "returnValue": {
-                "type": "System.Collections.Generic.List<Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceWithDetailsDto>",
-                "typeSimple": "[Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceWithDetailsDto]"
-              }
-            },
-            "GetAsyncById": {
-              "uniqueName": "GetAsyncById",
-              "name": "GetAsync",
-              "httpMethod": "GET",
-              "url": "api/identity-server/api-resources/{id}",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "id",
-                  "typeAsString": "System.Guid, System.Private.CoreLib",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "id",
-                  "name": "id",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": [],
-                  "bindingSourceId": "Path",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceWithDetailsDto",
-                "typeSimple": "Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceWithDetailsDto"
-              }
-            },
-            "CreateAsyncByInput": {
-              "uniqueName": "CreateAsyncByInput",
-              "name": "CreateAsync",
-              "httpMethod": "POST",
-              "url": "api/identity-server/api-resources",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "input",
-                  "typeAsString": "Volo.Abp.IdentityServer.ApiResource.Dtos.CreateApiResourceDto, Volo.Abp.IdentityServer.Application.Contracts",
-                  "type": "Volo.Abp.IdentityServer.ApiResource.Dtos.CreateApiResourceDto",
-                  "typeSimple": "Volo.Abp.IdentityServer.ApiResource.Dtos.CreateApiResourceDto",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "input",
-                  "name": "input",
-                  "type": "Volo.Abp.IdentityServer.ApiResource.Dtos.CreateApiResourceDto",
-                  "typeSimple": "Volo.Abp.IdentityServer.ApiResource.Dtos.CreateApiResourceDto",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "Body",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceWithDetailsDto",
-                "typeSimple": "Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceWithDetailsDto"
-              }
-            },
-            "UpdateAsyncByIdAndInput": {
-              "uniqueName": "UpdateAsyncByIdAndInput",
-              "name": "UpdateAsync",
-              "httpMethod": "PUT",
-              "url": "api/identity-server/api-resources/{id}",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "id",
-                  "typeAsString": "System.Guid, System.Private.CoreLib",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                },
-                {
-                  "name": "input",
-                  "typeAsString": "Volo.Abp.IdentityServer.ApiResource.Dtos.UpdateApiResourceDto, Volo.Abp.IdentityServer.Application.Contracts",
-                  "type": "Volo.Abp.IdentityServer.ApiResource.Dtos.UpdateApiResourceDto",
-                  "typeSimple": "Volo.Abp.IdentityServer.ApiResource.Dtos.UpdateApiResourceDto",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "id",
-                  "name": "id",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": [],
-                  "bindingSourceId": "Path",
-                  "descriptorName": ""
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "input",
-                  "type": "Volo.Abp.IdentityServer.ApiResource.Dtos.UpdateApiResourceDto",
-                  "typeSimple": "Volo.Abp.IdentityServer.ApiResource.Dtos.UpdateApiResourceDto",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "Body",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceWithDetailsDto",
-                "typeSimple": "Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceWithDetailsDto"
-              }
-            },
-            "DeleteAsyncById": {
-              "uniqueName": "DeleteAsyncById",
-              "name": "DeleteAsync",
-              "httpMethod": "DELETE",
-              "url": "api/identity-server/api-resources",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "id",
-                  "typeAsString": "System.Guid, System.Private.CoreLib",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "id",
-                  "name": "id",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "System.Void",
-                "typeSimple": "System.Void"
-              }
-            }
-          }
-        },
-        "Volo.Abp.IdentityServer.ClientsController": {
-          "controllerName": "Clients",
-          "type": "Volo.Abp.IdentityServer.ClientsController",
-          "interfaces": [
-            {
-              "type": "Volo.Abp.IdentityServer.Client.IClientAppService"
-            }
-          ],
-          "actions": {
-            "GetListAsyncByInput": {
-              "uniqueName": "GetListAsyncByInput",
-              "name": "GetListAsync",
-              "httpMethod": "GET",
-              "url": "api/identity-server/clients",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "input",
-                  "typeAsString": "Volo.Abp.IdentityServer.Client.Dtos.GetClientListInput, Volo.Abp.IdentityServer.Application.Contracts",
-                  "type": "Volo.Abp.IdentityServer.Client.Dtos.GetClientListInput",
-                  "typeSimple": "Volo.Abp.IdentityServer.Client.Dtos.GetClientListInput",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "input",
-                  "name": "Filter",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "Sorting",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "SkipCount",
-                  "type": "System.Int32",
-                  "typeSimple": "number",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "MaxResultCount",
-                  "type": "System.Int32",
-                  "typeSimple": "number",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                }
-              ],
-              "returnValue": {
-                "type": "Volo.Abp.Application.Dtos.PagedResultDto<Volo.Abp.IdentityServer.Client.Dtos.ClientWithDetailsDto>",
-                "typeSimple": "Volo.Abp.Application.Dtos.PagedResultDto<Volo.Abp.IdentityServer.Client.Dtos.ClientWithDetailsDto>"
-              }
-            },
-            "GetAsyncById": {
-              "uniqueName": "GetAsyncById",
-              "name": "GetAsync",
-              "httpMethod": "GET",
-              "url": "api/identity-server/clients/{id}",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "id",
-                  "typeAsString": "System.Guid, System.Private.CoreLib",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "id",
-                  "name": "id",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": [],
-                  "bindingSourceId": "Path",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "Volo.Abp.IdentityServer.Client.Dtos.ClientWithDetailsDto",
-                "typeSimple": "Volo.Abp.IdentityServer.Client.Dtos.ClientWithDetailsDto"
-              }
-            },
-            "CreateAsyncByInput": {
-              "uniqueName": "CreateAsyncByInput",
-              "name": "CreateAsync",
-              "httpMethod": "POST",
-              "url": "api/identity-server/clients",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "input",
-                  "typeAsString": "Volo.Abp.IdentityServer.Client.Dtos.CreateClientDto, Volo.Abp.IdentityServer.Application.Contracts",
-                  "type": "Volo.Abp.IdentityServer.Client.Dtos.CreateClientDto",
-                  "typeSimple": "Volo.Abp.IdentityServer.Client.Dtos.CreateClientDto",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "input",
-                  "name": "input",
-                  "type": "Volo.Abp.IdentityServer.Client.Dtos.CreateClientDto",
-                  "typeSimple": "Volo.Abp.IdentityServer.Client.Dtos.CreateClientDto",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "Body",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "Volo.Abp.IdentityServer.Client.Dtos.ClientWithDetailsDto",
-                "typeSimple": "Volo.Abp.IdentityServer.Client.Dtos.ClientWithDetailsDto"
-              }
-            },
-            "UpdateAsyncByIdAndInput": {
-              "uniqueName": "UpdateAsyncByIdAndInput",
-              "name": "UpdateAsync",
-              "httpMethod": "PUT",
-              "url": "api/identity-server/clients/{id}",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "id",
-                  "typeAsString": "System.Guid, System.Private.CoreLib",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                },
-                {
-                  "name": "input",
-                  "typeAsString": "Volo.Abp.IdentityServer.Client.Dtos.UpdateClientDto, Volo.Abp.IdentityServer.Application.Contracts",
-                  "type": "Volo.Abp.IdentityServer.Client.Dtos.UpdateClientDto",
-                  "typeSimple": "Volo.Abp.IdentityServer.Client.Dtos.UpdateClientDto",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "id",
-                  "name": "id",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": [],
-                  "bindingSourceId": "Path",
-                  "descriptorName": ""
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "input",
-                  "type": "Volo.Abp.IdentityServer.Client.Dtos.UpdateClientDto",
-                  "typeSimple": "Volo.Abp.IdentityServer.Client.Dtos.UpdateClientDto",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "Body",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "Volo.Abp.IdentityServer.Client.Dtos.ClientWithDetailsDto",
-                "typeSimple": "Volo.Abp.IdentityServer.Client.Dtos.ClientWithDetailsDto"
-              }
-            },
-            "DeleteAsyncById": {
-              "uniqueName": "DeleteAsyncById",
-              "name": "DeleteAsync",
-              "httpMethod": "DELETE",
-              "url": "api/identity-server/clients",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "id",
-                  "typeAsString": "System.Guid, System.Private.CoreLib",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "id",
-                  "name": "id",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "System.Void",
-                "typeSimple": "System.Void"
-              }
-            }
-          }
-        },
-        "Volo.Abp.IdentityServer.IdentityResourcesController": {
-          "controllerName": "IdentityResources",
-          "type": "Volo.Abp.IdentityServer.IdentityResourcesController",
-          "interfaces": [
-            {
-              "type": "Volo.Abp.IdentityServer.IdentityResource.IIdentityResourceAppService"
-            }
-          ],
-          "actions": {
-            "GetListAsyncByInput": {
-              "uniqueName": "GetListAsyncByInput",
-              "name": "GetListAsync",
-              "httpMethod": "GET",
-              "url": "api/identity-server/identity-resources",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "input",
-                  "typeAsString": "Volo.Abp.IdentityServer.IdentityResource.Dtos.GetIdentityResourceListInput, Volo.Abp.IdentityServer.Application.Contracts",
-                  "type": "Volo.Abp.IdentityServer.IdentityResource.Dtos.GetIdentityResourceListInput",
-                  "typeSimple": "Volo.Abp.IdentityServer.IdentityResource.Dtos.GetIdentityResourceListInput",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "input",
-                  "name": "Filter",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "Sorting",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "SkipCount",
-                  "type": "System.Int32",
-                  "typeSimple": "number",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "MaxResultCount",
-                  "type": "System.Int32",
-                  "typeSimple": "number",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": "input"
-                }
-              ],
-              "returnValue": {
-                "type": "Volo.Abp.Application.Dtos.PagedResultDto<Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityResourceWithDetailsDto>",
-                "typeSimple": "Volo.Abp.Application.Dtos.PagedResultDto<Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityResourceWithDetailsDto>"
-              }
-            },
-            "GetAllListAsync": {
-              "uniqueName": "GetAllListAsync",
-              "name": "GetAllListAsync",
-              "httpMethod": "GET",
-              "url": "api/identity-server/identity-resources/all",
-              "supportedVersions": [],
-              "parametersOnMethod": [],
-              "parameters": [],
-              "returnValue": {
-                "type": "System.Collections.Generic.List<Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityResourceWithDetailsDto>",
-                "typeSimple": "[Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityResourceWithDetailsDto]"
-              }
-            },
-            "GetAsyncById": {
-              "uniqueName": "GetAsyncById",
-              "name": "GetAsync",
-              "httpMethod": "GET",
-              "url": "api/identity-server/identity-resources/{id}",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "id",
-                  "typeAsString": "System.Guid, System.Private.CoreLib",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "id",
-                  "name": "id",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": [],
-                  "bindingSourceId": "Path",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityResourceWithDetailsDto",
-                "typeSimple": "Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityResourceWithDetailsDto"
-              }
-            },
-            "CreateAsyncByInput": {
-              "uniqueName": "CreateAsyncByInput",
-              "name": "CreateAsync",
-              "httpMethod": "POST",
-              "url": "api/identity-server/identity-resources",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "input",
-                  "typeAsString": "Volo.Abp.IdentityServer.IdentityResource.Dtos.CreateIdentityResourceDto, Volo.Abp.IdentityServer.Application.Contracts",
-                  "type": "Volo.Abp.IdentityServer.IdentityResource.Dtos.CreateIdentityResourceDto",
-                  "typeSimple": "Volo.Abp.IdentityServer.IdentityResource.Dtos.CreateIdentityResourceDto",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "input",
-                  "name": "input",
-                  "type": "Volo.Abp.IdentityServer.IdentityResource.Dtos.CreateIdentityResourceDto",
-                  "typeSimple": "Volo.Abp.IdentityServer.IdentityResource.Dtos.CreateIdentityResourceDto",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "Body",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityResourceWithDetailsDto",
-                "typeSimple": "Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityResourceWithDetailsDto"
-              }
-            },
-            "UpdateAsyncByIdAndInput": {
-              "uniqueName": "UpdateAsyncByIdAndInput",
-              "name": "UpdateAsync",
-              "httpMethod": "PUT",
-              "url": "api/identity-server/identity-resources/{id}",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "id",
-                  "typeAsString": "System.Guid, System.Private.CoreLib",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                },
-                {
-                  "name": "input",
-                  "typeAsString": "Volo.Abp.IdentityServer.IdentityResource.Dtos.UpdateIdentityResourceDto, Volo.Abp.IdentityServer.Application.Contracts",
-                  "type": "Volo.Abp.IdentityServer.IdentityResource.Dtos.UpdateIdentityResourceDto",
-                  "typeSimple": "Volo.Abp.IdentityServer.IdentityResource.Dtos.UpdateIdentityResourceDto",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "id",
-                  "name": "id",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": [],
-                  "bindingSourceId": "Path",
-                  "descriptorName": ""
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "input",
-                  "type": "Volo.Abp.IdentityServer.IdentityResource.Dtos.UpdateIdentityResourceDto",
-                  "typeSimple": "Volo.Abp.IdentityServer.IdentityResource.Dtos.UpdateIdentityResourceDto",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "Body",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityResourceWithDetailsDto",
-                "typeSimple": "Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityResourceWithDetailsDto"
-              }
-            },
-            "DeleteAsyncById": {
-              "uniqueName": "DeleteAsyncById",
-              "name": "DeleteAsync",
-              "httpMethod": "DELETE",
-              "url": "api/identity-server/identity-resources",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "id",
-                  "typeAsString": "System.Guid, System.Private.CoreLib",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "id",
-                  "name": "id",
-                  "type": "System.Guid",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "System.Void",
-                "typeSimple": "System.Void"
-              }
-            },
-            "CreateStandardResourcesAsync": {
-              "uniqueName": "CreateStandardResourcesAsync",
-              "name": "CreateStandardResourcesAsync",
-              "httpMethod": "POST",
-              "url": "api/identity-server/identity-resources/create-standard-resources",
-              "supportedVersions": [],
-              "parametersOnMethod": [],
-              "parameters": [],
-              "returnValue": {
-                "type": "System.Void",
-                "typeSimple": "System.Void"
-              }
-            }
-          }
-        },
-        "Volo.Abp.IdentityServer.IdentityServerClaimTypesController": {
-          "controllerName": "IdentityServerClaimTypes",
-          "type": "Volo.Abp.IdentityServer.IdentityServerClaimTypesController",
-          "interfaces": [
-            {
-              "type": "Volo.Abp.IdentityServer.ClaimType.IIdentityServerClaimTypeAppService"
-            }
-          ],
-          "actions": {
-            "GetListAsync": {
-              "uniqueName": "GetListAsync",
-              "name": "GetListAsync",
-              "httpMethod": "GET",
-              "url": "api/identity-server/claim-types",
-              "supportedVersions": [],
-              "parametersOnMethod": [],
-              "parameters": [],
-              "returnValue": {
-                "type": "System.Collections.Generic.List<Volo.Abp.IdentityServer.ClaimType.Dtos.IdentityClaimTypeDto>",
-                "typeSimple": "[Volo.Abp.IdentityServer.ClaimType.Dtos.IdentityClaimTypeDto]"
-              }
-            }
-          }
-        }
-      }
-    },
-    "accountAdmin": {
-      "rootPath": "accountAdmin",
-      "remoteServiceName": "AbpAccountAdmin",
-      "controllers": {
-        "Volo.Abp.Account.AccountSettingsController": {
-          "controllerName": "AccountSettings",
-          "type": "Volo.Abp.Account.AccountSettingsController",
-          "interfaces": [
-            {
-              "type": "Volo.Abp.Account.IAccountSettingsAppService"
-            }
-          ],
-          "actions": {
-            "GetAsync": {
-              "uniqueName": "GetAsync",
-              "name": "GetAsync",
-              "httpMethod": "GET",
-              "url": "api/account-admin/settings",
-              "supportedVersions": [],
-              "parametersOnMethod": [],
-              "parameters": [],
-              "returnValue": {
-                "type": "Volo.Abp.Account.AccountSettingsDto",
-                "typeSimple": "Volo.Abp.Account.AccountSettingsDto"
-              }
-            },
-            "UpdateAsyncByInput": {
-              "uniqueName": "UpdateAsyncByInput",
-              "name": "UpdateAsync",
-              "httpMethod": "PUT",
-              "url": "api/account-admin/settings",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "input",
-                  "typeAsString": "Volo.Abp.Account.AccountSettingsDto, Volo.Abp.Account.Pro.Admin.Application.Contracts",
-                  "type": "Volo.Abp.Account.AccountSettingsDto",
-                  "typeSimple": "Volo.Abp.Account.AccountSettingsDto",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "input",
-                  "name": "input",
-                  "type": "Volo.Abp.Account.AccountSettingsDto",
-                  "typeSimple": "Volo.Abp.Account.AccountSettingsDto",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "Body",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "System.Void",
-                "typeSimple": "System.Void"
-              }
-            }
-          }
-        }
-      }
-    },
-    "permissionManagement": {
-      "rootPath": "permissionManagement",
-      "remoteServiceName": "AbpPermissionManagement",
-      "controllers": {
-        "Volo.Abp.PermissionManagement.PermissionsController": {
-          "controllerName": "Permissions",
-          "type": "Volo.Abp.PermissionManagement.PermissionsController",
-          "interfaces": [
-            {
-              "type": "Volo.Abp.PermissionManagement.IPermissionAppService"
-            }
-          ],
-          "actions": {
-            "GetAsyncByProviderNameAndProviderKey": {
-              "uniqueName": "GetAsyncByProviderNameAndProviderKey",
-              "name": "GetAsync",
-              "httpMethod": "GET",
-              "url": "api/permission-management/permissions",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "providerName",
-                  "typeAsString": "System.String, System.Private.CoreLib",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                },
-                {
-                  "name": "providerKey",
-                  "typeAsString": "System.String, System.Private.CoreLib",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "providerName",
-                  "name": "providerName",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": ""
-                },
-                {
-                  "nameOnMethod": "providerKey",
-                  "name": "providerKey",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "Volo.Abp.PermissionManagement.GetPermissionListResultDto",
-                "typeSimple": "Volo.Abp.PermissionManagement.GetPermissionListResultDto"
-              }
-            },
-            "UpdateAsyncByProviderNameAndProviderKeyAndInput": {
-              "uniqueName": "UpdateAsyncByProviderNameAndProviderKeyAndInput",
-              "name": "UpdateAsync",
-              "httpMethod": "PUT",
-              "url": "api/permission-management/permissions",
-              "supportedVersions": [],
-              "parametersOnMethod": [
-                {
-                  "name": "providerName",
-                  "typeAsString": "System.String, System.Private.CoreLib",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                },
-                {
-                  "name": "providerKey",
-                  "typeAsString": "System.String, System.Private.CoreLib",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null
-                },
-                {
-                  "name": "input",
-                  "typeAsString": "Volo.Abp.PermissionManagement.UpdatePermissionsDto, Volo.Abp.PermissionManagement.Application.Contracts",
-                  "type": "Volo.Abp.PermissionManagement.UpdatePermissionsDto",
-                  "typeSimple": "Volo.Abp.PermissionManagement.UpdatePermissionsDto",
-                  "isOptional": false,
-                  "defaultValue": null
-                }
-              ],
-              "parameters": [
-                {
-                  "nameOnMethod": "providerName",
-                  "name": "providerName",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": ""
-                },
-                {
-                  "nameOnMethod": "providerKey",
-                  "name": "providerKey",
-                  "type": "System.String",
-                  "typeSimple": "string",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
-                  "descriptorName": ""
-                },
-                {
-                  "nameOnMethod": "input",
-                  "name": "input",
-                  "type": "Volo.Abp.PermissionManagement.UpdatePermissionsDto",
-                  "typeSimple": "Volo.Abp.PermissionManagement.UpdatePermissionsDto",
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": null,
-                  "bindingSourceId": "Body",
-                  "descriptorName": ""
-                }
-              ],
-              "returnValue": {
-                "type": "System.Void",
-                "typeSimple": "System.Void"
-              }
-            }
-          }
-        }
-      }
     }
   },
   "types": {
@@ -6341,17 +7645,249 @@
         {
           "name": "IsSelfRegistrationEnabled",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "EnableLocalLogin",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
+        }
+      ]
+    },
+    "Volo.Abp.Account.AccountLdapSettingsDto": {
+      "baseType": null,
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "EnableLdapLogin",
+          "type": "System.Boolean",
+          "typeSimple": "boolean",
+          "isRequired": false
+        },
+        {
+          "name": "LdapServerHost",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "LdapServerPort",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "LdapBaseDc",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "LdapUserName",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "LdapPassword",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        }
+      ]
+    },
+    "Volo.Abp.Account.AccountTwoFactorSettingsDto": {
+      "baseType": null,
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "TwoFactorBehaviour",
+          "type": "Volo.Abp.Identity.Features.IdentityTwoFactorBehaviour",
+          "typeSimple": "Volo.Abp.Identity.Features.IdentityTwoFactorBehaviour",
+          "isRequired": false
         },
         {
           "name": "IsRememberBrowserEnabled",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
+        },
+        {
+          "name": "UsersCanChange",
+          "type": "System.Boolean",
+          "typeSimple": "boolean",
+          "isRequired": false
+        }
+      ]
+    },
+    "Volo.Abp.Identity.Features.IdentityTwoFactorBehaviour": {
+      "baseType": "System.Enum",
+      "isEnum": true,
+      "enumNames": ["Optional", "Disabled", "Forced"],
+      "enumValues": [0, 1, 2],
+      "genericArguments": null,
+      "properties": null
+    },
+    "Volo.Abp.Account.AccountRecaptchaSettingsDto": {
+      "baseType": null,
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "UseCaptchaOnLogin",
+          "type": "System.Boolean",
+          "typeSimple": "boolean",
+          "isRequired": false
+        },
+        {
+          "name": "UseCaptchaOnRegistration",
+          "type": "System.Boolean",
+          "typeSimple": "boolean",
+          "isRequired": false
+        },
+        {
+          "name": "VerifyBaseUrl",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "SiteKey",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "SiteSecret",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "Version",
+          "type": "System.Int32",
+          "typeSimple": "number",
+          "isRequired": false
+        }
+      ]
+    },
+    "Volo.Abp.Account.AccountExternalProviderSettingsDto": {
+      "baseType": null,
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "Settings",
+          "type": "[Volo.Abp.Account.ExternalProviders.ExternalProviderSettings]",
+          "typeSimple": "[Volo.Abp.Account.ExternalProviders.ExternalProviderSettings]",
+          "isRequired": false
+        }
+      ]
+    },
+    "Volo.Abp.Account.ExternalProviders.ExternalProviderSettings": {
+      "baseType": null,
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "Name",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "Enabled",
+          "type": "System.Boolean",
+          "typeSimple": "boolean",
+          "isRequired": false
+        },
+        {
+          "name": "Properties",
+          "type": "[Volo.Abp.Account.ExternalProviders.ExternalProviderSettingsProperty]",
+          "typeSimple": "[Volo.Abp.Account.ExternalProviders.ExternalProviderSettingsProperty]",
+          "isRequired": false
+        },
+        {
+          "name": "SecretProperties",
+          "type": "[Volo.Abp.Account.ExternalProviders.ExternalProviderSettingsProperty]",
+          "typeSimple": "[Volo.Abp.Account.ExternalProviders.ExternalProviderSettingsProperty]",
+          "isRequired": false
+        }
+      ]
+    },
+    "Volo.Abp.Account.ExternalProviders.ExternalProviderSettingsProperty": {
+      "baseType": "Volo.Abp.NameValue<System.String>",
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": []
+    },
+    "Volo.Abp.NameValue<T0>": {
+      "baseType": null,
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": ["T"],
+      "properties": [
+        {
+          "name": "Name",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "Value",
+          "type": "T",
+          "typeSimple": "T",
+          "isRequired": false
+        }
+      ]
+    },
+    "Volo.Abp.Account.UpdateExternalProviderDto": {
+      "baseType": null,
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "Name",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "Enabled",
+          "type": "System.Boolean",
+          "typeSimple": "boolean",
+          "isRequired": false
+        },
+        {
+          "name": "Properties",
+          "type": "[Volo.Abp.Account.ExternalProviders.ExternalProviderSettingsProperty]",
+          "typeSimple": "[Volo.Abp.Account.ExternalProviders.ExternalProviderSettingsProperty]",
+          "isRequired": false
+        },
+        {
+          "name": "SecretProperties",
+          "type": "[Volo.Abp.Account.ExternalProviders.ExternalProviderSettingsProperty]",
+          "typeSimple": "[Volo.Abp.Account.ExternalProviders.ExternalProviderSettingsProperty]",
+          "isRequired": false
         }
       ]
     },
@@ -6365,22 +7901,26 @@
         {
           "name": "UserNameOrEmailAddress",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": true
         },
         {
           "name": "Password",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": true
         },
         {
           "name": "RememberMe",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "TenanId",
           "type": "System.Guid?",
-          "typeSimple": "string?"
+          "typeSimple": "string?",
+          "isRequired": false
         }
       ]
     },
@@ -6394,12 +7934,14 @@
         {
           "name": "Result",
           "type": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.LoginResultType",
-          "typeSimple": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.LoginResultType"
+          "typeSimple": "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.LoginResultType",
+          "isRequired": false
         },
         {
           "name": "Description",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -6411,11 +7953,33 @@
         "InvalidUserNameOrPassword",
         "NotAllowed",
         "LockedOut",
-        "RequiresTwoFactor"
+        "RequiresTwoFactor",
+        "NotLinked"
       ],
-      "enumValues": [1, 2, 3, 4, 5],
+      "enumValues": [1, 2, 3, 4, 5, 6],
       "genericArguments": null,
       "properties": null
+    },
+    "Volo.Abp.Account.Public.Web.Areas.Account.Controllers.Models.LinkUserLoginInfo": {
+      "baseType": null,
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "LinkUserId",
+          "type": "System.Guid",
+          "typeSimple": "string",
+          "isRequired": true
+        },
+        {
+          "name": "LinkTenantId",
+          "type": "System.Guid?",
+          "typeSimple": "string?",
+          "isRequired": false
+        }
+      ]
     },
     "Volo.Abp.Account.RegisterDto": {
       "baseType": null,
@@ -6427,22 +7991,44 @@
         {
           "name": "UserName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": true
         },
         {
           "name": "EmailAddress",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": true
         },
         {
           "name": "Password",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": true
         },
         {
           "name": "AppName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": true
+        },
+        {
+          "name": "ReturnUrl",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "ReturnUrlHash",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "CaptchaResponse",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -6456,62 +8042,74 @@
         {
           "name": "TenantId",
           "type": "System.Guid?",
-          "typeSimple": "string?"
+          "typeSimple": "string?",
+          "isRequired": false
         },
         {
           "name": "UserName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Email",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Surname",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "EmailConfirmed",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "PhoneNumber",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "PhoneNumberConfirmed",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
-          "name": "TwoFactorEnabled",
+          "name": "SupportTwoFactor",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "LockoutEnabled",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "IsLockedOut",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "ConcurrencyStamp",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -6525,7 +8123,8 @@
         {
           "name": "Id",
           "type": "TKey",
-          "typeSimple": "TKey"
+          "typeSimple": "TKey",
+          "isRequired": false
         }
       ]
     },
@@ -6539,7 +8138,8 @@
         {
           "name": "ExtraProperties",
           "type": "{System.String:System.Object}",
-          "typeSimple": "{string:object}"
+          "typeSimple": "{string:object}",
+          "isRequired": false
         }
       ]
     },
@@ -6553,12 +8153,26 @@
         {
           "name": "Email",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": true
         },
         {
           "name": "AppName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": true
+        },
+        {
+          "name": "ReturnUrl",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "ReturnUrlHash",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -6572,17 +8186,53 @@
         {
           "name": "UserId",
           "type": "System.Guid",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "ResetToken",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": true
         },
         {
           "name": "Password",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": true
+        }
+      ]
+    },
+    "Volo.Abp.Account.SendEmailConfirmationTokenDto": {
+      "baseType": null,
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "AppName",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": true
+        },
+        {
+          "name": "Email",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": true
+        },
+        {
+          "name": "ReturnUrl",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "ReturnUrlHash",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -6596,7 +8246,8 @@
         {
           "name": "Token",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": true
         }
       ]
     },
@@ -6610,12 +8261,219 @@
         {
           "name": "UserId",
           "type": "System.Guid",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": true
         },
         {
           "name": "Token",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": true
+        }
+      ]
+    },
+    "Volo.Abp.Account.ProfilePictureInput": {
+      "baseType": null,
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "Type",
+          "type": "Volo.Abp.Account.ProfilePictureType",
+          "typeSimple": "Volo.Abp.Account.ProfilePictureType",
+          "isRequired": false
+        },
+        {
+          "name": "ImageContent",
+          "type": "[System.Byte]",
+          "typeSimple": "[number]",
+          "isRequired": false
+        }
+      ]
+    },
+    "Volo.Abp.Account.ProfilePictureType": {
+      "baseType": "System.Enum",
+      "isEnum": true,
+      "enumNames": ["None", "Gravatar", "Image"],
+      "enumValues": [0, 1, 2],
+      "genericArguments": null,
+      "properties": null
+    },
+    "Volo.Abp.Account.ProfilePictureSourceDto": {
+      "baseType": null,
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "Type",
+          "type": "Volo.Abp.Account.ProfilePictureType",
+          "typeSimple": "Volo.Abp.Account.ProfilePictureType",
+          "isRequired": false
+        },
+        {
+          "name": "Source",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "FileContent",
+          "type": "[System.Byte]",
+          "typeSimple": "[number]",
+          "isRequired": false
+        }
+      ]
+    },
+    "Microsoft.AspNetCore.Http.IFormFile": {
+      "baseType": null,
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "ContentType",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "ContentDisposition",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "Headers",
+          "type": "{System.String:[System.String]}",
+          "typeSimple": "{string:[string]}",
+          "isRequired": false
+        },
+        {
+          "name": "Length",
+          "type": "System.Int64",
+          "typeSimple": "number",
+          "isRequired": false
+        },
+        {
+          "name": "Name",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "FileName",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        }
+      ]
+    },
+    "Microsoft.AspNetCore.Mvc.IActionResult": {
+      "baseType": null,
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": []
+    },
+    "Volo.Abp.Account.ExternalProviders.ExternalProviderDto": {
+      "baseType": null,
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "Providers",
+          "type": "[Volo.Abp.Account.ExternalProviders.ExternalProviderItemDto]",
+          "typeSimple": "[Volo.Abp.Account.ExternalProviders.ExternalProviderItemDto]",
+          "isRequired": false
+        }
+      ]
+    },
+    "Volo.Abp.Account.ExternalProviders.ExternalProviderItemDto": {
+      "baseType": null,
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "Name",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "Enabled",
+          "type": "System.Boolean",
+          "typeSimple": "boolean",
+          "isRequired": false
+        },
+        {
+          "name": "Properties",
+          "type": "[Volo.Abp.Account.ExternalProviders.ExternalProviderSettingsProperty]",
+          "typeSimple": "[Volo.Abp.Account.ExternalProviders.ExternalProviderSettingsProperty]",
+          "isRequired": false
+        }
+      ]
+    },
+    "Volo.Abp.Account.ExternalProviders.GetByNameInput": {
+      "baseType": null,
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "TenantId",
+          "type": "System.Guid?",
+          "typeSimple": "string?",
+          "isRequired": false
+        },
+        {
+          "name": "Name",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        }
+      ]
+    },
+    "Volo.Abp.Account.ExternalProviders.ExternalProviderItemWithSecretDto": {
+      "baseType": null,
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "Name",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "Enabled",
+          "type": "System.Boolean",
+          "typeSimple": "boolean",
+          "isRequired": false
+        },
+        {
+          "name": "Properties",
+          "type": "[Volo.Abp.Account.ExternalProviders.ExternalProviderSettingsProperty]",
+          "typeSimple": "[Volo.Abp.Account.ExternalProviders.ExternalProviderSettingsProperty]",
+          "isRequired": false
+        },
+        {
+          "name": "SecretProperties",
+          "type": "[Volo.Abp.Account.ExternalProviders.ExternalProviderSettingsProperty]",
+          "typeSimple": "[Volo.Abp.Account.ExternalProviders.ExternalProviderSettingsProperty]",
+          "isRequired": false
         }
       ]
     },
@@ -6629,17 +8487,20 @@
         {
           "name": "Success",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "TenantId",
           "type": "System.Guid?",
-          "typeSimple": "string?"
+          "typeSimple": "string?",
+          "isRequired": false
         },
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -6653,47 +8514,56 @@
         {
           "name": "Url",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "UserName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "ApplicationName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "CorrelationId",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "HttpMethod",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "HttpStatusCode",
           "type": "System.Net.HttpStatusCode?",
-          "typeSimple": "System.Net.HttpStatusCode?"
+          "typeSimple": "System.Net.HttpStatusCode?",
+          "isRequired": false
         },
         {
           "name": "MaxExecutionDuration",
           "type": "System.Int32?",
-          "typeSimple": "number?"
+          "typeSimple": "number?",
+          "isRequired": false
         },
         {
           "name": "MinExecutionDuration",
           "type": "System.Int32?",
-          "typeSimple": "number?"
+          "typeSimple": "number?",
+          "isRequired": false
         },
         {
           "name": "HasException",
           "type": "System.Boolean?",
-          "typeSimple": "boolean?"
+          "typeSimple": "boolean?",
+          "isRequired": false
         }
       ]
     },
@@ -6707,7 +8577,8 @@
         {
           "name": "Sorting",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -6721,7 +8592,8 @@
         {
           "name": "SkipCount",
           "type": "System.Int32",
-          "typeSimple": "number"
+          "typeSimple": "number",
+          "isRequired": false
         }
       ]
     },
@@ -6735,17 +8607,20 @@
         {
           "name": "DefaultMaxResultCount",
           "type": "System.Int32",
-          "typeSimple": "number"
+          "typeSimple": "number",
+          "isRequired": false
         },
         {
           "name": "MaxMaxResultCount",
           "type": "System.Int32",
-          "typeSimple": "number"
+          "typeSimple": "number",
+          "isRequired": false
         },
         {
           "name": "MaxResultCount",
           "type": "System.Int32",
-          "typeSimple": "number"
+          "typeSimple": "number",
+          "isRequired": false
         }
       ]
     },
@@ -6759,12 +8634,14 @@
         {
           "name": "HasValue",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "Value",
           "type": "T",
-          "typeSimple": "T"
+          "typeSimple": "T",
+          "isRequired": false
         }
       ]
     },
@@ -6920,7 +8797,8 @@
         {
           "name": "TotalCount",
           "type": "System.Int64",
-          "typeSimple": "number"
+          "typeSimple": "number",
+          "isRequired": false
         }
       ]
     },
@@ -6934,7 +8812,8 @@
         {
           "name": "Items",
           "type": "[T]",
-          "typeSimple": "[T]"
+          "typeSimple": "[T]",
+          "isRequired": false
         }
       ]
     },
@@ -6948,97 +8827,116 @@
         {
           "name": "UserId",
           "type": "System.Guid?",
-          "typeSimple": "string?"
+          "typeSimple": "string?",
+          "isRequired": false
         },
         {
           "name": "UserName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "TenantId",
           "type": "System.Guid?",
-          "typeSimple": "string?"
+          "typeSimple": "string?",
+          "isRequired": false
         },
         {
           "name": "ImpersonatorUserId",
           "type": "System.Guid?",
-          "typeSimple": "string?"
+          "typeSimple": "string?",
+          "isRequired": false
         },
         {
           "name": "ImpersonatorTenantId",
           "type": "System.Guid?",
-          "typeSimple": "string?"
+          "typeSimple": "string?",
+          "isRequired": false
         },
         {
           "name": "ExecutionTime",
           "type": "System.DateTime",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "ExecutionDuration",
           "type": "System.Int32",
-          "typeSimple": "number"
+          "typeSimple": "number",
+          "isRequired": false
         },
         {
           "name": "ClientIpAddress",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "ClientName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "BrowserInfo",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "HttpMethod",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Url",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Exceptions",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Comments",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "HttpStatusCode",
           "type": "System.Int32?",
-          "typeSimple": "number?"
+          "typeSimple": "number?",
+          "isRequired": false
         },
         {
           "name": "ApplicationName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "CorrelationId",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "EntityChanges",
           "type": "[Volo.Abp.AuditLogging.EntityChangeDto]",
-          "typeSimple": "[Volo.Abp.AuditLogging.EntityChangeDto]"
+          "typeSimple": "[Volo.Abp.AuditLogging.EntityChangeDto]",
+          "isRequired": false
         },
         {
           "name": "Actions",
           "type": "[Volo.Abp.AuditLogging.AuditLogActionDto]",
-          "typeSimple": "[Volo.Abp.AuditLogging.AuditLogActionDto]"
+          "typeSimple": "[Volo.Abp.AuditLogging.AuditLogActionDto]",
+          "isRequired": false
         }
       ]
     },
@@ -7052,37 +8950,44 @@
         {
           "name": "AuditLogId",
           "type": "System.Guid",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "TenantId",
           "type": "System.Guid?",
-          "typeSimple": "string?"
+          "typeSimple": "string?",
+          "isRequired": false
         },
         {
           "name": "ChangeTime",
           "type": "System.DateTime",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "ChangeType",
           "type": "Volo.Abp.Auditing.EntityChangeType",
-          "typeSimple": "Volo.Abp.Auditing.EntityChangeType"
+          "typeSimple": "Volo.Abp.Auditing.EntityChangeType",
+          "isRequired": false
         },
         {
           "name": "EntityId",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "EntityTypeFullName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "PropertyChanges",
           "type": "[Volo.Abp.AuditLogging.EntityPropertyChangeDto]",
-          "typeSimple": "[Volo.Abp.AuditLogging.EntityPropertyChangeDto]"
+          "typeSimple": "[Volo.Abp.AuditLogging.EntityPropertyChangeDto]",
+          "isRequired": false
         }
       ]
     },
@@ -7104,32 +9009,38 @@
         {
           "name": "TenantId",
           "type": "System.Guid?",
-          "typeSimple": "string?"
+          "typeSimple": "string?",
+          "isRequired": false
         },
         {
           "name": "EntityChangeId",
           "type": "System.Guid",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "NewValue",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "OriginalValue",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "PropertyName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "PropertyTypeFullName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -7143,7 +9054,8 @@
         {
           "name": "Id",
           "type": "TKey",
-          "typeSimple": "TKey"
+          "typeSimple": "TKey",
+          "isRequired": false
         }
       ]
     },
@@ -7165,37 +9077,44 @@
         {
           "name": "TenantId",
           "type": "System.Guid?",
-          "typeSimple": "string?"
+          "typeSimple": "string?",
+          "isRequired": false
         },
         {
           "name": "AuditLogId",
           "type": "System.Guid",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "ServiceName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "MethodName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Parameters",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "ExecutionTime",
           "type": "System.DateTime",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "ExecutionDuration",
           "type": "System.Int32",
-          "typeSimple": "number"
+          "typeSimple": "number",
+          "isRequired": false
         }
       ]
     },
@@ -7209,12 +9128,14 @@
         {
           "name": "StartDate",
           "type": "System.DateTime",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "EndDate",
           "type": "System.DateTime",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -7228,7 +9149,8 @@
         {
           "name": "Data",
           "type": "{System.String:System.Int64}",
-          "typeSimple": "{string:number}"
+          "typeSimple": "{string:number}",
+          "isRequired": false
         }
       ]
     },
@@ -7242,12 +9164,14 @@
         {
           "name": "StartDate",
           "type": "System.DateTime",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "EndDate",
           "type": "System.DateTime",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -7261,7 +9185,8 @@
         {
           "name": "Data",
           "type": "{System.String:System.Double}",
-          "typeSimple": "{string:number}"
+          "typeSimple": "{string:number}",
+          "isRequired": false
         }
       ]
     },
@@ -7275,32 +9200,38 @@
         {
           "name": "AuditLogId",
           "type": "System.Guid?",
-          "typeSimple": "string?"
+          "typeSimple": "string?",
+          "isRequired": false
         },
         {
           "name": "EntityChangeType",
           "type": "Volo.Abp.Auditing.EntityChangeType?",
-          "typeSimple": "Volo.Abp.Auditing.EntityChangeType?"
+          "typeSimple": "Volo.Abp.Auditing.EntityChangeType?",
+          "isRequired": false
         },
         {
           "name": "EntityId",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "EntityTypeFullName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "StartDate",
           "type": "System.DateTime?",
-          "typeSimple": "string?"
+          "typeSimple": "string?",
+          "isRequired": false
         },
         {
           "name": "EndDate",
           "type": "System.DateTime?",
-          "typeSimple": "string?"
+          "typeSimple": "string?",
+          "isRequired": false
         }
       ]
     },
@@ -7314,12 +9245,14 @@
         {
           "name": "EntityId",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "EntityTypeFullName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -7333,12 +9266,14 @@
         {
           "name": "EntityChange",
           "type": "Volo.Abp.AuditLogging.EntityChangeDto",
-          "typeSimple": "Volo.Abp.AuditLogging.EntityChangeDto"
+          "typeSimple": "Volo.Abp.AuditLogging.EntityChangeDto",
+          "isRequired": false
         },
         {
           "name": "UserName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -7352,7 +9287,8 @@
         {
           "name": "Filter",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -7366,42 +9302,50 @@
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Required",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "IsStatic",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "Regex",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "RegexDescription",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Description",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "ValueType",
           "type": "Volo.Abp.Identity.IdentityClaimValueType",
-          "typeSimple": "Volo.Abp.Identity.IdentityClaimValueType"
+          "typeSimple": "Volo.Abp.Identity.IdentityClaimValueType",
+          "isRequired": false
         },
         {
           "name": "ValueTypeAsString",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -7423,32 +9367,38 @@
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": true
         },
         {
           "name": "Required",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "Regex",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "RegexDescription",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Description",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "ValueType",
           "type": "Volo.Abp.Identity.IdentityClaimValueType",
-          "typeSimple": "Volo.Abp.Identity.IdentityClaimValueType"
+          "typeSimple": "Volo.Abp.Identity.IdentityClaimValueType",
+          "isRequired": false
         }
       ]
     },
@@ -7462,32 +9412,167 @@
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": true
         },
         {
           "name": "Required",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "Regex",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "RegexDescription",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Description",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "ValueType",
           "type": "Volo.Abp.Identity.IdentityClaimValueType",
-          "typeSimple": "Volo.Abp.Identity.IdentityClaimValueType"
+          "typeSimple": "Volo.Abp.Identity.IdentityClaimValueType",
+          "isRequired": false
+        }
+      ]
+    },
+    "Volo.Abp.Identity.LinkUserInput": {
+      "baseType": null,
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "UserId",
+          "type": "System.Guid",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "TenantId",
+          "type": "System.Guid?",
+          "typeSimple": "string?",
+          "isRequired": false
+        },
+        {
+          "name": "Token",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": true
+        }
+      ]
+    },
+    "Volo.Abp.Identity.UnLinkUserInput": {
+      "baseType": null,
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "UserId",
+          "type": "System.Guid",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "TenantId",
+          "type": "System.Guid?",
+          "typeSimple": "string?",
+          "isRequired": false
+        }
+      ]
+    },
+    "Volo.Abp.Identity.IsLinkedInput": {
+      "baseType": null,
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "UserId",
+          "type": "System.Guid",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "TenantId",
+          "type": "System.Guid?",
+          "typeSimple": "string?",
+          "isRequired": false
+        }
+      ]
+    },
+    "Volo.Abp.Identity.VerifyLinkTokenInput": {
+      "baseType": null,
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "UserId",
+          "type": "System.Guid",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "TenantId",
+          "type": "System.Guid?",
+          "typeSimple": "string?",
+          "isRequired": false
+        },
+        {
+          "name": "Token",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": true
+        }
+      ]
+    },
+    "Volo.Abp.Identity.LinkUserDto": {
+      "baseType": null,
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "TargetUserId",
+          "type": "System.Guid",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "TargetUserName",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "TargetTenantId",
+          "type": "System.Guid?",
+          "typeSimple": "string?",
+          "isRequired": false
+        },
+        {
+          "name": "TargetTenantName",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -7501,27 +9586,32 @@
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "IsDefault",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "IsStatic",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "IsPublic",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "ConcurrencyStamp",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -7543,17 +9633,20 @@
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": true
         },
         {
           "name": "IsDefault",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "IsPublic",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         }
       ]
     },
@@ -7567,7 +9660,8 @@
         {
           "name": "ConcurrencyStamp",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -7581,7 +9675,8 @@
         {
           "name": "Filter",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -7595,17 +9690,20 @@
         {
           "name": "RoleId",
           "type": "System.Guid",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "ClaimType",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "ClaimValue",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -7619,42 +9717,50 @@
         {
           "name": "StartTime",
           "type": "System.DateTime?",
-          "typeSimple": "string?"
+          "typeSimple": "string?",
+          "isRequired": false
         },
         {
           "name": "EndTime",
           "type": "System.DateTime?",
-          "typeSimple": "string?"
+          "typeSimple": "string?",
+          "isRequired": false
         },
         {
           "name": "ApplicationName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Identity",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Action",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "UserName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "ClientId",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "CorrelationId",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -7668,67 +9774,80 @@
         {
           "name": "TenantId",
           "type": "System.Guid?",
-          "typeSimple": "string?"
+          "typeSimple": "string?",
+          "isRequired": false
         },
         {
           "name": "ApplicationName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Identity",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Action",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "UserId",
           "type": "System.Guid?",
-          "typeSimple": "string?"
+          "typeSimple": "string?",
+          "isRequired": false
         },
         {
           "name": "UserName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "TenantName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "ClientId",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "CorrelationId",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "ClientIpAddress",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "BrowserInfo",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "CreationTime",
           "type": "System.DateTime",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "ExtraProperties",
           "type": "{System.String:System.Object}",
-          "typeSimple": "{string:object}"
+          "typeSimple": "{string:object}",
+          "isRequired": false
         }
       ]
     },
@@ -7742,22 +9861,26 @@
         {
           "name": "Password",
           "type": "Volo.Abp.Identity.IdentityPasswordSettingsDto",
-          "typeSimple": "Volo.Abp.Identity.IdentityPasswordSettingsDto"
+          "typeSimple": "Volo.Abp.Identity.IdentityPasswordSettingsDto",
+          "isRequired": false
         },
         {
           "name": "Lockout",
           "type": "Volo.Abp.Identity.IdentityLockoutSettingsDto",
-          "typeSimple": "Volo.Abp.Identity.IdentityLockoutSettingsDto"
+          "typeSimple": "Volo.Abp.Identity.IdentityLockoutSettingsDto",
+          "isRequired": false
         },
         {
           "name": "SignIn",
           "type": "Volo.Abp.Identity.IdentitySignInSettingsDto",
-          "typeSimple": "Volo.Abp.Identity.IdentitySignInSettingsDto"
+          "typeSimple": "Volo.Abp.Identity.IdentitySignInSettingsDto",
+          "isRequired": false
         },
         {
           "name": "User",
           "type": "Volo.Abp.Identity.IdentityUserSettingsDto",
-          "typeSimple": "Volo.Abp.Identity.IdentityUserSettingsDto"
+          "typeSimple": "Volo.Abp.Identity.IdentityUserSettingsDto",
+          "isRequired": false
         }
       ]
     },
@@ -7771,32 +9894,38 @@
         {
           "name": "RequiredLength",
           "type": "System.Int32",
-          "typeSimple": "number"
+          "typeSimple": "number",
+          "isRequired": false
         },
         {
           "name": "RequiredUniqueChars",
           "type": "System.Int32",
-          "typeSimple": "number"
+          "typeSimple": "number",
+          "isRequired": false
         },
         {
           "name": "RequireNonAlphanumeric",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "RequireLowercase",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "RequireUppercase",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "RequireDigit",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         }
       ]
     },
@@ -7810,17 +9939,20 @@
         {
           "name": "AllowedForNewUsers",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "LockoutDuration",
           "type": "System.Int32",
-          "typeSimple": "number"
+          "typeSimple": "number",
+          "isRequired": false
         },
         {
           "name": "MaxFailedAccessAttempts",
           "type": "System.Int32",
-          "typeSimple": "number"
+          "typeSimple": "number",
+          "isRequired": false
         }
       ]
     },
@@ -7834,17 +9966,20 @@
         {
           "name": "RequireConfirmedEmail",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "EnablePhoneNumberConfirmation",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "RequireConfirmedPhoneNumber",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         }
       ]
     },
@@ -7858,12 +9993,14 @@
         {
           "name": "IsUserNameUpdateEnabled",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "IsEmailUpdateEnabled",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         }
       ]
     },
@@ -7877,7 +10014,8 @@
         {
           "name": "Filter",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -7891,7 +10029,8 @@
         {
           "name": "Password",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": true
         }
       ]
     },
@@ -7905,47 +10044,50 @@
         {
           "name": "UserName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": true
         },
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Surname",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Email",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": true
         },
         {
           "name": "PhoneNumber",
           "type": "System.String",
-          "typeSimple": "string"
-        },
-        {
-          "name": "TwoFactorEnabled",
-          "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "LockoutEnabled",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "RoleNames",
           "type": "[System.String]",
-          "typeSimple": "[string]"
+          "typeSimple": "[string]",
+          "isRequired": false
         },
         {
           "name": "OrganizationUnitIds",
           "type": "[System.Guid]",
-          "typeSimple": "[string]"
+          "typeSimple": "[string]",
+          "isRequired": false
         }
       ]
     },
@@ -7959,7 +10101,8 @@
         {
           "name": "ConcurrencyStamp",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -7973,22 +10116,26 @@
         {
           "name": "ParentId",
           "type": "System.Guid?",
-          "typeSimple": "string?"
+          "typeSimple": "string?",
+          "isRequired": false
         },
         {
           "name": "Code",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "DisplayName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Roles",
           "type": "[Volo.Abp.Identity.IdentityRoleDto]",
-          "typeSimple": "[Volo.Abp.Identity.IdentityRoleDto]"
+          "typeSimple": "[Volo.Abp.Identity.IdentityRoleDto]",
+          "isRequired": false
         }
       ]
     },
@@ -8002,17 +10149,20 @@
         {
           "name": "IsDeleted",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "DeleterId",
           "type": "System.Guid?",
-          "typeSimple": "string?"
+          "typeSimple": "string?",
+          "isRequired": false
         },
         {
           "name": "DeletionTime",
           "type": "System.DateTime?",
-          "typeSimple": "string?"
+          "typeSimple": "string?",
+          "isRequired": false
         }
       ]
     },
@@ -8026,12 +10176,14 @@
         {
           "name": "LastModificationTime",
           "type": "System.DateTime?",
-          "typeSimple": "string?"
+          "typeSimple": "string?",
+          "isRequired": false
         },
         {
           "name": "LastModifierId",
           "type": "System.Guid?",
-          "typeSimple": "string?"
+          "typeSimple": "string?",
+          "isRequired": false
         }
       ]
     },
@@ -8045,12 +10197,14 @@
         {
           "name": "CreationTime",
           "type": "System.DateTime",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "CreatorId",
           "type": "System.Guid?",
-          "typeSimple": "string?"
+          "typeSimple": "string?",
+          "isRequired": false
         }
       ]
     },
@@ -8064,17 +10218,20 @@
         {
           "name": "UserId",
           "type": "System.Guid",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "ClaimType",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "ClaimValue",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -8088,22 +10245,26 @@
         {
           "name": "ParentId",
           "type": "System.Guid?",
-          "typeSimple": "string?"
+          "typeSimple": "string?",
+          "isRequired": false
         },
         {
           "name": "Code",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "DisplayName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Roles",
           "type": "[Volo.Abp.Identity.OrganizationUnitRoleDto]",
-          "typeSimple": "[Volo.Abp.Identity.OrganizationUnitRoleDto]"
+          "typeSimple": "[Volo.Abp.Identity.OrganizationUnitRoleDto]",
+          "isRequired": false
         }
       ]
     },
@@ -8117,12 +10278,14 @@
         {
           "name": "OrganizationUnitId",
           "type": "System.Guid",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "RoleId",
           "type": "System.Guid",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -8136,12 +10299,14 @@
         {
           "name": "CreationTime",
           "type": "System.DateTime",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "CreatorId",
           "type": "System.Guid?",
-          "typeSimple": "string?"
+          "typeSimple": "string?",
+          "isRequired": false
         }
       ]
     },
@@ -8155,7 +10320,8 @@
         {
           "name": "RoleNames",
           "type": "[System.String]",
-          "typeSimple": "[string]"
+          "typeSimple": "[string]",
+          "isRequired": true
         }
       ]
     },
@@ -8169,7 +10335,8 @@
         {
           "name": "NewPassword",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": true
         }
       ]
     },
@@ -8183,47 +10350,56 @@
         {
           "name": "Id",
           "type": "System.Guid",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "TenantId",
           "type": "System.Guid?",
-          "typeSimple": "string?"
+          "typeSimple": "string?",
+          "isRequired": false
         },
         {
           "name": "UserName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Surname",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Email",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "EmailConfirmed",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "PhoneNumber",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "PhoneNumberConfirmed",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         }
       ]
     },
@@ -8237,12 +10413,14 @@
         {
           "name": "Sorting",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Filter",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -8256,7 +10434,8 @@
         {
           "name": "Filter",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -8270,7 +10449,8 @@
         {
           "name": "RoleIds",
           "type": "[System.Guid]",
-          "typeSimple": "[string]"
+          "typeSimple": "[string]",
+          "isRequired": false
         }
       ]
     },
@@ -8284,7 +10464,8 @@
         {
           "name": "UserIds",
           "type": "[System.Guid]",
-          "typeSimple": "[string]"
+          "typeSimple": "[string]",
+          "isRequired": false
         }
       ]
     },
@@ -8298,7 +10479,8 @@
         {
           "name": "ParentId",
           "type": "System.Guid?",
-          "typeSimple": "string?"
+          "typeSimple": "string?",
+          "isRequired": false
         }
       ]
     },
@@ -8312,7 +10494,8 @@
         {
           "name": "DisplayName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": true
         }
       ]
     },
@@ -8326,7 +10509,8 @@
         {
           "name": "Filter",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -8340,7 +10524,50 @@
         {
           "name": "NewParentId",
           "type": "System.Guid?",
-          "typeSimple": "string?"
+          "typeSimple": "string?",
+          "isRequired": false
+        }
+      ]
+    },
+    "Volo.Abp.Identity.GetAvailableUsersInput": {
+      "baseType": "Volo.Abp.Application.Dtos.PagedAndSortedResultRequestDto",
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "Filter",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "Id",
+          "type": "System.Guid",
+          "typeSimple": "string",
+          "isRequired": false
+        }
+      ]
+    },
+    "Volo.Abp.Identity.GetAvailableRolesInput": {
+      "baseType": "Volo.Abp.Application.Dtos.PagedAndSortedResultRequestDto",
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "Filter",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "Id",
+          "type": "System.Guid",
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -8362,32 +10589,56 @@
         {
           "name": "UserName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Email",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "EmailConfirmed",
+          "type": "System.Boolean",
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Surname",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "PhoneNumber",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "PhoneNumberConfirmed",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
+        },
+        {
+          "name": "IsExternal",
+          "type": "System.Boolean",
+          "typeSimple": "boolean",
+          "isRequired": false
+        },
+        {
+          "name": "HasPassword",
+          "type": "System.Boolean",
+          "typeSimple": "boolean",
+          "isRequired": false
         }
       ]
     },
@@ -8401,27 +10652,32 @@
         {
           "name": "UserName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": true
         },
         {
           "name": "Email",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Surname",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "PhoneNumber",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -8435,12 +10691,14 @@
         {
           "name": "CurrentPassword",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "NewPassword",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": true
         }
       ]
     },
@@ -8454,7 +10712,8 @@
         {
           "name": "Filter",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -8468,114 +10727,66 @@
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "DisplayName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Description",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Enabled",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
-          "name": "UserClaims",
-          "type": "[Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceClaimClaimDto]",
-          "typeSimple": "[Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceClaimClaimDto]"
-        },
-        {
-          "name": "Properties",
-          "type": "{System.String:System.String}",
-          "typeSimple": "{string:string}"
-        },
-        {
-          "name": "Scopes",
-          "type": "[Volo.Abp.IdentityServer.ApiResource.Dtos.ApiScopeDto]",
-          "typeSimple": "[Volo.Abp.IdentityServer.ApiResource.Dtos.ApiScopeDto]"
-        },
-        {
-          "name": "Secrets",
-          "type": "[Volo.Abp.IdentityServer.ApiResource.Dtos.ApiSecretDto]",
-          "typeSimple": "[Volo.Abp.IdentityServer.ApiResource.Dtos.ApiSecretDto]"
-        }
-      ]
-    },
-    "Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceClaimClaimDto": {
-      "baseType": null,
-      "isEnum": false,
-      "enumNames": null,
-      "enumValues": null,
-      "genericArguments": null,
-      "properties": [
-        {
-          "name": "ApiResourceId",
-          "type": "System.Guid",
-          "typeSimple": "string"
-        },
-        {
-          "name": "Type",
+          "name": "AllowedAccessTokenSigningAlgorithms",
           "type": "System.String",
-          "typeSimple": "string"
-        }
-      ]
-    },
-    "Volo.Abp.IdentityServer.ApiResource.Dtos.ApiScopeDto": {
-      "baseType": null,
-      "isEnum": false,
-      "enumNames": null,
-      "enumValues": null,
-      "genericArguments": null,
-      "properties": [
-        {
-          "name": "ApiResourceId",
-          "type": "System.Guid",
-          "typeSimple": "string"
-        },
-        {
-          "name": "Name",
-          "type": "System.String",
-          "typeSimple": "string"
-        },
-        {
-          "name": "DisplayName",
-          "type": "System.String",
-          "typeSimple": "string"
-        },
-        {
-          "name": "Description",
-          "type": "System.String",
-          "typeSimple": "string"
-        },
-        {
-          "name": "Required",
-          "type": "System.Boolean",
-          "typeSimple": "boolean"
-        },
-        {
-          "name": "Emphasize",
-          "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "ShowInDiscoveryDocument",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
+        },
+        {
+          "name": "Secrets",
+          "type": "[Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceSecretDto]",
+          "typeSimple": "[Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceSecretDto]",
+          "isRequired": false
+        },
+        {
+          "name": "Scopes",
+          "type": "[Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceScopeDto]",
+          "typeSimple": "[Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceScopeDto]",
+          "isRequired": false
         },
         {
           "name": "UserClaims",
-          "type": "[Volo.Abp.IdentityServer.ApiResource.Dtos.ApiScopeClaimDto]",
-          "typeSimple": "[Volo.Abp.IdentityServer.ApiResource.Dtos.ApiScopeClaimDto]"
+          "type": "[Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceClaimDto]",
+          "typeSimple": "[Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceClaimDto]",
+          "isRequired": false
+        },
+        {
+          "name": "Properties",
+          "type": "[Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourcePropertyDto]",
+          "typeSimple": "[Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourcePropertyDto]",
+          "isRequired": false
         }
       ]
     },
-    "Volo.Abp.IdentityServer.ApiResource.Dtos.ApiScopeClaimDto": {
+    "Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceSecretDto": {
       "baseType": null,
       "isEnum": false,
       "enumNames": null,
@@ -8585,51 +10796,101 @@
         {
           "name": "ApiResourceId",
           "type": "System.Guid",
-          "typeSimple": "string"
-        },
-        {
-          "name": "Name",
-          "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Type",
           "type": "System.String",
-          "typeSimple": "string"
-        }
-      ]
-    },
-    "Volo.Abp.IdentityServer.ApiResource.Dtos.ApiSecretDto": {
-      "baseType": null,
-      "isEnum": false,
-      "enumNames": null,
-      "enumValues": null,
-      "genericArguments": null,
-      "properties": [
-        {
-          "name": "ApiResourceId",
-          "type": "System.Guid",
-          "typeSimple": "string"
-        },
-        {
-          "name": "Type",
-          "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Value",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Description",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Expiration",
           "type": "System.DateTime?",
-          "typeSimple": "string?"
+          "typeSimple": "string?",
+          "isRequired": false
+        }
+      ]
+    },
+    "Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceScopeDto": {
+      "baseType": null,
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "ApiResourceId",
+          "type": "System.Guid",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "Scope",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        }
+      ]
+    },
+    "Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceClaimDto": {
+      "baseType": null,
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "ApiResourceId",
+          "type": "System.Guid",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "Type",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        }
+      ]
+    },
+    "Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourcePropertyDto": {
+      "baseType": null,
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "ApiResourceId",
+          "type": "System.Guid",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "Key",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "Value",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -8643,22 +10904,38 @@
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "DisplayName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Description",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
-          "name": "Claims",
-          "type": "[System.String]",
-          "typeSimple": "[string]"
+          "name": "AllowedAccessTokenSigningAlgorithms",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "ShowInDiscoveryDocument",
+          "type": "System.Boolean",
+          "typeSimple": "boolean",
+          "isRequired": false
+        },
+        {
+          "name": "UserClaims",
+          "type": "[Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceClaimDto]",
+          "typeSimple": "[Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceClaimDto]",
+          "isRequired": false
         }
       ]
     },
@@ -8672,32 +10949,296 @@
         {
           "name": "DisplayName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Description",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "AllowedAccessTokenSigningAlgorithms",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Enabled",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
-        },
-        {
-          "name": "Claims",
-          "type": "[System.String]",
-          "typeSimple": "[string]"
-        },
-        {
-          "name": "Scopes",
-          "type": "[Volo.Abp.IdentityServer.ApiResource.Dtos.ApiScopeDto]",
-          "typeSimple": "[Volo.Abp.IdentityServer.ApiResource.Dtos.ApiScopeDto]"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "Secrets",
-          "type": "[Volo.Abp.IdentityServer.ApiResource.Dtos.ApiSecretDto]",
-          "typeSimple": "[Volo.Abp.IdentityServer.ApiResource.Dtos.ApiSecretDto]"
+          "type": "[Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceSecretDto]",
+          "typeSimple": "[Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceSecretDto]",
+          "isRequired": false
+        },
+        {
+          "name": "Scopes",
+          "type": "[Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceScopeDto]",
+          "typeSimple": "[Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceScopeDto]",
+          "isRequired": false
+        },
+        {
+          "name": "UserClaims",
+          "type": "[Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceClaimDto]",
+          "typeSimple": "[Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourceClaimDto]",
+          "isRequired": false
+        },
+        {
+          "name": "Properties",
+          "type": "[Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourcePropertyDto]",
+          "typeSimple": "[Volo.Abp.IdentityServer.ApiResource.Dtos.ApiResourcePropertyDto]",
+          "isRequired": false
+        }
+      ]
+    },
+    "Volo.Abp.IdentityServer.ApiScope.Dtos.GetApiScopeListInput": {
+      "baseType": "Volo.Abp.Application.Dtos.PagedAndSortedResultRequestDto",
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "Filter",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        }
+      ]
+    },
+    "Volo.Abp.IdentityServer.ApiScope.Dtos.ApiScopeWithDetailsDto": {
+      "baseType": "Volo.Abp.Application.Dtos.ExtensibleEntityDto<System.Guid>",
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "Enabled",
+          "type": "System.Boolean",
+          "typeSimple": "boolean",
+          "isRequired": false
+        },
+        {
+          "name": "Name",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "DisplayName",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "Description",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "Required",
+          "type": "System.Boolean",
+          "typeSimple": "boolean",
+          "isRequired": false
+        },
+        {
+          "name": "Emphasize",
+          "type": "System.Boolean",
+          "typeSimple": "boolean",
+          "isRequired": false
+        },
+        {
+          "name": "ShowInDiscoveryDocument",
+          "type": "System.Boolean",
+          "typeSimple": "boolean",
+          "isRequired": false
+        },
+        {
+          "name": "UserClaims",
+          "type": "[Volo.Abp.IdentityServer.ApiScope.Dtos.ApiScopeClaimDto]",
+          "typeSimple": "[Volo.Abp.IdentityServer.ApiScope.Dtos.ApiScopeClaimDto]",
+          "isRequired": false
+        },
+        {
+          "name": "Properties",
+          "type": "[Volo.Abp.IdentityServer.ApiScope.Dtos.ApiScopePropertyDto]",
+          "typeSimple": "[Volo.Abp.IdentityServer.ApiScope.Dtos.ApiScopePropertyDto]",
+          "isRequired": false
+        }
+      ]
+    },
+    "Volo.Abp.IdentityServer.ApiScope.Dtos.ApiScopeClaimDto": {
+      "baseType": null,
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "ApiScopeId",
+          "type": "System.Guid",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "Type",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        }
+      ]
+    },
+    "Volo.Abp.IdentityServer.ApiScope.Dtos.ApiScopePropertyDto": {
+      "baseType": null,
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "ApiScopeId",
+          "type": "System.Guid",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "Key",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "Value",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        }
+      ]
+    },
+    "Volo.Abp.IdentityServer.ApiScope.Dtos.CreateApiScopeDto": {
+      "baseType": "Volo.Abp.ObjectExtending.ExtensibleObject",
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "Name",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "DisplayName",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "Description",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "Required",
+          "type": "System.Boolean",
+          "typeSimple": "boolean",
+          "isRequired": false
+        },
+        {
+          "name": "Enabled",
+          "type": "System.Boolean",
+          "typeSimple": "boolean",
+          "isRequired": false
+        },
+        {
+          "name": "Emphasize",
+          "type": "System.Boolean",
+          "typeSimple": "boolean",
+          "isRequired": false
+        },
+        {
+          "name": "ShowInDiscoveryDocument",
+          "type": "System.Boolean",
+          "typeSimple": "boolean",
+          "isRequired": false
+        },
+        {
+          "name": "UserClaims",
+          "type": "[Volo.Abp.IdentityServer.ApiScope.Dtos.ApiScopeClaimDto]",
+          "typeSimple": "[Volo.Abp.IdentityServer.ApiScope.Dtos.ApiScopeClaimDto]",
+          "isRequired": false
+        },
+        {
+          "name": "Properties",
+          "type": "[Volo.Abp.IdentityServer.ApiScope.Dtos.ApiScopePropertyDto]",
+          "typeSimple": "[Volo.Abp.IdentityServer.ApiScope.Dtos.ApiScopePropertyDto]",
+          "isRequired": false
+        }
+      ]
+    },
+    "Volo.Abp.IdentityServer.ApiScope.Dtos.UpdateApiScopeDto": {
+      "baseType": "Volo.Abp.ObjectExtending.ExtensibleObject",
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "DisplayName",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "Description",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "Required",
+          "type": "System.Boolean",
+          "typeSimple": "boolean",
+          "isRequired": false
+        },
+        {
+          "name": "Enabled",
+          "type": "System.Boolean",
+          "typeSimple": "boolean",
+          "isRequired": false
+        },
+        {
+          "name": "Emphasize",
+          "type": "System.Boolean",
+          "typeSimple": "boolean",
+          "isRequired": false
+        },
+        {
+          "name": "ShowInDiscoveryDocument",
+          "type": "System.Boolean",
+          "typeSimple": "boolean",
+          "isRequired": false
+        },
+        {
+          "name": "UserClaims",
+          "type": "[Volo.Abp.IdentityServer.ApiScope.Dtos.ApiScopeClaimDto]",
+          "typeSimple": "[Volo.Abp.IdentityServer.ApiScope.Dtos.ApiScopeClaimDto]",
+          "isRequired": false
+        },
+        {
+          "name": "Properties",
+          "type": "[Volo.Abp.IdentityServer.ApiScope.Dtos.ApiScopePropertyDto]",
+          "typeSimple": "[Volo.Abp.IdentityServer.ApiScope.Dtos.ApiScopePropertyDto]",
+          "isRequired": false
         }
       ]
     },
@@ -8711,7 +11252,8 @@
         {
           "name": "Filter",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -8725,232 +11267,290 @@
         {
           "name": "ClientId",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "ClientName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Description",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "ClientUri",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "LogoUri",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Enabled",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "ProtocolType",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "RequireClientSecret",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "RequireConsent",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "AllowRememberConsent",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "AlwaysIncludeUserClaimsInIdToken",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "RequirePkce",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "AllowPlainTextPkce",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
+        },
+        {
+          "name": "RequireRequestObject",
+          "type": "System.Boolean",
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "AllowAccessTokensViaBrowser",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "FrontChannelLogoutUri",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "FrontChannelLogoutSessionRequired",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "BackChannelLogoutUri",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "BackChannelLogoutSessionRequired",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "AllowOfflineAccess",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "IdentityTokenLifetime",
           "type": "System.Int32",
-          "typeSimple": "number"
+          "typeSimple": "number",
+          "isRequired": false
+        },
+        {
+          "name": "AllowedIdentityTokenSigningAlgorithms",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "AccessTokenLifetime",
           "type": "System.Int32",
-          "typeSimple": "number"
+          "typeSimple": "number",
+          "isRequired": false
         },
         {
           "name": "AuthorizationCodeLifetime",
           "type": "System.Int32",
-          "typeSimple": "number"
+          "typeSimple": "number",
+          "isRequired": false
         },
         {
           "name": "ConsentLifetime",
           "type": "System.Int32?",
-          "typeSimple": "number?"
+          "typeSimple": "number?",
+          "isRequired": false
         },
         {
           "name": "AbsoluteRefreshTokenLifetime",
           "type": "System.Int32",
-          "typeSimple": "number"
+          "typeSimple": "number",
+          "isRequired": false
         },
         {
           "name": "SlidingRefreshTokenLifetime",
           "type": "System.Int32",
-          "typeSimple": "number"
+          "typeSimple": "number",
+          "isRequired": false
         },
         {
           "name": "RefreshTokenUsage",
           "type": "System.Int32",
-          "typeSimple": "number"
+          "typeSimple": "number",
+          "isRequired": false
         },
         {
           "name": "UpdateAccessTokenClaimsOnRefresh",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "RefreshTokenExpiration",
           "type": "System.Int32",
-          "typeSimple": "number"
+          "typeSimple": "number",
+          "isRequired": false
         },
         {
           "name": "AccessTokenType",
           "type": "System.Int32",
-          "typeSimple": "number"
+          "typeSimple": "number",
+          "isRequired": false
         },
         {
           "name": "EnableLocalLogin",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "IncludeJwtId",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "AlwaysSendClientClaims",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "ClientClaimsPrefix",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "PairWiseSubjectSalt",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "UserSsoLifetime",
           "type": "System.Int32?",
-          "typeSimple": "number?"
+          "typeSimple": "number?",
+          "isRequired": false
         },
         {
           "name": "UserCodeType",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "DeviceCodeLifetime",
           "type": "System.Int32",
-          "typeSimple": "number"
+          "typeSimple": "number",
+          "isRequired": false
         },
         {
           "name": "ClientSecrets",
           "type": "[Volo.Abp.IdentityServer.Client.Dtos.ClientSecretDto]",
-          "typeSimple": "[Volo.Abp.IdentityServer.Client.Dtos.ClientSecretDto]"
+          "typeSimple": "[Volo.Abp.IdentityServer.Client.Dtos.ClientSecretDto]",
+          "isRequired": false
         },
         {
           "name": "AllowedScopes",
           "type": "[Volo.Abp.IdentityServer.Client.Dtos.ClientScopeDto]",
-          "typeSimple": "[Volo.Abp.IdentityServer.Client.Dtos.ClientScopeDto]"
+          "typeSimple": "[Volo.Abp.IdentityServer.Client.Dtos.ClientScopeDto]",
+          "isRequired": false
         },
         {
           "name": "Claims",
           "type": "[Volo.Abp.IdentityServer.Client.Dtos.ClientClaimDto]",
-          "typeSimple": "[Volo.Abp.IdentityServer.Client.Dtos.ClientClaimDto]"
+          "typeSimple": "[Volo.Abp.IdentityServer.Client.Dtos.ClientClaimDto]",
+          "isRequired": false
         },
         {
           "name": "AllowedGrantTypes",
           "type": "[Volo.Abp.IdentityServer.Client.Dtos.ClientGrantTypeDto]",
-          "typeSimple": "[Volo.Abp.IdentityServer.Client.Dtos.ClientGrantTypeDto]"
+          "typeSimple": "[Volo.Abp.IdentityServer.Client.Dtos.ClientGrantTypeDto]",
+          "isRequired": false
         },
         {
           "name": "IdentityProviderRestrictions",
           "type": "[Volo.Abp.IdentityServer.Client.Dtos.ClientIdentityProviderRestrictionDto]",
-          "typeSimple": "[Volo.Abp.IdentityServer.Client.Dtos.ClientIdentityProviderRestrictionDto]"
+          "typeSimple": "[Volo.Abp.IdentityServer.Client.Dtos.ClientIdentityProviderRestrictionDto]",
+          "isRequired": false
         },
         {
           "name": "Properties",
           "type": "[Volo.Abp.IdentityServer.Client.Dtos.ClientPropertyDto]",
-          "typeSimple": "[Volo.Abp.IdentityServer.Client.Dtos.ClientPropertyDto]"
+          "typeSimple": "[Volo.Abp.IdentityServer.Client.Dtos.ClientPropertyDto]",
+          "isRequired": false
         },
         {
           "name": "AllowedCorsOrigins",
           "type": "[Volo.Abp.IdentityServer.Client.Dtos.ClientCorsOriginDto]",
-          "typeSimple": "[Volo.Abp.IdentityServer.Client.Dtos.ClientCorsOriginDto]"
+          "typeSimple": "[Volo.Abp.IdentityServer.Client.Dtos.ClientCorsOriginDto]",
+          "isRequired": false
         },
         {
           "name": "RedirectUris",
           "type": "[Volo.Abp.IdentityServer.Client.Dtos.ClientRedirectUriDto]",
-          "typeSimple": "[Volo.Abp.IdentityServer.Client.Dtos.ClientRedirectUriDto]"
+          "typeSimple": "[Volo.Abp.IdentityServer.Client.Dtos.ClientRedirectUriDto]",
+          "isRequired": false
         },
         {
           "name": "PostLogoutRedirectUris",
           "type": "[Volo.Abp.IdentityServer.Client.Dtos.ClientPostLogoutRedirectUriDto]",
-          "typeSimple": "[Volo.Abp.IdentityServer.Client.Dtos.ClientPostLogoutRedirectUriDto]"
+          "typeSimple": "[Volo.Abp.IdentityServer.Client.Dtos.ClientPostLogoutRedirectUriDto]",
+          "isRequired": false
         }
       ]
     },
@@ -8964,27 +11564,32 @@
         {
           "name": "ClientId",
           "type": "System.Guid",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Type",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Value",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Description",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Expiration",
           "type": "System.DateTime?",
-          "typeSimple": "string?"
+          "typeSimple": "string?",
+          "isRequired": false
         }
       ]
     },
@@ -8998,12 +11603,14 @@
         {
           "name": "ClientId",
           "type": "System.Guid",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Scope",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -9017,12 +11624,14 @@
         {
           "name": "Type",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Value",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -9036,12 +11645,14 @@
         {
           "name": "ClientId",
           "type": "System.Guid",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "GrantType",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -9055,12 +11666,14 @@
         {
           "name": "ClientId",
           "type": "System.Guid",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Provider",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -9074,17 +11687,20 @@
         {
           "name": "ClientId",
           "type": "System.Guid",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Key",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Value",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -9098,12 +11714,14 @@
         {
           "name": "ClientId",
           "type": "System.Guid",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Origin",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -9117,12 +11735,14 @@
         {
           "name": "ClientId",
           "type": "System.Guid",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "RedirectUri",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -9136,12 +11756,14 @@
         {
           "name": "ClientId",
           "type": "System.Guid",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "PostLogoutRedirectUri",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -9155,52 +11777,62 @@
         {
           "name": "ClientId",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "ClientName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Description",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "ClientUri",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "LogoUri",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "RequireConsent",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "CallbackUrl",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "LogoutUrl",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Secrets",
           "type": "[Volo.Abp.IdentityServer.Client.Dtos.ClientSecretDto]",
-          "typeSimple": "[Volo.Abp.IdentityServer.Client.Dtos.ClientSecretDto]"
+          "typeSimple": "[Volo.Abp.IdentityServer.Client.Dtos.ClientSecretDto]",
+          "isRequired": false
         },
         {
           "name": "Scopes",
           "type": "[System.String]",
-          "typeSimple": "[string]"
+          "typeSimple": "[string]",
+          "isRequired": false
         }
       ]
     },
@@ -9214,167 +11846,212 @@
         {
           "name": "ClientName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Description",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "ClientUri",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "LogoUri",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Enabled",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "RequireConsent",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "AllowOfflineAccess",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "AllowRememberConsent",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "RequirePkce",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "RequireClientSecret",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
+        },
+        {
+          "name": "RequireRequestObject",
+          "type": "System.Boolean",
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "AccessTokenLifetime",
           "type": "System.Int32",
-          "typeSimple": "number"
+          "typeSimple": "number",
+          "isRequired": false
         },
         {
           "name": "ConsentLifetime",
           "type": "System.Int32?",
-          "typeSimple": "number?"
+          "typeSimple": "number?",
+          "isRequired": false
         },
         {
           "name": "AccessTokenType",
           "type": "System.Int32",
-          "typeSimple": "number"
+          "typeSimple": "number",
+          "isRequired": false
         },
         {
           "name": "EnableLocalLogin",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "FrontChannelLogoutUri",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "FrontChannelLogoutSessionRequired",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "BackChannelLogoutUri",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "AllowedIdentityTokenSigningAlgorithms",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "BackChannelLogoutSessionRequired",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "IncludeJwtId",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "AlwaysSendClientClaims",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "PairWiseSubjectSalt",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "UserSsoLifetime",
           "type": "System.Int32?",
-          "typeSimple": "number?"
+          "typeSimple": "number?",
+          "isRequired": false
         },
         {
           "name": "UserCodeType",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "DeviceCodeLifetime",
           "type": "System.Int32",
-          "typeSimple": "number"
+          "typeSimple": "number",
+          "isRequired": false
         },
         {
           "name": "ClientSecrets",
           "type": "[Volo.Abp.IdentityServer.Client.Dtos.ClientSecretDto]",
-          "typeSimple": "[Volo.Abp.IdentityServer.Client.Dtos.ClientSecretDto]"
+          "typeSimple": "[Volo.Abp.IdentityServer.Client.Dtos.ClientSecretDto]",
+          "isRequired": false
         },
         {
           "name": "Claims",
           "type": "[Volo.Abp.IdentityServer.Client.Dtos.ClientClaimDto]",
-          "typeSimple": "[Volo.Abp.IdentityServer.Client.Dtos.ClientClaimDto]"
+          "typeSimple": "[Volo.Abp.IdentityServer.Client.Dtos.ClientClaimDto]",
+          "isRequired": false
         },
         {
           "name": "Properties",
           "type": "[Volo.Abp.IdentityServer.Client.Dtos.ClientPropertyDto]",
-          "typeSimple": "[Volo.Abp.IdentityServer.Client.Dtos.ClientPropertyDto]"
+          "typeSimple": "[Volo.Abp.IdentityServer.Client.Dtos.ClientPropertyDto]",
+          "isRequired": false
         },
         {
           "name": "AllowedGrantTypes",
           "type": "[System.String]",
-          "typeSimple": "[string]"
+          "typeSimple": "[string]",
+          "isRequired": false
         },
         {
           "name": "IdentityProviderRestrictions",
           "type": "[System.String]",
-          "typeSimple": "[string]"
+          "typeSimple": "[string]",
+          "isRequired": false
         },
         {
           "name": "Scopes",
           "type": "[System.String]",
-          "typeSimple": "[string]"
+          "typeSimple": "[string]",
+          "isRequired": false
         },
         {
           "name": "AllowedCorsOrigins",
           "type": "[System.String]",
-          "typeSimple": "[string]"
+          "typeSimple": "[string]",
+          "isRequired": false
         },
         {
           "name": "RedirectUris",
           "type": "[System.String]",
-          "typeSimple": "[string]"
+          "typeSimple": "[string]",
+          "isRequired": false
         },
         {
           "name": "PostLogoutRedirectUris",
           "type": "[System.String]",
-          "typeSimple": "[string]"
+          "typeSimple": "[string]",
+          "isRequired": false
         }
       ]
     },
@@ -9388,7 +12065,8 @@
         {
           "name": "Filter",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -9402,51 +12080,60 @@
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "DisplayName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Description",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Enabled",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "Required",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "Emphasize",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "ShowInDiscoveryDocument",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "UserClaims",
-          "type": "[Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityClaimDto]",
-          "typeSimple": "[Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityClaimDto]"
+          "type": "[Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityResourceClaimDto]",
+          "typeSimple": "[Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityResourceClaimDto]",
+          "isRequired": false
         },
         {
           "name": "Properties",
-          "type": "{System.String:System.String}",
-          "typeSimple": "{string:string}"
+          "type": "[Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityResourcePropertyDto]",
+          "typeSimple": "[Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityResourcePropertyDto]",
+          "isRequired": false
         }
       ]
     },
-    "Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityClaimDto": {
+    "Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityResourceClaimDto": {
       "baseType": null,
       "isEnum": false,
       "enumNames": null,
@@ -9456,12 +12143,41 @@
         {
           "name": "IdentityResourceId",
           "type": "System.Guid",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Type",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
+        }
+      ]
+    },
+    "Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityResourcePropertyDto": {
+      "baseType": null,
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "IdentityResourceId",
+          "type": "System.Guid",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "Key",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "Value",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -9475,42 +12191,56 @@
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "DisplayName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Description",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Enabled",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "Required",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "Emphasize",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "ShowInDiscoveryDocument",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
-          "name": "Claims",
-          "type": "[System.String]",
-          "typeSimple": "[string]"
+          "name": "UserClaims",
+          "type": "[Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityResourceClaimDto]",
+          "typeSimple": "[Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityResourceClaimDto]",
+          "isRequired": false
+        },
+        {
+          "name": "Properties",
+          "type": "[Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityResourcePropertyDto]",
+          "typeSimple": "[Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityResourcePropertyDto]",
+          "isRequired": false
         }
       ]
     },
@@ -9524,42 +12254,56 @@
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "DisplayName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Description",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Enabled",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "Required",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "Emphasize",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "ShowInDiscoveryDocument",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
-          "name": "Claims",
-          "type": "[System.String]",
-          "typeSimple": "[string]"
+          "name": "UserClaims",
+          "type": "[Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityResourceClaimDto]",
+          "typeSimple": "[Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityResourceClaimDto]",
+          "isRequired": false
+        },
+        {
+          "name": "Properties",
+          "type": "[Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityResourcePropertyDto]",
+          "typeSimple": "[Volo.Abp.IdentityServer.IdentityResource.Dtos.IdentityResourcePropertyDto]",
+          "isRequired": false
         }
       ]
     },
@@ -9573,7 +12317,8 @@
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -9587,32 +12332,38 @@
         {
           "name": "CultureName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "UiCultureName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "DisplayName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "FlagIcon",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "IsEnabled",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "IsDefaultLanguage",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         }
       ]
     },
@@ -9626,27 +12377,32 @@
         {
           "name": "Filter",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "ResourceName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "BaseCultureName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "TargetCultureName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "GetOnlyEmptyValues",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         }
       ]
     },
@@ -9660,27 +12416,32 @@
         {
           "name": "DisplayName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "CultureName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "UiCultureName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "FlagIcon",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "IsEnabled",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         }
       ]
     },
@@ -9694,17 +12455,20 @@
         {
           "name": "DisplayName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "FlagIcon",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "IsEnabled",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         }
       ]
     },
@@ -9718,7 +12482,8 @@
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -9732,12 +12497,14 @@
         {
           "name": "DisplayName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -9751,32 +12518,38 @@
         {
           "name": "ResourceName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "CultureName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "BaseCultureName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "BaseValue",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Value",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -9790,22 +12563,26 @@
         {
           "name": "BoxedLayout",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "MenuPlacement",
           "type": "Volo.Abp.LeptonTheme.Management.MenuPlacement",
-          "typeSimple": "Volo.Abp.LeptonTheme.Management.MenuPlacement"
+          "typeSimple": "Volo.Abp.LeptonTheme.Management.MenuPlacement",
+          "isRequired": false
         },
         {
           "name": "MenuStatus",
           "type": "Volo.Abp.LeptonTheme.Management.MenuStatus",
-          "typeSimple": "Volo.Abp.LeptonTheme.Management.MenuStatus"
+          "typeSimple": "Volo.Abp.LeptonTheme.Management.MenuStatus",
+          "isRequired": false
         },
         {
           "name": "Style",
           "type": "Volo.Abp.LeptonTheme.Management.LeptonStyle",
-          "typeSimple": "Volo.Abp.LeptonTheme.Management.LeptonStyle"
+          "typeSimple": "Volo.Abp.LeptonTheme.Management.LeptonStyle",
+          "isRequired": false
         }
       ]
     },
@@ -9843,22 +12620,26 @@
         {
           "name": "BoxedLayout",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "MenuPlacement",
           "type": "Volo.Abp.LeptonTheme.Management.MenuPlacement",
-          "typeSimple": "Volo.Abp.LeptonTheme.Management.MenuPlacement"
+          "typeSimple": "Volo.Abp.LeptonTheme.Management.MenuPlacement",
+          "isRequired": false
         },
         {
           "name": "MenuStatus",
           "type": "Volo.Abp.LeptonTheme.Management.MenuStatus",
-          "typeSimple": "Volo.Abp.LeptonTheme.Management.MenuStatus"
+          "typeSimple": "Volo.Abp.LeptonTheme.Management.MenuStatus",
+          "isRequired": false
         },
         {
           "name": "Style",
           "type": "Volo.Abp.LeptonTheme.Management.LeptonStyle",
-          "typeSimple": "Volo.Abp.LeptonTheme.Management.LeptonStyle"
+          "typeSimple": "Volo.Abp.LeptonTheme.Management.LeptonStyle",
+          "isRequired": false
         }
       ]
     },
@@ -9872,12 +12653,14 @@
         {
           "name": "EntityDisplayName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Groups",
           "type": "[Volo.Abp.PermissionManagement.PermissionGroupDto]",
-          "typeSimple": "[Volo.Abp.PermissionManagement.PermissionGroupDto]"
+          "typeSimple": "[Volo.Abp.PermissionManagement.PermissionGroupDto]",
+          "isRequired": false
         }
       ]
     },
@@ -9891,17 +12674,20 @@
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "DisplayName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Permissions",
           "type": "[Volo.Abp.PermissionManagement.PermissionGrantInfoDto]",
-          "typeSimple": "[Volo.Abp.PermissionManagement.PermissionGrantInfoDto]"
+          "typeSimple": "[Volo.Abp.PermissionManagement.PermissionGrantInfoDto]",
+          "isRequired": false
         }
       ]
     },
@@ -9915,32 +12701,38 @@
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "DisplayName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "ParentName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "IsGranted",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "AllowedProviders",
           "type": "[System.String]",
-          "typeSimple": "[string]"
+          "typeSimple": "[string]",
+          "isRequired": false
         },
         {
           "name": "GrantedProviders",
           "type": "[Volo.Abp.PermissionManagement.ProviderInfoDto]",
-          "typeSimple": "[Volo.Abp.PermissionManagement.ProviderInfoDto]"
+          "typeSimple": "[Volo.Abp.PermissionManagement.ProviderInfoDto]",
+          "isRequired": false
         }
       ]
     },
@@ -9954,12 +12746,14 @@
         {
           "name": "ProviderName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "ProviderKey",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -9973,7 +12767,8 @@
         {
           "name": "Permissions",
           "type": "[Volo.Abp.PermissionManagement.UpdatePermissionDto]",
-          "typeSimple": "[Volo.Abp.PermissionManagement.UpdatePermissionDto]"
+          "typeSimple": "[Volo.Abp.PermissionManagement.UpdatePermissionDto]",
+          "isRequired": false
         }
       ]
     },
@@ -9987,12 +12782,14 @@
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "IsGranted",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         }
       ]
     },
@@ -10006,12 +12803,14 @@
         {
           "name": "TemplateName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": true
         },
         {
           "name": "CultureName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -10025,17 +12824,20 @@
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "CultureName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Content",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -10049,12 +12851,14 @@
         {
           "name": "TemplateName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": true
         },
         {
           "name": "CultureName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -10068,17 +12872,20 @@
         {
           "name": "TemplateName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": true
         },
         {
           "name": "CultureName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Content",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -10092,7 +12899,8 @@
         {
           "name": "FilterText",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -10106,32 +12914,38 @@
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "DisplayName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "IsLayout",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "Layout",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "IsInlineLocalized",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "DefaultCultureName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -10145,7 +12959,8 @@
         {
           "name": "DisplayName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -10159,7 +12974,8 @@
         {
           "name": "Filter",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -10181,7 +12997,8 @@
         {
           "name": "DisplayName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": true
         }
       ]
     },
@@ -10203,7 +13020,8 @@
         {
           "name": "Data",
           "type": "{System.String:System.Int32}",
-          "typeSimple": "{string:number}"
+          "typeSimple": "{string:number}",
+          "isRequired": false
         }
       ]
     },
@@ -10217,17 +13035,20 @@
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "EditionId",
           "type": "System.Guid?",
-          "typeSimple": "string?"
+          "typeSimple": "string?",
+          "isRequired": false
         },
         {
           "name": "EditionName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -10241,12 +13062,14 @@
         {
           "name": "Filter",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "GetEditionNames",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         }
       ]
     },
@@ -10260,12 +13083,14 @@
         {
           "name": "AdminEmailAddress",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": true
         },
         {
           "name": "AdminPassword",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": true
         }
       ]
     },
@@ -10279,12 +13104,14 @@
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": true
         },
         {
           "name": "EditionId",
           "type": "System.Guid?",
-          "typeSimple": "string?"
+          "typeSimple": "string?",
+          "isRequired": false
         }
       ]
     },
@@ -10296,7 +13123,7 @@
       "genericArguments": null,
       "properties": []
     },
-    "Volo.Abp.FeatureManagement.FeatureListDto": {
+    "Volo.Abp.FeatureManagement.GetFeatureListResultDto": {
       "baseType": null,
       "isEnum": false,
       "enumNames": null,
@@ -10304,9 +13131,37 @@
       "genericArguments": null,
       "properties": [
         {
+          "name": "Groups",
+          "type": "[Volo.Abp.FeatureManagement.FeatureGroupDto]",
+          "typeSimple": "[Volo.Abp.FeatureManagement.FeatureGroupDto]",
+          "isRequired": false
+        }
+      ]
+    },
+    "Volo.Abp.FeatureManagement.FeatureGroupDto": {
+      "baseType": null,
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "Name",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "DisplayName",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
           "name": "Features",
           "type": "[Volo.Abp.FeatureManagement.FeatureDto]",
-          "typeSimple": "[Volo.Abp.FeatureManagement.FeatureDto]"
+          "typeSimple": "[Volo.Abp.FeatureManagement.FeatureDto]",
+          "isRequired": false
         }
       ]
     },
@@ -10320,37 +13175,71 @@
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "DisplayName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Value",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "Provider",
+          "type": "Volo.Abp.FeatureManagement.FeatureProviderDto",
+          "typeSimple": "Volo.Abp.FeatureManagement.FeatureProviderDto",
+          "isRequired": false
         },
         {
           "name": "Description",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "ValueType",
           "type": "Volo.Abp.Validation.StringValues.IStringValueType",
-          "typeSimple": "Volo.Abp.Validation.StringValues.IStringValueType"
+          "typeSimple": "Volo.Abp.Validation.StringValues.IStringValueType",
+          "isRequired": false
         },
         {
           "name": "Depth",
           "type": "System.Int32",
-          "typeSimple": "number"
+          "typeSimple": "number",
+          "isRequired": false
         },
         {
           "name": "ParentName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
+        }
+      ]
+    },
+    "Volo.Abp.FeatureManagement.FeatureProviderDto": {
+      "baseType": null,
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "Name",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "Key",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -10364,22 +13253,26 @@
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Item",
           "type": "System.Object",
-          "typeSimple": "object"
+          "typeSimple": "object",
+          "isRequired": false
         },
         {
           "name": "Properties",
           "type": "{System.String:System.Object}",
-          "typeSimple": "{string:object}"
+          "typeSimple": "{string:object}",
+          "isRequired": false
         },
         {
           "name": "Validator",
           "type": "Volo.Abp.Validation.StringValues.IValueValidator",
-          "typeSimple": "Volo.Abp.Validation.StringValues.IValueValidator"
+          "typeSimple": "Volo.Abp.Validation.StringValues.IValueValidator",
+          "isRequired": false
         }
       ]
     },
@@ -10393,17 +13286,20 @@
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Item",
           "type": "System.Object",
-          "typeSimple": "object"
+          "typeSimple": "object",
+          "isRequired": false
         },
         {
           "name": "Properties",
           "type": "{System.String:System.Object}",
-          "typeSimple": "{string:object}"
+          "typeSimple": "{string:object}",
+          "isRequired": false
         }
       ]
     },
@@ -10417,7 +13313,8 @@
         {
           "name": "Features",
           "type": "[Volo.Abp.FeatureManagement.UpdateFeatureDto]",
-          "typeSimple": "[Volo.Abp.FeatureManagement.UpdateFeatureDto]"
+          "typeSimple": "[Volo.Abp.FeatureManagement.UpdateFeatureDto]",
+          "isRequired": false
         }
       ]
     },
@@ -10431,12 +13328,14 @@
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Value",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -10450,52 +13349,62 @@
         {
           "name": "Localization",
           "type": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ApplicationLocalizationConfigurationDto",
-          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ApplicationLocalizationConfigurationDto"
+          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ApplicationLocalizationConfigurationDto",
+          "isRequired": false
         },
         {
           "name": "Auth",
           "type": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ApplicationAuthConfigurationDto",
-          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ApplicationAuthConfigurationDto"
+          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ApplicationAuthConfigurationDto",
+          "isRequired": false
         },
         {
           "name": "Setting",
           "type": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ApplicationSettingConfigurationDto",
-          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ApplicationSettingConfigurationDto"
+          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ApplicationSettingConfigurationDto",
+          "isRequired": false
         },
         {
           "name": "CurrentUser",
           "type": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.CurrentUserDto",
-          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.CurrentUserDto"
+          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.CurrentUserDto",
+          "isRequired": false
         },
         {
           "name": "Features",
           "type": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ApplicationFeatureConfigurationDto",
-          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ApplicationFeatureConfigurationDto"
+          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ApplicationFeatureConfigurationDto",
+          "isRequired": false
         },
         {
           "name": "MultiTenancy",
           "type": "Volo.Abp.AspNetCore.Mvc.MultiTenancy.MultiTenancyInfoDto",
-          "typeSimple": "Volo.Abp.AspNetCore.Mvc.MultiTenancy.MultiTenancyInfoDto"
+          "typeSimple": "Volo.Abp.AspNetCore.Mvc.MultiTenancy.MultiTenancyInfoDto",
+          "isRequired": false
         },
         {
           "name": "CurrentTenant",
           "type": "Volo.Abp.AspNetCore.Mvc.MultiTenancy.CurrentTenantDto",
-          "typeSimple": "Volo.Abp.AspNetCore.Mvc.MultiTenancy.CurrentTenantDto"
+          "typeSimple": "Volo.Abp.AspNetCore.Mvc.MultiTenancy.CurrentTenantDto",
+          "isRequired": false
         },
         {
           "name": "Timing",
           "type": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.TimingDto",
-          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.TimingDto"
+          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.TimingDto",
+          "isRequired": false
         },
         {
           "name": "Clock",
           "type": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ClockDto",
-          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ClockDto"
+          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ClockDto",
+          "isRequired": false
         },
         {
           "name": "ObjectExtensions",
           "type": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ObjectExtensionsDto",
-          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ObjectExtensionsDto"
+          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ObjectExtensionsDto",
+          "isRequired": false
         }
       ]
     },
@@ -10509,32 +13418,38 @@
         {
           "name": "Values",
           "type": "{System.String:{System.String:System.String}}",
-          "typeSimple": "{string:{string:string}}"
+          "typeSimple": "{string:{string:string}}",
+          "isRequired": false
         },
         {
           "name": "Languages",
           "type": "[Volo.Abp.Localization.LanguageInfo]",
-          "typeSimple": "[Volo.Abp.Localization.LanguageInfo]"
+          "typeSimple": "[Volo.Abp.Localization.LanguageInfo]",
+          "isRequired": false
         },
         {
           "name": "CurrentCulture",
           "type": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.CurrentCultureDto",
-          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.CurrentCultureDto"
+          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.CurrentCultureDto",
+          "isRequired": false
         },
         {
           "name": "DefaultResourceName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "LanguagesMap",
           "type": "{System.String:[Volo.Abp.NameValue]}",
-          "typeSimple": "{string:[Volo.Abp.NameValue]}"
+          "typeSimple": "{string:[Volo.Abp.NameValue]}",
+          "isRequired": false
         },
         {
           "name": "LanguageFilesMap",
           "type": "{System.String:[Volo.Abp.NameValue]}",
-          "typeSimple": "{string:[Volo.Abp.NameValue]}"
+          "typeSimple": "{string:[Volo.Abp.NameValue]}",
+          "isRequired": false
         }
       ]
     },
@@ -10548,22 +13463,26 @@
         {
           "name": "CultureName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "UiCultureName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "DisplayName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "FlagIcon",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -10577,47 +13496,56 @@
         {
           "name": "DisplayName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "EnglishName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "ThreeLetterIsoLanguageName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "TwoLetterIsoLanguageName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "IsRightToLeft",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "CultureName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "NativeName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "DateTimeFormat",
           "type": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.DateTimeFormatDto",
-          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.DateTimeFormatDto"
+          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.DateTimeFormatDto",
+          "isRequired": false
         }
       ]
     },
@@ -10631,37 +13559,44 @@
         {
           "name": "CalendarAlgorithmType",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "DateTimeFormatLong",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "ShortDatePattern",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "FullDateTimePattern",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "DateSeparator",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "ShortTimePattern",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "LongTimePattern",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -10673,25 +13608,6 @@
       "genericArguments": null,
       "properties": []
     },
-    "Volo.Abp.NameValue<T0>": {
-      "baseType": null,
-      "isEnum": false,
-      "enumNames": null,
-      "enumValues": null,
-      "genericArguments": ["T"],
-      "properties": [
-        {
-          "name": "Name",
-          "type": "System.String",
-          "typeSimple": "string"
-        },
-        {
-          "name": "Value",
-          "type": "T",
-          "typeSimple": "T"
-        }
-      ]
-    },
     "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ApplicationAuthConfigurationDto": {
       "baseType": null,
       "isEnum": false,
@@ -10702,12 +13618,14 @@
         {
           "name": "Policies",
           "type": "{System.String:System.Boolean}",
-          "typeSimple": "{string:boolean}"
+          "typeSimple": "{string:boolean}",
+          "isRequired": false
         },
         {
           "name": "GrantedPolicies",
           "type": "{System.String:System.Boolean}",
-          "typeSimple": "{string:boolean}"
+          "typeSimple": "{string:boolean}",
+          "isRequired": false
         }
       ]
     },
@@ -10721,7 +13639,8 @@
         {
           "name": "Values",
           "type": "{System.String:System.String}",
-          "typeSimple": "{string:string}"
+          "typeSimple": "{string:string}",
+          "isRequired": false
         }
       ]
     },
@@ -10735,32 +13654,68 @@
         {
           "name": "IsAuthenticated",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "Id",
           "type": "System.Guid?",
-          "typeSimple": "string?"
+          "typeSimple": "string?",
+          "isRequired": false
         },
         {
           "name": "TenantId",
           "type": "System.Guid?",
-          "typeSimple": "string?"
+          "typeSimple": "string?",
+          "isRequired": false
         },
         {
           "name": "UserName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "Name",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "SurName",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Email",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "EmailVerified",
+          "type": "System.Boolean",
+          "typeSimple": "boolean",
+          "isRequired": false
+        },
+        {
+          "name": "PhoneNumber",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "PhoneNumberVerified",
+          "type": "System.Boolean",
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "Roles",
           "type": "[System.String]",
-          "typeSimple": "[string]"
+          "typeSimple": "[string]",
+          "isRequired": false
         }
       ]
     },
@@ -10774,7 +13729,8 @@
         {
           "name": "Values",
           "type": "{System.String:System.String}",
-          "typeSimple": "{string:string}"
+          "typeSimple": "{string:string}",
+          "isRequired": false
         }
       ]
     },
@@ -10788,7 +13744,8 @@
         {
           "name": "IsEnabled",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         }
       ]
     },
@@ -10802,17 +13759,20 @@
         {
           "name": "Id",
           "type": "System.Guid?",
-          "typeSimple": "string?"
+          "typeSimple": "string?",
+          "isRequired": false
         },
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "IsAvailable",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         }
       ]
     },
@@ -10826,7 +13786,8 @@
         {
           "name": "TimeZone",
           "type": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.TimeZone",
-          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.TimeZone"
+          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.TimeZone",
+          "isRequired": false
         }
       ]
     },
@@ -10840,12 +13801,14 @@
         {
           "name": "Iana",
           "type": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.IanaTimeZone",
-          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.IanaTimeZone"
+          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.IanaTimeZone",
+          "isRequired": false
         },
         {
           "name": "Windows",
           "type": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.WindowsTimeZone",
-          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.WindowsTimeZone"
+          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.WindowsTimeZone",
+          "isRequired": false
         }
       ]
     },
@@ -10859,7 +13822,8 @@
         {
           "name": "TimeZoneName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -10873,7 +13837,8 @@
         {
           "name": "TimeZoneId",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -10887,7 +13852,8 @@
         {
           "name": "Kind",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -10901,12 +13867,14 @@
         {
           "name": "Modules",
           "type": "{System.String:Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ModuleExtensionDto}",
-          "typeSimple": "{string:Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ModuleExtensionDto}"
+          "typeSimple": "{string:Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ModuleExtensionDto}",
+          "isRequired": false
         },
         {
           "name": "Enums",
           "type": "{System.String:Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionEnumDto}",
-          "typeSimple": "{string:Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionEnumDto}"
+          "typeSimple": "{string:Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionEnumDto}",
+          "isRequired": false
         }
       ]
     },
@@ -10920,12 +13888,14 @@
         {
           "name": "Entities",
           "type": "{System.String:Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.EntityExtensionDto}",
-          "typeSimple": "{string:Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.EntityExtensionDto}"
+          "typeSimple": "{string:Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.EntityExtensionDto}",
+          "isRequired": false
         },
         {
           "name": "Configuration",
           "type": "{System.String:System.Object}",
-          "typeSimple": "{string:object}"
+          "typeSimple": "{string:object}",
+          "isRequired": false
         }
       ]
     },
@@ -10939,12 +13909,14 @@
         {
           "name": "Properties",
           "type": "{System.String:Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionPropertyDto}",
-          "typeSimple": "{string:Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionPropertyDto}"
+          "typeSimple": "{string:Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionPropertyDto}",
+          "isRequired": false
         },
         {
           "name": "Configuration",
           "type": "{System.String:System.Object}",
-          "typeSimple": "{string:object}"
+          "typeSimple": "{string:object}",
+          "isRequired": false
         }
       ]
     },
@@ -10958,42 +13930,50 @@
         {
           "name": "Type",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "TypeSimple",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "DisplayName",
           "type": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.LocalizableStringDto",
-          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.LocalizableStringDto"
+          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.LocalizableStringDto",
+          "isRequired": false
         },
         {
           "name": "Api",
           "type": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionPropertyApiDto",
-          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionPropertyApiDto"
+          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionPropertyApiDto",
+          "isRequired": false
         },
         {
           "name": "Ui",
           "type": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionPropertyUiDto",
-          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionPropertyUiDto"
+          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionPropertyUiDto",
+          "isRequired": false
         },
         {
           "name": "Attributes",
           "type": "[Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionPropertyAttributeDto]",
-          "typeSimple": "[Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionPropertyAttributeDto]"
+          "typeSimple": "[Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionPropertyAttributeDto]",
+          "isRequired": false
         },
         {
           "name": "Configuration",
           "type": "{System.String:System.Object}",
-          "typeSimple": "{string:object}"
+          "typeSimple": "{string:object}",
+          "isRequired": false
         },
         {
           "name": "DefaultValue",
           "type": "System.Object",
-          "typeSimple": "object"
+          "typeSimple": "object",
+          "isRequired": false
         }
       ]
     },
@@ -11007,12 +13987,14 @@
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Resource",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -11026,17 +14008,20 @@
         {
           "name": "OnGet",
           "type": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionPropertyApiGetDto",
-          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionPropertyApiGetDto"
+          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionPropertyApiGetDto",
+          "isRequired": false
         },
         {
           "name": "OnCreate",
           "type": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionPropertyApiCreateDto",
-          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionPropertyApiCreateDto"
+          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionPropertyApiCreateDto",
+          "isRequired": false
         },
         {
           "name": "OnUpdate",
           "type": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionPropertyApiUpdateDto",
-          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionPropertyApiUpdateDto"
+          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionPropertyApiUpdateDto",
+          "isRequired": false
         }
       ]
     },
@@ -11050,7 +14035,8 @@
         {
           "name": "IsAvailable",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         }
       ]
     },
@@ -11064,7 +14050,8 @@
         {
           "name": "IsAvailable",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         }
       ]
     },
@@ -11078,7 +14065,8 @@
         {
           "name": "IsAvailable",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         }
       ]
     },
@@ -11092,17 +14080,20 @@
         {
           "name": "OnTable",
           "type": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionPropertyUiTableDto",
-          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionPropertyUiTableDto"
+          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionPropertyUiTableDto",
+          "isRequired": false
         },
         {
           "name": "OnCreateForm",
           "type": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionPropertyUiFormDto",
-          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionPropertyUiFormDto"
+          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionPropertyUiFormDto",
+          "isRequired": false
         },
         {
           "name": "OnEditForm",
           "type": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionPropertyUiFormDto",
-          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionPropertyUiFormDto"
+          "typeSimple": "Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionPropertyUiFormDto",
+          "isRequired": false
         }
       ]
     },
@@ -11116,7 +14107,8 @@
         {
           "name": "IsVisible",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         }
       ]
     },
@@ -11130,7 +14122,8 @@
         {
           "name": "IsVisible",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         }
       ]
     },
@@ -11144,12 +14137,14 @@
         {
           "name": "TypeSimple",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Config",
           "type": "{System.String:System.Object}",
-          "typeSimple": "{string:object}"
+          "typeSimple": "{string:object}",
+          "isRequired": false
         }
       ]
     },
@@ -11163,12 +14158,14 @@
         {
           "name": "Fields",
           "type": "[Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionEnumFieldDto]",
-          "typeSimple": "[Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionEnumFieldDto]"
+          "typeSimple": "[Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending.ExtensionEnumFieldDto]",
+          "isRequired": false
         },
         {
           "name": "LocalizationResource",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -11182,12 +14179,14 @@
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Value",
           "type": "System.Object",
-          "typeSimple": "object"
+          "typeSimple": "object",
+          "isRequired": false
         }
       ]
     },
@@ -11201,7 +14200,8 @@
         {
           "name": "IncludeTypes",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         }
       ]
     },
@@ -11215,12 +14215,14 @@
         {
           "name": "Modules",
           "type": "{System.String:Volo.Abp.Http.Modeling.ModuleApiDescriptionModel}",
-          "typeSimple": "{string:Volo.Abp.Http.Modeling.ModuleApiDescriptionModel}"
+          "typeSimple": "{string:Volo.Abp.Http.Modeling.ModuleApiDescriptionModel}",
+          "isRequired": false
         },
         {
           "name": "Types",
           "type": "{System.String:Volo.Abp.Http.Modeling.TypeApiDescriptionModel}",
-          "typeSimple": "{string:Volo.Abp.Http.Modeling.TypeApiDescriptionModel}"
+          "typeSimple": "{string:Volo.Abp.Http.Modeling.TypeApiDescriptionModel}",
+          "isRequired": false
         }
       ]
     },
@@ -11234,17 +14236,20 @@
         {
           "name": "RootPath",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "RemoteServiceName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Controllers",
           "type": "{System.String:Volo.Abp.Http.Modeling.ControllerApiDescriptionModel}",
-          "typeSimple": "{string:Volo.Abp.Http.Modeling.ControllerApiDescriptionModel}"
+          "typeSimple": "{string:Volo.Abp.Http.Modeling.ControllerApiDescriptionModel}",
+          "isRequired": false
         }
       ]
     },
@@ -11258,22 +14263,26 @@
         {
           "name": "ControllerName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Type",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Interfaces",
           "type": "[Volo.Abp.Http.Modeling.ControllerInterfaceApiDescriptionModel]",
-          "typeSimple": "[Volo.Abp.Http.Modeling.ControllerInterfaceApiDescriptionModel]"
+          "typeSimple": "[Volo.Abp.Http.Modeling.ControllerInterfaceApiDescriptionModel]",
+          "isRequired": false
         },
         {
           "name": "Actions",
           "type": "{System.String:Volo.Abp.Http.Modeling.ActionApiDescriptionModel}",
-          "typeSimple": "{string:Volo.Abp.Http.Modeling.ActionApiDescriptionModel}"
+          "typeSimple": "{string:Volo.Abp.Http.Modeling.ActionApiDescriptionModel}",
+          "isRequired": false
         }
       ]
     },
@@ -11287,7 +14296,8 @@
         {
           "name": "Type",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -11301,42 +14311,50 @@
         {
           "name": "UniqueName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "HttpMethod",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Url",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "SupportedVersions",
           "type": "[System.String]",
-          "typeSimple": "[string]"
+          "typeSimple": "[string]",
+          "isRequired": false
         },
         {
           "name": "ParametersOnMethod",
           "type": "[Volo.Abp.Http.Modeling.MethodParameterApiDescriptionModel]",
-          "typeSimple": "[Volo.Abp.Http.Modeling.MethodParameterApiDescriptionModel]"
+          "typeSimple": "[Volo.Abp.Http.Modeling.MethodParameterApiDescriptionModel]",
+          "isRequired": false
         },
         {
           "name": "Parameters",
           "type": "[Volo.Abp.Http.Modeling.ParameterApiDescriptionModel]",
-          "typeSimple": "[Volo.Abp.Http.Modeling.ParameterApiDescriptionModel]"
+          "typeSimple": "[Volo.Abp.Http.Modeling.ParameterApiDescriptionModel]",
+          "isRequired": false
         },
         {
           "name": "ReturnValue",
           "type": "Volo.Abp.Http.Modeling.ReturnValueApiDescriptionModel",
-          "typeSimple": "Volo.Abp.Http.Modeling.ReturnValueApiDescriptionModel"
+          "typeSimple": "Volo.Abp.Http.Modeling.ReturnValueApiDescriptionModel",
+          "isRequired": false
         }
       ]
     },
@@ -11350,32 +14368,38 @@
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "TypeAsString",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Type",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "TypeSimple",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "IsOptional",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "DefaultValue",
           "type": "System.Object",
-          "typeSimple": "object"
+          "typeSimple": "object",
+          "isRequired": false
         }
       ]
     },
@@ -11389,47 +14413,56 @@
         {
           "name": "NameOnMethod",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Type",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "TypeSimple",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "IsOptional",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "DefaultValue",
           "type": "System.Object",
-          "typeSimple": "object"
+          "typeSimple": "object",
+          "isRequired": false
         },
         {
           "name": "ConstraintTypes",
           "type": "[System.String]",
-          "typeSimple": "[string]"
+          "typeSimple": "[string]",
+          "isRequired": false
         },
         {
           "name": "BindingSourceId",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "DescriptorName",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -11443,12 +14476,14 @@
         {
           "name": "Type",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "TypeSimple",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     },
@@ -11462,32 +14497,38 @@
         {
           "name": "BaseType",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "IsEnum",
           "type": "System.Boolean",
-          "typeSimple": "boolean"
+          "typeSimple": "boolean",
+          "isRequired": false
         },
         {
           "name": "EnumNames",
           "type": "[System.String]",
-          "typeSimple": "[string]"
+          "typeSimple": "[string]",
+          "isRequired": false
         },
         {
           "name": "EnumValues",
           "type": "[System.Object]",
-          "typeSimple": "[object]"
+          "typeSimple": "[object]",
+          "isRequired": false
         },
         {
           "name": "GenericArguments",
           "type": "[System.String]",
-          "typeSimple": "[string]"
+          "typeSimple": "[string]",
+          "isRequired": false
         },
         {
           "name": "Properties",
           "type": "[Volo.Abp.Http.Modeling.PropertyApiDescriptionModel]",
-          "typeSimple": "[Volo.Abp.Http.Modeling.PropertyApiDescriptionModel]"
+          "typeSimple": "[Volo.Abp.Http.Modeling.PropertyApiDescriptionModel]",
+          "isRequired": false
         }
       ]
     },
@@ -11501,17 +14542,62 @@
         {
           "name": "Name",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "Type",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
         },
         {
           "name": "TypeSimple",
           "type": "System.String",
-          "typeSimple": "string"
+          "typeSimple": "string",
+          "isRequired": false
+        },
+        {
+          "name": "IsRequired",
+          "type": "System.Boolean",
+          "typeSimple": "boolean",
+          "isRequired": false
+        }
+      ]
+    },
+    "MyCompanyName.MyProjectName.BookListFilterDto": {
+      "baseType": null,
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "RequiredStr",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": true
+        },
+        {
+          "name": "NonRequiredStr",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
+        }
+      ]
+    },
+    "MyCompanyName.MyProjectName.BookDto": {
+      "baseType": null,
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "Name",
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false
         }
       ]
     }

--- a/npm/ng-packs/packages/schematics/src/models/api-definition.ts
+++ b/npm/ng-packs/packages/schematics/src/models/api-definition.ts
@@ -18,6 +18,7 @@ export interface PropertyDef {
   name: string;
   type: string;
   typeSimple: string;
+  isRequired: boolean;
 }
 
 export interface Module {

--- a/npm/ng-packs/packages/schematics/src/utils/model.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/model.ts
@@ -1,5 +1,5 @@
 import { VOLO_NAME_VALUE, VOLO_REGEX } from '../constants';
-import { Interface, Model, Property, Type, TypeWithEnum } from '../models';
+import { Interface, Model, Property, PropertyDef, Type, TypeWithEnum } from '../models';
 import { parseNamespace } from './namespace';
 import { relativePathToModel } from './path';
 import { camel } from './text';
@@ -119,7 +119,7 @@ export function createImportRefToInterfaceReducerCreator(params: ModelGeneratorP
 
     typeDef.properties?.forEach(prop => {
       const name = camel(prop.name);
-      const optional = prop.typeSimple.endsWith('?') ? '?' : '';
+      const optional = isOptionalProperty(prop) ? '?' : '';
       const type = simplifyType(prop.typeSimple);
       const refs = parseType(prop.type).reduce(
         (acc: string[], r) => acc.concat(parseGenerics(r).toGenerics()),
@@ -149,4 +149,10 @@ export function createImportRefToInterfaceReducerCreator(params: ModelGeneratorP
 export function createRefToImportReducerCreator(params: ModelGeneratorParams) {
   const { solution } = params;
   return (namespace: string) => createTypesToImportsReducer(solution, namespace);
+}
+
+function isOptionalProperty(prop: PropertyDef) {
+  return (
+    prop.typeSimple.endsWith('?') || (prop.typeSimple === 'string' && prop.isRequired === false)
+  );
 }


### PR DESCRIPTION
Used the new `isRequired` property in the `/api/abp/api-definition` response.

Fixes #6085