### PR TITLE
 Include symbol files (*.pdb) in the built .nupkg.

### DIFF
--- a/common.props
+++ b/common.props
@@ -10,10 +10,8 @@
     <RepositoryUrl>https://github.com/abpframework/abp/</RepositoryUrl>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
-    <!-- https://github.com/dotnet/sourcelink -->
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-
+    <!-- Include symbol files (*.pdb) in the built .nupkg -->
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.0-beta-20204-02">

--- a/nupkg/pack.ps1
+++ b/nupkg/pack.ps1
@@ -26,8 +26,6 @@ foreach($project in $projects) {
     $projectName = $project.Substring($project.LastIndexOf("/") + 1)
     $projectPackPath = Join-Path $projectFolder ("/bin/Release/" + $projectName + ".*.nupkg")
     Move-Item $projectPackPath $packFolder
-    $projectSymbolPackPath = Join-Path $projectFolder ("/bin/Release/" + $projectName + ".*.snupkg")
-    Move-Item $projectSymbolPackPath $packFolder
 }
 
 # Go back to the pack folder


### PR DESCRIPTION
Resolve #6702

Because https://github.com/dotnet/sdk/issues/1458 we need to install https://www.nuget.org/packages/SourceLink.Copy.PdbFiles when we use the source link