### PR TITLE
Remove AsyncHelper usage for the IdentityOptions

### DIFF
--- a/framework/src/Volo.Abp.BlazoriseUI/Components/UiNotificationAlert.razor
+++ b/framework/src/Volo.Abp.BlazoriseUI/Components/UiNotificationAlert.razor
@@ -1,1 +1,1 @@
-﻿<SnackbarStack @ref="SnackbarStack" Location="SnackbarStackLocation.Right" Multiline="true" Closed="@OnSnackbarClosed" />
+﻿<SnackbarStack @ref="SnackbarStack" Location="SnackbarStackLocation.Right" Multiline="true" DelayCloseOnClick="true" DelayCloseOnClickInterval="10000" Closed="@OnSnackbarClosed" />

--- a/framework/src/Volo.Abp.BlazoriseUI/Components/UiNotificationAlert.razor.cs
+++ b/framework/src/Volo.Abp.BlazoriseUI/Components/UiNotificationAlert.razor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Blazorise;
 using Blazorise.Snackbar;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;
@@ -47,7 +48,7 @@ namespace Volo.Abp.BlazoriseUI.Components
             UiNotificationService.NotificationReceived += OnNotificationReceived;
         }
 
-        protected virtual void OnNotificationReceived(object sender, UiNotificationEventArgs e)
+        protected virtual async void OnNotificationReceived(object sender, UiNotificationEventArgs e)
         {
             NotificationType = e.NotificationType;
             Message = e.Message;
@@ -56,7 +57,11 @@ namespace Volo.Abp.BlazoriseUI.Components
 
             var okButtonText = Options?.OkButtonText?.Localize(StringLocalizerFactory);
 
-            SnackbarStack.Push(Message, GetSnackbarColor( e.NotificationType ), okButtonText);
+            await SnackbarStack.PushAsync(Message, Title, GetSnackbarColor( e.NotificationType ), (options) =>
+            {
+                options.CloseButtonIcon = IconName.Times;
+                options.ActionButtonText = okButtonText;
+            });
         }
 
         public virtual void Dispose()

--- a/framework/src/Volo.Abp.BlazoriseUI/Volo.Abp.BlazoriseUI.csproj
+++ b/framework/src/Volo.Abp.BlazoriseUI/Volo.Abp.BlazoriseUI.csproj
@@ -12,9 +12,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Blazorise" Version="0.9.2-rc4" />
-        <PackageReference Include="Blazorise.DataGrid" Version="0.9.2-rc4" />
-        <PackageReference Include="Blazorise.Snackbar" Version="0.9.2-rc4" />
+        <PackageReference Include="Blazorise" Version="0.9.3-preview2" />
+        <PackageReference Include="Blazorise.DataGrid" Version="0.9.3-preview2" />
+        <PackageReference Include="Blazorise.Snackbar" Version="0.9.3-preview2" />
     </ItemGroup>
 
 </Project>

--- a/framework/src/Volo.Abp.Core/Microsoft/Extensions/DependencyInjection/ServiceCollectionDynamicOptionsManagerExtensions.cs
+++ b/framework/src/Volo.Abp.Core/Microsoft/Extensions/DependencyInjection/ServiceCollectionDynamicOptionsManagerExtensions.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using Volo.Abp.Options;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class ServiceCollectionDynamicOptionsManagerExtensions
+    {
+        public static IServiceCollection AddAbpDynamicOptions<TOptions, TManager>(this IServiceCollection services)
+            where TOptions : class
+            where TManager : AbpDynamicOptionsManager<TOptions>
+        {
+            services.Replace(ServiceDescriptor.Scoped(typeof(IOptions<TOptions>), typeof(TManager)));
+            services.Replace(ServiceDescriptor.Scoped(typeof(IOptionsSnapshot<TOptions>), typeof(TManager)));
+
+            return services;
+        }
+    }
+}

