### PR TITLE
Make FeatureManagementProvider's NormalizeProviderKey method async.

### DIFF
--- a/modules/feature-management/src/Volo.Abp.FeatureManagement.Domain/Volo/Abp/FeatureManagement/EditionFeatureManagementProvider.cs
+++ b/modules/feature-management/src/Volo.Abp.FeatureManagement.Domain/Volo/Abp/FeatureManagement/EditionFeatureManagementProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System.Security.Principal;
+using System.Threading.Tasks;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Features;
 using Volo.Abp.Security.Claims;
@@ -12,21 +13,21 @@ namespace Volo.Abp.FeatureManagement
         protected ICurrentPrincipalAccessor PrincipalAccessor { get; }
 
         public EditionFeatureManagementProvider(
-            IFeatureManagementStore store, 
-            ICurrentPrincipalAccessor principalAccessor) 
+            IFeatureManagementStore store,
+            ICurrentPrincipalAccessor principalAccessor)
             : base(store)
         {
             PrincipalAccessor = principalAccessor;
         }
 
-        protected override string NormalizeProviderKey(string providerKey)
+        protected override Task<string> NormalizeProviderKeyAsync(string providerKey)
         {
             if (providerKey != null)
             {
-                return providerKey;
+                return Task.FromResult(providerKey);
             }
 
-            return PrincipalAccessor.Principal?.FindEditionId()?.ToString("N");
+            return Task.FromResult(PrincipalAccessor.Principal?.FindEditionId()?.ToString("N"));
         }
     }
 }

--- a/modules/feature-management/src/Volo.Abp.FeatureManagement.Domain/Volo/Abp/FeatureManagement/FeatureManagementProvider.cs
+++ b/modules/feature-management/src/Volo.Abp.FeatureManagement.Domain/Volo/Abp/FeatureManagement/FeatureManagementProvider.cs
@@ -21,22 +21,22 @@ namespace Volo.Abp.FeatureManagement
 
         public virtual async Task<string> GetOrNullAsync(FeatureDefinition feature, string providerKey)
         {
-            return await Store.GetOrNullAsync(feature.Name, Name, NormalizeProviderKey(providerKey));
+            return await Store.GetOrNullAsync(feature.Name, Name, await NormalizeProviderKeyAsync(providerKey));
         }
 
         public virtual async Task SetAsync(FeatureDefinition feature, string value, string providerKey)
         {
-            await Store.SetAsync(feature.Name, value, Name, NormalizeProviderKey(providerKey));
+            await Store.SetAsync(feature.Name, value, Name, await NormalizeProviderKeyAsync(providerKey));
         }
 
         public virtual async Task ClearAsync(FeatureDefinition feature, string providerKey)
         {
-            await Store.DeleteAsync(feature.Name, Name, NormalizeProviderKey(providerKey));
+            await Store.DeleteAsync(feature.Name, Name, await NormalizeProviderKeyAsync(providerKey));
         }
 
-        protected virtual string NormalizeProviderKey(string providerKey)
+        protected virtual Task<string> NormalizeProviderKeyAsync(string providerKey)
         {
-            return providerKey;
+            return Task.FromResult(providerKey);
         }
     }
 }

--- a/modules/feature-management/src/Volo.Abp.FeatureManagement.Domain/Volo/Abp/FeatureManagement/TenantFeatureManagementProvider.cs
+++ b/modules/feature-management/src/Volo.Abp.FeatureManagement.Domain/Volo/Abp/FeatureManagement/TenantFeatureManagementProvider.cs
@@ -1,4 +1,5 @@
-﻿using Volo.Abp.DependencyInjection;
+﻿using System.Threading.Tasks;
+using Volo.Abp.DependencyInjection;
 using Volo.Abp.Features;
 using Volo.Abp.MultiTenancy;
 
@@ -18,14 +19,14 @@ namespace Volo.Abp.FeatureManagement
             CurrentTenant = currentTenant;
         }
 
-        protected override string NormalizeProviderKey(string providerKey)
+        protected override Task<string> NormalizeProviderKeyAsync(string providerKey)
         {
             if (providerKey != null)
             {
-                return providerKey;
+                return Task.FromResult(providerKey);
             }
 
-            return CurrentTenant.Id?.ToString();
+            return Task.FromResult(CurrentTenant.Id?.ToString());
         }
     }
 }


### PR DESCRIPTION

Consider below use case.
```cs
protected override Task<string> NormalizeProviderKeyAsync(string providerKey)
{
	if (Guid.TryParse(providerKey, out var parsedTenantId))
	{
		var tenant = await TenantRepository.FindByIdAsync(parsedTenantId);
		return tenant?.EditionId?.ToString();
	}

	return null;
}
```