### PR TITLE
Bulk Operations

### DIFF
--- a/common.DotSettings
+++ b/common.DotSettings
@@ -29,6 +29,7 @@
 	<s:String x:Key="/Default/Environment/InlayHints/CSharpTypeNameHintsOptions/ShowTypeNameHintsForLambdaExpressionParameters/@EntryValue">Never</s:String>
 	<s:String x:Key="/Default/Environment/InlayHints/CSharpTypeNameHintsOptions/ShowTypeNameHintsForLinqQueryRangeVariables/@EntryValue">Never</s:String>
 	<s:String x:Key="/Default/Environment/InlayHints/CSharpTypeNameHintsOptions/ShowTypeNameHintsForPatternMatchingExpressions/@EntryValue">Never</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002ECpp_002EDaemon_002EInlayHints_002ETypeNameHints_002ECppTypeNameHintsOptionsMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002ECpp_002EDaemon_002ETypeNameHints_002ECppTypeNameHintsOptionsMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002ECSharp_002ETypeNameHints_002ECSharpTypeNameHintsOptionsMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/TypeNameHintsOptions/HideTypeNameHintsWhenTypeNameIsEvidentFromVariableName/@EntryValue">False</s:Boolean>

--- a/docs/en/Entity-Framework-Core.md
+++ b/docs/en/Entity-Framework-Core.md
@@ -735,6 +735,47 @@ Configure<AbpDbContextOptions>(options =>
 });
 ````
 
+### Customize Bulk Operations
+
+If you have better logic or using an external library for bulk operations, you can override the logic via implementing`IEfCoreBulkOperationProvider`.
+
+- You may use example template below:
+
+```csharp
+public class MyCustomEfCoreBulkOperationProvider : IEfCoreBulkOperationProvider, ITransientDependency
+{
+    public async Task DeleteManyAsync<TDbContext, TEntity>(IEfCoreRepository<TEntity> repository,
+                                                            IEnumerable<TEntity> entities,
+                                                            bool autoSave,
+                                                            CancellationToken cancellationToken)
+        where TDbContext : IEfCoreDbContext
+        where TEntity : class, IEntity
+    {
+        // Your logic here.
+    }
+
+    public async Task InsertManyAsync<TDbContext, TEntity>(IEfCoreRepository<TEntity> repository,
+                                                            IEnumerable<TEntity> entities,
+                                                            bool autoSave,
+                                                            CancellationToken cancellationToken)
+        where TDbContext : IEfCoreDbContext
+        where TEntity : class, IEntity
+    {
+        // Your logic here.
+    }
+
+    public async Task UpdateManyAsync<TDbContext, TEntity>(IEfCoreRepository<TEntity> repository,
+                                                            IEnumerable<TEntity> entities,
+                                                            bool autoSave,
+                                                            CancellationToken cancellationToken)
+        where TDbContext : IEfCoreDbContext
+        where TEntity : class, IEntity
+    {
+        // Your logic here.
+    }
+}
+```
+
 ## See Also
 
 * [Entities](Entities.md)

