### PR TITLE
Use a specialized dictionary class for IHasExtraProperties

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AbpMvcOptionsExtensions.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AbpMvcOptionsExtensions.cs
@@ -59,7 +59,7 @@ namespace Volo.Abp.AspNetCore.Mvc
         private static void AddModelBinders(MvcOptions options)
         {
             options.ModelBinderProviders.Insert(0, new AbpDateTimeModelBinderProvider());
-            options.ModelBinderProviders.Insert(0, new AbpExtraPropertiesDictionaryModelBinderProvider());
+            options.ModelBinderProviders.Insert(1, new AbpExtraPropertiesDictionaryModelBinderProvider());
         }
 
         private static void AddMetadataProviders(MvcOptions options, IServiceCollection services)

--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/ModelBinding/AbpExtraPropertiesDictionaryModelBinderProvider.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/ModelBinding/AbpExtraPropertiesDictionaryModelBinderProvider.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
@@ -19,7 +18,7 @@ namespace Volo.Abp.AspNetCore.Mvc.ModelBinding
                 throw new ArgumentNullException(nameof(context));
             }
 
-            if (context.Metadata.ModelType != typeof(Dictionary<string, object>))
+            if (context.Metadata.ModelType != typeof(ExtraPropertyDictionary))
             {
                 return null;
             }

--- a/framework/src/Volo.Abp.Auditing/Volo/Abp/Auditing/AuditLogActionInfo.cs
+++ b/framework/src/Volo.Abp.Auditing/Volo/Abp/Auditing/AuditLogActionInfo.cs
@@ -17,11 +17,11 @@ namespace Volo.Abp.Auditing
 
         public int ExecutionDuration { get; set; }
 
-        public Dictionary<string, object> ExtraProperties { get; }
+        public ExtraPropertyDictionary ExtraProperties { get; }
 
         public AuditLogActionInfo()
         {
-            ExtraProperties = new Dictionary<string, object>();
+            ExtraProperties = new ExtraPropertyDictionary();
         }
     }
 }

--- a/framework/src/Volo.Abp.Auditing/Volo/Abp/Auditing/AuditLogInfo.cs
+++ b/framework/src/Volo.Abp.Auditing/Volo/Abp/Auditing/AuditLogInfo.cs
@@ -47,7 +47,7 @@ namespace Volo.Abp.Auditing
 
         public List<Exception> Exceptions { get; }
 
-        public Dictionary<string, object> ExtraProperties { get; }
+        public ExtraPropertyDictionary ExtraProperties { get; }
 
         public List<EntityChangeInfo> EntityChanges { get; }
 
@@ -57,7 +57,7 @@ namespace Volo.Abp.Auditing
         {
             Actions = new List<AuditLogActionInfo>();
             Exceptions = new List<Exception>();
-            ExtraProperties = new Dictionary<string, object>();
+            ExtraProperties = new ExtraPropertyDictionary();
             EntityChanges = new List<EntityChangeInfo>();
             Comments = new List<string>();
         }

--- a/framework/src/Volo.Abp.Auditing/Volo/Abp/Auditing/EntityChangeInfo.cs
+++ b/framework/src/Volo.Abp.Auditing/Volo/Abp/Auditing/EntityChangeInfo.cs
@@ -25,13 +25,13 @@ namespace Volo.Abp.Auditing
 
         public List<EntityPropertyChangeInfo> PropertyChanges { get; set; }
 
-        public Dictionary<string, object> ExtraProperties { get; }
+        public ExtraPropertyDictionary ExtraProperties { get; }
 
         public virtual object EntityEntry { get; set; } //TODO: Try to remove since it breaks serializability
 
         public EntityChangeInfo()
         {
-            ExtraProperties = new Dictionary<string, object>();
+            ExtraProperties = new ExtraPropertyDictionary();
         }
 
         public virtual void Merge(EntityChangeInfo changeInfo)

--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Entities/AggregateRoot.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Entities/AggregateRoot.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.ComponentModel.DataAnnotations;
 using Volo.Abp.Auditing;
 using Volo.Abp.Data;
