### PR TITLE
Set job name for Hangfire background job integration

### DIFF
--- a/framework/src/Volo.Abp.BackgroundJobs.HangFire/Volo/Abp/BackgroundJobs/Hangfire/AbpBackgroundJobsHangfireModule.cs
+++ b/framework/src/Volo.Abp.BackgroundJobs.HangFire/Volo/Abp/BackgroundJobs/Hangfire/AbpBackgroundJobsHangfireModule.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Hangfire;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -13,6 +14,21 @@ namespace Volo.Abp.BackgroundJobs.Hangfire
     )]
     public class AbpBackgroundJobsHangfireModule : AbpModule
     {
+        public override void ConfigureServices(ServiceConfigurationContext context)
+        {
+            context.Services.AddTransient(serviceProvider =>
+            {
+                return new DashboardOptions
+                {
+                    DisplayNameFunc = (_, job) =>
+                    {
+                        var backgroundJobOptions = serviceProvider.GetRequiredService<IOptions<AbpBackgroundJobOptions>>().Value;
+                        return backgroundJobOptions.GetJob(job.Args.First().GetType()).JobName;
+                    }
+                };
+            });
+        }
+
         public override void OnPreApplicationInitialization(ApplicationInitializationContext context)
         {
             var options = context.ServiceProvider.GetRequiredService<IOptions<AbpBackgroundJobOptions>>().Value;

--- a/framework/src/Volo.Abp.BackgroundJobs.HangFire/Volo/Abp/BackgroundJobs/Hangfire/AbpBackgroundJobsHangfireModule.cs
+++ b/framework/src/Volo.Abp.BackgroundJobs.HangFire/Volo/Abp/BackgroundJobs/Hangfire/AbpBackgroundJobsHangfireModule.cs
@@ -17,16 +17,7 @@ namespace Volo.Abp.BackgroundJobs.Hangfire
         public override void ConfigureServices(ServiceConfigurationContext context)
         {
             context.Services.AddTransient(serviceProvider =>
-            {
-                return new DashboardOptions
-                {
-                    DisplayNameFunc = (_, job) =>
-                    {
-                        var backgroundJobOptions = serviceProvider.GetRequiredService<IOptions<AbpBackgroundJobOptions>>().Value;
-                        return backgroundJobOptions.GetJob(job.Args.First().GetType()).JobName;
-                    }
-                };
-            });
+                serviceProvider.GetRequiredService<AbpDashboardOptionsProvider>().Get());
         }
 
         public override void OnPreApplicationInitialization(ApplicationInitializationContext context)

--- a/framework/src/Volo.Abp.BackgroundJobs.HangFire/Volo/Abp/BackgroundJobs/Hangfire/AbpDashboardOptionsProvider.cs
+++ b/framework/src/Volo.Abp.BackgroundJobs.HangFire/Volo/Abp/BackgroundJobs/Hangfire/AbpDashboardOptionsProvider.cs
@@ -1,0 +1,26 @@
+﻿using System.Linq;
+using Hangfire;
+using Microsoft.Extensions.Options;
+using Volo.Abp.DependencyInjection;
+
+namespace Volo.Abp.BackgroundJobs.Hangfire
+{
+    public class AbpDashboardOptionsProvider : ITransientDependency
+    {
+        protected AbpBackgroundJobOptions AbpBackgroundJobOptions { get; }
+
+        public AbpDashboardOptionsProvider(IOptions<AbpBackgroundJobOptions> abpBackgroundJobOptions)
+        {
+            AbpBackgroundJobOptions = abpBackgroundJobOptions.Value;
+        }
+
+        public virtual DashboardOptions Get()
+        {
+            return new DashboardOptions
+            {
+                DisplayNameFunc = (dashboardContext, job) =>
+                    AbpBackgroundJobOptions.GetJob(job.Args.First().GetType()).JobName
+            };
+        }
+    }
+}


### PR DESCRIPTION
Resolve https://github.com/abpframework/abp/issues/6700

```csharp
public class SmsSenderJob : BackgroundJob<SmsSenderJobArgs>, ITransientDependency
{
    public override void Execute(SmsSenderJobArgs args)
    {

    }
}

public class SmsSenderJobArgs
{

}

public class EmailSenderJob : BackgroundJob<EmailSenderJobArgs>, ITransientDependency
{
    public override void Execute(EmailSenderJobArgs args)
    {
    }
}

[BackgroundJobName("EmailSenderJob")]
public class EmailSenderJobArgs
{
    public string Name { get; set; }
}
```

![image](https://user-images.githubusercontent.com/16813853/102591172-8fc05a80-414c-11eb-8a70-c8f1580abd30.png)