--- a/docs/en/MongoDB.md
+++ b/docs/en/MongoDB.md
@@ -394,6 +394,7 @@ public class MyCustomMongoDbBulkOperationProvider : IMongoDbBulkOperationProvide
 {
     public async Task DeleteManyAsync<TEntity>(IMongoDbRepository<TEntity> repository,
                                                 IEnumerable<TEntity> entities,
+                                                IClientSessionHandle sessionHandle,
                                                 bool autoSave,
                                                 CancellationToken cancellationToken)
         where TEntity : class, IEntity
@@ -403,6 +404,7 @@ public class MyCustomMongoDbBulkOperationProvider : IMongoDbBulkOperationProvide
 
     public async Task InsertManyAsync<TEntity>(IMongoDbRepository<TEntity> repository,
                                                 IEnumerable<TEntity> entities,
+                                                IClientSessionHandle sessionHandle,
                                                 bool autoSave,
                                                 CancellationToken cancellationToken)
         where TEntity : class, IEntity
@@ -411,9 +413,10 @@ public class MyCustomMongoDbBulkOperationProvider : IMongoDbBulkOperationProvide
     }
 
     public async Task UpdateManyAsync<TEntity>(IMongoDbRepository<TEntity> repository,
-                                            IEnumerable<TEntity> entities,
-                                            bool autoSave,
-                                            CancellationToken cancellationToken)
+                                                IEnumerable<TEntity> entities,
+                                                IClientSessionHandle sessionHandle,
+                                                bool autoSave,
+                                                CancellationToken cancellationToken)
         where TEntity : class, IEntity
     {
         // Your logic here.

--- a/docs/en/MongoDB.md
+++ b/docs/en/MongoDB.md
@@ -382,3 +382,42 @@ context.Services.AddMongoDbContext<OtherMongoDbContext>(options =>
 ```
 
 In this example, `OtherMongoDbContext` implements `IBookStoreMongoDbContext`. This feature allows you to have multiple MongoDbContext (one per module) on development, but single MongoDbContext (implements all interfaces of all MongoDbContexts) on runtime.
+
+### Customize Bulk Operations
+
+
+If you have better logic or using an external library for bulk operations, you can override the logic via implementing `IMongoDbBulkOperationProvider`.
+
+- You may use example template below:
+
+```csharp
+public class MyCustomMongoDbBulkOperationProvider : IMongoDbBulkOperationProvider, ITransientDependency
+{
+    public async Task DeleteManyAsync<TEntity>(IMongoDbRepository<TEntity> repository,
+                                                IEnumerable<TEntity> entities,
+                                                bool autoSave,
+                                                CancellationToken cancellationToken)
+        where TEntity : class, IEntity
+    {
+        // Your logic here.
+    }
+
+    public async Task InsertManyAsync<TEntity>(IMongoDbRepository<TEntity> repository,
+                                                IEnumerable<TEntity> entities,
+                                                bool autoSave,
+                                                CancellationToken cancellationToken)
+        where TEntity : class, IEntity
+    {
+        // Your logic here.
+    }
+
+    public async Task UpdateManyAsync<TEntity>(IMongoDbRepository<TEntity> repository,
+                                            IEnumerable<TEntity> entities,
+                                            bool autoSave,
+                                            CancellationToken cancellationToken)
+        where TEntity : class, IEntity
+    {
+        // Your logic here.
+    }
+}
+```

--- a/docs/en/MongoDB.md
+++ b/docs/en/MongoDB.md
@@ -385,7 +385,6 @@ In this example, `OtherMongoDbContext` implements `IBookStoreMongoDbContext`. Th
 
 ### Customize Bulk Operations
 
-
 If you have better logic or using an external library for bulk operations, you can override the logic via implementing `IMongoDbBulkOperationProvider`.
 
 - You may use example template below:

--- a/docs/en/Repositories.md
+++ b/docs/en/Repositories.md
@@ -166,7 +166,7 @@ public class MyCustomEfCoreBulkOperationProvider : IEfCoreBulkOperationProvider,
 }
 ```
 
-
+> **WARNING:** ConcurrencyStamp can't be checked at bulk operations!
 
 
 ## Custom Repositories

--- a/docs/en/Repositories.md
+++ b/docs/en/Repositories.md
@@ -88,86 +88,9 @@ If your entity is a soft-delete entity, you can use the `HardDeleteAsync` method
 See the [Data Filtering](Data-Filtering.md) documentation for more about soft-delete.
 
 ## Bulk Operations
-You can execute bulk operations with `InsertMany`, `UpdateMany`, `DeleteMany` methods.
-
-Both providers `MongoDb` and `Ef Core` support bulk operations.
-
-### Customization
-
-If you have better logic or using an external library for bulk operations, you can override the logic via implementing `IMongoDbBulkOperationProvider` for MongoDb and `IEfCoreBulkOperationProvider` for Ef Core.
-
-- MongoDb Customization:
-
-```csharp
-public class MyCustomMongoDbBulkOperationProvider : IMongoDbBulkOperationProvider, ITransientDependency
-{
-    public async Task DeleteManyAsync<TEntity>(IMongoDbRepository<TEntity> repository,
-                                                IEnumerable<TEntity> entities,
-                                                bool autoSave,
-                                                CancellationToken cancellationToken)
-        where TEntity : class, IEntity
-    {
-        // Your logic here.
-    }
-
-    public async Task InsertManyAsync<TEntity>(IMongoDbRepository<TEntity> repository,
-                                                IEnumerable<TEntity> entities,
-                                                bool autoSave,
-                                                CancellationToken cancellationToken)
-        where TEntity : class, IEntity
-    {
-        // Your logic here.
-    }
-
-    public async Task UpdateManyAsync<TEntity>(IMongoDbRepository<TEntity> repository,
-                                            IEnumerable<TEntity> entities,
-                                            bool autoSave,
-                                            CancellationToken cancellationToken)
-        where TEntity : class, IEntity
-    {
-        // Your logic here.
-    }
-}
-```
-
-- Entitiy Framework Core Customization
-```csharp
-public class MyCustomEfCoreBulkOperationProvider : IEfCoreBulkOperationProvider, ITransientDependency
-{
-    public async Task DeleteManyAsync<TDbContext, TEntity>(IEfCoreRepository<TEntity> repository,
-                                                            IEnumerable<TEntity> entities,
-                                                            bool autoSave,
-                                                            CancellationToken cancellationToken)
-        where TDbContext : IEfCoreDbContext
-        where TEntity : class, IEntity
-    {
-        // Your logic here.
-    }
-
-    public async Task InsertManyAsync<TDbContext, TEntity>(IEfCoreRepository<TEntity> repository,
-                                                            IEnumerable<TEntity> entities,
-                                                            bool autoSave,
-                                                            CancellationToken cancellationToken)
-        where TDbContext : IEfCoreDbContext
-        where TEntity : class, IEntity
-    {
-        // Your logic here.
-    }
-
-    public async Task UpdateManyAsync<TDbContext, TEntity>(IEfCoreRepository<TEntity> repository,
-                                                            IEnumerable<TEntity> entities,
-                                                            bool autoSave,
-                                                            CancellationToken cancellationToken)
-        where TDbContext : IEfCoreDbContext
-        where TEntity : class, IEntity
-    {
-        // Your logic here.
-    }
-}
-```
+You can execute bulk operations with `InsertManyAsync`, `UpdateManyAsync`, `DeleteManyAsync` methods.
 
 > **WARNING:** ConcurrencyStamp can't be checked at bulk operations!
-
 
 ## Custom Repositories
 

--- a/docs/en/Repositories.md
+++ b/docs/en/Repositories.md
@@ -87,6 +87,88 @@ If your entity is a soft-delete entity, you can use the `HardDeleteAsync` method
 
 See the [Data Filtering](Data-Filtering.md) documentation for more about soft-delete.
 
+## Bulk Operations
+You can execute bulk operations with `InsertMany`, `UpdateMany`, `DeleteMany` methods.
+
+Both providers `MongoDb` and `Ef Core` support bulk operations.
+
+### Customization
+
+If you have better logic or using an external library for bulk operations, you can override the logic via implementing `IMongoDbBulkOperationProvider` for MongoDb and `IEfCoreBulkOperationProvider` for Ef Core.
+
+- MongoDb Customization:
+
+```csharp
+public class MyCustomMongoDbBulkOperationProvider : IMongoDbBulkOperationProvider, ITransientDependency
+{
+    public async Task DeleteManyAsync<TEntity>(IMongoDbRepository<TEntity> repository,
+                                                IEnumerable<TEntity> entities,
+                                                bool autoSave,
+                                                CancellationToken cancellationToken)
+        where TEntity : class, IEntity
+    {
+        // Your logic here.
+    }
+
+    public async Task InsertManyAsync<TEntity>(IMongoDbRepository<TEntity> repository,
+                                                IEnumerable<TEntity> entities,
+                                                bool autoSave,
+                                                CancellationToken cancellationToken)
+        where TEntity : class, IEntity
+    {
+        // Your logic here.
+    }
+
+    public async Task UpdateManyAsync<TEntity>(IMongoDbRepository<TEntity> repository,
+                                            IEnumerable<TEntity> entities,
+                                            bool autoSave,
+                                            CancellationToken cancellationToken)
+        where TEntity : class, IEntity
+    {
+        // Your logic here.
+    }
+}
+```
+
+- Entitiy Framework Core Customization
+```csharp
+public class MyCustomEfCoreBulkOperationProvider : IEfCoreBulkOperationProvider, ITransientDependency
+{
+    public async Task DeleteManyAsync<TDbContext, TEntity>(IEfCoreRepository<TEntity> repository,
+                                                            IEnumerable<TEntity> entities,
+                                                            bool autoSave,
+                                                            CancellationToken cancellationToken)
+        where TDbContext : IEfCoreDbContext
+        where TEntity : class, IEntity
+    {
+        // Your logic here.
+    }
+
+    public async Task InsertManyAsync<TDbContext, TEntity>(IEfCoreRepository<TEntity> repository,
+                                                            IEnumerable<TEntity> entities,
+                                                            bool autoSave,
+                                                            CancellationToken cancellationToken)
+        where TDbContext : IEfCoreDbContext
+        where TEntity : class, IEntity
+    {
+        // Your logic here.
+    }
+
+    public async Task UpdateManyAsync<TDbContext, TEntity>(IEfCoreRepository<TEntity> repository,
+                                                            IEnumerable<TEntity> entities,
+                                                            bool autoSave,
+                                                            CancellationToken cancellationToken)
+        where TDbContext : IEfCoreDbContext
+        where TEntity : class, IEntity
+    {
+        // Your logic here.
+    }
+}
+```
+
+
+
+
 ## Custom Repositories
 
 Default generic repositories will be sufficient for most cases. However, you may need to create a custom repository class for your entity.

--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/BasicRepositoryBase.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/BasicRepositoryBase.cs
@@ -55,7 +55,7 @@ namespace Volo.Abp.Domain.Repositories
         {
             if (UnitOfWorkManager?.Current != null)
             {
-                return UnitOfWorkManager?.Current.SaveChangesAsync(cancellationToken);
+                return UnitOfWorkManager.Current.SaveChangesAsync(cancellationToken);
             }
 
             return Task.CompletedTask;
@@ -63,7 +63,33 @@ namespace Volo.Abp.Domain.Repositories
 
         public abstract Task<TEntity> UpdateAsync(TEntity entity, bool autoSave = false, CancellationToken cancellationToken = default);
 
+        public virtual async Task UpdateManyAsync(IEnumerable<TEntity> entities, bool autoSave = false, CancellationToken cancellationToken = default)
+        {
+            foreach (var entity in entities)
+            {
+                await UpdateAsync(entity, cancellationToken: cancellationToken);
+            }
+
+            if (autoSave)
+            {
+                await SaveChangesAsync(cancellationToken);
+            }
+        }
+
         public abstract Task DeleteAsync(TEntity entity, bool autoSave = false, CancellationToken cancellationToken = default);
+
+        public virtual async Task DeleteManyAsync(IEnumerable<TEntity> entities, bool autoSave = false, CancellationToken cancellationToken = default)
+        {
+            foreach (var entity in entities)
+            {
+                await DeleteAsync(entity, cancellationToken: cancellationToken);
+            }
+
+            if (autoSave)
+            {
+                await SaveChangesAsync(cancellationToken);
+            }
+        }
 
         public abstract Task<List<TEntity>> GetListAsync(bool includeDetails = false, CancellationToken cancellationToken = default);
 

--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/BasicRepositoryBase.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/BasicRepositoryBase.cs
@@ -2,21 +2,32 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Volo.Abp.Data;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Domain.Entities;
+using Volo.Abp.Linq;
+using Volo.Abp.MultiTenancy;
 using Volo.Abp.Threading;
 using Volo.Abp.Uow;
 
 namespace Volo.Abp.Domain.Repositories
 {
-    public abstract class BasicRepositoryBase<TEntity> : 
-        IBasicRepository<TEntity>, 
+    public abstract class BasicRepositoryBase<TEntity> :
+        IBasicRepository<TEntity>,
         IServiceProviderAccessor,
         IUnitOfWorkEnabled,
         ITransientDependency
         where TEntity : class, IEntity
     {
         public IServiceProvider ServiceProvider { get; set; }
+
+        public IDataFilter DataFilter { get; set; }
+
+        public ICurrentTenant CurrentTenant { get; set; }
+
+        public IAsyncQueryableExecuter AsyncExecuter { get; set; }
+
+        public IUnitOfWorkManager UnitOfWorkManager { get; set; }
 
         public ICancellationTokenProvider CancellationTokenProvider { get; set; }
 
@@ -26,6 +37,29 @@ namespace Volo.Abp.Domain.Repositories
         }
 
         public abstract Task<TEntity> InsertAsync(TEntity entity, bool autoSave = false, CancellationToken cancellationToken = default);
+
+        public virtual async Task InsertManyAsync(IEnumerable<TEntity> entities, bool autoSave = false, CancellationToken cancellationToken = default)
+        {
+            foreach (var entity in entities)
+            {
+                await InsertAsync(entity, cancellationToken: cancellationToken);
+            }
+
+            if (autoSave)
+            {
+                await SaveChangesAsync(cancellationToken);
+            }
+        }
+
+        protected virtual Task SaveChangesAsync(CancellationToken cancellationToken)
+        {
+            if (UnitOfWorkManager?.Current != null)
+            {
+                return UnitOfWorkManager?.Current.SaveChangesAsync(cancellationToken);
+            }
+
+            return Task.CompletedTask;
+        }
 
         public abstract Task<TEntity> UpdateAsync(TEntity entity, bool autoSave = false, CancellationToken cancellationToken = default);
 
@@ -59,7 +93,7 @@ namespace Volo.Abp.Domain.Repositories
         }
 
         public abstract Task<TEntity> FindAsync(TKey id, bool includeDetails = true, CancellationToken cancellationToken = default);
-        
+
         public virtual async Task DeleteAsync(TKey id, bool autoSave = false, CancellationToken cancellationToken = default)
         {
             var entity = await FindAsync(id, cancellationToken: cancellationToken);

--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/BasicRepositoryBase.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/BasicRepositoryBase.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using JetBrains.Annotations;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -129,6 +130,19 @@ namespace Volo.Abp.Domain.Repositories
             }
 
             await DeleteAsync(entity, autoSave, cancellationToken);
+        }
+
+        public async Task DeleteManyAsync([NotNull] IEnumerable<TKey> ids, bool autoSave = false, CancellationToken cancellationToken = default)
+        {
+            foreach (var id in ids)
+            {
+                await DeleteAsync(id, cancellationToken: cancellationToken);
+            }
+
+            if (autoSave)
+            {
+                await SaveChangesAsync(cancellationToken);
+            }
         }
     }
 }

