### PR TITLE
Use object as the parameter of form binding & convert all parameters into camel case.

### DIFF
--- a/framework/src/Volo.Abp.Http/Volo/Abp/Http/ProxyScripting/Generators/ProxyScriptingJsFuncHelper.cs
+++ b/framework/src/Volo.Abp.Http/Volo/Abp/Http/ProxyScripting/Generators/ProxyScriptingJsFuncHelper.cs
@@ -110,9 +110,11 @@ namespace Volo.Abp.Http.ProxyScripting.Generators
 
         public static string GetParamNameInJsFunc(ParameterApiDescriptionModel parameterInfo)
         {
+            var parameterInfoName = string.Join(".", parameterInfo.Name.Split(".").Select(x => NormalizeJsVariableName(x.ToCamelCase())));
+
             return parameterInfo.Name == parameterInfo.NameOnMethod
-                ? NormalizeJsVariableName(parameterInfo.Name.ToCamelCase(), ".")
-                : NormalizeJsVariableName(parameterInfo.NameOnMethod.ToCamelCase()) + "." + NormalizeJsVariableName(parameterInfo.Name.ToCamelCase(), ".");
+                ? parameterInfoName
+                : NormalizeJsVariableName(parameterInfo.NameOnMethod.ToCamelCase()) + "." + parameterInfoName;
         }
 
         public static string CreateJsObjectLiteral(ParameterApiDescriptionModel[] parameters, int indent = 0)
@@ -133,9 +135,11 @@ namespace Volo.Abp.Http.ProxyScripting.Generators
 
         public static string GetFormPostParamNameInJsFunc(ParameterApiDescriptionModel parameterInfo)
         {
+            var parameterInfoName = string.Join(".", parameterInfo.Name.Split(".").Select(x => NormalizeJsVariableName(x.ToCamelCase())));
+
             return parameterInfo.Name == parameterInfo.NameOnMethod
-                ? NormalizeJsVariableName((parameterInfo.DescriptorName + parameterInfo.Name).ToCamelCase(), ".")
-                : NormalizeJsVariableName(parameterInfo.NameOnMethod.ToCamelCase()) + "." + NormalizeJsVariableName((parameterInfo.DescriptorName + parameterInfo.Name).ToCamelCase(), ".");
+                ? parameterInfoName
+                : NormalizeJsVariableName(parameterInfo.NameOnMethod.ToCamelCase()) + "." + parameterInfoName;
         }
 
         public static string CreateJsFormPostData(ParameterApiDescriptionModel[] parameters, int indent)
@@ -158,10 +162,7 @@ namespace Volo.Abp.Http.ProxyScripting.Generators
 
         public static string GenerateJsFuncParameterList(ActionApiDescriptionModel action, string ajaxParametersName)
         {
-            var paramsIsFromForm = action.Parameters.Any(x => x.BindingSourceId == ParameterBindingSources.Form);
-            var methodParamNames = paramsIsFromForm
-                ? action.Parameters.Select(p => p.DescriptorName + p.Name).Distinct().ToList()
-                : action.ParametersOnMethod.Select(p => p.Name).Distinct().ToList();
+            var methodParamNames = action.ParametersOnMethod.Select(p => p.Name).Distinct().ToList();
             methodParamNames.Add(ajaxParametersName);
             return methodParamNames.Select(prmName => NormalizeJsVariableName(prmName.ToCamelCase())).JoinAsString(", ");
         }


### PR DESCRIPTION
Resolve #6157

```cs
public string GetTest([FromQuery]TestDto input)
{
      return input.Name + " / " + input.Price?.MinLength + "-" + input.Price?.MaxLength ;
}

public string PostTest([FromForm]TestDto input)
{
      return input.Name + " / " + input.Price?.MinLength + "-" + input.Price?.MaxLength ;
}

public class TestDto
{
      public string Name { get; set; }
      public Range<int> Price { get; set; }
}

public class Range<T>
{
      public T Min { get; set; }
      public T Max { get; set; }
}
```

```js
getTest = function(input, ajaxParams) {
  return abp.ajax($.extend(true, {
	url: abp.appPath + 'api/app/book/test' + abp.utils.buildQueryString([{ name: 'name', value: input.name }, { name: 'price.MinLength', value: input.price.minLength }, { name: 'price.MaxLength', value: input.price.maxLength }]) + '',
	type: 'GET'
  }, ajaxParams));
};

postTest = function(input, ajaxParams) {
  return abp.ajax($.extend(true, {
	url: abp.appPath + 'api/app/book/test',
	type: 'POST',
	data: 'input.Name=' + input.name + '&' + 'input.Price.MinLength=' + input.price.minLength + '&' + 'input.Price.MaxLength=' + input.price.maxLength
  }, $.extend(true, {}, ajaxParams, { contentType: 'application/x-www-form-urlencoded; charset=UTF-8' })));
};

```

#### This is a breaking change because we previously generated incorrect Javascript for the `FromForm `method.

Incorrect Javascript :
```js
postTest = function(inputName, inputPriceMinLength, inputPriceMaxLength, ajaxParams) {
  return abp.ajax($.extend(true, {
	url: abp.appPath + 'api/app/book/test',
	type: 'POST',
	data: 'input.Name=' + input.inputName + '&' + 'input.Price.MinLength=' + input.inputPrice.MinLength + '&' + 'input.Price.MaxLength=' + input.inputPrice.MaxLength
  }, $.extend(true, {}, ajaxParams, { contentType: 'application/x-www-form-urlencoded; charset=UTF-8' })));
};
```


