### PR TITLE
Enabling split queries globally.

### DIFF
--- a/framework/src/Volo.Abp.EntityFrameworkCore.MySQL/Volo/Abp/EntityFrameworkCore/AbpDbContextConfigurationContextMySQLExtensions.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore.MySQL/Volo/Abp/EntityFrameworkCore/AbpDbContextConfigurationContextMySQLExtensions.cs
@@ -14,11 +14,21 @@ namespace Volo.Abp.EntityFrameworkCore
         {
             if (context.ExistingConnection != null)
             {
-                return context.DbContextOptions.UseMySql(context.ExistingConnection, ServerVersion.AutoDetect(context.ConnectionString), mySQLOptionsAction);
+                return context.DbContextOptions.UseMySql(context.ExistingConnection,
+                    ServerVersion.AutoDetect(context.ConnectionString), optionsBuilder =>
+                    {
+                        optionsBuilder.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery);
+                        mySQLOptionsAction?.Invoke(optionsBuilder);
+                    });
             }
             else
             {
-                return context.DbContextOptions.UseMySql(context.ConnectionString, ServerVersion.AutoDetect(context.ConnectionString), mySQLOptionsAction);
+                return context.DbContextOptions.UseMySql(context.ConnectionString,
+                    ServerVersion.AutoDetect(context.ConnectionString), optionsBuilder =>
+                    {
+                        optionsBuilder.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery);
+                        mySQLOptionsAction?.Invoke(optionsBuilder);
+                    });
             }
         }
     }

--- a/framework/src/Volo.Abp.EntityFrameworkCore.Oracle.Devart/Volo/Abp/EntityFrameworkCore/AbpDbContextConfigurationContextOracleDevartExtensions.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore.Oracle.Devart/Volo/Abp/EntityFrameworkCore/AbpDbContextConfigurationContextOracleDevartExtensions.cs
@@ -13,6 +13,7 @@
 //            [CanBeNull] Action<OracleDbContextOptionsBuilder> oracleOptionsAction = null,
 //            bool useExistingConnectionIfAvailable = false)
 //         {
+//             TODO: UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery);
 //             if (useExistingConnectionIfAvailable && context.ExistingConnection != null)
 //             {
 //                 return context.DbContextOptions.UseOracle(context.ExistingConnection, oracleOptionsAction);

--- a/framework/src/Volo.Abp.EntityFrameworkCore.Oracle/Volo/Abp/EntityFrameworkCore/AbpDbContextConfigurationContextOracleExtensions.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore.Oracle/Volo/Abp/EntityFrameworkCore/AbpDbContextConfigurationContextOracleExtensions.cs
@@ -12,6 +12,7 @@
 //            [NotNull] this AbpDbContextConfigurationContext context,
 //            [CanBeNull] Action<OracleDbContextOptionsBuilder> oracleOptionsAction = null)
 //         {
+//             TODO: UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery);
 //             if (context.ExistingConnection != null)
 //             {
 //                 return context.DbContextOptions.UseOracle(context.ExistingConnection, oracleOptionsAction);

--- a/framework/src/Volo.Abp.EntityFrameworkCore.PostgreSql/Volo/Abp/EntityFrameworkCore/AbpDbContextConfigurationContextPostgreSqlExtensions.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore.PostgreSql/Volo/Abp/EntityFrameworkCore/AbpDbContextConfigurationContextPostgreSqlExtensions.cs
@@ -22,11 +22,19 @@ namespace Volo.Abp.EntityFrameworkCore
         {
             if (context.ExistingConnection != null)
             {
-                return context.DbContextOptions.UseNpgsql(context.ExistingConnection, postgreSqlOptionsAction);
+                return context.DbContextOptions.UseNpgsql(context.ExistingConnection, optionsBuilder =>
+                {
+                    optionsBuilder.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery);
+                    postgreSqlOptionsAction?.Invoke(optionsBuilder);
+                });
             }
             else
             {
-                return context.DbContextOptions.UseNpgsql(context.ConnectionString, postgreSqlOptionsAction);
+                return context.DbContextOptions.UseNpgsql(context.ConnectionString, optionsBuilder =>
+                {
+                    optionsBuilder.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery);
+                    postgreSqlOptionsAction?.Invoke(optionsBuilder);
+                });
             }
         }
     }

