### PR TITLE
fix bug of FeatureManager.GetAllWithProviderAsync and add unittest

### DIFF
--- a/modules/feature-management/src/Volo.Abp.FeatureManagement.Domain/Volo/Abp/FeatureManagement/FeatureManager.cs
+++ b/modules/feature-management/src/Volo.Abp.FeatureManagement.Domain/Volo/Abp/FeatureManagement/FeatureManager.cs
@@ -84,9 +84,7 @@ namespace Volo.Abp.FeatureManagement
                 providers = providers.TakeWhile(c => c.Name == providerName);
             }
 
-            var providerList = providers.Reverse().ToList();
-
-            if (!providerList.Any())
+            if (!providers.Any())
             {
                 return new List<FeatureNameValueWithGrantedProvider>();
             }
@@ -96,7 +94,7 @@ namespace Volo.Abp.FeatureManagement
             foreach (var feature in featureDefinitions)
             {
                 var featureNameValueWithGrantedProvider = new FeatureNameValueWithGrantedProvider(feature.Name, null);
-                foreach (var provider in providerList)
+                foreach (var provider in providers)
                 {
                     string pk = null;
                     if (provider.Compatible(providerName))

--- a/modules/feature-management/test/Volo.Abp.FeatureManagement.Domain.Tests/Volo/Abp/FeatureManagement/FeatureManager_Tests.cs
+++ b/modules/feature-management/test/Volo.Abp.FeatureManagement.Domain.Tests/Volo/Abp/FeatureManagement/FeatureManager_Tests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Shouldly;
 using Volo.Abp.Features;
@@ -19,7 +20,15 @@ namespace Volo.Abp.FeatureManagement
             _featureChecker = GetRequiredService<IFeatureChecker>();
             _currentTenant = GetRequiredService<ICurrentTenant>();
         }
-
+        [Fact]
+        public async Task Should_Get_A_Correct_FeatureValue_By_GetAllWithProviderAsync()
+        {
+            (await _featureManager.GetAllWithProviderAsync(
+                EditionFeatureValueProvider.ProviderName,
+                TestEditionIds.Enterprise.ToString()
+            )).FirstOrDefault(x=>x.Name== TestFeatureDefinitionProvider.ProjectCount)
+            .Value.ShouldBe("3");
+        }
         [Fact]
         public async Task Should_Get_A_FeatureValue_For_A_Provider()
         {


### PR DESCRIPTION
Add a unittest to test `FeatureManager.GetAllWithProviderAsync` method ,
It should be the same result with `featureManager.GetOrNullForEditionAsync`,but not
So this pull request will fix it