--- a/framework/src/Volo.Abp.Core/Microsoft/Extensions/Options/OptionsAbpDynamicOptionsManagerExtensions.cs
+++ b/framework/src/Volo.Abp.Core/Microsoft/Extensions/Options/OptionsAbpDynamicOptionsManagerExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System.Threading.Tasks;
+using Volo.Abp;
+using Volo.Abp.Options;
+
+namespace Microsoft.Extensions.Options
+{
+    public static class OptionsAbpDynamicOptionsManagerExtensions
+    {
+        public static Task SetAsync<T>(this IOptions<T> options)
+            where T : class
+        {
+            return options.ToDynamicOptions().SetAsync();
+        }
+
+        public static Task SetAsync<T>(this IOptions<T> options, string name)
+            where T : class
+        {
+            return options.ToDynamicOptions().SetAsync(name);
+        }
+
+        private static AbpDynamicOptionsManager<T> ToDynamicOptions<T>(this IOptions<T> options)
+            where T : class
+        {
+            if (options is AbpDynamicOptionsManager<T> dynamicOptionsManager)
+            {
+                return dynamicOptionsManager;
+            }
+
+            throw new AbpException($"Options must be derived from the {typeof(AbpDynamicOptionsManager<>).FullName}!");
+        }
+    }
+}

--- a/framework/src/Volo.Abp.Core/Volo/Abp/Options/AbpDynamicOptionsManager.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/Options/AbpDynamicOptionsManager.cs
@@ -1,0 +1,24 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+
+namespace Volo.Abp.Options
+{
+    public abstract class AbpDynamicOptionsManager<T> : OptionsManager<T>
+        where T : class
+    {
+        protected AbpDynamicOptionsManager(IOptionsFactory<T> factory)
+            : base(factory)
+        {
+
+        }
+
+        public Task SetAsync() => SetAsync(Microsoft.Extensions.Options.Options.DefaultName);
+
+        public virtual Task SetAsync(string name)
+        {
+            return OverrideOptionsAsync(base.Get(name));
+        }
+
+        protected abstract Task OverrideOptionsAsync(T options);
+    }
+}

--- a/modules/account/src/Volo.Abp.Account.Application/Volo/Abp/Account/AccountAppService.cs
+++ b/modules/account/src/Volo.Abp.Account.Application/Volo/Abp/Account/AccountAppService.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
 using Volo.Abp.Account.Emailing;
 using Volo.Abp.Account.Localization;
 using Volo.Abp.Account.Settings;
@@ -16,22 +17,29 @@ namespace Volo.Abp.Account
         protected IAccountEmailer AccountEmailer { get; }
         protected IdentitySecurityLogManager IdentitySecurityLogManager { get; }
 
+        protected IOptions<IdentityOptions> IdentityOptions { get; }
+
         public AccountAppService(
             IdentityUserManager userManager,
             IIdentityRoleRepository roleRepository,
             IAccountEmailer accountEmailer,
-            IdentitySecurityLogManager identitySecurityLogManager)
+            IdentitySecurityLogManager identitySecurityLogManager,
+            IOptions<IdentityOptions> identityOptions)
         {
             RoleRepository = roleRepository;
             AccountEmailer = accountEmailer;
             IdentitySecurityLogManager = identitySecurityLogManager;
             UserManager = userManager;
+            IdentityOptions = identityOptions;
+
             LocalizationResource = typeof(AccountResource);
         }
 
         public virtual async Task<IdentityUserDto> RegisterAsync(RegisterDto input)
         {
             await CheckSelfRegistrationAsync();
+
+            await IdentityOptions.SetAsync();
 
             var user = new IdentityUser(GuidGenerator.Create(), input.UserName, input.EmailAddress, CurrentTenant.Id);
 
@@ -52,6 +60,8 @@ namespace Volo.Abp.Account
 
         public virtual async Task ResetPasswordAsync(ResetPasswordDto input)
         {
+            await IdentityOptions.SetAsync();
+
             var user = await UserManager.GetByIdAsync(input.UserId);
             (await UserManager.ResetPasswordAsync(user, input.ResetToken, input.Password)).CheckErrors();
 

--- a/modules/account/src/Volo.Abp.Account.Web.IdentityServer/Pages/Account/IdentityServerSupportedLoginModel.cs
+++ b/modules/account/src/Volo.Abp.Account.Web.IdentityServer/Pages/Account/IdentityServerSupportedLoginModel.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Security.Claims;
 using System.Security.Principal;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
 using Volo.Abp.Account.Settings;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Identity;
@@ -33,17 +34,19 @@ namespace Volo.Abp.Account.Web.Pages.Account
             IOptions<AbpAccountOptions> accountOptions,
             IIdentityServerInteractionService interaction,
             IClientStore clientStore,
-            IEventService identityServerEvents)
+            IEventService identityServerEvents,
+            IOptions<IdentityOptions> identityOptions)
             :base(
                 schemeProvider,
-                accountOptions)
+                accountOptions,
+                identityOptions)
         {
             Interaction = interaction;
             ClientStore = clientStore;
             IdentityServerEvents = identityServerEvents;
         }
 