--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/IBasicRepository.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/IBasicRepository.cs
@@ -21,6 +21,16 @@ namespace Volo.Abp.Domain.Repositories
         [NotNull]
         Task<TEntity> InsertAsync([NotNull] TEntity entity, bool autoSave = false, CancellationToken cancellationToken = default);
 
+        /// <summary>
+        /// Inserts multiple new entities.
+        /// </summary>
+        /// <param name="autoSave">
+        /// Set true to automatically save changes to database.
+        /// This is useful for ORMs / database APIs those only save changes with an explicit method call, but you need to immediately save changes to the database.
+        /// </param>
+        /// <param name="cancellationToken">A <see cref="T:System.Threading.CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <param name="entities">Entities to be inserted.</param>
+        /// <returns>Awaitable <see cref="Task"/>.</returns>
         Task InsertManyAsync([NotNull] IEnumerable<TEntity> entities, bool autoSave = false, CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -36,6 +46,17 @@ namespace Volo.Abp.Domain.Repositories
         Task<TEntity> UpdateAsync([NotNull] TEntity entity, bool autoSave = false, CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Updates multiple entities.
+        /// </summary>
+        /// <param name="entities">Entities to be updated.</param>
+        /// <param name="autoSave">
+        /// Set true to automatically save changes to database.
+        /// This is useful for ORMs / database APIs those only save changes with an explicit method call, but you need to immediately save changes to the database.</param>
+        /// <param name="cancellationToken">A <see cref="T:System.Threading.CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>Awaitable <see cref="Task"/>.</returns>
+
+        Task UpdateManyAsync(IEnumerable<TEntity> entities, bool autoSave = false, CancellationToken cancellationToken = default);
+        /// <summary>
         /// Deletes an entity.
         /// </summary>
         /// <param name="entity">Entity to be deleted</param>
@@ -45,6 +66,18 @@ namespace Volo.Abp.Domain.Repositories
         /// </param>
         /// <param name="cancellationToken">A <see cref="T:System.Threading.CancellationToken" /> to observe while waiting for the task to complete.</param>
         Task DeleteAsync([NotNull] TEntity entity, bool autoSave = false, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Deletes multiple entities.
+        /// </summary>
+        /// <param name="entities">Entities to be deleted.</param>
+        /// <param name="autoSave">
+        /// Set true to automatically save changes to database.
+        /// This is useful for ORMs / database APIs those only save changes with an explicit method call, but you need to immediately save changes to the database.
+        /// </param>
+        /// <param name="cancellationToken">A <see cref="T:System.Threading.CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>Awaitable <see cref="Task"/>.</returns>
+        Task DeleteManyAsync([NotNull] IEnumerable<TEntity> entities, bool autoSave = false, CancellationToken cancellationToken = default);
     }
 
     public interface IBasicRepository<TEntity, TKey> : IBasicRepository<TEntity>, IReadOnlyBasicRepository<TEntity, TKey>

--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/IBasicRepository.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/IBasicRepository.cs
@@ -55,7 +55,7 @@ namespace Volo.Abp.Domain.Repositories
         /// <param name="cancellationToken">A <see cref="T:System.Threading.CancellationToken" /> to observe while waiting for the task to complete.</param>
         /// <returns>Awaitable <see cref="Task"/>.</returns>
 
-        Task UpdateManyAsync(IEnumerable<TEntity> entities, bool autoSave = false, CancellationToken cancellationToken = default);
+        Task UpdateManyAsync([NotNull] IEnumerable<TEntity> entities, bool autoSave = false, CancellationToken cancellationToken = default);
         /// <summary>
         /// Deletes an entity.
         /// </summary>
@@ -93,5 +93,17 @@ namespace Volo.Abp.Domain.Repositories
         /// </param>
         /// <param name="cancellationToken">A <see cref="T:System.Threading.CancellationToken" /> to observe while waiting for the task to complete.</param>
         Task DeleteAsync(TKey id, bool autoSave = false, CancellationToken cancellationToken = default);  //TODO: Return true if deleted
+
+        /// <summary>
+        /// Deletes multiple entities by primary keys.
+        /// </summary>
+        /// <param name="ids">Primary keys of the each entity.</param>
+        /// <param name="autoSave">
+        /// Set true to automatically save changes to database.
+        /// This is useful for ORMs / database APIs those only save changes with an explicit method call, but you need to immediately save changes to the database.
+        /// </param>
+        /// <param name="cancellationToken">A <see cref="T:System.Threading.CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>Awaitable <see cref="Task"/>.</returns>
+        Task DeleteManyAsync([NotNull] IEnumerable<TKey> ids, bool autoSave = false, CancellationToken cancellationToken = default);
     }
 }

