### PR TITLE
Fix AbpStringExtensions

### DIFF
--- a/framework/src/Volo.Abp.Core/System/AbpStringExtensions.cs
+++ b/framework/src/Volo.Abp.Core/System/AbpStringExtensions.cs
@@ -133,7 +133,7 @@ namespace System
         {
             if (str.IsNullOrEmpty())
             {
-                return null;
+                return str;
             }
 
             if (postFixes.IsNullOrEmpty())
@@ -174,7 +174,7 @@ namespace System
         {
             if (str.IsNullOrEmpty())
             {
-                return null;
+                return str;
             }
 
             if (preFixes.IsNullOrEmpty())

--- a/framework/test/Volo.Abp.Core.Tests/System/StringExtensions_Tests.cs
+++ b/framework/test/Volo.Abp.Core.Tests/System/StringExtensions_Tests.cs
@@ -211,7 +211,7 @@ namespace System
             //empty case
             string.Empty.RemovePreFix("Test").ShouldBe(string.Empty);
 
-            "Home.Index".RemovePreFix("NotMatchedPostfix").ShouldBe("Home.Index");
+            "Home.Index".RemovePreFix("NotMatchedPrefix").ShouldBe("Home.Index");
             "Home.About".RemovePreFix("Home.").ShouldBe("About");
 
             //Ignore case

--- a/framework/test/Volo.Abp.Core.Tests/System/StringExtensions_Tests.cs
+++ b/framework/test/Volo.Abp.Core.Tests/System/StringExtensions_Tests.cs
@@ -182,7 +182,10 @@ namespace System
         public void RemovePostFix_Tests()
         {
             //null case
-            (null as string).RemovePreFix("Test").ShouldBeNull();
+            (null as string).RemovePostFix("Test").ShouldBeNull();
+
+            //empty case
+            string.Empty.RemovePostFix("Test").ShouldBe(string.Empty);
 
             //Simple case
             "MyTestAppService".RemovePostFix("AppService").ShouldBe("MyTest");
@@ -202,6 +205,12 @@ namespace System
         [Fact]
         public void RemovePreFix_Tests()
         {
+            //null case
+            (null as string).RemovePreFix("Test").ShouldBeNull();
+
+            //empty case
+            string.Empty.RemovePreFix("Test").ShouldBe(string.Empty);
+
             "Home.Index".RemovePreFix("NotMatchedPostfix").ShouldBe("Home.Index");
             "Home.About".RemovePreFix("Home.").ShouldBe("About");
 


### PR DESCRIPTION
For now, `"".RemovePreFix("x")` will return null.
It's not a expected result. I think we shouldn't make empty string be null when trim prefix or postfix.