### PR TITLE
Introduce AbpRequestLocalizationOptions

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore/Microsoft/AspNetCore/RequestLocalization/AbpRequestLocalizationMiddleware.cs
+++ b/framework/src/Volo.Abp.AspNetCore/Microsoft/AspNetCore/RequestLocalization/AbpRequestLocalizationMiddleware.cs
@@ -23,10 +23,10 @@ namespace Microsoft.AspNetCore.RequestLocalization
 
         public async Task InvokeAsync(HttpContext context, RequestDelegate next)
         {
-
             var middleware = new RequestLocalizationMiddleware(
                 next,
-                new OptionsWrapper<RequestLocalizationOptions>(await _requestLocalizationOptionsProvider.GetLocalizationOptionsAsync()), _loggerFactory
+                new OptionsWrapper<RequestLocalizationOptions>(await _requestLocalizationOptionsProvider.GetLocalizationOptionsAsync()),
+                _loggerFactory
             );
 
             await middleware.Invoke(context);

--- a/framework/src/Volo.Abp.AspNetCore/Microsoft/AspNetCore/RequestLocalization/AbpRequestLocalizationOptions.cs
+++ b/framework/src/Volo.Abp.AspNetCore/Microsoft/AspNetCore/RequestLocalization/AbpRequestLocalizationOptions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+
+namespace Microsoft.AspNetCore.RequestLocalization
+{
+    public class AbpRequestLocalizationOptions
+    {
+        public List<Func<IServiceProvider, RequestLocalizationOptions, Task>> RequestLocalizationOptionConfigurators { get; }
+
+        public AbpRequestLocalizationOptions()
+        {
+            RequestLocalizationOptionConfigurators = new List<Func<IServiceProvider, RequestLocalizationOptions, Task>>();
+        }
+    }
+}

--- a/framework/src/Volo.Abp.AspNetCore/Microsoft/AspNetCore/RequestLocalization/DefaultAbpRequestLocalizationOptionsProvider.cs
+++ b/framework/src/Volo.Abp.AspNetCore/Microsoft/AspNetCore/RequestLocalization/DefaultAbpRequestLocalizationOptionsProvider.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Localization;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Localization;
 using Volo.Abp.Settings;
@@ -66,6 +67,13 @@ namespace Microsoft.AspNetCore.RequestLocalization
                                         .Select(c => new CultureInfo(c))
                                         .ToArray()
                                 };
+
+                            foreach (var configurator in serviceScope.ServiceProvider
+                                .GetRequiredService<IOptions<AbpRequestLocalizationOptions>>()
+                                .Value.RequestLocalizationOptionConfigurators)
+                            {
+                                await configurator(serviceScope.ServiceProvider, options);
+                            }
 
                             _optionsAction?.Invoke(options);
                             _requestLocalizationOptions = options;

--- a/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/Localization/LocalizationTestController.cs
+++ b/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/Localization/LocalizationTestController.cs
@@ -1,0 +1,15 @@
+﻿using System.Globalization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Volo.Abp.AspNetCore.Mvc.Localization
+{
+    [Route("api/LocalizationTestController")]
+    public class LocalizationTestController : AbpController
+    {
+        [HttpGet]
+        public string Culture()
+        {
+            return CultureInfo.CurrentCulture.Name + ":" + CultureInfo.CurrentUICulture.Name;
+        }
+    }
+}

--- a/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/Localization/LocalizationTestController_Tests.cs
+++ b/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/Localization/LocalizationTestController_Tests.cs
@@ -1,0 +1,45 @@
+﻿using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Localization;
+using Microsoft.AspNetCore.RequestLocalization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Primitives;
+using Shouldly;
+using Volo.Abp.DependencyInjection;
+using Xunit;
+
+namespace Volo.Abp.AspNetCore.Mvc.Localization
+{
+    public class LocalizationTestController_Tests : AspNetCoreMvcTestBase
+    {
+        class TestRequestCultureProvider : RequestCultureProvider, ITransientDependency
+        {
+            public override Task<ProviderCultureResult> DetermineProviderCultureResult(HttpContext httpContext)
+            {
+                return Task.FromResult(new ProviderCultureResult((StringSegment) "tr", (StringSegment) "hu"));
+            }
+        }
+
+        protected override void ConfigureServices(HostBuilderContext context, IServiceCollection services)
+        {
+            services.Configure<AbpRequestLocalizationOptions>(options =>
+            {
+                options.RequestLocalizationOptionConfigurators.Add((provider, localizationOptions) =>
+                {
+                    localizationOptions.RequestCultureProviders.Insert(0, provider.GetRequiredService<TestRequestCultureProvider>());
+                    return Task.CompletedTask;
+                });
+            });
+        }
+
+        [Fact]
+        public async Task TestRequestCultureProvider_Test()
+        {
+            var response = await GetResponseAsync("api/LocalizationTestController", HttpStatusCode.OK);
+            var resultAsString = await response.Content.ReadAsStringAsync();
+            resultAsString.ToLower().ShouldBe("tr:hu");
+        }
+    }
+}

--- a/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/Localization/LocalizationTestController_Tests.cs
+++ b/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/Localization/LocalizationTestController_Tests.cs
@@ -7,14 +7,13 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Primitives;
 using Shouldly;
-using Volo.Abp.DependencyInjection;
 using Xunit;
 
 namespace Volo.Abp.AspNetCore.Mvc.Localization
 {
     public class LocalizationTestController_Tests : AspNetCoreMvcTestBase
     {
-        class TestRequestCultureProvider : RequestCultureProvider, ITransientDependency
+        class TestRequestCultureProvider : RequestCultureProvider
         {
             public override Task<ProviderCultureResult> DetermineProviderCultureResult(HttpContext httpContext)
             {
@@ -26,9 +25,9 @@ namespace Volo.Abp.AspNetCore.Mvc.Localization
         {
             services.Configure<AbpRequestLocalizationOptions>(options =>
             {
-                options.RequestLocalizationOptionConfigurators.Add((provider, localizationOptions) =>
+                options.RequestLocalizationOptionConfigurators.Add((serviceProvider, localizationOptions) =>
                 {
-                    localizationOptions.RequestCultureProviders.Insert(0, provider.GetRequiredService<TestRequestCultureProvider>());
+                    localizationOptions.RequestCultureProviders.Insert(0, new TestRequestCultureProvider());
                     return Task.CompletedTask;
                 });
             });


### PR DESCRIPTION
Sometimes the module may need to configure **RequestLocalizationOptions**

```cs
Configure<AbpRequestLocalizationOptions>(options =>
{
    options.RequestLocalizationOptionConfigurators.Add((serviceProvider, localizationOptions) =>
    {
        localizationOptions.RequestCultureProviders.Insert(0, new TestRequestCultureProvider());
        return Task.CompletedTask;
    });
});
```