--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/IBasicRepository.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/IBasicRepository.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Volo.Abp.Domain.Entities;
@@ -20,8 +21,10 @@ namespace Volo.Abp.Domain.Repositories
         [NotNull]
         Task<TEntity> InsertAsync([NotNull] TEntity entity, bool autoSave = false, CancellationToken cancellationToken = default);
 
+        Task InsertManyAsync([NotNull] IEnumerable<TEntity> entities, bool autoSave = false, CancellationToken cancellationToken = default);
+
         /// <summary>
-        /// Updates an existing entity. 
+        /// Updates an existing entity.
         /// </summary>
         /// <param name="autoSave">
         /// Set true to automatically save changes to database.

--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/IBasicRepository.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/IBasicRepository.cs
@@ -54,8 +54,8 @@ namespace Volo.Abp.Domain.Repositories
         /// This is useful for ORMs / database APIs those only save changes with an explicit method call, but you need to immediately save changes to the database.</param>
         /// <param name="cancellationToken">A <see cref="T:System.Threading.CancellationToken" /> to observe while waiting for the task to complete.</param>
         /// <returns>Awaitable <see cref="Task"/>.</returns>
-
         Task UpdateManyAsync([NotNull] IEnumerable<TEntity> entities, bool autoSave = false, CancellationToken cancellationToken = default);
