### PR TITLE
Remove AsyncHelper usage for the IdentityOptions

### DIFF
--- a/framework/src/Volo.Abp.Core/Microsoft/Extensions/DependencyInjection/ServiceCollectionDynamicOptionsManagerExtensions.cs
+++ b/framework/src/Volo.Abp.Core/Microsoft/Extensions/DependencyInjection/ServiceCollectionDynamicOptionsManagerExtensions.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using Volo.Abp.Options;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class ServiceCollectionDynamicOptionsManagerExtensions
+    {
+        public static IServiceCollection AddAbpDynamicOptions<TOptions, TManager>(this IServiceCollection services)
+            where TOptions : class
+            where TManager : AbpDynamicOptionsManager<TOptions>
+        {
+            services.Replace(ServiceDescriptor.Scoped(typeof(IOptions<TOptions>), typeof(TManager)));
+            services.Replace(ServiceDescriptor.Scoped(typeof(IOptionsSnapshot<TOptions>), typeof(TManager)));
+
+            return services;
+        }
+    }
+}

--- a/framework/src/Volo.Abp.Core/Microsoft/Extensions/Options/OptionsAbpDynamicOptionsManagerExtensions.cs
+++ b/framework/src/Volo.Abp.Core/Microsoft/Extensions/Options/OptionsAbpDynamicOptionsManagerExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System.Threading.Tasks;
+using Volo.Abp;
+using Volo.Abp.Options;
+
+namespace Microsoft.Extensions.Options
+{
+    public static class OptionsAbpDynamicOptionsManagerExtensions
+    {
+        public static Task SetAsync<T>(this IOptions<T> options)
+            where T : class
+        {
+            return options.ToDynamicOptions().SetAsync();
+        }
+
+        public static Task SetAsync<T>(this IOptions<T> options, string name)
+            where T : class
+        {
+            return options.ToDynamicOptions().SetAsync(name);
+        }
+
+        private static AbpDynamicOptionsManager<T> ToDynamicOptions<T>(this IOptions<T> options)
+            where T : class
+        {
+            if (options is AbpDynamicOptionsManager<T> dynamicOptionsManager)
+            {
+                return dynamicOptionsManager;
+            }
+
+            throw new AbpException($"Options must be derived from the {typeof(AbpDynamicOptionsManager<>).FullName}!");
+        }
+    }
+}

--- a/framework/src/Volo.Abp.Core/Volo/Abp/Options/AbpDynamicOptionsManager.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/Options/AbpDynamicOptionsManager.cs
@@ -1,0 +1,24 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+
+namespace Volo.Abp.Options
+{
+    public abstract class AbpDynamicOptionsManager<T> : OptionsManager<T>
+        where T : class
+    {
+        protected AbpDynamicOptionsManager(IOptionsFactory<T> factory)
+            : base(factory)
+        {
+
+        }
+
+        public Task SetAsync() => SetAsync(Microsoft.Extensions.Options.Options.DefaultName);
+
+        public virtual Task SetAsync(string name)
+        {
+            return OverrideOptionsAsync(base.Get(name));
+        }
+
+        protected abstract Task OverrideOptionsAsync(T options);
+    }
+}

--- a/modules/account/src/Volo.Abp.Account.Application/Volo/Abp/Account/AccountAppService.cs
+++ b/modules/account/src/Volo.Abp.Account.Application/Volo/Abp/Account/AccountAppService.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
 using Volo.Abp.Account.Emailing;
 using Volo.Abp.Account.Localization;
 using Volo.Abp.Account.Settings;
@@ -16,22 +17,29 @@ namespace Volo.Abp.Account
         protected IAccountEmailer AccountEmailer { get; }
         protected IdentitySecurityLogManager IdentitySecurityLogManager { get; }
 