@@ -13,7 +12,7 @@ namespace Volo.Abp.Domain.Entities
         IHasExtraProperties,
         IHasConcurrencyStamp
     {
-        public virtual Dictionary<string, object> ExtraProperties { get; protected set; }
+        public virtual ExtraPropertyDictionary ExtraProperties { get; protected set; }
 
         [DisableAuditing]
         public virtual string ConcurrencyStamp { get; set; }
@@ -21,7 +20,7 @@ namespace Volo.Abp.Domain.Entities
         protected AggregateRoot()
         {
             ConcurrencyStamp = Guid.NewGuid().ToString("N");
-            ExtraProperties = new Dictionary<string, object>();
+            ExtraProperties = new ExtraPropertyDictionary();
             this.SetDefaultsForExtraProperties();
         }
 
@@ -39,7 +38,7 @@ namespace Volo.Abp.Domain.Entities
         IHasExtraProperties,
         IHasConcurrencyStamp
     {
-        public virtual Dictionary<string, object> ExtraProperties { get; protected set; }
+        public virtual ExtraPropertyDictionary ExtraProperties { get; protected set; }
 
         [DisableAuditing]
         public virtual string ConcurrencyStamp { get; set; }
@@ -47,7 +46,7 @@ namespace Volo.Abp.Domain.Entities
         protected AggregateRoot()
         {
             ConcurrencyStamp = Guid.NewGuid().ToString("N");
-            ExtraProperties = new Dictionary<string, object>();
+            ExtraProperties = new ExtraPropertyDictionary();
             this.SetDefaultsForExtraProperties();
         }
 
@@ -55,7 +54,7 @@ namespace Volo.Abp.Domain.Entities
             : base(id)
         {
             ConcurrencyStamp = Guid.NewGuid().ToString("N");
-            ExtraProperties = new Dictionary<string, object>();
+            ExtraProperties = new ExtraPropertyDictionary();
             this.SetDefaultsForExtraProperties();
         }
 

--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/Modeling/AbpEntityTypeBuilderExtensions.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/Modeling/AbpEntityTypeBuilderExtensions.cs
@@ -60,10 +60,10 @@ namespace Volo.Abp.EntityFrameworkCore.Modeling
                 return;
             }
 
-            b.Property<Dictionary<string, object>>(nameof(IHasExtraProperties.ExtraProperties))
+            b.Property<ExtraPropertyDictionary>(nameof(IHasExtraProperties.ExtraProperties))
                 .HasColumnName(nameof(IHasExtraProperties.ExtraProperties))
                 .HasConversion(new ExtraPropertiesValueConverter(b.Metadata.ClrType))
-                .Metadata.SetValueComparer(new AbpDictionaryValueComparer<string, object>());
+                .Metadata.SetValueComparer(new ExtraPropertyDictionaryValueComparer());
 
             b.TryConfigureObjectExtensions();
         }

--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/ValueComparers/ExtraPropertyDictionaryValueComparer.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/ValueComparers/ExtraPropertyDictionaryValueComparer.cs
@@ -1,17 +1,17 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Volo.Abp.Data;
 
 namespace Volo.Abp.EntityFrameworkCore.ValueComparers
 {
-    public class AbpDictionaryValueComparer<TKey, TValue> : ValueComparer<Dictionary<TKey, TValue>>
+    public class ExtraPropertyDictionaryValueComparer : ValueComparer<ExtraPropertyDictionary>
     {
-        public AbpDictionaryValueComparer()
+        public ExtraPropertyDictionaryValueComparer()
             : base(
                   (d1, d2) => d1.SequenceEqual(d2),
                   d => d.Aggregate(0, (k, v) => HashCode.Combine(k, v.GetHashCode())),
-                  d => d.ToDictionary(k => k.Key, v => v.Value))
+                  d => new ExtraPropertyDictionary(d))
         {
         }
     }

