### PR TITLE
Introduce SemaphoreSlimExtensions.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore/Microsoft/AspNetCore/RequestLocalization/DefaultAbpRequestLocalizationOptionsProvider.cs
+++ b/framework/src/Volo.Abp.AspNetCore/Microsoft/AspNetCore/RequestLocalization/DefaultAbpRequestLocalizationOptionsProvider.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Localization;
 using Microsoft.Extensions.DependencyInjection;
-using Nito.AsyncEx;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Localization;
 using Volo.Abp.Settings;
@@ -47,7 +46,7 @@ namespace Microsoft.AspNetCore.RequestLocalization
         {
             if (_requestLocalizationOptions == null)
             {
-                using (await _syncSemaphore.LockAsync().ConfigureAwait(false))
+                using (await _syncSemaphore.LockAsync())
                 {
                     if (_requestLocalizationOptions == null)
                     {

--- a/framework/src/Volo.Abp.BackgroundJobs.RabbitMQ/Volo/Abp/BackgroundJobs/RabbitMQ/JobQueue.cs
+++ b/framework/src/Volo.Abp.BackgroundJobs.RabbitMQ/Volo/Abp/BackgroundJobs/RabbitMQ/JobQueue.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
-using Nito.AsyncEx;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using Volo.Abp.ExceptionHandling;
@@ -76,7 +75,7 @@ namespace Volo.Abp.BackgroundJobs.RabbitMQ
         {
             CheckDisposed();
 
-            using (await SyncObj.LockAsync().ConfigureAwait(false))
+            using (await SyncObj.LockAsync())
             {
                 await EnsureInitializedAsync();
 
@@ -95,7 +94,7 @@ namespace Volo.Abp.BackgroundJobs.RabbitMQ
                 return;
             }
 
-            using (await SyncObj.LockAsync().ConfigureAwait(false))
+            using (await SyncObj.LockAsync(cancellationToken))
             {
                 await EnsureInitializedAsync();
             }

--- a/framework/src/Volo.Abp.BackgroundJobs.RabbitMQ/Volo/Abp/BackgroundJobs/RabbitMQ/JobQueueManager.cs
+++ b/framework/src/Volo.Abp.BackgroundJobs.RabbitMQ/Volo/Abp/BackgroundJobs/RabbitMQ/JobQueueManager.cs
@@ -4,7 +4,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using Nito.AsyncEx;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Threading;
 
@@ -64,7 +63,7 @@ namespace Volo.Abp.BackgroundJobs.RabbitMQ
                 return (IJobQueue<TArgs>)jobQueue;
             }
 
-            using (await SyncSemaphore.LockAsync().ConfigureAwait(false))
+            using (await SyncSemaphore.LockAsync())
             {
                 if (JobQueues.TryGetValue(jobConfiguration.JobName, out jobQueue))
                 {

--- a/framework/src/Volo.Abp.Caching/Volo/Abp/Caching/DistributedCache.cs
+++ b/framework/src/Volo.Abp.Caching/Volo/Abp/Caching/DistributedCache.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
-using Nito.AsyncEx;
 using Volo.Abp.ExceptionHandling;
 using Volo.Abp.MultiTenancy;
 using Volo.Abp.Threading;
@@ -499,7 +498,7 @@ namespace Volo.Abp.Caching
                 return value;
             }
 
-            using (await SyncSemaphore.LockAsync(token).ConfigureAwait(false))
+            using (await SyncSemaphore.LockAsync(token))
             {
                 value = await GetAsync(key, hideErrors, considerUow, token);
                 if (value != null)

--- a/framework/src/Volo.Abp.Core/Volo/Abp/Threading/AsyncOneTimeRunner.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/Threading/AsyncOneTimeRunner.cs
@@ -21,7 +21,7 @@ namespace Volo.Abp.Threading
                 return;
             }
 
-            using (await _semaphore.LockAsync().ConfigureAwait(false))
+            using (await _semaphore.LockAsync())
             {
                 if (_runBefore)
                 {

--- a/framework/src/Volo.Abp.Core/Volo/Abp/Threading/SemaphoreSlimExtensions.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/Threading/SemaphoreSlimExtensions.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Volo.Abp.Threading
+{
+    public static class SemaphoreSlimExtensions
+    {
+        public static async Task<IDisposable> LockAsync(this SemaphoreSlim semaphoreSlim)
+        {
+            await semaphoreSlim.WaitAsync();
+            return GetDispose(semaphoreSlim);
+        }
+
+        public static async Task<IDisposable> LockAsync(this SemaphoreSlim semaphoreSlim, CancellationToken cancellationToken)
+        {
+            await semaphoreSlim.WaitAsync(cancellationToken);
+            return GetDispose(semaphoreSlim);
+        }
+
+        public static async Task<IDisposable> LockAsync(this SemaphoreSlim semaphoreSlim, int millisecondsTimeout)
+        {
+            await semaphoreSlim.WaitAsync(millisecondsTimeout);
+            return GetDispose(semaphoreSlim);
+        }
+
+        public static async Task<IDisposable> LockAsync(this SemaphoreSlim semaphoreSlim, int millisecondsTimeout, CancellationToken cancellationToken)
+        {
+            await semaphoreSlim.WaitAsync(millisecondsTimeout, cancellationToken);
+            return GetDispose(semaphoreSlim);
+        }
+
+        public static async Task<IDisposable> LockAsync(this SemaphoreSlim semaphoreSlim, TimeSpan timeout)
+        {
+            await semaphoreSlim.WaitAsync(timeout);
+            return GetDispose(semaphoreSlim);
+        }
+
+        public static async Task<IDisposable> LockAsync(this SemaphoreSlim semaphoreSlim, TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            await semaphoreSlim.WaitAsync(timeout, cancellationToken);
+            return GetDispose(semaphoreSlim);
+        }
+
+        public static IDisposable Lock(this SemaphoreSlim semaphoreSlim)
+        {
+            semaphoreSlim.Wait();
+            return GetDispose(semaphoreSlim);
+        }
+
+        public static IDisposable Lock(this SemaphoreSlim semaphoreSlim, CancellationToken cancellationToken)
+        {
+            semaphoreSlim.Wait(cancellationToken);
+            return GetDispose(semaphoreSlim);
+        }
+
+        public static IDisposable Lock(this SemaphoreSlim semaphoreSlim, int millisecondsTimeout)
+        {
+            semaphoreSlim.Wait(millisecondsTimeout);
+            return GetDispose(semaphoreSlim);
+        }
+
+        public static IDisposable Lock(this SemaphoreSlim semaphoreSlim, int millisecondsTimeout, CancellationToken cancellationToken)
+        {
+            semaphoreSlim.Wait(millisecondsTimeout, cancellationToken);
+            return GetDispose(semaphoreSlim);
+        }
+
+        public static IDisposable Lock(this SemaphoreSlim semaphoreSlim, TimeSpan timeout)
+        {
+            semaphoreSlim.Wait(timeout);
+            return GetDispose(semaphoreSlim);
+        }
+
+        public static IDisposable Lock(this SemaphoreSlim semaphoreSlim, TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            semaphoreSlim.Wait(timeout, cancellationToken);
+            return GetDispose(semaphoreSlim);
+        }
+
+        private static IDisposable GetDispose(this SemaphoreSlim semaphoreSlim)
+        {
+            return new DisposeAction(() =>
+            {
+                semaphoreSlim.Release();
+            });
+        }
+    }
+}

--- a/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/DynamicProxying/ApiDescriptionCache.cs
+++ b/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/DynamicProxying/ApiDescriptionCache.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Nito.AsyncEx;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Http.Modeling;
 using Volo.Abp.Threading;
@@ -24,10 +23,10 @@ namespace Volo.Abp.Http.Client.DynamicProxying
         }
 
         public async Task<ApplicationApiDescriptionModel> GetAsync(
-            string baseUrl, 
+            string baseUrl,
             Func<Task<ApplicationApiDescriptionModel>> factory)
         {
-            using (await _semaphore.LockAsync(CancellationTokenProvider.Token).ConfigureAwait(false))
+            using (await _semaphore.LockAsync(CancellationTokenProvider.Token))
             {
                 var model = _cache.GetOrDefault(baseUrl);
                 if (model == null)

--- a/framework/src/Volo.Abp.TextTemplating/Volo/Abp/TextTemplating/VirtualFiles/LocalizedTemplateContentReaderFactory.cs
+++ b/framework/src/Volo.Abp.TextTemplating/Volo/Abp/TextTemplating/VirtualFiles/LocalizedTemplateContentReaderFactory.cs
@@ -27,7 +27,7 @@ namespace Volo.Abp.TextTemplating.VirtualFiles
                 return reader;
             }
 
-            using (await SyncObj.LockAsync().ConfigureAwait(false))
+            using (await SyncObj.LockAsync())
             {
                 if (ReaderCache.TryGetValue(templateDefinition.Name, out reader))
                 {


### PR DESCRIPTION
```cs
public virtual async Task StartAsync(CancellationToken cancellationToken = default)
{
  using (await Volo.Abp.Threading.SemaphoreSlimExtensions.LockAsync(SyncObj, cancellationToken))
  {
	var a = 1;
	var b = TestMethod(a);
  }

  using (await Nito.AsyncEx.SemaphoreSlimExtensions.LockAsync(SyncObj, cancellationToken))
  {
	var a = 1;
	var b = TestMethod(a);
  }
}
```

```cs

public virtual async Task StartAsync(CancellationToken cancellationToken = default (CancellationToken))
{
  using (await SemaphoreSlimExtensions.LockAsync(this.SyncObj, cancellationToken).ConfigureAwait(false))
  {
	this.TestMethod(1);
  }
	
  ConfiguredTaskAwaitable<IDisposable>.ConfiguredTaskAwaiter awaiter = (ConfiguredTaskAwaitable<IDisposable>.ConfiguredTaskAwaiter) this.SyncObj.LockAsync(cancellationToken).GetAwaiter();
  if (!awaiter.IsCompleted)
  {
	int num;
	// ISSUE: explicit reference operation
	// ISSUE: reference to a compiler-generated field
	(^this).\u003C\u003E1__state = num = 1;
	ConfiguredTaskAwaitable<IDisposable>.ConfiguredTaskAwaiter configuredTaskAwaiter = awaiter;
	// ISSUE: explicit reference operation
	// ISSUE: reference to a compiler-generated field
	(^this).\u003C\u003Et__builder.AwaitUnsafeOnCompleted<ConfiguredTaskAwaitable<IDisposable>.ConfiguredTaskAwaiter, JobQueue<TArgs>.\u003CStartAsync\u003Ed__48>(ref awaiter, this);
  }
  else
  {
	using (awaiter.GetResult())
	{
		this.TestMethod(1);
	}
  }
}

```
