### PR TITLE
Remove BasicRepositoryBase from DI.

### DIFF
--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/AbpDddDomainModule.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/AbpDddDomainModule.cs
@@ -1,4 +1,5 @@
-﻿using Volo.Abp.Auditing;
+﻿using Microsoft.Extensions.DependencyInjection;
+using Volo.Abp.Auditing;
 using Volo.Abp.Data;
 using Volo.Abp.EventBus;
 using Volo.Abp.ExceptionHandling;
@@ -28,6 +29,9 @@ namespace Volo.Abp.Domain
         )]
     public class AbpDddDomainModule : AbpModule
     {
-
+        public override void PreConfigureServices(ServiceConfigurationContext context)
+        {
+            context.Services.AddConventionalRegistrar(new AbpRepositoryConventionalRegistrar());
+        }
     }
 }

--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/AbpRepositoryConventionalRegistrar.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/AbpRepositoryConventionalRegistrar.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.Domain.Repositories;
+
+namespace Volo.Abp.Domain
+{
+    public class AbpRepositoryConventionalRegistrar : DefaultConventionalRegistrar
+    {
+        public override void AddType(IServiceCollection services, Type type)
+        {
+            if (!typeof(IRepository).IsAssignableFrom(type))
+            {
+                return;
+            }
+
+            var dependencyAttribute = GetDependencyAttributeOrNull(type);
+            var lifeTime = GetLifeTimeOrNull(type, dependencyAttribute);
+
+            if (lifeTime != null)
+            {
+                return;
+            }
+
+            var exposedServiceTypes = ExposedServiceExplorer.GetExposedServices(type)
+                .Where(x => x.IsInterface).ToList();;
+
+            TriggerServiceExposing(services, type, exposedServiceTypes);
+
+            foreach (var exposedServiceType in exposedServiceTypes)
+            {
+                var serviceDescriptor = CreateServiceDescriptor(
+                    type,
+                    exposedServiceType,
+                    exposedServiceTypes,
+                    ServiceLifetime.Transient
+                );
+
+                services.TryAdd(serviceDescriptor);
+            }
+        }
+    }
+}

--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/BasicRepositoryBase.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/BasicRepositoryBase.cs
@@ -9,11 +9,10 @@ using Volo.Abp.Uow;
 
 namespace Volo.Abp.Domain.Repositories
 {
-    public abstract class BasicRepositoryBase<TEntity> : 
-        IBasicRepository<TEntity>, 
+    public abstract class BasicRepositoryBase<TEntity> :
+        IBasicRepository<TEntity>,
         IServiceProviderAccessor,
-        IUnitOfWorkEnabled,
-        ITransientDependency
+        IUnitOfWorkEnabled
         where TEntity : class, IEntity
     {
         public IServiceProvider ServiceProvider { get; set; }
@@ -59,7 +58,7 @@ namespace Volo.Abp.Domain.Repositories
         }
 
         public abstract Task<TEntity> FindAsync(TKey id, bool includeDetails = true, CancellationToken cancellationToken = default);
-        
+
         public virtual async Task DeleteAsync(TKey id, bool autoSave = false, CancellationToken cancellationToken = default)
         {
             var entity = await FindAsync(id, cancellationToken: cancellationToken);


### PR DESCRIPTION
Because `BasicRepositoryBase ` no longer implement the the `ITransientDependency `interface, I use `AbpRepositoryConventionalRegistrar `to register a custom `repository `interface.

```cs
public class ClientRepository : EfCoreRepository<IIdentityServerDbContext, Client, Guid>, IClientRepository
```