-        public async override Task<IActionResult> OnGetAsync()
+        public override async Task<IActionResult> OnGetAsync()
         {
             LoginInput = new LoginInputModel();
 
@@ -98,7 +101,7 @@ namespace Volo.Abp.Account.Web.Pages.Account
             return Page();
         }
 
-        public async override Task<IActionResult> OnPostAsync(string action)
+        public override async Task<IActionResult> OnPostAsync(string action)
         {
             if (action == "Cancel")
             {
@@ -119,6 +122,8 @@ namespace Volo.Abp.Account.Web.Pages.Account
             await CheckLocalLoginAsync();
 
             ValidateModel();
+
+            await IdentityOptions.SetAsync();
 
             ExternalProviders = await GetExternalProviders();
 
@@ -173,7 +178,7 @@ namespace Volo.Abp.Account.Web.Pages.Account
             return RedirectSafely(ReturnUrl, ReturnUrlHash);
         }
 
-        public async override Task<IActionResult> OnPostExternalLogin(string provider)
+        public override async Task<IActionResult> OnPostExternalLogin(string provider)
         {
             if (AccountOptions.WindowsAuthenticationSchemeName == provider)
             {

--- a/modules/account/src/Volo.Abp.Account.Web/Pages/Account/Login.cshtml.cs
+++ b/modules/account/src/Volo.Abp.Account.Web/Pages/Account/Login.cshtml.cs
@@ -51,14 +51,17 @@ namespace Volo.Abp.Account.Web.Pages.Account
 
         protected IAuthenticationSchemeProvider SchemeProvider { get; }
         protected AbpAccountOptions AccountOptions { get; }
+        protected IOptions<IdentityOptions> IdentityOptions { get; }
 
         public bool ShowCancelButton { get; set; }
 
         public LoginModel(
             IAuthenticationSchemeProvider schemeProvider,
-            IOptions<AbpAccountOptions> accountOptions)
+            IOptions<AbpAccountOptions> accountOptions,
+            IOptions<IdentityOptions> identityOptions)
         {
             SchemeProvider = schemeProvider;
+            IdentityOptions = identityOptions;
             AccountOptions = accountOptions.Value;
         }
 
@@ -90,6 +93,8 @@ namespace Volo.Abp.Account.Web.Pages.Account
             EnableLocalLogin = await SettingProvider.IsTrueAsync(AccountSettingNames.EnableLocalLogin);
 
             await ReplaceEmailToUsernameOfInputIfNeeds();
+
+            await IdentityOptions.SetAsync();
 
             var result = await SignInManager.PasswordSignInAsync(
                 LoginInput.UserNameOrEmailAddress,

--- a/modules/identity/src/Volo.Abp.Identity.Application/Volo/Abp/Identity/IdentityUserAppService.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Application/Volo/Abp/Identity/IdentityUserAppService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.ObjectExtending;
 
@@ -12,16 +13,19 @@ namespace Volo.Abp.Identity
     {
         protected IdentityUserManager UserManager { get; }
         protected IIdentityUserRepository UserRepository { get; }
-        public IIdentityRoleRepository RoleRepository { get; }
+        protected IIdentityRoleRepository RoleRepository { get; }
+        protected IOptions<IdentityOptions> IdentityOptions { get; }
 
         public IdentityUserAppService(
             IdentityUserManager userManager,
             IIdentityUserRepository userRepository,
-            IIdentityRoleRepository roleRepository)
+            IIdentityRoleRepository roleRepository,
+            IOptions<IdentityOptions> identityOptions)
         {
             UserManager = userManager;
             UserRepository = userRepository;
             RoleRepository = roleRepository;
+            IdentityOptions = identityOptions;
         }
 
         //TODO: [Authorize(IdentityPermissions.Users.Default)] should go the IdentityUserAppService class.
@@ -68,6 +72,8 @@ namespace Volo.Abp.Identity
         [Authorize(IdentityPermissions.Users.Create)]
         public virtual async Task<IdentityUserDto> CreateAsync(IdentityUserCreateDto input)
         {
+            await IdentityOptions.SetAsync();
+
             var user = new IdentityUser(
                 GuidGenerator.Create(),
                 input.UserName,
@@ -88,6 +94,8 @@ namespace Volo.Abp.Identity
         [Authorize(IdentityPermissions.Users.Update)]
         public virtual async Task<IdentityUserDto> UpdateAsync(Guid id, IdentityUserUpdateDto input)
         {
+            await IdentityOptions.SetAsync();
+
             var user = await UserManager.GetByIdAsync(id);
             user.ConcurrencyStamp = input.ConcurrencyStamp;
 

--- a/modules/identity/src/Volo.Abp.Identity.Application/Volo/Abp/Identity/ProfileAppService.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Application/Volo/Abp/Identity/ProfileAppService.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
 using Volo.Abp.Identity.Settings;
 using Volo.Abp.ObjectExtending;
 using Volo.Abp.Settings;
@@ -13,10 +14,14 @@ namespace Volo.Abp.Identity
     public class ProfileAppService : IdentityAppServiceBase, IProfileAppService
     {
         protected IdentityUserManager UserManager { get; }
+        protected IOptions<IdentityOptions> IdentityOptions { get; }
 
-        public ProfileAppService(IdentityUserManager userManager)
+        public ProfileAppService(
+            IdentityUserManager userManager,
+            IOptions<IdentityOptions> identityOptions)
         {
             UserManager = userManager;
+            IdentityOptions = identityOptions;
         }
 
         public virtual async Task<ProfileDto> GetAsync()
@@ -28,6 +33,8 @@ namespace Volo.Abp.Identity
 
         public virtual async Task<ProfileDto> UpdateAsync(UpdateProfileDto input)
         {
+            await IdentityOptions.SetAsync();
+
             var user = await UserManager.GetByIdAsync(CurrentUser.GetId());
 
             if (await SettingProvider.IsTrueAsync(IdentitySettingNames.User.IsUserNameUpdateEnabled))
@@ -56,6 +63,8 @@ namespace Volo.Abp.Identity
 
         public virtual async Task ChangePasswordAsync(ChangePasswordInput input)
         {
+            await IdentityOptions.SetAsync();
+
             var currentUser = await UserManager.GetByIdAsync(CurrentUser.GetId());
 
             if (currentUser.IsExternal)

--- a/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/AbpIdentityDomainModule.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/AbpIdentityDomainModule.cs
@@ -85,8 +85,7 @@ namespace Volo.Abp.Identity
 
         private static void AddAbpIdentityOptionsFactory(IServiceCollection services)
         {
-            services.Replace(ServiceDescriptor.Transient<IOptionsFactory<IdentityOptions>, AbpIdentityOptionsFactory>());
-            services.Replace(ServiceDescriptor.Scoped<IOptions<IdentityOptions>, OptionsManager<IdentityOptions>>());
+            services.AddAbpDynamicOptions<IdentityOptions, AbpIdentityOptionsManager>();
         }
     }
 }

--- a/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/AbpIdentityDomainModule.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/AbpIdentityDomainModule.cs
@@ -53,7 +53,7 @@ namespace Volo.Abp.Identity
                 options.ClaimsIdentity.RoleClaimType = AbpClaimTypes.Role;
             });
 
-            AddAbpIdentityOptionsFactory(context.Services);
+            context.Services.AddAbpDynamicOptions<IdentityOptions, AbpIdentityOptionsManager>();
         }
 
         public override void PostConfigureServices(ServiceConfigurationContext context)
@@ -81,11 +81,6 @@ namespace Volo.Abp.Identity
                 IdentityModuleExtensionConsts.EntityNames.OrganizationUnit,
                 typeof(OrganizationUnit)
             );
-        }
-
-        private static void AddAbpIdentityOptionsFactory(IServiceCollection services)
-        {
-            services.AddAbpDynamicOptions<IdentityOptions, AbpIdentityOptionsManager>();
         }
     }
 }

