### PR TITLE
Remove MultipleActiveResultSets from the templates project connection string.

### DIFF
--- a/docs/en/CLI.md
+++ b/docs/en/CLI.md
@@ -105,7 +105,7 @@ abp new Acme.BookStore
 * `--preview`: Use latest preview version.
 * `--template-source` or `-ts`: Specifies a custom template source to use to build the project. Local and network sources can be used(Like `D:\local-template` or `https://.../my-template-file.zip`).
 * `--create-solution-folder` or `-csf`: Specifies if the project will be in a new folder in the output folder or directly the output folder.
-* `--connection-string` or `-cs`:  Overwrites the default connection strings in all `appsettings.json` files. The default connection string is `Server=localhost;Database=MyProjectName;Trusted_Connection=True;MultipleActiveResultSets=true` for EF Core and it is configured to use the SQL Server. If you want to use the EF Core, but need to change the DBMS, you can change it as [described here](Entity-Framework-Core-Other-DBMS.md) (after creating the solution).
+* `--connection-string` or `-cs`:  Overwrites the default connection strings in all `appsettings.json` files. The default connection string is `Server=localhost;Database=MyProjectName;Trusted_Connection=True` for EF Core and it is configured to use the SQL Server. If you want to use the EF Core, but need to change the DBMS, you can change it as [described here](Entity-Framework-Core-Other-DBMS.md) (after creating the solution).
 * `--database-management-system` or `-dbms`: Sets the database management system. Default is **SQL Server**. Supported DBMS's:
   * `SqlServer`
   * `MySQL`

--- a/docs/en/Entity-Framework-Core-Migrations.md
+++ b/docs/en/Entity-Framework-Core-Migrations.md
@@ -586,7 +586,7 @@ First step is to change the connection string section inside all the `appsetting
 
 ````json
 "ConnectionStrings": {
-  "Default": "Server=localhost;Database=BookStore;Trusted_Connection=True;MultipleActiveResultSets=true"
+  "Default": "Server=localhost;Database=BookStore;Trusted_Connection=True"
 }
 ````
 
@@ -594,10 +594,10 @@ Change it as shown below:
 
 ````json
 "ConnectionStrings": {
-  "Default": "Server=localhost;Database=BookStore;Trusted_Connection=True;MultipleActiveResultSets=true",
-  "AbpPermissionManagement": "Server=localhost;Database=BookStore_SecondDb;Trusted_Connection=True;MultipleActiveResultSets=true",
-  "AbpSettingManagement": "Server=localhost;Database=BookStore_SecondDb;Trusted_Connection=True;MultipleActiveResultSets=true",
-  "AbpAuditLogging": "Server=localhost;Database=BookStore_SecondDb;Trusted_Connection=True;MultipleActiveResultSets=true"
+  "Default": "Server=localhost;Database=BookStore;Trusted_Connection=True",
+  "AbpPermissionManagement": "Server=localhost;Database=BookStore_SecondDb;Trusted_Connection=True",
+  "AbpSettingManagement": "Server=localhost;Database=BookStore_SecondDb;Trusted_Connection=True",
+  "AbpAuditLogging": "Server=localhost;Database=BookStore_SecondDb;Trusted_Connection=True"
 }
 ````
 

--- a/docs/en/Modules/Docs.md
+++ b/docs/en/Modules/Docs.md
@@ -47,7 +47,7 @@ The database connection string is located in `appsettings.json` of your `Acme.My
 ```json
 {
   "ConnectionStrings": {
-    "Default": "Server=(LocalDb)\\MSSQLLocalDB;Database=MyProject;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "Default": "Server=(LocalDb)\\MSSQLLocalDB;Database=MyProject;Trusted_Connection=True"
   }
 }
 ```

--- a/docs/en/Samples/Microservice-Demo.md
+++ b/docs/en/Samples/Microservice-Demo.md
@@ -842,7 +842,7 @@ It has a dedicated MongoDB database (MsDemo_Blogging) to store blog and posts. I
 
 ````json
 "ConnectionStrings": {
-  "Default": "Server=localhost;Database=MsDemo_Identity;Trusted_Connection=True;MultipleActiveResultSets=true",
+  "Default": "Server=localhost;Database=MsDemo_Identity;Trusted_Connection=True",
   "Blogging": "mongodb://localhost/MsDemo_Blogging"
 }
 ````