+        protected IOptions<IdentityOptions> IdentityOptions { get; }
+
         public AccountAppService(
             IdentityUserManager userManager,
             IIdentityRoleRepository roleRepository,
             IAccountEmailer accountEmailer,
-            IdentitySecurityLogManager identitySecurityLogManager)
+            IdentitySecurityLogManager identitySecurityLogManager,
+            IOptions<IdentityOptions> identityOptions)
         {
             RoleRepository = roleRepository;
             AccountEmailer = accountEmailer;
             IdentitySecurityLogManager = identitySecurityLogManager;
             UserManager = userManager;
+            IdentityOptions = identityOptions;
+
             LocalizationResource = typeof(AccountResource);
         }
 
         public virtual async Task<IdentityUserDto> RegisterAsync(RegisterDto input)
         {
             await CheckSelfRegistrationAsync();
+
+            await IdentityOptions.SetAsync();
 
             var user = new IdentityUser(GuidGenerator.Create(), input.UserName, input.EmailAddress, CurrentTenant.Id);
 
@@ -52,6 +60,8 @@ namespace Volo.Abp.Account
 
         public virtual async Task ResetPasswordAsync(ResetPasswordDto input)
         {
+            await IdentityOptions.SetAsync();
+
             var user = await UserManager.GetByIdAsync(input.UserId);
             (await UserManager.ResetPasswordAsync(user, input.ResetToken, input.Password)).CheckErrors();
 

--- a/modules/account/src/Volo.Abp.Account.Application/Volo/Abp/Account/AccountAppService.cs
+++ b/modules/account/src/Volo.Abp.Account.Application/Volo/Abp/Account/AccountAppService.cs
@@ -16,7 +16,6 @@ namespace Volo.Abp.Account
         protected IdentityUserManager UserManager { get; }
         protected IAccountEmailer AccountEmailer { get; }
         protected IdentitySecurityLogManager IdentitySecurityLogManager { get; }
-
         protected IOptions<IdentityOptions> IdentityOptions { get; }
 
         public AccountAppService(

--- a/modules/account/src/Volo.Abp.Account.Web.IdentityServer/Pages/Account/IdentityServerSupportedLoginModel.cs
+++ b/modules/account/src/Volo.Abp.Account.Web.IdentityServer/Pages/Account/IdentityServerSupportedLoginModel.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Security.Claims;
 using System.Security.Principal;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
 using Volo.Abp.Account.Settings;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Identity;
@@ -33,17 +34,19 @@ namespace Volo.Abp.Account.Web.Pages.Account
             IOptions<AbpAccountOptions> accountOptions,
             IIdentityServerInteractionService interaction,
             IClientStore clientStore,
-            IEventService identityServerEvents)
+            IEventService identityServerEvents,
+            IOptions<IdentityOptions> identityOptions)
             :base(
                 schemeProvider,
-                accountOptions)
+                accountOptions,
+                identityOptions)
         {
             Interaction = interaction;
             ClientStore = clientStore;
             IdentityServerEvents = identityServerEvents;
         }
 
-        public async override Task<IActionResult> OnGetAsync()
+        public override async Task<IActionResult> OnGetAsync()
         {
             LoginInput = new LoginInputModel();
 
@@ -98,7 +101,7 @@ namespace Volo.Abp.Account.Web.Pages.Account
             return Page();
         }
 
-        public async override Task<IActionResult> OnPostAsync(string action)
+        public override async Task<IActionResult> OnPostAsync(string action)
         {
             if (action == "Cancel")
             {
@@ -119,6 +122,8 @@ namespace Volo.Abp.Account.Web.Pages.Account
             await CheckLocalLoginAsync();
 
             ValidateModel();
+
+            await IdentityOptions.SetAsync();
 
             ExternalProviders = await GetExternalProviders();
 
@@ -173,7 +178,7 @@ namespace Volo.Abp.Account.Web.Pages.Account
             return RedirectSafely(ReturnUrl, ReturnUrlHash);
         }
 
-        public async override Task<IActionResult> OnPostExternalLogin(string provider)
+        public override async Task<IActionResult> OnPostExternalLogin(string provider)
         {
             if (AccountOptions.WindowsAuthenticationSchemeName == provider)
             {

--- a/modules/account/src/Volo.Abp.Account.Web/Areas/Account/Controllers/AccountController.cs
+++ b/modules/account/src/Volo.Abp.Account.Web/Areas/Account/Controllers/AccountController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 using Volo.Abp.Account.Localization;
 using Volo.Abp.Account.Settings;
 using Volo.Abp.Account.Web.Areas.Account.Controllers.Models;
@@ -27,12 +28,14 @@ namespace Volo.Abp.Account.Web.Areas.Account.Controllers
         protected IdentityUserManager UserManager { get; }
         protected ISettingProvider SettingProvider { get; }
         protected IdentitySecurityLogManager IdentitySecurityLogManager { get; }
+        protected IOptions<IdentityOptions> IdentityOptions { get; }
 
         public AccountController(
             SignInManager<IdentityUser> signInManager,
             IdentityUserManager userManager,
             ISettingProvider settingProvider,
-            IdentitySecurityLogManager identitySecurityLogManager)
+            IdentitySecurityLogManager identitySecurityLogManager,
+            IOptions<IdentityOptions> identityOptions)
         {
             LocalizationResource = typeof(AccountResource);
 
@@ -40,6 +43,7 @@ namespace Volo.Abp.Account.Web.Areas.Account.Controllers
             UserManager = userManager;
             SettingProvider = settingProvider;
             IdentitySecurityLogManager = identitySecurityLogManager;
+            IdentityOptions = identityOptions;
         }
 
         [HttpPost]
@@ -104,6 +108,7 @@ namespace Volo.Abp.Account.Web.Areas.Account.Controllers
                 return new AbpLoginResult(LoginResultType.InvalidUserNameOrPassword);
             }
 
+            await IdentityOptions.SetAsync();
             return GetAbpLoginResult(await SignInManager.CheckPasswordSignInAsync(identityUser, login.Password, true));
         }
 