--- a/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/AbpIdentityOptionsManager.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/AbpIdentityOptionsManager.cs
@@ -1,43 +1,25 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Options;
 using Volo.Abp.Identity.Settings;
 using Volo.Abp.Options;
 using Volo.Abp.Settings;
-using Volo.Abp.Threading;
 
 namespace Volo.Abp.Identity
 {
-    public class AbpIdentityOptionsFactory : AbpOptionsFactory<IdentityOptions>
+    public class AbpIdentityOptionsManager : AbpDynamicOptionsManager<IdentityOptions>
     {
         protected ISettingProvider SettingProvider { get; }
 
-        public AbpIdentityOptionsFactory(
-            IEnumerable<IConfigureOptions<IdentityOptions>> setups,
-            IEnumerable<IPostConfigureOptions<IdentityOptions>> postConfigures,
+        public AbpIdentityOptionsManager(IOptionsFactory<IdentityOptions> factory,
             ISettingProvider settingProvider)
-            : base(setups, postConfigures)
+            : base(factory)
         {
             SettingProvider = settingProvider;
         }
 
-        public override IdentityOptions Create(string name)
-        {
-            var options = base.Create(name);
-
-            OverrideOptions(options);
-
-            return options;
-        }
-
-        protected virtual void OverrideOptions(IdentityOptions options)
-        {
-            AsyncHelper.RunSync(()=>OverrideOptionsAsync(options));
-        }
-
-        protected virtual async Task OverrideOptionsAsync(IdentityOptions options)
+        protected override async Task OverrideOptionsAsync(IdentityOptions options)
         {
             options.Password.RequiredLength = await SettingProvider.GetAsync(IdentitySettingNames.Password.RequiredLength, options.Password.RequiredLength);
             options.Password.RequiredUniqueChars = await SettingProvider.GetAsync(IdentitySettingNames.Password.RequiredUniqueChars, options.Password.RequiredUniqueChars);
@@ -52,7 +34,6 @@ namespace Volo.Abp.Identity
 
             options.SignIn.RequireConfirmedEmail = await SettingProvider.GetAsync(IdentitySettingNames.SignIn.RequireConfirmedEmail, options.SignIn.RequireConfirmedEmail);
             options.SignIn.RequireConfirmedPhoneNumber = await SettingProvider.GetAsync(IdentitySettingNames.SignIn.RequireConfirmedPhoneNumber, options.SignIn.RequireConfirmedPhoneNumber);
-
         }
     }
 }

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor/MyCompanyName.MyProjectName.Blazor.csproj
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor/MyCompanyName.MyProjectName.Blazor.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Blazorise.Bootstrap" Version="0.9.2-rc4" />
-    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="0.9.2-rc4" />
+    <PackageReference Include="Blazorise.Bootstrap" Version="0.9.3-preview2" />
+    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="0.9.3-preview2" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="5.0.0" />
   </ItemGroup>

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor/MyProjectNameBlazorModule.cs
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor/MyProjectNameBlazorModule.cs
@@ -100,12 +100,5 @@ namespace MyCompanyName.MyProjectName.Blazor
                 options.AddMaps<MyProjectNameBlazorModule>();
             });
         }