+
         /// <summary>
         /// Deletes an entity.
         /// </summary>

--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/RepositoryBase.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/RepositoryBase.cs
@@ -16,14 +16,6 @@ namespace Volo.Abp.Domain.Repositories
     public abstract class RepositoryBase<TEntity> : BasicRepositoryBase<TEntity>, IRepository<TEntity>, IUnitOfWorkManagerAccessor
         where TEntity : class, IEntity
     {
-        public IDataFilter DataFilter { get; set; }
-
-        public ICurrentTenant CurrentTenant { get; set; }
-
-        public IAsyncQueryableExecuter AsyncExecuter { get; set; }
-
-        public IUnitOfWorkManager UnitOfWorkManager { get; set; }
-
         public virtual Type ElementType => GetQueryable().ElementType;
 
         public virtual Expression Expression => GetQueryable().Expression;

--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/RepositoryBase.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/RepositoryBase.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using JetBrains.Annotations;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -100,6 +101,21 @@ namespace Volo.Abp.Domain.Repositories
             }
 
             await DeleteAsync(entity, autoSave, cancellationToken);
+        }
+
+
+
+        public async Task DeleteManyAsync([NotNull] IEnumerable<TKey> ids, bool autoSave = false, CancellationToken cancellationToken = default)
+        {
+            foreach (var id in ids)
+            {
+                await DeleteAsync(id, cancellationToken: cancellationToken);
+            }
+
+            if (autoSave)
+            {
+                await SaveChangesAsync(cancellationToken);
+            }
         }
     }
 }

--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/Domain/Repositories/EntityFrameworkCore/EfCoreRepository.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/Domain/Repositories/EntityFrameworkCore/EfCoreRepository.cs
@@ -344,17 +344,11 @@ namespace Volo.Abp.Domain.Repositories.EntityFrameworkCore
             await DeleteAsync(entity, autoSave, cancellationToken);
         }
 
-        public async Task DeleteManyAsync([NotNull] IEnumerable<TKey> ids, bool autoSave = false, CancellationToken cancellationToken = default)
+        public async virtual Task DeleteManyAsync([NotNull] IEnumerable<TKey> ids, bool autoSave = false, CancellationToken cancellationToken = default)
         {
-            foreach (var id in ids)
-            {
-                await DeleteAsync(id, cancellationToken: cancellationToken);
-            }
+            var entities = await DbSet.Where(x => ids.Contains(x.Id)).ToListAsync();
 
-            if (autoSave)
-            {
-                await SaveChangesAsync(cancellationToken);
-            }
+            await DeleteManyAsync(entities, autoSave, cancellationToken);
         }
     }
 }

--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/Domain/Repositories/EntityFrameworkCore/IEfCoreBulkOperationProvider.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/Domain/Repositories/EntityFrameworkCore/IEfCoreBulkOperationProvider.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Volo.Abp.Domain.Entities;
+using Volo.Abp.EntityFrameworkCore;
+
+namespace Volo.Abp.Domain.Repositories.EntityFrameworkCore
+{
+    public interface IEfCoreBulkOperationProvider
+    {
+        Task InsertManyAsync<TDbContext, TEntity>(
+            IEfCoreRepository<TEntity> repository,
+            IEnumerable<TEntity> entities,
+            bool autoSave,
+            CancellationToken cancellationToken
+        )
+            where TDbContext : IEfCoreDbContext
+            where TEntity : class, IEntity;
+    }
+}

--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/Domain/Repositories/EntityFrameworkCore/IEfCoreBulkOperationProvider.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/Domain/Repositories/EntityFrameworkCore/IEfCoreBulkOperationProvider.cs
@@ -16,5 +16,25 @@ namespace Volo.Abp.Domain.Repositories.EntityFrameworkCore
         )
             where TDbContext : IEfCoreDbContext
             where TEntity : class, IEntity;
+
+
+        Task UpdateManyAsync<TDbContext, TEntity>(
+            IEfCoreRepository<TEntity> repository,
+            IEnumerable<TEntity> entities,
+            bool autoSave,
+            CancellationToken cancellationToken
+        )
+            where TDbContext : IEfCoreDbContext
+            where TEntity : class, IEntity;
+
+
+        Task DeleteManyAsync<TDbContext, TEntity>(
+            IEfCoreRepository<TEntity> repository,
+            IEnumerable<TEntity> entities,
+            bool autoSave,
+            CancellationToken cancellationToken
+        )
+            where TDbContext : IEfCoreDbContext
+            where TEntity : class, IEntity;
     }
 }

--- a/framework/src/Volo.Abp.MemoryDb/Volo/Abp/Domain/Repositories/MemoryDb/MemoryDbRepository.cs
+++ b/framework/src/Volo.Abp.MemoryDb/Volo/Abp/Domain/Repositories/MemoryDb/MemoryDbRepository.cs
@@ -1,3 +1,4 @@
+using JetBrains.Annotations;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -308,6 +309,19 @@ namespace Volo.Abp.Domain.Repositories.MemoryDb
         public virtual async Task DeleteAsync(TKey id, bool autoSave = false, CancellationToken cancellationToken = default)
         {
             await DeleteAsync(x => x.Id.Equals(id), autoSave, cancellationToken);
+        }
+
+        public virtual async Task DeleteManyAsync([NotNull] IEnumerable<TKey> ids, bool autoSave = false, CancellationToken cancellationToken = default)
+        {
+            foreach (var id in ids)
+            {
+                await DeleteAsync(id, cancellationToken: cancellationToken);
+            }
+
+            if (autoSave)
+            {
+                await SaveChangesAsync(cancellationToken);
+            }
         }
     }
 }

--- a/framework/src/Volo.Abp.MemoryDb/Volo/Abp/Domain/Repositories/MemoryDb/MemoryDbRepository.cs
+++ b/framework/src/Volo.Abp.MemoryDb/Volo/Abp/Domain/Repositories/MemoryDb/MemoryDbRepository.cs
@@ -313,15 +313,8 @@ namespace Volo.Abp.Domain.Repositories.MemoryDb
 
         public virtual async Task DeleteManyAsync([NotNull] IEnumerable<TKey> ids, bool autoSave = false, CancellationToken cancellationToken = default)
         {
-            foreach (var id in ids)
-            {
-                await DeleteAsync(id, cancellationToken: cancellationToken);
-            }
-
-            if (autoSave)
-            {
-                await SaveChangesAsync(cancellationToken);
-            }
+            var entities = await AsyncExecuter.ToListAsync(GetQueryable().Where(x => ids.Contains(x.Id)));
+            DeleteManyAsync(entities, autoSave, cancellationToken);
         }
     }
 }

