### PR TITLE
Always use Repository.GetQueryableAsync() in the method of RepositoryAsyncExtensions

### DIFF
--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/RepositoryAsyncExtensions.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/RepositoryAsyncExtensions.cs
@@ -26,415 +26,458 @@ namespace Volo.Abp.Domain.Repositories
 
         #region Any/All
 
-        public static Task<bool> AnyAsync<T>(
+        public static async Task<bool> AnyAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             [NotNull] Expression<Func<T, bool>> predicate,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.AnyAsync(repository, predicate, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.AnyAsync(queryable, predicate, cancellationToken);
         }
 
-        public static Task<bool> AllAsync<T>(
+        public static async Task<bool> AllAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             [NotNull] Expression<Func<T, bool>> predicate,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.AllAsync(repository, predicate, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.AllAsync(queryable, predicate, cancellationToken);
         }
 
         #endregion
 
         #region Count/LongCount
 
-        public static Task<int> CountAsync<T>(
+        public static async Task<int> CountAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.CountAsync(repository, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.CountAsync(queryable, cancellationToken);
         }
 
-        public static Task<int> CountAsync<T>(
+        public static async Task<int> CountAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             [NotNull] Expression<Func<T, bool>> predicate,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.CountAsync(repository, predicate, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.CountAsync(queryable, predicate, cancellationToken);
         }
 
-        public static Task<long> LongCountAsync<T>(
+        public static async Task<long> LongCountAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.LongCountAsync(repository, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.LongCountAsync(queryable, cancellationToken);
         }
 
-        public static Task<long> LongCountAsync<T>(
+        public static async Task<long> LongCountAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             [NotNull] Expression<Func<T, bool>> predicate,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.LongCountAsync(repository, predicate, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.LongCountAsync(queryable, predicate, cancellationToken);
         }
 
         #endregion
 
         #region First/FirstOrDefault
 
-        public static Task<T> FirstAsync<T>(
+        public static async Task<T> FirstAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.FirstAsync(repository, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.FirstAsync(queryable, cancellationToken);
         }
 
-        public static Task<T> FirstAsync<T>(
+        public static async Task<T> FirstAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             [NotNull] Expression<Func<T, bool>> predicate,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.FirstAsync(repository, predicate, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.FirstAsync(queryable, predicate, cancellationToken);
         }
 
-        public static Task<T> FirstOrDefaultAsync<T>(
+        public static async Task<T> FirstOrDefaultAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.FirstOrDefaultAsync(repository, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.FirstOrDefaultAsync(queryable, cancellationToken);
         }
 
-        public static Task<T> FirstOrDefaultAsync<T>(
+        public static async Task<T> FirstOrDefaultAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             [NotNull] Expression<Func<T, bool>> predicate,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.FirstOrDefaultAsync(repository, predicate, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.FirstOrDefaultAsync(queryable, predicate, cancellationToken);
         }
 
         #endregion
 
         #region Last/LastOrDefault
 
-        public static Task<T> LastAsync<T>(
+        public static async Task<T> LastAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.LastAsync(repository, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.LastAsync(queryable, cancellationToken);
         }
 
-        public static Task<T> LastAsync<T>(
+        public static async Task<T> LastAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             [NotNull] Expression<Func<T, bool>> predicate,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.LastAsync(repository, predicate, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.LastAsync(queryable, predicate, cancellationToken);
         }
 
-        public static Task<T> LastOrDefaultAsync<T>(
+        public static async Task<T> LastOrDefaultAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.LastOrDefaultAsync(repository, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.LastOrDefaultAsync(queryable, cancellationToken);
         }
 
-        public static Task<T> LastOrDefaultAsync<T>(
+        public static async Task<T> LastOrDefaultAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             [NotNull] Expression<Func<T, bool>> predicate,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.LastOrDefaultAsync(repository, predicate, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.LastOrDefaultAsync(queryable, predicate, cancellationToken);
         }
 
         #endregion
 
         #region Single/SingleOrDefault
 
-        public static Task<T> SingleAsync<T>(
+        public static async Task<T> SingleAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.SingleAsync(repository, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.SingleAsync(queryable, cancellationToken);
         }
 
-        public static Task<T> SingleAsync<T>(
+        public static async Task<T> SingleAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             [NotNull] Expression<Func<T, bool>> predicate,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.SingleAsync(repository, predicate, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.SingleAsync(queryable, predicate, cancellationToken);
         }
 
-        public static Task<T> SingleOrDefaultAsync<T>(
+        public static async Task<T> SingleOrDefaultAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.SingleOrDefaultAsync(repository, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.SingleOrDefaultAsync(queryable, cancellationToken);
         }
 
-        public static Task<T> SingleOrDefaultAsync<T>(
+        public static async Task<T> SingleOrDefaultAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             [NotNull] Expression<Func<T, bool>> predicate,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.SingleOrDefaultAsync(repository, predicate, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.SingleOrDefaultAsync(queryable, predicate, cancellationToken);
         }
 
         #endregion
 
         #region Min
 
-        public static Task<T> MinAsync<T>(
+        public static async Task<T> MinAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.MinAsync(repository, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.MinAsync(queryable, cancellationToken);
         }
 
-        public static Task<TResult> MinAsync<T, TResult>(
+        public static async Task<TResult> MinAsync<T, TResult>(
             [NotNull] this IReadOnlyRepository<T> repository,
             [NotNull] Expression<Func<T, TResult>> selector,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.MinAsync(repository, selector, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.MinAsync(queryable, selector, cancellationToken);
         }
 
         #endregion
 
         #region Max
 
-        public static Task<T> MaxAsync<T>(
+        public static async Task<T> MaxAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.MaxAsync(repository, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.MaxAsync(queryable, cancellationToken);
         }
 
-        public static Task<TResult> MaxAsync<T, TResult>(
+        public static async Task<TResult> MaxAsync<T, TResult>(
             [NotNull] this IReadOnlyRepository<T> repository,
             [NotNull] Expression<Func<T, TResult>> selector,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.MaxAsync(repository, selector, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.MaxAsync(queryable, selector, cancellationToken);
         }
 
         #endregion
 
         #region Sum
 
-        public static Task<decimal> SumAsync<T>(
+        public static async Task<decimal> SumAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             [NotNull] Expression<Func<T, decimal>> selector,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.SumAsync(repository, selector, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.SumAsync(queryable, selector, cancellationToken);
         }
 
-        public static Task<decimal?> SumAsync<T>(
+        public static async Task<decimal?> SumAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             [NotNull] Expression<Func<T, decimal?>> selector,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.SumAsync(repository, selector, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.SumAsync(queryable, selector, cancellationToken);
         }
 
-        public static Task<int> SumAsync<T>(
+        public static async Task<int> SumAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             [NotNull] Expression<Func<T, int>> selector,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.SumAsync(repository, selector, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.SumAsync(queryable, selector, cancellationToken);
         }
 
-        public static Task<int?> SumAsync<T>(
+        public static async Task<int?> SumAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             [NotNull] Expression<Func<T, int?>> selector,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.SumAsync(repository, selector, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.SumAsync(queryable, selector, cancellationToken);
         }
 
-        public static Task<long> SumAsync<T>(
+        public static async Task<long> SumAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             [NotNull] Expression<Func<T, long>> selector,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.SumAsync(repository, selector, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.SumAsync(queryable, selector, cancellationToken);
         }
 
-        public static Task<long?> SumAsync<T>(
+        public static async Task<long?> SumAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             [NotNull] Expression<Func<T, long?>> selector,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.SumAsync(repository, selector, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.SumAsync(queryable, selector, cancellationToken);
         }
 
-        public static Task<double> SumAsync<T>(
+        public static async Task<double> SumAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             [NotNull] Expression<Func<T, double>> selector,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.SumAsync(repository, selector, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.SumAsync(queryable, selector, cancellationToken);
         }
 
-        public static Task<double?> SumAsync<T>(
+        public static async Task<double?> SumAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             [NotNull] Expression<Func<T, double?>> selector,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.SumAsync(repository, selector, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.SumAsync(queryable, selector, cancellationToken);
         }
 
-        public static Task<float> SumAsync<T>(
+        public static async Task<float> SumAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             [NotNull] Expression<Func<T, float>> selector,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.SumAsync(repository, selector, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.SumAsync(queryable, selector, cancellationToken);
         }
 
-        public static Task<float?> SumAsync<T>(
+        public static async Task<float?> SumAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             [NotNull] Expression<Func<T, float?>> selector,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.SumAsync(repository, selector, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.SumAsync(queryable, selector, cancellationToken);
         }
 
         #endregion
 
         #region Average
 
-        public static Task<decimal> AverageAsync<T>(
+        public static async Task<decimal> AverageAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             [NotNull] Expression<Func<T, decimal>> selector,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.AverageAsync(repository, selector, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.AverageAsync(queryable, selector, cancellationToken);
         }
 
-        public static Task<decimal?> AverageAsync<T>(
+        public static async Task<decimal?> AverageAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             [NotNull] Expression<Func<T, decimal?>> selector,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.AverageAsync(repository, selector, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.AverageAsync(queryable, selector, cancellationToken);
         }
 
-        public static Task<double> AverageAsync<T>(
+        public static async Task<double> AverageAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             [NotNull] Expression<Func<T, int>> selector,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.AverageAsync(repository, selector, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.AverageAsync(queryable, selector, cancellationToken);
         }
 
-        public static Task<double?> AverageAsync<T>(
+        public static async Task<double?> AverageAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             [NotNull] Expression<Func<T, int?>> selector,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.AverageAsync(repository, selector, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.AverageAsync(queryable, selector, cancellationToken);
         }
 
-        public static Task<double> AverageAsync<T>(
+        public static async Task<double> AverageAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             [NotNull] Expression<Func<T, long>> selector,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.AverageAsync(repository, selector, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.AverageAsync(queryable, selector, cancellationToken);
         }
 
-        public static Task<double?> AverageAsync<T>(
+        public static async Task<double?> AverageAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             [NotNull] Expression<Func<T, long?>> selector,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.AverageAsync(repository, selector, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.AverageAsync(queryable, selector, cancellationToken);
         }
 
-        public static Task<double> AverageAsync<T>(
+        public static async Task<double> AverageAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             [NotNull] Expression<Func<T, double>> selector,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.AverageAsync(repository, selector, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.AverageAsync(queryable, selector, cancellationToken);
         }
 
-        public static Task<double?> AverageAsync<T>(
+        public static async Task<double?> AverageAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             [NotNull] Expression<Func<T, double?>> selector,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.AverageAsync(repository, selector, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.AverageAsync(queryable, selector, cancellationToken);
         }
 
-        public static Task<float?> AverageAsync<T>(
+        public static async Task<float?> AverageAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             [NotNull] Expression<Func<T, float?>> selector,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.AverageAsync(repository, selector, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.AverageAsync(queryable, selector, cancellationToken);
         }
 
         #endregion
 
         #region ToList/Array
 
-        public static Task<List<T>> ToListAsync<T>(
+        public static async Task<List<T>> ToListAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.ToListAsync(repository, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.ToListAsync(queryable, cancellationToken);
         }
 
-        public static Task<T[]> ToArrayAsync<T>(
+        public static async Task<T[]> ToArrayAsync<T>(
             [NotNull] this IReadOnlyRepository<T> repository,
             CancellationToken cancellationToken = default)
             where T : class, IEntity
         {
-            return repository.AsyncExecuter.ToArrayAsync(repository, cancellationToken);
+            var queryable = await repository.GetQueryableAsync();
+            return await repository.AsyncExecuter.ToArrayAsync(queryable, cancellationToken);
         }
 
         #endregion


### PR DESCRIPTION
Resolve https://github.com/abpframework/abp/issues/6992