-
-        public override void OnApplicationInitialization(ApplicationInitializationContext context)
-        {
-            context.ServiceProvider
-                .UseBootstrapProviders()
-                .UseFontAwesomeIcons();
-        }
     }
 }

--- a/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.Blazor.Host/MyCompanyName.MyProjectName.Blazor.Host.csproj
+++ b/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.Blazor.Host/MyCompanyName.MyProjectName.Blazor.Host.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Blazorise.Bootstrap" Version="0.9.2-rc4" />
-    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="0.9.2-rc4" />
+    <PackageReference Include="Blazorise.Bootstrap" Version="0.9.3-preview2" />
+    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="0.9.3-preview2" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly"  Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="5.0.0" />
   </ItemGroup>

--- a/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.Blazor.Host/MyProjectNameBlazorHostModule.cs
+++ b/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.Blazor.Host/MyProjectNameBlazorHostModule.cs
@@ -95,12 +95,5 @@ namespace MyCompanyName.MyProjectName.Blazor.Host
                 options.AddMaps<MyProjectNameBlazorHostModule>();
             });
         }
-
-        public override void OnApplicationInitialization(ApplicationInitializationContext context)
-        {
-            context.ServiceProvider
-                .UseBootstrapProviders()
-                .UseFontAwesomeIcons();
-        }
     }
 }