@@ -968,8 +968,8 @@ There are two connection strings in the `appsettings.json` file:
 
 ````json
 "ConnectionStrings": {
-  "Default": "Server=localhost;Database=MsDemo_Identity;Trusted_Connection=True;MultipleActiveResultSets=true",
-  "ProductManagement": "Server=localhost;Database=MsDemo_ProductManagement;Trusted_Connection=True;MultipleActiveResultSets=true"
+  "Default": "Server=localhost;Database=MsDemo_Identity;Trusted_Connection=True",
+  "ProductManagement": "Server=localhost;Database=MsDemo_ProductManagement;Trusted_Connection=True"
 }
 ````
 

--- a/docs/zh-Hans/CLI.md
+++ b/docs/zh-Hans/CLI.md
@@ -103,7 +103,7 @@ abp new Acme.BookStore
 * `--preview`: 使用最新的预览版本.
 * `--template-source` 或者 `-ts`: 指定自定义模板源用于生成项目,可以使用本地源和网络源(例如 `D:\local-templat` 或 `https://.../my-template-file.zip`).
 * `--create-solution-folder` 或者 `-csf`: 指定项目是在输出文件夹中的新文件夹中还是直接在输出文件夹中.
-* `--connection-string` 或者 `-cs`:  重写所有 `appsettings.json` 文件的默认连接字符串. 默认连接字符串是 `Server=localhost;Database=MyProjectName;Trusted_Connection=True;MultipleActiveResultSets=true`. 默认的数据库提供程序是 `SQL Server`. 如果你使用EF Core但需要更改DBMS,可以按[这里所述](Entity-Framework-Core-Other-DBMS.md)进行更改(创建解决方案之后).
+* `--connection-string` 或者 `-cs`:  重写所有 `appsettings.json` 文件的默认连接字符串. 默认连接字符串是 `Server=localhost;Database=MyProjectName;Trusted_Connection=True`. 默认的数据库提供程序是 `SQL Server`. 如果你使用EF Core但需要更改DBMS,可以按[这里所述](Entity-Framework-Core-Other-DBMS.md)进行更改(创建解决方案之后).
 * `--local-framework-ref --abp-path`: 使用对项目的本地引用,而不是替换为NuGet包引用.
 
 ### update

--- a/docs/zh-Hans/Entity-Framework-Core-Migrations.md
+++ b/docs/zh-Hans/Entity-Framework-Core-Migrations.md
@@ -588,7 +588,7 @@ public class IdentityRoleExtendingService : ITransientDependency
 
 ````json
 "ConnectionStrings": {
-  "Default": "Server=localhost;Database=BookStore;Trusted_Connection=True;MultipleActiveResultSets=true"
+  "Default": "Server=localhost;Database=BookStore;Trusted_Connection=True"
 }
 ````
 
@@ -596,10 +596,10 @@ public class IdentityRoleExtendingService : ITransientDependency
 
 ````json
 "ConnectionStrings": {
-  "Default": "Server=localhost;Database=BookStore;Trusted_Connection=True;MultipleActiveResultSets=true",
-  "AbpPermissionManagement": "Server=localhost;Database=BookStore_SecondDb;Trusted_Connection=True;MultipleActiveResultSets=true",
-  "AbpSettingManagement": "Server=localhost;Database=BookStore_SecondDb;Trusted_Connection=True;MultipleActiveResultSets=true",
-  "AbpAuditLogging": "Server=localhost;Database=BookStore_SecondDb;Trusted_Connection=True;MultipleActiveResultSets=true"
+  "Default": "Server=localhost;Database=BookStore;Trusted_Connection=True",
+  "AbpPermissionManagement": "Server=localhost;Database=BookStore_SecondDb;Trusted_Connection=True",
+  "AbpSettingManagement": "Server=localhost;Database=BookStore_SecondDb;Trusted_Connection=True",
+  "AbpAuditLogging": "Server=localhost;Database=BookStore_SecondDb;Trusted_Connection=True"
 }
 ````
 

--- a/docs/zh-Hans/Modules/Docs.md
+++ b/docs/zh-Hans/Modules/Docs.md
@@ -47,7 +47,7 @@ ABP框架的[文档](docs.abp.io)也是使用的此模块.
 ```json
 {
   "ConnectionStrings": {
-    "Default": "Server=(LocalDb)\\MSSQLLocalDB;Database=MyProject;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "Default": "Server=(LocalDb)\\MSSQLLocalDB;Database=MyProject;Trusted_Connection=True"
   }
 }
 ```