--- a/modules/account/src/Volo.Abp.Account.Web/Pages/Account/AccountPageModel.cs
+++ b/modules/account/src/Volo.Abp.Account.Web/Pages/Account/AccountPageModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 using Volo.Abp.Account.Localization;
 using Volo.Abp.AspNetCore.Mvc.UI.RazorPages;
 using Volo.Abp.Identity;
@@ -16,6 +17,7 @@ namespace Volo.Abp.Account.Web.Pages.Account
         public SignInManager<IdentityUser> SignInManager { get; set; }
         public IdentityUserManager UserManager { get; set; }
         public IdentitySecurityLogManager IdentitySecurityLogManager { get; set; }
+        public IOptions<IdentityOptions> IdentityOptions { get; set; }
 
         protected AccountPageModel()
         {

--- a/modules/account/src/Volo.Abp.Account.Web/Pages/Account/Login.cshtml.cs
+++ b/modules/account/src/Volo.Abp.Account.Web/Pages/Account/Login.cshtml.cs
@@ -186,6 +186,8 @@ namespace Volo.Abp.Account.Web.Pages.Account
                 return RedirectToPage("./Login");
             }
 
+            await IdentityOptions.SetAsync();
+
             var loginInfo = await SignInManager.GetExternalLoginInfoAsync();
             if (loginInfo == null)
             {
@@ -259,6 +261,8 @@ namespace Volo.Abp.Account.Web.Pages.Account
 
         protected virtual async Task<IdentityUser> CreateExternalUserAsync(ExternalLoginInfo info)
         {
+            await IdentityOptions.SetAsync();
+
             var emailAddress = info.Principal.FindFirstValue(AbpClaimTypes.Email);
 
             var user = new IdentityUser(GuidGenerator.Create(), emailAddress, emailAddress, CurrentTenant.Id);

--- a/modules/account/src/Volo.Abp.Account.Web/Pages/Account/Login.cshtml.cs
+++ b/modules/account/src/Volo.Abp.Account.Web/Pages/Account/Login.cshtml.cs
@@ -51,14 +51,17 @@ namespace Volo.Abp.Account.Web.Pages.Account
 
         protected IAuthenticationSchemeProvider SchemeProvider { get; }
         protected AbpAccountOptions AccountOptions { get; }
+        protected IOptions<IdentityOptions> IdentityOptions { get; }
 
         public bool ShowCancelButton { get; set; }
 
         public LoginModel(
             IAuthenticationSchemeProvider schemeProvider,
-            IOptions<AbpAccountOptions> accountOptions)
+            IOptions<AbpAccountOptions> accountOptions,
+            IOptions<IdentityOptions> identityOptions)
         {
             SchemeProvider = schemeProvider;
+            IdentityOptions = identityOptions;
             AccountOptions = accountOptions.Value;
         }
 
@@ -90,6 +93,8 @@ namespace Volo.Abp.Account.Web.Pages.Account
             EnableLocalLogin = await SettingProvider.IsTrueAsync(AccountSettingNames.EnableLocalLogin);
 
             await ReplaceEmailToUsernameOfInputIfNeeds();
+
+            await IdentityOptions.SetAsync();
 
             var result = await SignInManager.PasswordSignInAsync(
                 LoginInput.UserNameOrEmailAddress,

--- a/modules/account/src/Volo.Abp.Account.Web/Pages/Account/Register.cshtml.cs
+++ b/modules/account/src/Volo.Abp.Account.Web/Pages/Account/Register.cshtml.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Volo.Abp.Account.Settings;
 using Volo.Abp.Auditing;
 using Volo.Abp.Identity;
@@ -124,6 +125,8 @@ namespace Volo.Abp.Account.Web.Pages.Account
 
         protected virtual async Task RegisterExternalUserAsync(ExternalLoginInfo externalLoginInfo, string emailAddress)
         {
+            await IdentityOptions.SetAsync();
+
             var user = new IdentityUser(GuidGenerator.Create(), emailAddress, emailAddress, CurrentTenant.Id);
 
             (await UserManager.CreateAsync(user)).CheckErrors();

--- a/modules/account/test/Volo.Abp.Account.Application.Tests/Volo/Abp/Account/AccountAppService_Tests.cs
+++ b/modules/account/test/Volo.Abp.Account.Application.Tests/Volo/Abp/Account/AccountAppService_Tests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
 using Shouldly;
 using Volo.Abp.Identity;
 using Xunit;
@@ -12,18 +13,22 @@ namespace Volo.Abp.Account
         private readonly IIdentityUserRepository _identityUserRepository;
         private readonly ILookupNormalizer _lookupNormalizer;
         private readonly IdentityUserManager _userManager;
-        
+        private readonly IOptions<IdentityOptions> _identityOptions;
+
         public AccountAppService_Tests()
         {
             _accountAppService = GetRequiredService<IAccountAppService>();
             _identityUserRepository = GetRequiredService<IIdentityUserRepository>();
             _lookupNormalizer = GetRequiredService<ILookupNormalizer>();
             _userManager = GetRequiredService<IdentityUserManager>();
+            _identityOptions = GetRequiredService<IOptions<IdentityOptions>>();
         }
 
         [Fact]
         public async Task RegisterAsync()
         {
+            await _identityOptions.SetAsync();
+
             var registerDto = new RegisterDto
             {
                 UserName = "bob.lee",

--- a/modules/identity/src/Volo.Abp.Identity.Application/Volo/Abp/Identity/IdentityUserAppService.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Application/Volo/Abp/Identity/IdentityUserAppService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.ObjectExtending;
 
@@ -12,16 +13,19 @@ namespace Volo.Abp.Identity
     {
         protected IdentityUserManager UserManager { get; }
         protected IIdentityUserRepository UserRepository { get; }
-        public IIdentityRoleRepository RoleRepository { get; }
+        protected IIdentityRoleRepository RoleRepository { get; }
+        protected IOptions<IdentityOptions> IdentityOptions { get; }
 
         public IdentityUserAppService(
             IdentityUserManager userManager,
             IIdentityUserRepository userRepository,
-            IIdentityRoleRepository roleRepository)
+            IIdentityRoleRepository roleRepository,
+            IOptions<IdentityOptions> identityOptions)
         {
             UserManager = userManager;
             UserRepository = userRepository;
             RoleRepository = roleRepository;
+            IdentityOptions = identityOptions;
         }
 
         //TODO: [Authorize(IdentityPermissions.Users.Default)] should go the IdentityUserAppService class.
@@ -68,6 +72,8 @@ namespace Volo.Abp.Identity
         [Authorize(IdentityPermissions.Users.Create)]
         public virtual async Task<IdentityUserDto> CreateAsync(IdentityUserCreateDto input)
         {
+            await IdentityOptions.SetAsync();
+
             var user = new IdentityUser(
                 GuidGenerator.Create(),
                 input.UserName,
@@ -88,6 +94,8 @@ namespace Volo.Abp.Identity
         [Authorize(IdentityPermissions.Users.Update)]
         public virtual async Task<IdentityUserDto> UpdateAsync(Guid id, IdentityUserUpdateDto input)
         {
+            await IdentityOptions.SetAsync();
+
             var user = await UserManager.GetByIdAsync(id);
             user.ConcurrencyStamp = input.ConcurrencyStamp;
 

--- a/modules/identity/src/Volo.Abp.Identity.Application/Volo/Abp/Identity/ProfileAppService.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Application/Volo/Abp/Identity/ProfileAppService.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
 using Volo.Abp.Identity.Settings;
 using Volo.Abp.ObjectExtending;
 using Volo.Abp.Settings;
@@ -13,10 +14,14 @@ namespace Volo.Abp.Identity
     public class ProfileAppService : IdentityAppServiceBase, IProfileAppService
     {
         protected IdentityUserManager UserManager { get; }
+        protected IOptions<IdentityOptions> IdentityOptions { get; }
 
-        public ProfileAppService(IdentityUserManager userManager)
+        public ProfileAppService(
+            IdentityUserManager userManager,
+            IOptions<IdentityOptions> identityOptions)
         {
             UserManager = userManager;
+            IdentityOptions = identityOptions;
         }
 
         public virtual async Task<ProfileDto> GetAsync()
@@ -28,6 +33,8 @@ namespace Volo.Abp.Identity
 
         public virtual async Task<ProfileDto> UpdateAsync(UpdateProfileDto input)
         {
+            await IdentityOptions.SetAsync();
+
             var user = await UserManager.GetByIdAsync(CurrentUser.GetId());
 
             if (await SettingProvider.IsTrueAsync(IdentitySettingNames.User.IsUserNameUpdateEnabled))
@@ -56,6 +63,8 @@ namespace Volo.Abp.Identity
 
         public virtual async Task ChangePasswordAsync(ChangePasswordInput input)
         {
+            await IdentityOptions.SetAsync();
+
             var currentUser = await UserManager.GetByIdAsync(CurrentUser.GetId());
 
             if (currentUser.IsExternal)

--- a/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/AbpIdentityDomainModule.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/AbpIdentityDomainModule.cs
@@ -85,8 +85,7 @@ namespace Volo.Abp.Identity
 
         private static void AddAbpIdentityOptionsFactory(IServiceCollection services)
         {
-            services.Replace(ServiceDescriptor.Transient<IOptionsFactory<IdentityOptions>, AbpIdentityOptionsFactory>());
-            services.Replace(ServiceDescriptor.Scoped<IOptions<IdentityOptions>, OptionsManager<IdentityOptions>>());
+            services.AddAbpDynamicOptions<IdentityOptions, AbpIdentityOptionsManager>();
         }
     }
 }

--- a/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/AbpIdentityDomainModule.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/AbpIdentityDomainModule.cs
@@ -53,7 +53,7 @@ namespace Volo.Abp.Identity
                 options.ClaimsIdentity.RoleClaimType = AbpClaimTypes.Role;
             });
 
-            AddAbpIdentityOptionsFactory(context.Services);
+            context.Services.AddAbpDynamicOptions<IdentityOptions, AbpIdentityOptionsManager>();
         }
 
         public override void PostConfigureServices(ServiceConfigurationContext context)
@@ -81,11 +81,6 @@ namespace Volo.Abp.Identity
                 IdentityModuleExtensionConsts.EntityNames.OrganizationUnit,
                 typeof(OrganizationUnit)
             );
-        }
-
-        private static void AddAbpIdentityOptionsFactory(IServiceCollection services)
-        {
-            services.AddAbpDynamicOptions<IdentityOptions, AbpIdentityOptionsManager>();
         }
     }
 }

--- a/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/AbpIdentityOptionsManager.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/AbpIdentityOptionsManager.cs
@@ -1,43 +1,25 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Options;
 using Volo.Abp.Identity.Settings;
 using Volo.Abp.Options;
 using Volo.Abp.Settings;
-using Volo.Abp.Threading;
 
 namespace Volo.Abp.Identity
 {
-    public class AbpIdentityOptionsFactory : AbpOptionsFactory<IdentityOptions>
+    public class AbpIdentityOptionsManager : AbpDynamicOptionsManager<IdentityOptions>
     {
         protected ISettingProvider SettingProvider { get; }
 
-        public AbpIdentityOptionsFactory(
-            IEnumerable<IConfigureOptions<IdentityOptions>> setups,
-            IEnumerable<IPostConfigureOptions<IdentityOptions>> postConfigures,
+        public AbpIdentityOptionsManager(IOptionsFactory<IdentityOptions> factory,
             ISettingProvider settingProvider)
-            : base(setups, postConfigures)
+            : base(factory)
         {
             SettingProvider = settingProvider;
         }
 
-        public override IdentityOptions Create(string name)
-        {
-            var options = base.Create(name);
-
-            OverrideOptions(options);
-
-            return options;
-        }
-
-        protected virtual void OverrideOptions(IdentityOptions options)
-        {
-            AsyncHelper.RunSync(()=>OverrideOptionsAsync(options));
-        }
-
-        protected virtual async Task OverrideOptionsAsync(IdentityOptions options)
+        protected override async Task OverrideOptionsAsync(IdentityOptions options)
         {
             options.Password.RequiredLength = await SettingProvider.GetAsync(IdentitySettingNames.Password.RequiredLength, options.Password.RequiredLength);
             options.Password.RequiredUniqueChars = await SettingProvider.GetAsync(IdentitySettingNames.Password.RequiredUniqueChars, options.Password.RequiredUniqueChars);
@@ -52,7 +34,6 @@ namespace Volo.Abp.Identity
 
             options.SignIn.RequireConfirmedEmail = await SettingProvider.GetAsync(IdentitySettingNames.SignIn.RequireConfirmedEmail, options.SignIn.RequireConfirmedEmail);
             options.SignIn.RequireConfirmedPhoneNumber = await SettingProvider.GetAsync(IdentitySettingNames.SignIn.RequireConfirmedPhoneNumber, options.SignIn.RequireConfirmedPhoneNumber);
-
         }
     }
 }

--- a/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/ExternalLoginProviderBase.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/ExternalLoginProviderBase.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
 using Volo.Abp.Domain.Repositories;
 using Volo.Abp.Guids;
 using Volo.Abp.MultiTenancy;
@@ -14,23 +15,28 @@ namespace Volo.Abp.Identity
         protected ICurrentTenant CurrentTenant { get; }
         protected IdentityUserManager UserManager { get; }
         protected IIdentityUserRepository IdentityUserRepository { get; }
+        protected IOptions<IdentityOptions> IdentityOptions { get; }
 
         protected ExternalLoginProviderBase(
             IGuidGenerator guidGenerator,
             ICurrentTenant currentTenant,
             IdentityUserManager userManager,
-            IIdentityUserRepository identityUserRepository)
+            IIdentityUserRepository identityUserRepository,
+            IOptions<IdentityOptions> identityOptions)
         {
             GuidGenerator = guidGenerator;
             CurrentTenant = currentTenant;
             UserManager = userManager;
             IdentityUserRepository = identityUserRepository;
+            IdentityOptions = identityOptions;
         }
 
         public abstract Task<bool> TryAuthenticateAsync(string userName, string plainPassword);
 
         public virtual async Task<IdentityUser> CreateUserAsync(string userName, string providerName)
         {
+            await IdentityOptions.SetAsync();
+
             var externalUser = await GetUserInfoAsync(userName);
             NormalizeExternalLoginUserInfo(externalUser, userName);
 

--- a/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/IdentityDataSeeder.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/IdentityDataSeeder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Guids;
 using Volo.Abp.MultiTenancy;
@@ -17,6 +18,7 @@ namespace Volo.Abp.Identity
         protected IdentityUserManager UserManager { get; }
         protected IdentityRoleManager RoleManager { get; }
         protected ICurrentTenant CurrentTenant { get; }
+        protected IOptions<IdentityOptions> IdentityOptions { get; }
 
         public IdentityDataSeeder(
             IGuidGenerator guidGenerator,
@@ -25,7 +27,8 @@ namespace Volo.Abp.Identity
             ILookupNormalizer lookupNormalizer,
             IdentityUserManager userManager,
             IdentityRoleManager roleManager,
-            ICurrentTenant currentTenant)
+            ICurrentTenant currentTenant,
+            IOptions<IdentityOptions> identityOptions)
         {
             GuidGenerator = guidGenerator;
             RoleRepository = roleRepository;
@@ -34,6 +37,7 @@ namespace Volo.Abp.Identity
             UserManager = userManager;
             RoleManager = roleManager;
             CurrentTenant = currentTenant;
+            IdentityOptions = identityOptions;
         }
 
         [UnitOfWork]
@@ -44,6 +48,8 @@ namespace Volo.Abp.Identity
         {
             Check.NotNullOrWhiteSpace(adminEmail, nameof(adminEmail));
             Check.NotNullOrWhiteSpace(adminPassword, nameof(adminPassword));
+
+            await IdentityOptions.SetAsync();
 
             var result = new IdentityDataSeedResult();
 

--- a/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/FakeExternalLoginProvider.cs
+++ b/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/FakeExternalLoginProvider.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Guids;
 using Volo.Abp.MultiTenancy;
@@ -14,12 +16,14 @@ namespace Volo.Abp.Identity.AspNetCore
             IGuidGenerator guidGenerator,
             ICurrentTenant currentTenant,
             IdentityUserManager userManager,
-            IIdentityUserRepository identityUserRepository)
+            IIdentityUserRepository identityUserRepository,
+            IOptions<IdentityOptions> identityOptions)
             : base(
                 guidGenerator,
                 currentTenant,
                 userManager,
-                identityUserRepository)
+                identityUserRepository,
+                identityOptions)
         {
 
         }