### PR DESCRIPTION
Resolved #6318 

We currently need to inject `IOptions<IdentityOptions> identityOptions` and use `await identityOptions.SetAsync();` to override the options from the setting provider. In this way, it will be truly async.

This is open to bugs if we forget to call `SetAsync` before using the options. However, Microsoft's Options pattern has no way to get options in an async way.

@maliming, check please, if we have another such usage, we should also change them.

To make an options class can be used in this way;

1. Define a class like:

````csharp
using System;
using System.Threading.Tasks;
using Microsoft.AspNetCore.Identity;
using Microsoft.Extensions.Options;
using Volo.Abp.Identity.Settings;
using Volo.Abp.Options;
using Volo.Abp.Settings;

namespace Volo.Abp.Identity
{
    public class AbpIdentityOptionsManager : AbpDynamicOptionsManager<IdentityOptions>
    {
        protected ISettingProvider SettingProvider { get; }

        public AbpIdentityOptionsManager(IOptionsFactory<IdentityOptions> factory,
            ISettingProvider settingProvider)
            : base(factory)
        {
            SettingProvider = settingProvider;
        }

        protected override async Task OverrideOptionsAsync(IdentityOptions options)
        {
            options.Password.RequiredLength = await SettingProvider.GetAsync(IdentitySettingNames.Password.RequiredLength, options.Password.RequiredLength);
            options.Password.RequiredUniqueChars = await SettingProvider.GetAsync(IdentitySettingNames.Password.RequiredUniqueChars, options.Password.RequiredUniqueChars);
            options.Password.RequireNonAlphanumeric = await SettingProvider.GetAsync(IdentitySettingNames.Password.RequireNonAlphanumeric, options.Password.RequireNonAlphanumeric);
            options.Password.RequireLowercase = await SettingProvider.GetAsync(IdentitySettingNames.Password.RequireLowercase, options.Password.RequireLowercase);
            options.Password.RequireUppercase = await SettingProvider.GetAsync(IdentitySettingNames.Password.RequireUppercase, options.Password.RequireUppercase);
            options.Password.RequireDigit = await SettingProvider.GetAsync(IdentitySettingNames.Password.RequireDigit, options.Password.RequireDigit);

            options.Lockout.AllowedForNewUsers = await SettingProvider.GetAsync(IdentitySettingNames.Lockout.AllowedForNewUsers, options.Lockout.AllowedForNewUsers);
            options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromSeconds(await SettingProvider.GetAsync(IdentitySettingNames.Lockout.LockoutDuration, options.Lockout.DefaultLockoutTimeSpan.TotalSeconds.To<int>()));
            options.Lockout.MaxFailedAccessAttempts = await SettingProvider.GetAsync(IdentitySettingNames.Lockout.MaxFailedAccessAttempts, options.Lockout.MaxFailedAccessAttempts);

            options.SignIn.RequireConfirmedEmail = await SettingProvider.GetAsync(IdentitySettingNames.SignIn.RequireConfirmedEmail, options.SignIn.RequireConfirmedEmail);
            options.SignIn.RequireConfirmedPhoneNumber = await SettingProvider.GetAsync(IdentitySettingNames.SignIn.RequireConfirmedPhoneNumber, options.SignIn.RequireConfirmedPhoneNumber);
        }
    }
}
````

Then use this to replace the options:

````csharp
context.Services.AddAbpDynamicOptions<IdentityOptions, AbpIdentityOptionsManager>();
````