### PR TITLE
Fix enum file template with string enum.

### DIFF
--- a/npm/ng-packs/packages/schematics/src/commands/api/files-enum/proxy/__namespace@dir__/__name@kebab__.enum.ts.template
+++ b/npm/ng-packs/packages/schematics/src/commands/api/files-enum/proxy/__namespace@dir__/__name@kebab__.enum.ts.template
@@ -2,7 +2,7 @@ import { mapEnumToOptions } from '@abp/ng.core';
 
 export enum <%= name %> {<%
   for (let member of members) { %>
-  <%= member.key %> = <%= member.value %>,<% } %>
+  <%= member.key %> = <%= quote(member.value) %>,<% } %>
 }
 
 export const <%= camel(name) %>Options = mapEnumToOptions(<%= name %>);

--- a/npm/ng-packs/packages/schematics/src/utils/text.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/text.ts
@@ -11,7 +11,7 @@ export const dir = (text: string) =>
   strings.dasherize(text.replace(/\./g, '/').replace(/\/\//g, '/'));
 
 export const quote = (value: number | string) =>
-  typeof value === 'string' ? `'${value.replace(/'/g, `\\'`)}'` : value;
+  typeof value === 'string' ? `'${value.replace(/'/g, '\\\'')}'` : value;
 
 function _(text: string): string {
   return text.replace(/\./g, '_');

--- a/npm/ng-packs/packages/schematics/src/utils/text.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/text.ts
@@ -10,6 +10,9 @@ export const macro = (text: string) => upper(snake(text));
 export const dir = (text: string) =>
   strings.dasherize(text.replace(/\./g, '/').replace(/\/\//g, '/'));
 
+// TODO: Is there a standard function to do this? There is a leak if the value contains single quote.
+export const quote = (value: number | string) => typeof value === 'string' ? `'${value}'` : value;
+
 function _(text: string): string {
   return text.replace(/\./g, '_');
 }

--- a/npm/ng-packs/packages/schematics/src/utils/text.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/text.ts
@@ -10,8 +10,8 @@ export const macro = (text: string) => upper(snake(text));
 export const dir = (text: string) =>
   strings.dasherize(text.replace(/\./g, '/').replace(/\/\//g, '/'));
 
-// TODO: Is there a standard function to do this? There is a leak if the value contains single quote.
-export const quote = (value: number | string) => typeof value === 'string' ? `'${value}'` : value;
+export const quote = (value: number | string) =>
+  typeof value === 'string' ? `'${value.replace(/'/g, `\\'`)}'` : value;
 
 function _(text: string): string {
   return text.replace(/\./g, '_');


### PR DESCRIPTION
I'm using `JsonStringEnumConverter` in backend json options.
Then `abp generate-proxy` generated the broken code like that:
```ts
export enum OrderStatus {
  WaitForPayment = WaitForPayment,
  Finished = Finished,
  Cancelled = Cancelled,
}
```

I think the value should be quoted as string value, so I make this fix.
After the fix, the generated code will be like:
```ts
export enum OrderStatus {
  WaitForPayment = 'WaitForPayment',
  Finished = 'Finished',
  Cancelled = 'Cancelled',
}
```