--- a/modules/identity/test/Volo.Abp.Identity.Domain.Tests/Volo/Abp/Identity/IdentityUserManager_Tests.cs
+++ b/modules/identity/test/Volo.Abp.Identity.Domain.Tests/Volo/Abp/Identity/IdentityUserManager_Tests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
 using Shouldly;
 using Volo.Abp.Uow;
 using Xunit;
@@ -18,6 +19,7 @@ namespace Volo.Abp.Identity
         private readonly ILookupNormalizer _lookupNormalizer;
         private readonly IUnitOfWorkManager _unitOfWorkManager;
         private readonly IdentityTestData _testData;
+        protected IOptions<IdentityOptions> _identityOptions { get; }
 
         public IdentityUserManager_Tests()
         {
@@ -28,6 +30,7 @@ namespace Volo.Abp.Identity
             _lookupNormalizer = GetRequiredService<ILookupNormalizer>();
             _testData = GetRequiredService<IdentityTestData>();
             _unitOfWorkManager = GetRequiredService<IUnitOfWorkManager>();
+            _identityOptions = GetRequiredService<IOptions<IdentityOptions>>();
         }
 
         [Fact]
@@ -120,6 +123,8 @@ namespace Volo.Abp.Identity
         [Fact]
         public async Task AddDefaultRolesAsync_In_Same_Uow()
         {
+            await _identityOptions.SetAsync();
+
             await CreateRandomDefaultRoleAsync();
 
             using (var uow = _unitOfWorkManager.Begin())
@@ -176,6 +181,8 @@ namespace Volo.Abp.Identity
         [Fact]
         public async Task AddDefaultRolesAsync_In_Different_Uow()
         {
+            await _identityOptions.SetAsync();
+
             await CreateRandomDefaultRoleAsync();
 
             Guid userId;

--- a/modules/identityserver/src/Volo.Abp.IdentityServer.Domain/Volo/Abp/IdentityServer/AspNetIdentity/AbpResourceOwnerPasswordValidator.cs
+++ b/modules/identityserver/src/Volo.Abp.IdentityServer.Domain/Volo/Abp/IdentityServer/AspNetIdentity/AbpResourceOwnerPasswordValidator.cs
@@ -33,6 +33,7 @@ namespace Volo.Abp.IdentityServer.AspNetIdentity
         protected IStringLocalizer<AbpIdentityServerResource> Localizer { get; }
         protected IHybridServiceScopeFactory ServiceScopeFactory { get; }
         protected AbpIdentityOptions AbpIdentityOptions { get; }
+        protected IOptions<IdentityOptions> IdentityOptions { get; }
 
         public AbpResourceOwnerPasswordValidator(
             UserManager<IdentityUser> userManager,
@@ -41,7 +42,8 @@ namespace Volo.Abp.IdentityServer.AspNetIdentity
             ILogger<ResourceOwnerPasswordValidator<IdentityUser>> logger,
             IStringLocalizer<AbpIdentityServerResource> localizer,
             IOptions<AbpIdentityOptions> abpIdentityOptions,
-            IHybridServiceScopeFactory serviceScopeFactory)
+            IHybridServiceScopeFactory serviceScopeFactory,
+            IOptions<IdentityOptions> identityOptions)
         {
             UserManager = userManager;
             SignInManager = signInManager;
@@ -50,6 +52,7 @@ namespace Volo.Abp.IdentityServer.AspNetIdentity
             Localizer = localizer;
             ServiceScopeFactory = serviceScopeFactory;
             AbpIdentityOptions = abpIdentityOptions.Value;
+            IdentityOptions = identityOptions;
         }
 
         /// <summary>
@@ -123,6 +126,7 @@ namespace Volo.Abp.IdentityServer.AspNetIdentity
             string errorDescription;
             if (user != null)
             {
+                await IdentityOptions.SetAsync();
                 var result = await SignInManager.CheckPasswordSignInAsync(user, context.Password, true);
                 if (result.Succeeded)
                 {


### PR DESCRIPTION
Resolved #6318 

We currently need to inject `IOptions<IdentityOptions> identityOptions` and use `await identityOptions.SetAsync();` to override the options from the setting provider. In this way, it will be truly async.

This is open to bugs if we forget to call `SetAsync` before using the options. However, Microsoft's Options pattern has no way to get options in an async way.

@maliming, check please, if we have another such usage, we should also change them.

To make an options class can be used in this way;

1. Define a class like:

````csharp
using System;
using System.Threading.Tasks;
using Microsoft.AspNetCore.Identity;
using Microsoft.Extensions.Options;
using Volo.Abp.Identity.Settings;
using Volo.Abp.Options;
using Volo.Abp.Settings;

namespace Volo.Abp.Identity
{
    public class AbpIdentityOptionsManager : AbpDynamicOptionsManager<IdentityOptions>
    {
        protected ISettingProvider SettingProvider { get; }

        public AbpIdentityOptionsManager(IOptionsFactory<IdentityOptions> factory,
            ISettingProvider settingProvider)
            : base(factory)
        {
            SettingProvider = settingProvider;
        }

        protected override async Task OverrideOptionsAsync(IdentityOptions options)
        {
            options.Password.RequiredLength = await SettingProvider.GetAsync(IdentitySettingNames.Password.RequiredLength, options.Password.RequiredLength);
            options.Password.RequiredUniqueChars = await SettingProvider.GetAsync(IdentitySettingNames.Password.RequiredUniqueChars, options.Password.RequiredUniqueChars);
            options.Password.RequireNonAlphanumeric = await SettingProvider.GetAsync(IdentitySettingNames.Password.RequireNonAlphanumeric, options.Password.RequireNonAlphanumeric);
            options.Password.RequireLowercase = await SettingProvider.GetAsync(IdentitySettingNames.Password.RequireLowercase, options.Password.RequireLowercase);
            options.Password.RequireUppercase = await SettingProvider.GetAsync(IdentitySettingNames.Password.RequireUppercase, options.Password.RequireUppercase);
            options.Password.RequireDigit = await SettingProvider.GetAsync(IdentitySettingNames.Password.RequireDigit, options.Password.RequireDigit);

            options.Lockout.AllowedForNewUsers = await SettingProvider.GetAsync(IdentitySettingNames.Lockout.AllowedForNewUsers, options.Lockout.AllowedForNewUsers);
            options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromSeconds(await SettingProvider.GetAsync(IdentitySettingNames.Lockout.LockoutDuration, options.Lockout.DefaultLockoutTimeSpan.TotalSeconds.To<int>()));
            options.Lockout.MaxFailedAccessAttempts = await SettingProvider.GetAsync(IdentitySettingNames.Lockout.MaxFailedAccessAttempts, options.Lockout.MaxFailedAccessAttempts);

            options.SignIn.RequireConfirmedEmail = await SettingProvider.GetAsync(IdentitySettingNames.SignIn.RequireConfirmedEmail, options.SignIn.RequireConfirmedEmail);
            options.SignIn.RequireConfirmedPhoneNumber = await SettingProvider.GetAsync(IdentitySettingNames.SignIn.RequireConfirmedPhoneNumber, options.SignIn.RequireConfirmedPhoneNumber);
        }
    }
}
````

Then use this to replace the options:

````csharp
context.Services.AddAbpDynamicOptions<IdentityOptions, AbpIdentityOptionsManager>();
````