--- a/framework/src/Volo.Abp.MongoDB/Volo/Abp/Domain/Repositories/MongoDB/IMongoDbBulkOperationProvider.cs
+++ b/framework/src/Volo.Abp.MongoDB/Volo/Abp/Domain/Repositories/MongoDB/IMongoDbBulkOperationProvider.cs
@@ -16,7 +16,6 @@ namespace Volo.Abp.MongoDB.Volo.Abp.Domain.Repositories.MongoDB
        )
            where TEntity : class, IEntity;
 
-
         Task UpdateManyAsync<TEntity>(
             IMongoDbRepository<TEntity> repository,
             IEnumerable<TEntity> entities,
@@ -24,7 +23,6 @@ namespace Volo.Abp.MongoDB.Volo.Abp.Domain.Repositories.MongoDB
             CancellationToken cancellationToken
         )
             where TEntity : class, IEntity;
-
 
         Task DeleteManyAsync<TEntity>(
             IMongoDbRepository<TEntity> repository,

--- a/framework/src/Volo.Abp.MongoDB/Volo/Abp/Domain/Repositories/MongoDB/IMongoDbBulkOperationProvider.cs
+++ b/framework/src/Volo.Abp.MongoDB/Volo/Abp/Domain/Repositories/MongoDB/IMongoDbBulkOperationProvider.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Volo.Abp.Domain.Entities;
+using Volo.Abp.Domain.Repositories.MongoDB;
+
+namespace Volo.Abp.MongoDB.Volo.Abp.Domain.Repositories.MongoDB
+{
+    public interface IMongoDbBulkOperationProvider
+    {
+        Task InsertManyAsync<TEntity>(
+           IMongoDbRepository<TEntity> repository,
+           IEnumerable<TEntity> entities,
+           bool autoSave,
+           CancellationToken cancellationToken
+       )
+           where TEntity : class, IEntity;
+
+
+        Task UpdateManyAsync<TDbContext, TEntity>(
+            IMongoDbRepository<TEntity> repository,
+            IEnumerable<TEntity> entities,
+            bool autoSave,
+            CancellationToken cancellationToken
+        )
+            where TEntity : class, IEntity;
+
+
+        Task DeleteManyAsync<TDbContext, TEntity>(
+            IMongoDbRepository<TEntity> repository,
+            IEnumerable<TEntity> entities,
+            bool autoSave,
+            CancellationToken cancellationToken
+        )
+            where TEntity : class, IEntity;
+    }
+}

--- a/framework/src/Volo.Abp.MongoDB/Volo/Abp/Domain/Repositories/MongoDB/IMongoDbBulkOperationProvider.cs
+++ b/framework/src/Volo.Abp.MongoDB/Volo/Abp/Domain/Repositories/MongoDB/IMongoDbBulkOperationProvider.cs
@@ -17,7 +17,7 @@ namespace Volo.Abp.MongoDB.Volo.Abp.Domain.Repositories.MongoDB
            where TEntity : class, IEntity;
 
 
-        Task UpdateManyAsync<TDbContext, TEntity>(
+        Task UpdateManyAsync<TEntity>(
             IMongoDbRepository<TEntity> repository,
             IEnumerable<TEntity> entities,
             bool autoSave,
@@ -26,7 +26,7 @@ namespace Volo.Abp.MongoDB.Volo.Abp.Domain.Repositories.MongoDB
             where TEntity : class, IEntity;
 
 
-        Task DeleteManyAsync<TDbContext, TEntity>(
+        Task DeleteManyAsync<TEntity>(
             IMongoDbRepository<TEntity> repository,
             IEnumerable<TEntity> entities,
             bool autoSave,

--- a/framework/src/Volo.Abp.MongoDB/Volo/Abp/Domain/Repositories/MongoDB/IMongoDbBulkOperationProvider.cs
+++ b/framework/src/Volo.Abp.MongoDB/Volo/Abp/Domain/Repositories/MongoDB/IMongoDbBulkOperationProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using MongoDB.Driver;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Volo.Abp.Domain.Entities;
@@ -11,6 +12,7 @@ namespace Volo.Abp.MongoDB.Volo.Abp.Domain.Repositories.MongoDB
         Task InsertManyAsync<TEntity>(
            IMongoDbRepository<TEntity> repository,
            IEnumerable<TEntity> entities,
+            IClientSessionHandle sessionHandle,
            bool autoSave,
            CancellationToken cancellationToken
        )
@@ -19,6 +21,7 @@ namespace Volo.Abp.MongoDB.Volo.Abp.Domain.Repositories.MongoDB
         Task UpdateManyAsync<TEntity>(
             IMongoDbRepository<TEntity> repository,
             IEnumerable<TEntity> entities,
+            IClientSessionHandle sessionHandle,
             bool autoSave,
             CancellationToken cancellationToken
         )
@@ -27,6 +30,7 @@ namespace Volo.Abp.MongoDB.Volo.Abp.Domain.Repositories.MongoDB
         Task DeleteManyAsync<TEntity>(
             IMongoDbRepository<TEntity> repository,
             IEnumerable<TEntity> entities,
+            IClientSessionHandle sessionHandle,
             bool autoSave,
             CancellationToken cancellationToken
         )

--- a/framework/src/Volo.Abp.MongoDB/Volo/Abp/Domain/Repositories/MongoDB/IMongoDbRepositoryFilterer.cs
+++ b/framework/src/Volo.Abp.MongoDB/Volo/Abp/Domain/Repositories/MongoDB/IMongoDbRepositoryFilterer.cs
@@ -16,7 +16,7 @@ namespace Volo.Abp.Domain.Repositories.MongoDB
         FilterDefinition<TEntity> CreateEntityFilter(TEntity entity, bool withConcurrencyStamp = false, string concurrencyStamp = null);
 
         /// <summary>
-        /// Creates 'In' filter for mongoDb.
+        /// Creates filter for given entities.
         /// </summary>
         /// <remarks>
         /// Visit https://docs.mongodb.com/manual/reference/operator/query/in/ to get more information about 'in' operator.
@@ -27,7 +27,7 @@ namespace Volo.Abp.Domain.Repositories.MongoDB
         FilterDefinition<TEntity> CreateEntitiesFilter(IEnumerable<TEntity> entities, bool applyFilters = false);
 
         /// <summary>
-        /// Creates 'In' filter for mongoDb.
+        /// Creates filter for given ids.
         /// </summary>
         /// <remarks>
         /// Visit https://docs.mongodb.com/manual/reference/operator/query/in/ to get more information about 'in' operator.

--- a/framework/src/Volo.Abp.MongoDB/Volo/Abp/Domain/Repositories/MongoDB/IMongoDbRepositoryFilterer.cs
+++ b/framework/src/Volo.Abp.MongoDB/Volo/Abp/Domain/Repositories/MongoDB/IMongoDbRepositoryFilterer.cs
@@ -14,5 +14,26 @@ namespace Volo.Abp.Domain.Repositories.MongoDB
         FilterDefinition<TEntity> CreateEntityFilter(TKey id, bool applyFilters = false);
 
         FilterDefinition<TEntity> CreateEntityFilter(TEntity entity, bool withConcurrencyStamp = false, string concurrencyStamp = null);
+
+        /// <summary>
+        /// Creates 'In' filter for mongoDb.
+        /// </summary>
+        /// <remarks>
+        /// Visit https://docs.mongodb.com/manual/reference/operator/query/in/ to get more information about 'in' operator.
+        /// </remarks>
+        /// <param name="entities">Entities to be filtered.</param>
+        /// <param name="applyFilters">Set true to use GlobalFilters. Default is false.</param>
+        /// <returns>Created <see cref="FilterDefinition{TDocument}"/>.</returns>
+        FilterDefinition<TEntity> CreateEntitiesFilter(IEnumerable<TEntity> entities, bool applyFilters = false);
+
+        /// <summary>
+        /// Creates 'In' filter for mongoDb.
+        /// </summary>
+        /// <remarks>
+        /// Visit https://docs.mongodb.com/manual/reference/operator/query/in/ to get more information about 'in' operator.
+        /// </remarks>
+        /// <param name="ids">Entity Ids to be filtered.</param>
+        /// <param name="applyFilters">Set true to use GlobalFilters. Default is false.</param>
+        FilterDefinition<TEntity> CreateEntitiesFilter(IEnumerable<TKey> ids, bool applyFilters = false);
     }
 }

--- a/framework/src/Volo.Abp.MongoDB/Volo/Abp/Domain/Repositories/MongoDB/MongoDbRepository.cs
+++ b/framework/src/Volo.Abp.MongoDB/Volo/Abp/Domain/Repositories/MongoDB/MongoDbRepository.cs
@@ -1,3 +1,4 @@
+using JetBrains.Annotations;
 using MongoDB.Driver;
 using MongoDB.Driver.Linq;
 using System;
@@ -480,6 +481,11 @@ namespace Volo.Abp.Domain.Repositories.MongoDB
         protected override FilterDefinition<TEntity> CreateEntityFilter(TEntity entity, bool withConcurrencyStamp = false, string concurrencyStamp = null)
         {
             return RepositoryFilterer.CreateEntityFilter(entity, withConcurrencyStamp, concurrencyStamp);
+        }
+
+        public async Task DeleteManyAsync([NotNull] IEnumerable<TKey> ids, bool autoSave = false, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/framework/src/Volo.Abp.MongoDB/Volo/Abp/Domain/Repositories/MongoDB/MongoDbRepository.cs
+++ b/framework/src/Volo.Abp.MongoDB/Volo/Abp/Domain/Repositories/MongoDB/MongoDbRepository.cs
@@ -195,26 +195,24 @@ namespace Volo.Abp.Domain.Repositories.MongoDB
             var entitiesCount = entities.Count();
             BulkWriteResult result;
 
+            List<WriteModel<TEntity>> replaceRequests = new List<WriteModel<TEntity>>();
+            foreach (var entity in entities)
+            {
+                replaceRequests.Add(new ReplaceOneModel<TEntity>(CreateEntityFilter(entity), entity));
+            }
+
             if (SessionHandle != null)
             {
-                result = await Collection.BulkWriteAsync(SessionHandle, GetReplaceRequests());
+                result = await Collection.BulkWriteAsync(SessionHandle, replaceRequests);
             }
             else
             {
-                result = await Collection.BulkWriteAsync(GetReplaceRequests());
+                result = await Collection.BulkWriteAsync(replaceRequests);
             }
 
             if (result.MatchedCount < entitiesCount)
             {
                 ThrowOptimisticConcurrencyException();
-            }
-
-            IEnumerable<WriteModel<TEntity>> GetReplaceRequests()
-            {
-                foreach (var entity in entities)
-                {
-                    yield return new ReplaceOneModel<TEntity>(CreateEntityFilter(entity), entity);
-                }
             }
         }
 

--- a/framework/src/Volo.Abp.MongoDB/Volo/Abp/Domain/Repositories/MongoDB/MongoDbRepository.cs
+++ b/framework/src/Volo.Abp.MongoDB/Volo/Abp/Domain/Repositories/MongoDB/MongoDbRepository.cs
@@ -94,7 +94,7 @@ namespace Volo.Abp.Domain.Repositories.MongoDB
 
             if (BulkOperationProvider != null)
             {
-                await BulkOperationProvider.InsertManyAsync(this, entities, autoSave, cancellationToken);
+                await BulkOperationProvider.InsertManyAsync(this, entities, SessionHandle, autoSave, cancellationToken);
                 return;
             }
 
@@ -188,7 +188,7 @@ namespace Volo.Abp.Domain.Repositories.MongoDB
 
             if (BulkOperationProvider != null)
             {
-                await BulkOperationProvider.UpdateManyAsync(this, entities, autoSave, cancellationToken);
+                await BulkOperationProvider.UpdateManyAsync(this, entities, SessionHandle, autoSave, cancellationToken);
                 return;
             }
 
@@ -292,7 +292,7 @@ namespace Volo.Abp.Domain.Repositories.MongoDB
 
             if (BulkOperationProvider != null)
             {
-                await BulkOperationProvider.DeleteManyAsync(this, entities, autoSave, cancellationToken);
+                await BulkOperationProvider.DeleteManyAsync(this, entities, SessionHandle, autoSave, cancellationToken);
                 return;
             }
 

--- a/framework/src/Volo.Abp.MongoDB/Volo/Abp/Domain/Repositories/MongoDB/MongoDbRepository.cs
+++ b/framework/src/Volo.Abp.MongoDB/Volo/Abp/Domain/Repositories/MongoDB/MongoDbRepository.cs
@@ -638,6 +638,15 @@ namespace Volo.Abp.Domain.Repositories.MongoDB
             return DeleteAsync(x => x.Id.Equals(id), autoSave, cancellationToken);
         }
 
+        public virtual async Task DeleteManyAsync([NotNull] IEnumerable<TKey> ids, bool autoSave = false, CancellationToken cancellationToken = default)
+        {
+            var entities = await GetMongoQueryable()
+                .Where(x => ids.Contains(x.Id))
+                .ToListAsync(GetCancellationToken(cancellationToken));
+
+            await DeleteManyAsync(entities, autoSave, cancellationToken);
+        }
+
         protected override FilterDefinition<TEntity> CreateEntityFilter(TEntity entity, bool withConcurrencyStamp = false, string concurrencyStamp = null)
         {
             return RepositoryFilterer.CreateEntityFilter(entity, withConcurrencyStamp, concurrencyStamp);
@@ -646,11 +655,6 @@ namespace Volo.Abp.Domain.Repositories.MongoDB
         protected override FilterDefinition<TEntity> CreateEntitiesFilter(IEnumerable<TEntity> entities, bool withConcurrencyStamp = false)
         {
             return RepositoryFilterer.CreateEntitiesFilter(entities, withConcurrencyStamp);
-        }
-
-        public async Task DeleteManyAsync([NotNull] IEnumerable<TKey> ids, bool autoSave = false, CancellationToken cancellationToken = default)
-        {
-
         }
     }
 }

--- a/framework/test/Volo.Abp.Ddd.Tests/Volo/Abp/Domain/Repositories/RepositoryRegistration_Tests.cs
+++ b/framework/test/Volo.Abp.Ddd.Tests/Volo/Abp/Domain/Repositories/RepositoryRegistration_Tests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Domain.Entities;
@@ -302,6 +303,11 @@ namespace Volo.Abp.Domain.Repositories
             }
 
             public Task DeleteAsync(TKey id, bool autoSave = false, CancellationToken cancellationToken = default)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task DeleteManyAsync([NotNull] IEnumerable<TKey> ids, bool autoSave = false, CancellationToken cancellationToken = default)
             {
                 throw new NotImplementedException();
             }