--- a/framework/src/Volo.Abp.EntityFrameworkCore.SqlServer/Volo/Abp/EntityFrameworkCore/AbpDbContextConfigurationContextSqlServerExtensions.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore.SqlServer/Volo/Abp/EntityFrameworkCore/AbpDbContextConfigurationContextSqlServerExtensions.cs
@@ -14,11 +14,19 @@ namespace Volo.Abp.EntityFrameworkCore
         {
             if (context.ExistingConnection != null)
             {
-                return context.DbContextOptions.UseSqlServer(context.ExistingConnection, sqlServerOptionsAction);
+                return context.DbContextOptions.UseSqlServer(context.ExistingConnection, optionsBuilder =>
+                {
+                    optionsBuilder.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery);
+                    sqlServerOptionsAction?.Invoke(optionsBuilder);
+                });
             }
             else
             {
-                return context.DbContextOptions.UseSqlServer(context.ConnectionString, sqlServerOptionsAction);
+                return context.DbContextOptions.UseSqlServer(context.ConnectionString, optionsBuilder =>
+                {
+                    optionsBuilder.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery);
+                    sqlServerOptionsAction?.Invoke(optionsBuilder);
+                });
             }
         }
     }

--- a/framework/src/Volo.Abp.EntityFrameworkCore.Sqlite/Volo/Abp/EntityFrameworkCore/AbpDbContextConfigurationContextSqliteExtensions.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore.Sqlite/Volo/Abp/EntityFrameworkCore/AbpDbContextConfigurationContextSqliteExtensions.cs
@@ -14,11 +14,19 @@ namespace Volo.Abp.EntityFrameworkCore
         {
             if (context.ExistingConnection != null)
             {
-                return context.DbContextOptions.UseSqlite(context.ExistingConnection, sqliteOptionsAction);
+                return context.DbContextOptions.UseSqlite(context.ExistingConnection, optionsBuilder =>
+                {
+                    optionsBuilder.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery);
+                    sqliteOptionsAction?.Invoke(optionsBuilder);
+                });
             }
             else
             {
-                return context.DbContextOptions.UseSqlite(context.ConnectionString, sqliteOptionsAction);
+                return context.DbContextOptions.UseSqlite(context.ConnectionString, optionsBuilder =>
+                {
+                    optionsBuilder.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery);
+                    sqliteOptionsAction?.Invoke(optionsBuilder);
+                });
             }
         }
     }

--- a/modules/audit-logging/src/Volo.Abp.AuditLogging.EntityFrameworkCore/Volo/Abp/AuditLogging/AbpAuditLoggingEfCoreQueryableExtensions.cs
+++ b/modules/audit-logging/src/Volo.Abp.AuditLogging.EntityFrameworkCore/Volo/Abp/AuditLogging/AbpAuditLoggingEfCoreQueryableExtensions.cs
@@ -15,7 +15,6 @@ namespace Volo.Abp.AuditLogging
             }
 
             return queryable
-                .AsSplitQuery()
                 .Include(x => x.Actions)
                 .Include(x => x.EntityChanges).ThenInclude(ec=>ec.PropertyChanges);
         }

--- a/modules/identity/src/Volo.Abp.Identity.EntityFrameworkCore/Volo/Abp/Identity/EntityFrameworkCore/IdentityEfCoreQueryableExtensions.cs
+++ b/modules/identity/src/Volo.Abp.Identity.EntityFrameworkCore/Volo/Abp/Identity/EntityFrameworkCore/IdentityEfCoreQueryableExtensions.cs
@@ -13,7 +13,6 @@ namespace Volo.Abp.Identity.EntityFrameworkCore
             }
 
             return queryable
-                .AsSplitQuery()
                 .Include(x => x.Roles)
                 .Include(x => x.Logins)
                 .Include(x => x.Claims)

--- a/modules/identityserver/src/Volo.Abp.IdentityServer.EntityFrameworkCore/Volo/Abp/IdentityServer/AbpIdentityServerEfCoreQueryableExtensions.cs
+++ b/modules/identityserver/src/Volo.Abp.IdentityServer.EntityFrameworkCore/Volo/Abp/IdentityServer/AbpIdentityServerEfCoreQueryableExtensions.cs
@@ -17,7 +17,6 @@ namespace Volo.Abp.IdentityServer
             }
 
             return queryable
-                .AsSplitQuery()
                 .Include(x => x.Secrets)
                 .Include(x => x.UserClaims)
                 .Include(x => x.Scopes)
@@ -57,7 +56,6 @@ namespace Volo.Abp.IdentityServer
             }
 
             return queryable
-                .AsSplitQuery()
                 .Include(x => x.AllowedGrantTypes)
                 .Include(x => x.RedirectUris)
                 .Include(x => x.PostLogoutRedirectUris)


### PR DESCRIPTION
EF Core uses single query mode by default in the absence of any configuration. Since it may cause performance issues, EF Core generates a warning whenever following conditions are met:

* EF Core detects that the query loads multiple collections.
* User hasn't configured query splitting mode globally.
* User hasn't used AsSingleQuery/AsSplitQuery operator on the query.

To turn off the warning, configure query splitting mode globally or at the query level to an appropriate value.

https://docs.microsoft.com/en-us/ef/core/querying/single-split-queries#enabling-split-queries-globally
