### PR TITLE
Use commas to separate header objects.

### DIFF
--- a/framework/src/Volo.Abp.Http/Volo/Abp/Http/ProxyScripting/Generators/ProxyScriptingJsFuncHelper.cs
+++ b/framework/src/Volo.Abp.Http/Volo/Abp/Http/ProxyScripting/Generators/ProxyScriptingJsFuncHelper.cs
@@ -123,10 +123,9 @@ namespace Volo.Abp.Http.ProxyScripting.Generators
 
             sb.AppendLine("{");
 
-            foreach (var prm in parameters)
-            {
-                sb.AppendLine($"{new string(' ', indent)}  '{prm.Name}': {GetParamNameInJsFunc(prm)}");
-            }
+            sb.AppendLine(parameters
+                .Select(prm => $"{new string(' ', indent)}  '{prm.Name}': {GetParamNameInJsFunc(prm)}")
+                .JoinAsString(", " + Environment.NewLine));
 
             sb.Append(new string(' ', indent) + "}");
 


### PR DESCRIPTION
Fix #7031

```cs
public Task Test([FromHeader] string mystr1, [FromHeader] string mystr2)
{
    return Task.CompletedTask;
}

(function(){
  abp.utils.createNamespace(window, 'volo.abp.aspNetCore.mvc.uI.bootstrap.demo.pages.test');

  volo.abp.aspNetCore.mvc.uI.bootstrap.demo.pages.test.test = function(mystr1, mystr2, ajaxParams) {
    return abp.ajax($.extend(true, {
      url: abp.appPath + 'api/app/test/test',
      type: 'POST',
      dataType: null,
      headers: {
        'mystr1': mystr1, 
        'mystr2': mystr2
      }
    }, ajaxParams));
  };

})();
```