--- a/docs/zh-Hans/Samples/Microservice-Demo.md
+++ b/docs/zh-Hans/Samples/Microservice-Demo.md
@@ -843,7 +843,7 @@ Swagger UI已配置,是此服务的默认页面. 如果你导航到URL`http://lo
 
 ````json
 "ConnectionStrings": {
-  "Default": "Server=localhost;Database=MsDemo_Identity;Trusted_Connection=True;MultipleActiveResultSets=true",
+  "Default": "Server=localhost;Database=MsDemo_Identity;Trusted_Connection=True",
   "Blogging": "mongodb://localhost/MsDemo_Blogging"
 }
 ````
@@ -969,8 +969,8 @@ public class ProductServiceMigrationDbContext : AbpDbContext<ProductServiceMigra
 
 ````json
 "ConnectionStrings": {
-  "Default": "Server=localhost;Database=MsDemo_Identity;Trusted_Connection=True;MultipleActiveResultSets=true",
-  "ProductManagement": "Server=localhost;Database=MsDemo_ProductManagement;Trusted_Connection=True;MultipleActiveResultSets=true"
+  "Default": "Server=localhost;Database=MsDemo_Identity;Trusted_Connection=True",
+  "ProductManagement": "Server=localhost;Database=MsDemo_ProductManagement;Trusted_Connection=True"
 }
 ````
 

--- a/modules/background-jobs/app/Volo.Abp.BackgroundJobs.DemoApp.HangFire/appsettings.json
+++ b/modules/background-jobs/app/Volo.Abp.BackgroundJobs.DemoApp.HangFire/appsettings.json
@@ -1,5 +1,5 @@
 ﻿{
   "ConnectionStrings": {
-    "Default": "Server=localhost;Database=BackgroundJobsDemoApp;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "Default": "Server=localhost;Database=BackgroundJobsDemoApp;Trusted_Connection=True"
   }
 }

--- a/modules/background-jobs/app/Volo.Abp.BackgroundJobs.DemoApp/appsettings.json
+++ b/modules/background-jobs/app/Volo.Abp.BackgroundJobs.DemoApp/appsettings.json
@@ -1,5 +1,5 @@
 ﻿{
   "ConnectionStrings": {
-    "Default": "Server=localhost;Database=BackgroundJobsDemoApp;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "Default": "Server=localhost;Database=BackgroundJobsDemoApp;Trusted_Connection=True"
   }
 }

--- a/modules/blob-storing-database/host/BlobStoring.Database.Host.ConsoleApp/src/BlobStoring.Database.Host.ConsoleApp.ConsoleApp/ConsoleAppConsoleAppModule.cs
+++ b/modules/blob-storing-database/host/BlobStoring.Database.Host.ConsoleApp/src/BlobStoring.Database.Host.ConsoleApp.ConsoleApp/ConsoleAppConsoleAppModule.cs
@@ -39,7 +39,7 @@ namespace BlobStoring.Database.Host.ConsoleApp.ConsoleApp
         {
             Configure<AbpDbConnectionOptions>(options =>
             {
-                options.ConnectionStrings.Default = "Server=localhost;Database=BlobStoring_Host;Trusted_Connection=True;MultipleActiveResultSets=true";
+                options.ConnectionStrings.Default = "Server=localhost;Database=BlobStoring_Host;Trusted_Connection=True";
             });
             
             context.Services.AddAbpDbContext<BlobStoringHostDbContext>(options =>

--- a/modules/blob-storing-database/host/BlobStoring.Database.Host.ConsoleApp/src/BlobStoring.Database.Host.ConsoleApp.ConsoleApp/appsettings.json
+++ b/modules/blob-storing-database/host/BlobStoring.Database.Host.ConsoleApp/src/BlobStoring.Database.Host.ConsoleApp.ConsoleApp/appsettings.json
@@ -1,5 +1,5 @@
 {
   "ConnectionStrings": {
-    "Default": "Server=localhost;Database=BlobStoring_Host;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "Default": "Server=localhost;Database=BlobStoring_Host;Trusted_Connection=True"
   }
 }

--- a/modules/blogging/app/Volo.BloggingTestApp/appsettings.json
+++ b/modules/blogging/app/Volo.BloggingTestApp/appsettings.json
@@ -1,6 +1,6 @@
 ﻿{
   "ConnectionStrings": {
-    "SqlServer": "Server=localhost;Database=BloggingTestApp;Trusted_Connection=True;MultipleActiveResultSets=true",
+    "SqlServer": "Server=localhost;Database=BloggingTestApp;Trusted_Connection=True",
     "MongoDb": "mongodb://localhost:27017/BloggingTestApp"
   }
 }

--- a/modules/cms-kit/docker-compose.override.yml
+++ b/modules/cms-kit/docker-compose.override.yml
@@ -11,19 +11,19 @@ services:
   identity-server:
     environment:
       - ASPNETCORE_URLS=http://0.0.0.0:80
-      - ConnectionStrings__Default=Server=sqlserver;Database=CmsKit_Identity;Trusted_Connection=True;MultipleActiveResultSets=true;User=sa;Password=yourStrong(!)Password;Integrated Security=false
-      - ConnectionStrings__SqlServerCache=Server=sqlserver;Database=CmsKit_Cache;Trusted_Connection=True;MultipleActiveResultSets=true;User=sa;Password=yourStrong(!)Password;Integrated Security=false
+      - ConnectionStrings__Default=Server=sqlserver;Database=CmsKit_Identity;Trusted_Connection=True;User=sa;Password=yourStrong(!)Password;Integrated Security=false
+      - ConnectionStrings__SqlServerCache=Server=sqlserver;Database=CmsKit_Cache;Trusted_Connection=True;User=sa;Password=yourStrong(!)Password;Integrated Security=false
     ports:
       - "51600:80"
 
   cms-kit:
     environment:
       - ASPNETCORE_URLS=http://0.0.0.0:80
-      - ConnectionStrings__Default=Server=sqlserver;Database=CmsKit_ModuleDb;Trusted_Connection=True;MultipleActiveResultSets=true;User=sa;Password=yourStrong(!)Password;Integrated Security=false
-      - ConnectionStrings__AbpSettingManagement=Server=sqlserver;Database=CmsKit_Identity;Trusted_Connection=True;MultipleActiveResultSets=true;User=sa;Password=yourStrong(!)Password;Integrated Security=false
-      - ConnectionStrings__AbpPermissionManagement=Server=sqlserver;Database=CmsKit_Identity;Trusted_Connection=True;MultipleActiveResultSets=true;User=sa;Password=yourStrong(!)Password;Integrated Security=false
-      - ConnectionStrings__AbpAuditLogging=Server=sqlserver;Database=CmsKit_Identity;Trusted_Connection=True;MultipleActiveResultSets=true;User=sa;Password=yourStrong(!)Password;Integrated Security=false
-      - ConnectionStrings__SqlServerCache=Server=sqlserver;Database=CmsKit_Cache;Trusted_Connection=True;MultipleActiveResultSets=true;User=sa;Password=yourStrong(!)Password;Integrated Security=false
+      - ConnectionStrings__Default=Server=sqlserver;Database=CmsKit_ModuleDb;Trusted_Connection=True;User=sa;Password=yourStrong(!)Password;Integrated Security=false
+      - ConnectionStrings__AbpSettingManagement=Server=sqlserver;Database=CmsKit_Identity;Trusted_Connection=True;User=sa;Password=yourStrong(!)Password;Integrated Security=false
+      - ConnectionStrings__AbpPermissionManagement=Server=sqlserver;Database=CmsKit_Identity;Trusted_Connection=True;User=sa;Password=yourStrong(!)Password;Integrated Security=false
+      - ConnectionStrings__AbpAuditLogging=Server=sqlserver;Database=CmsKit_Identity;Trusted_Connection=True;User=sa;Password=yourStrong(!)Password;Integrated Security=false
+      - ConnectionStrings__SqlServerCache=Server=sqlserver;Database=CmsKit_Cache;Trusted_Connection=True;User=sa;Password=yourStrong(!)Password;Integrated Security=false
       - AuthServer__Authority=http://identity-server
     ports:
       - "51601:80"

--- a/modules/cms-kit/host/Volo.CmsKit.HttpApi.Host/appsettings.json
+++ b/modules/cms-kit/host/Volo.CmsKit.HttpApi.Host/appsettings.json
@@ -3,8 +3,8 @@
     "CorsOrigins": "https://*.CmsKit.com,http://localhost:4200"
   },
   "ConnectionStrings": {
-    "Default": "Server=localhost;Database=CmsKit_Main;Trusted_Connection=True;MultipleActiveResultSets=true",
-    "CmsKit": "Server=localhost;Database=CmsKit_Module;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "Default": "Server=localhost;Database=CmsKit_Main;Trusted_Connection=True",
+    "CmsKit": "Server=localhost;Database=CmsKit_Module;Trusted_Connection=True"
   },
   "Redis": {
     "Configuration": "127.0.0.1"

--- a/modules/cms-kit/host/Volo.CmsKit.IdentityServer/appsettings.json
+++ b/modules/cms-kit/host/Volo.CmsKit.IdentityServer/appsettings.json
@@ -5,7 +5,7 @@
   },
   "AppSelfUrl": "https://localhost:44318/",
   "ConnectionStrings": {
-    "Default": "Server=localhost;Database=CmsKit_Main;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "Default": "Server=localhost;Database=CmsKit_Main;Trusted_Connection=True"
   },
   "Redis": {
     "Configuration": "127.0.0.1"

--- a/modules/cms-kit/host/Volo.CmsKit.Web.Unified/appsettings.json
+++ b/modules/cms-kit/host/Volo.CmsKit.Web.Unified/appsettings.json
@@ -1,5 +1,5 @@
 ﻿{
   "ConnectionStrings": {
-    "Default": "Server=localhost;Database=CmsKit_Unified;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "Default": "Server=localhost;Database=CmsKit_Unified;Trusted_Connection=True"
   }
 }

--- a/modules/docs/app/VoloDocs.Migrator/appsettings.json
+++ b/modules/docs/app/VoloDocs.Migrator/appsettings.json
@@ -1,3 +1,3 @@
 ﻿{
-  "ConnectionString": "Server=localhost;Database=VoloDocs;Trusted_Connection=True;MultipleActiveResultSets=true"
+  "ConnectionString": "Server=localhost;Database=VoloDocs;Trusted_Connection=True"
 }

--- a/modules/docs/app/VoloDocs.Web/appsettings.json
+++ b/modules/docs/app/VoloDocs.Web/appsettings.json
@@ -1,5 +1,5 @@
 ﻿{
-  "ConnectionString": "Server=localhost;Database=VoloDocs;Trusted_Connection=True;MultipleActiveResultSets=true",
+  "ConnectionString": "Server=localhost;Database=VoloDocs;Trusted_Connection=True",
   "LogoUrl": "/assets/images/Logo.png",
   "ElasticSearch": {
     "Url": "http://localhost:9200"

--- a/modules/docs/docker-compose.migrate.yml
+++ b/modules/docs/docker-compose.migrate.yml
@@ -7,6 +7,6 @@ services:
       context: ../../
       dockerfile: modules/docs/app/VoloDocs.Migrator/Dockerfile
     environment:
-      - ConnectionString=Server=sqlserver;Database=VoloDocs;Trusted_Connection=True;MultipleActiveResultSets=true;User=sa;Password=yourStrong(!)Password;Integrated Security=false
+      - ConnectionString=Server=sqlserver;Database=VoloDocs;Trusted_Connection=True;User=sa;Password=yourStrong(!)Password;Integrated Security=false
     depends_on:
       - sqlserver

--- a/modules/docs/docker-compose.override.yml
+++ b/modules/docs/docker-compose.override.yml
@@ -10,7 +10,7 @@ services:
 
   volo-docs:
     environment:
-      - ConnectionString=Server=sqlserver;Database=VoloDocs;Trusted_Connection=True;MultipleActiveResultSets=true;User=sa;Password=yourStrong(!)Password;Integrated Security=false
+      - ConnectionString=Server=sqlserver;Database=VoloDocs;Trusted_Connection=True;User=sa;Password=yourStrong(!)Password;Integrated Security=false
       - Title=VoloDocs
       - LogoUrl=/assets/images/Logo.png
     ports:

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.DbMigrator/appsettings.json
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.DbMigrator/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "Default": "Server=(LocalDb)\\MSSQLLocalDB;Database=MyProjectName;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "Default": "Server=(LocalDb)\\MSSQLLocalDB;Database=MyProjectName;Trusted_Connection=True"
   },
   "IdentityServer": {
     "Clients": {

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.HttpApi.Host/appsettings.json
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.HttpApi.Host/appsettings.json
@@ -3,7 +3,7 @@
     "CorsOrigins": "https://*.MyProjectName.com,http://localhost:4200,https://localhost:44307"
   },
   "ConnectionStrings": {
-    "Default": "Server=(LocalDb)\\MSSQLLocalDB;Database=MyProjectName;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "Default": "Server=(LocalDb)\\MSSQLLocalDB;Database=MyProjectName;Trusted_Connection=True"
   },
   "Redis": {
     "Configuration": "127.0.0.1"

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.HttpApi.HostWithIds/appsettings.json
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.HttpApi.HostWithIds/appsettings.json
@@ -5,7 +5,7 @@
     "RedirectAllowedUrls": "http://localhost:4200,https://localhost:44307"
   },
   "ConnectionStrings": {
-    "Default": "Server=(LocalDb)\\MSSQLLocalDB;Database=MyProjectName;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "Default": "Server=(LocalDb)\\MSSQLLocalDB;Database=MyProjectName;Trusted_Connection=True"
   },
   "AuthServer": {
     "Authority": "https://localhost:44305",

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.IdentityServer/appsettings.json
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.IdentityServer/appsettings.json
@@ -5,7 +5,7 @@
     "RedirectAllowedUrls": "http://localhost:4200,https://localhost:44307"
   },
   "ConnectionStrings": {
-    "Default": "Server=(LocalDb)\\MSSQLLocalDB;Database=MyProjectName;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "Default": "Server=(LocalDb)\\MSSQLLocalDB;Database=MyProjectName;Trusted_Connection=True"
   },
   "Redis": {
     "Configuration": "127.0.0.1"

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Web/appsettings.json
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Web/appsettings.json
@@ -3,7 +3,7 @@
     "SelfUrl": "https://localhost:44303"
   },
   "ConnectionStrings": {
-    "Default": "Server=(LocalDb)\\MSSQLLocalDB;Database=MyProjectName;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "Default": "Server=(LocalDb)\\MSSQLLocalDB;Database=MyProjectName;Trusted_Connection=True"
   },
   "AuthServer": {
     "Authority": "https://localhost:44303",

--- a/templates/module/aspnet-core/docker-compose.override.yml
+++ b/templates/module/aspnet-core/docker-compose.override.yml
@@ -11,19 +11,19 @@ services:
   identity-server:
     environment:
       - ASPNETCORE_URLS=http://0.0.0.0:80
-      - ConnectionStrings__Default=Server=sqlserver;Database=MyProjectName_Identity;Trusted_Connection=True;MultipleActiveResultSets=true;User=sa;Password=yourStrong(!)Password;Integrated Security=false
-      - ConnectionStrings__SqlServerCache=Server=sqlserver;Database=MyProjectName_Cache;Trusted_Connection=True;MultipleActiveResultSets=true;User=sa;Password=yourStrong(!)Password;Integrated Security=false
+      - ConnectionStrings__Default=Server=sqlserver;Database=MyProjectName_Identity;Trusted_Connection=True;User=sa;Password=yourStrong(!)Password;Integrated Security=false
+      - ConnectionStrings__SqlServerCache=Server=sqlserver;Database=MyProjectName_Cache;Trusted_Connection=True;User=sa;Password=yourStrong(!)Password;Integrated Security=false
     ports:
       - "51600:80"
 
   my-project-name:
     environment:
       - ASPNETCORE_URLS=http://0.0.0.0:80
-      - ConnectionStrings__Default=Server=sqlserver;Database=MyProjectName_ModuleDb;Trusted_Connection=True;MultipleActiveResultSets=true;User=sa;Password=yourStrong(!)Password;Integrated Security=false
-      - ConnectionStrings__AbpSettingManagement=Server=sqlserver;Database=MyProjectName_Identity;Trusted_Connection=True;MultipleActiveResultSets=true;User=sa;Password=yourStrong(!)Password;Integrated Security=false
-      - ConnectionStrings__AbpPermissionManagement=Server=sqlserver;Database=MyProjectName_Identity;Trusted_Connection=True;MultipleActiveResultSets=true;User=sa;Password=yourStrong(!)Password;Integrated Security=false
-      - ConnectionStrings__AbpAuditLogging=Server=sqlserver;Database=MyProjectName_Identity;Trusted_Connection=True;MultipleActiveResultSets=true;User=sa;Password=yourStrong(!)Password;Integrated Security=false
-      - ConnectionStrings__SqlServerCache=Server=sqlserver;Database=MyProjectName_Cache;Trusted_Connection=True;MultipleActiveResultSets=true;User=sa;Password=yourStrong(!)Password;Integrated Security=false
+      - ConnectionStrings__Default=Server=sqlserver;Database=MyProjectName_ModuleDb;Trusted_Connection=True;User=sa;Password=yourStrong(!)Password;Integrated Security=false
+      - ConnectionStrings__AbpSettingManagement=Server=sqlserver;Database=MyProjectName_Identity;Trusted_Connection=True;User=sa;Password=yourStrong(!)Password;Integrated Security=false
+      - ConnectionStrings__AbpPermissionManagement=Server=sqlserver;Database=MyProjectName_Identity;Trusted_Connection=True;User=sa;Password=yourStrong(!)Password;Integrated Security=false
+      - ConnectionStrings__AbpAuditLogging=Server=sqlserver;Database=MyProjectName_Identity;Trusted_Connection=True;User=sa;Password=yourStrong(!)Password;Integrated Security=false
+      - ConnectionStrings__SqlServerCache=Server=sqlserver;Database=MyProjectName_Cache;Trusted_Connection=True;User=sa;Password=yourStrong(!)Password;Integrated Security=false
       - AuthServer__Authority=http://identity-server
     ports:
       - "51601:80"

--- a/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.HttpApi.Host/appsettings.json
+++ b/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.HttpApi.Host/appsettings.json
@@ -3,8 +3,8 @@
     "CorsOrigins": "https://*.MyProjectName.com,http://localhost:4200,http://localhost:44307,https://localhost:44307"
   },
   "ConnectionStrings": {
-    "Default": "Server=(LocalDb)\\MSSQLLocalDB;Database=MyProjectName_Main;Trusted_Connection=True;MultipleActiveResultSets=true",
-    "MyProjectName": "Server=(LocalDb)\\MSSQLLocalDB;Database=MyProjectName_Module;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "Default": "Server=(LocalDb)\\MSSQLLocalDB;Database=MyProjectName_Main;Trusted_Connection=True",
+    "MyProjectName": "Server=(LocalDb)\\MSSQLLocalDB;Database=MyProjectName_Module;Trusted_Connection=True"
   },
   "Redis": {
     "Configuration": "127.0.0.1"

--- a/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.IdentityServer/appsettings.json
+++ b/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.IdentityServer/appsettings.json
@@ -5,7 +5,7 @@
   },
   "AppSelfUrl": "https://localhost:44301/",
   "ConnectionStrings": {
-    "Default": "Server=(LocalDb)\\MSSQLLocalDB;Database=MyProjectName_Main;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "Default": "Server=(LocalDb)\\MSSQLLocalDB;Database=MyProjectName_Main;Trusted_Connection=True"
   },
   "Redis": {
     "Configuration": "127.0.0.1"

--- a/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.Web.Unified/appsettings.json
+++ b/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.Web.Unified/appsettings.json
@@ -1,5 +1,5 @@
 ﻿{
   "ConnectionStrings": {
-    "Default": "Server=(LocalDb)\\MSSQLLocalDB;Database=MyProjectName_Unified;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "Default": "Server=(LocalDb)\\MSSQLLocalDB;Database=MyProjectName_Unified;Trusted_Connection=True"
   }
 }

--- a/test/AbpPerfTest/AbpPerfTest.WithAbp/appsettings.json
+++ b/test/AbpPerfTest/AbpPerfTest.WithAbp/appsettings.json
@@ -8,6 +8,6 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "Default": "Server=(LocalDb)\\MSSQLLocalDB;Database=AbpPerfTest_WithAbp;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "Default": "Server=(LocalDb)\\MSSQLLocalDB;Database=AbpPerfTest_WithAbp;Trusted_Connection=True"
   }
 }

--- a/test/AbpPerfTest/AbpPerfTest.WithoutAbp/appsettings.json
+++ b/test/AbpPerfTest/AbpPerfTest.WithoutAbp/appsettings.json
@@ -8,6 +8,6 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "Default": "Server=(LocalDb)\\MSSQLLocalDB;Database=AbpPerfTest_WithoutAbp;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "Default": "Server=(LocalDb)\\MSSQLLocalDB;Database=AbpPerfTest_WithoutAbp;Trusted_Connection=True"
   }
 }


### PR DESCRIPTION
Resolve https://github.com/abpframework/abp/issues/6819
For SQL Server, the connection string does not enable the `MultipleActiveResultSets=true` feature by default.