--- a/framework/test/Volo.Abp.TestApp/Volo/Abp/TestApp/Testing/Repository_Basic_Tests.cs
+++ b/framework/test/Volo.Abp.TestApp/Volo/Abp/TestApp/Testing/Repository_Basic_Tests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Shouldly;
 using Volo.Abp.Domain.Repositories;
@@ -114,6 +116,73 @@ namespace Volo.Abp.TestApp.Testing
             await PersonRepository.InsertAsync(person);
 
             person.Id.ShouldNotBe(Guid.Empty);
+        }
+
+        [Fact]
+        public async Task InserManyAsync()
+        {
+            var entities = new List<Person>
+            {
+                new Person(Guid.NewGuid(), "Person 1", 30),
+                new Person(Guid.NewGuid(), "Person 2", 31),
+                new Person(Guid.NewGuid(), "Person 3", 32),
+                new Person(Guid.NewGuid(), "Person 4", 33),
+            };
+
+            await PersonRepository.InsertManyAsync(entities);
+
+            foreach (var entity in entities)
+            {
+                var person = await PersonRepository.FindAsync(entity.Id);
+                person.ShouldNotBeNull();
+            }
+        }
+
+        [Fact]
+        public async Task UpdateManyAsync()
+        {
+            var entities = await PersonRepository.GetListAsync();
+            var random = new Random();
+            entities.ForEach(f => f.Age = random.Next());
+
+            await PersonRepository.UpdateManyAsync(entities);
+
+            foreach (var entity in entities)
+            {
+                var person = await PersonRepository.FindAsync(entity.Id);
+                person.ShouldNotBeNull();
+                person.Age.ShouldBe(entity.Age);
+            }
+        }
+
+        [Fact]
+        public async Task DeleteManyAsync()
+        {
+            var entities = await PersonRepository.GetListAsync();
+
+            await PersonRepository.DeleteManyAsync(entities);
+
+            foreach (var entity in entities)
+            {
+                var person = await PersonRepository.FindAsync(entity.Id);
+                person.ShouldBeNull();
+            }
+        }
+
+        [Fact]
+        public async Task DeleteManyAsync_WithId()
+        {
+            var entities = await PersonRepository.GetListAsync();
+
+            var ids = entities.Select(s => s.Id).ToArray();
+
+            await PersonRepository.DeleteManyAsync(ids);
+
+            foreach (var id in ids)
+            {
+                var person = await PersonRepository.FindAsync(id);
+                person.ShouldBeNull();
+            }
         }
     }
 }


### PR DESCRIPTION
Resolved #6654 

## Summary
MongoDb has its own bulk operation options over MongoDb Driver. So it has a native implementation.
EfCore doesn't have a visible solution as exact bulk operation. But ChangeTracker helps to execute waiting operations at the same time. This PR has implementation which aims to improve MongoDb bulk operations behavior & performance.

~~There is a library for Bulk Operations for Ef Core
https://github.com/borisdj/EFCore.BulkExtensions
We can add an extension for this library, but I'm not sure, It doesn't have Ef Core 5.0 support.
This implementation will be included in another PR.
Default implementation solves main problem for now.~~

## Usage
You don't need to do anything more. Just use new methods over your repository:

```csharp
await repository.InsertManyAsync(entities); // collection of entities
```

```csharp
await repository.UpdateManyAsync(entities); // collection of entities
```

```csharp
await repository.DeleteManyAsync(entities); // collection of entities
```