--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/ValueConverters/ExtraPropertiesValueConverter.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/ValueConverters/ExtraPropertiesValueConverter.cs
@@ -42,10 +42,16 @@ namespace Volo.Abp.EntityFrameworkCore.ValueConverters
 
         private static ExtraPropertyDictionary DeserializeObject(string extraPropertiesAsJson, Type entityType)
         {
+            if (extraPropertiesAsJson.IsNullOrEmpty() || extraPropertiesAsJson == "{}")
+            {
+                return new ExtraPropertyDictionary();
+            }
+
             var deserializeOptions = new JsonSerializerOptions();
             deserializeOptions.Converters.Add(new ObjectToInferredTypesConverter());
             var dictionary = JsonSerializer.Deserialize<ExtraPropertyDictionary>(extraPropertiesAsJson, deserializeOptions) ??
                              new ExtraPropertyDictionary();
+
             if (entityType != null)
             {
                 var objectExtension = ObjectExtensionManager.Instance.GetOrNull(entityType);

--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/ValueConverters/ExtraPropertiesValueConverter.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/ValueConverters/ExtraPropertiesValueConverter.cs
@@ -2,12 +2,13 @@
 using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Volo.Abp.Data;
 using Volo.Abp.Json.SystemTextJson.JsonConverters;
 using Volo.Abp.ObjectExtending;
 
 namespace Volo.Abp.EntityFrameworkCore.ValueConverters
 {
-    public class ExtraPropertiesValueConverter : ValueConverter<Dictionary<string, object>, string>
+    public class ExtraPropertiesValueConverter : ValueConverter<ExtraPropertyDictionary, string>
     {
         public ExtraPropertiesValueConverter(Type entityType)
             : base(
@@ -17,7 +18,7 @@ namespace Volo.Abp.EntityFrameworkCore.ValueConverters
 
         }
 
-        private static string SerializeObject(Dictionary<string, object> extraProperties, Type entityType)
+        private static string SerializeObject(ExtraPropertyDictionary extraProperties, Type entityType)
         {
             var copyDictionary = new Dictionary<string, object>(extraProperties);
 
@@ -39,11 +40,12 @@ namespace Volo.Abp.EntityFrameworkCore.ValueConverters
             return JsonSerializer.Serialize(copyDictionary);
         }
 
-        private static Dictionary<string, object> DeserializeObject(string extraPropertiesAsJson, Type entityType)
+        private static ExtraPropertyDictionary DeserializeObject(string extraPropertiesAsJson, Type entityType)
         {
             var deserializeOptions = new JsonSerializerOptions();
             deserializeOptions.Converters.Add(new ObjectToInferredTypesConverter());
-            var dictionary = JsonSerializer.Deserialize<Dictionary<string, object>>(extraPropertiesAsJson, deserializeOptions) ?? new Dictionary<string, object>();
+            var dictionary = JsonSerializer.Deserialize<ExtraPropertyDictionary>(extraPropertiesAsJson, deserializeOptions) ??
+                             new ExtraPropertyDictionary();
             if (entityType != null)
             {
                 var objectExtension = ObjectExtensionManager.Instance.GetOrNull(entityType);

--- a/framework/src/Volo.Abp.ObjectExtending/Volo/Abp/Data/ExtraPropertyDictionary.cs
+++ b/framework/src/Volo.Abp.ObjectExtending/Volo/Abp/Data/ExtraPropertyDictionary.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Volo.Abp.Data
+{
+    [Serializable]
+    public class ExtraPropertyDictionary : Dictionary<string, object>
+    {
+        public ExtraPropertyDictionary()
+        {
+
+        }
+
+        public ExtraPropertyDictionary(IDictionary<string, object> dictionary)
+            : base(dictionary)
+        {
+        }
+    }
+}

--- a/framework/src/Volo.Abp.ObjectExtending/Volo/Abp/Data/IHasExtraProperties.cs
+++ b/framework/src/Volo.Abp.ObjectExtending/Volo/Abp/Data/IHasExtraProperties.cs
@@ -1,23 +1,9 @@
-﻿using System.Collections.Generic;
-
-namespace Volo.Abp.Data
+﻿namespace Volo.Abp.Data
 {
     //TODO: Move to Volo.Abp.Data.ObjectExtending namespace at 4.0?
 
     public interface IHasExtraProperties
     {
         ExtraPropertyDictionary ExtraProperties { get; }
-    }
-
-    public class ExtraPropertyDictionary : Dictionary<string, object>
-    {
-        public ExtraPropertyDictionary()
-        {
-        }
-
-        public ExtraPropertyDictionary(IDictionary<string, object> dictionary)
-            : base(dictionary)
-        {
-        }
     }
 }

--- a/framework/src/Volo.Abp.ObjectExtending/Volo/Abp/Data/IHasExtraProperties.cs
+++ b/framework/src/Volo.Abp.ObjectExtending/Volo/Abp/Data/IHasExtraProperties.cs
@@ -6,6 +6,18 @@ namespace Volo.Abp.Data
 
     public interface IHasExtraProperties
     {
-        Dictionary<string, object> ExtraProperties { get; }
+        ExtraPropertyDictionary ExtraProperties { get; }
+    }
+
+    public class ExtraPropertyDictionary : Dictionary<string, object>
+    {
+        public ExtraPropertyDictionary()
+        {
+        }
+
+        public ExtraPropertyDictionary(IDictionary<string, object> dictionary)
+            : base(dictionary)
+        {
+        }
     }
 }

--- a/framework/src/Volo.Abp.ObjectExtending/Volo/Abp/ObjectExtending/ExtensibleObject.cs
+++ b/framework/src/Volo.Abp.ObjectExtending/Volo/Abp/ObjectExtending/ExtensibleObject.cs
@@ -9,7 +9,7 @@ namespace Volo.Abp.ObjectExtending
     [Serializable]
     public class ExtensibleObject : IHasExtraProperties, IValidatableObject
     {
-        public Dictionary<string, object> ExtraProperties { get; protected set; }
+        public ExtraPropertyDictionary ExtraProperties { get; protected set; }
 
         public ExtensibleObject()
             : this(true)
@@ -19,7 +19,7 @@ namespace Volo.Abp.ObjectExtending
 
         public ExtensibleObject(bool setDefaultsForExtraProperties)
         {
-            ExtraProperties = new Dictionary<string, object>();
+            ExtraProperties = new ExtraPropertyDictionary();
 
             if (setDefaultsForExtraProperties)
             {

--- a/modules/audit-logging/src/Volo.Abp.AuditLogging.Domain/Volo/Abp/AuditLogging/AuditLog.cs
+++ b/modules/audit-logging/src/Volo.Abp.AuditLogging.Domain/Volo/Abp/AuditLogging/AuditLog.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Volo.Abp.Auditing;
+using Volo.Abp.Data;
 using Volo.Abp.Domain.Entities;
 using Volo.Abp.Guids;
 using Volo.Abp.MultiTenancy;
@@ -55,12 +56,12 @@ namespace Volo.Abp.AuditLogging
 
         protected AuditLog()
         {
-            ExtraProperties = new Dictionary<string, object>();
+
         }
 
         public AuditLog(IGuidGenerator guidGenerator, AuditLogInfo auditInfo)
+            : base(guidGenerator.Create())
         {
-            Id = guidGenerator.Create();
             ApplicationName = auditInfo.ApplicationName.Truncate(AuditLogConsts.MaxApplicationNameLength);
             TenantId = auditInfo.TenantId;
             TenantName = auditInfo.TenantName.Truncate(AuditLogConsts.MaxTenantNameLength);
@@ -79,10 +80,14 @@ namespace Volo.Abp.AuditLogging
             ImpersonatorUserId = auditInfo.ImpersonatorUserId;
             ImpersonatorTenantId = auditInfo.ImpersonatorTenantId;
 
-            ExtraProperties = auditInfo
-                                  .ExtraProperties?
-                                  .ToDictionary(pair => pair.Key, pair => pair.Value)
-                              ?? new Dictionary<string, object>();
+            ExtraProperties = new ExtraPropertyDictionary();
+            if (auditInfo.ExtraProperties != null)
+            {
+                foreach (var pair in auditInfo.ExtraProperties)
+                {
+                    ExtraProperties.Add(pair.Key, pair.Value);
+                }
+            }
 
             EntityChanges = auditInfo
                                 .EntityChanges?

--- a/modules/audit-logging/src/Volo.Abp.AuditLogging.Domain/Volo/Abp/AuditLogging/AuditLogAction.cs
+++ b/modules/audit-logging/src/Volo.Abp.AuditLogging.Domain/Volo/Abp/AuditLogging/AuditLogAction.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Volo.Abp.Auditing;
 using Volo.Abp.Data;
 using Volo.Abp.Domain.Entities;
@@ -25,11 +23,10 @@ namespace Volo.Abp.AuditLogging
 
         public virtual int ExecutionDuration { get; protected set; }
 
-        public virtual Dictionary<string, object> ExtraProperties { get; protected set; }
-        
+        public virtual ExtraPropertyDictionary ExtraProperties { get; protected set; }
+
         protected AuditLogAction()
         {
-            ExtraProperties = new Dictionary<string, object>();
         }
 
         public AuditLogAction(Guid id, Guid auditLogId, AuditLogActionInfo actionInfo, Guid? tenantId = null)
@@ -40,7 +37,7 @@ namespace Volo.Abp.AuditLogging
             AuditLogId = auditLogId;
             ExecutionTime = actionInfo.ExecutionTime;
             ExecutionDuration = actionInfo.ExecutionDuration;
-            ExtraProperties = actionInfo.ExtraProperties.ToDictionary(pair => pair.Key, pair => pair.Value);
+            ExtraProperties = new ExtraPropertyDictionary(actionInfo.ExtraProperties);
             ServiceName = actionInfo.ServiceName.TruncateFromBeginning(AuditLogActionConsts.MaxServiceNameLength);
             MethodName = actionInfo.MethodName.TruncateFromBeginning(AuditLogActionConsts.MaxMethodNameLength);
             Parameters = actionInfo.Parameters.Length > AuditLogActionConsts.MaxParametersLength ? "" : actionInfo.Parameters;

--- a/modules/audit-logging/src/Volo.Abp.AuditLogging.Domain/Volo/Abp/AuditLogging/EntityChange.cs
+++ b/modules/audit-logging/src/Volo.Abp.AuditLogging.Domain/Volo/Abp/AuditLogging/EntityChange.cs
@@ -28,16 +28,16 @@ namespace Volo.Abp.AuditLogging
 
         public virtual ICollection<EntityPropertyChange> PropertyChanges { get; protected set; }
 
-        public virtual Dictionary<string, object> ExtraProperties { get; protected set; }
+        public virtual ExtraPropertyDictionary ExtraProperties { get; protected set; }
 
         protected EntityChange()
         {
-            ExtraProperties = new Dictionary<string, object>();
+            ExtraProperties = new ExtraPropertyDictionary();
         }
 
         public EntityChange(
-            IGuidGenerator guidGenerator, 
-            Guid auditLogId, 
+            IGuidGenerator guidGenerator,
+            Guid auditLogId,
             EntityChangeInfo entityChangeInfo,
             Guid? tenantId = null)
         {
@@ -55,10 +55,14 @@ namespace Volo.Abp.AuditLogging
                                   .ToList()
                               ?? new List<EntityPropertyChange>();
 
-            ExtraProperties = entityChangeInfo
-                                  .ExtraProperties?
-                                  .ToDictionary(pair => pair.Key, pair => pair.Value)
-                              ?? new Dictionary<string, object>();
+            ExtraProperties = new ExtraPropertyDictionary();
+            if (entityChangeInfo.ExtraProperties != null)
+            {
+                foreach (var pair in entityChangeInfo.ExtraProperties)
+                {
+                    ExtraProperties.Add(pair.Key, pair.Value);
+                }
+            }
         }
     }
 }

--- a/modules/docs/src/Volo.Docs.Domain/Volo/Docs/Documents/Document.cs
+++ b/modules/docs/src/Volo.Docs.Domain/Volo/Docs/Documents/Document.cs
@@ -32,9 +32,9 @@ namespace Volo.Docs.Documents
         public virtual string LocalDirectory { get; set; }
 
         public virtual DateTime CreationTime { get; set; }
-        
+
         public virtual DateTime LastUpdatedTime { get; set; }
-        
+
         public virtual DateTime? LastSignificantUpdateTime { get; set; }
 
         public virtual DateTime LastCachedTime { get; set; }
@@ -44,7 +44,6 @@ namespace Volo.Docs.Documents
         protected Document()
         {
             Contributors = new List<DocumentContributor>();
-            ExtraProperties = new Dictionary<string, object>();
         }
 
         public Document(
@@ -65,8 +64,8 @@ namespace Volo.Docs.Documents
             DateTime lastCachedTime,
             DateTime? lastSignificantUpdateTime = null
         )
+            : base(id)
         {
-            Id = id;
             ProjectId = projectId;
 
             Name = Check.NotNullOrWhiteSpace(name, nameof(name));
@@ -86,7 +85,6 @@ namespace Volo.Docs.Documents
             LastSignificantUpdateTime = lastSignificantUpdateTime;
 
             Contributors = new List<DocumentContributor>();
-            ExtraProperties = new Dictionary<string, object>();
         }
 
         public virtual void AddContributor(string username, string userProfileUrl, string avatarUrl)

--- a/modules/docs/src/Volo.Docs.Domain/Volo/Docs/Projects/Project.cs
+++ b/modules/docs/src/Volo.Docs.Domain/Volo/Docs/Projects/Project.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using Volo.Abp;
-using Volo.Abp.Data;
 using Volo.Abp.Domain.Entities;
 
 namespace Volo.Docs.Projects
@@ -52,21 +51,19 @@ namespace Volo.Docs.Projects
 
         protected Project()
         {
-            ExtraProperties = new Dictionary<string, object>();
         }
 
         public Project(
-            Guid id, 
-            [NotNull] string name, 
-            [NotNull] string shortName, 
+            Guid id,
+            [NotNull] string name,
+            [NotNull] string shortName,
             [NotNull] string documentStoreType,
             [NotNull] string format,
-            [NotNull] string defaultDocumentName = "Index", 
-            [NotNull] string navigationDocumentName = "docs-nav.json", 
+            [NotNull] string defaultDocumentName = "Index",
+            [NotNull] string navigationDocumentName = "docs-nav.json",
             [NotNull] string parametersDocumentName = "docs-params.json")
+            : base(id)
         {
-            Id = id;
-
             Name = Check.NotNullOrWhiteSpace(name, nameof(name));
             ShortName = Check.NotNullOrWhiteSpace(shortName, nameof(shortName));
             DocumentStoreType = Check.NotNullOrWhiteSpace(documentStoreType, nameof(documentStoreType));
@@ -74,8 +71,6 @@ namespace Volo.Docs.Projects
             DefaultDocumentName = Check.NotNullOrWhiteSpace(defaultDocumentName, nameof(defaultDocumentName));
             NavigationDocumentName = Check.NotNullOrWhiteSpace(navigationDocumentName, nameof(navigationDocumentName));
             ParametersDocumentName = Check.NotNullOrWhiteSpace(parametersDocumentName, nameof(parametersDocumentName));
-
-            ExtraProperties = new Dictionary<string, object>();
 
             NormalizeShortName();
         }

--- a/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/IdentitySecurityLog.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/IdentitySecurityLog.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using Volo.Abp.Domain.Entities;
 using Volo.Abp.Guids;
 using Volo.Abp.MultiTenancy;
@@ -35,12 +34,12 @@ namespace Volo.Abp.Identity
 
         protected IdentitySecurityLog()
         {
-            ExtraProperties = new Dictionary<string, object>();
+
         }
 
         public IdentitySecurityLog(IGuidGenerator guidGenerator, SecurityLogInfo securityLogInfo)
+            : base(guidGenerator.Create())
         {
-            Id = guidGenerator.Create();
             TenantId = securityLogInfo.TenantId;
             TenantName = securityLogInfo.TenantName.Truncate(IdentitySecurityLogConsts.MaxTenantNameLength);
 
@@ -57,8 +56,6 @@ namespace Volo.Abp.Identity
             ClientId = securityLogInfo.ClientId.Truncate(IdentitySecurityLogConsts.MaxClientIdLength);
             CorrelationId = securityLogInfo.CorrelationId.Truncate(IdentitySecurityLogConsts.MaxCorrelationIdLength);
             BrowserInfo = securityLogInfo.BrowserInfo.Truncate(IdentitySecurityLogConsts.MaxBrowserInfoLength);
-
-            ExtraProperties = securityLogInfo.ExtraProperties;
         }
     }
 }

--- a/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/IdentityUser.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/IdentityUser.cs
@@ -143,11 +143,11 @@ namespace Volo.Abp.Identity
             [NotNull] string userName,
             [NotNull] string email,
             Guid? tenantId = null)
+            : base(id)
         {
             Check.NotNull(userName, nameof(userName));
             Check.NotNull(email, nameof(email));
 
-            Id = id;
             TenantId = tenantId;
             UserName = userName;
             NormalizedUserName = userName.ToUpperInvariant();
@@ -161,8 +161,6 @@ namespace Volo.Abp.Identity
             Logins = new Collection<IdentityUserLogin>();
             Tokens = new Collection<IdentityUserToken>();
             OrganizationUnits = new Collection<IdentityUserOrganizationUnit>();
-
-            ExtraProperties = new Dictionary<string, object>();
         }
 
         public virtual void AddRole(Guid roleId)

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Domain.Shared/MyProjectNameGlobalFeatureConfigurator.cs
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Domain.Shared/MyProjectNameGlobalFeatureConfigurator.cs
@@ -15,7 +15,7 @@ namespace MyCompanyName.MyProjectName
                  * YOU CAN SAFELY DELETE THIS CLASS AND REMOVE ITS USAGES IF YOU DON'T NEED TO IT!
                  *
                  * Please refer to the documentation to lear more about the Global Features System:
-                 * https://docs.abp.io/en/commercial/latest/Global-Features
+                 * https://docs.abp.io/en/abp/latest/Global-Features
                  */
             });
         }

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Domain.Shared/MyProjectNameModuleExtensionConfigurator.cs
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Domain.Shared/MyProjectNameModuleExtensionConfigurator.cs
@@ -37,25 +37,6 @@ namespace MyCompanyName.MyProjectName
 
         private static void ConfigureExtraProperties()
         {
-            ObjectExtensionManager.Instance.Modules()
-                .ConfigureIdentity(identity =>
-                {
-                    identity.ConfigureUser(user =>
-                    {
-                        user.AddOrUpdateProperty<string>( //property type: string
-                            "SocialSecurityNumber", //property name
-                            property =>
-                            {
-                                //validation rules
-                                property.Attributes.Add(new RequiredAttribute());
-                                property.Attributes.Add(new StringLengthAttribute(64) {MinimumLength = 4});
-
-                                //...other configurations for this property
-                            }
-                        );
-                    });
-                });
-
             /* You can configure extra properties for the
              * entities defined in the modules used by your application.
              *

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Domain.Shared/MyProjectNameModuleExtensionConfigurator.cs
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Domain.Shared/MyProjectNameModuleExtensionConfigurator.cs
@@ -37,6 +37,25 @@ namespace MyCompanyName.MyProjectName
 
         private static void ConfigureExtraProperties()
         {
+            ObjectExtensionManager.Instance.Modules()
+                .ConfigureIdentity(identity =>
+                {
+                    identity.ConfigureUser(user =>
+                    {
+                        user.AddOrUpdateProperty<string>( //property type: string
+                            "SocialSecurityNumber", //property name
+                            property =>
+                            {
+                                //validation rules
+                                property.Attributes.Add(new RequiredAttribute());
+                                property.Attributes.Add(new StringLengthAttribute(64) {MinimumLength = 4});
+
+                                //...other configurations for this property
+                            }
+                        );
+                    });
+                });
+
             /* You can configure extra properties for the
              * entities defined in the modules used by your application.
              *


### PR DESCRIPTION
Resolves #3751

Introducing `ExtraPropertyDictionary` and using it in the `IHasExtraProperties` interface as a replacement to the standard dictionary. 