### PR TITLE
Make AccountEmailer.NormalizeReturnUrl method protected

### DIFF
--- a/modules/account/src/Volo.Abp.Account.Application/Volo/Abp/Account/Emailing/AccountEmailer.cs
+++ b/modules/account/src/Volo.Abp.Account.Application/Volo/Abp/Account/Emailing/AccountEmailer.cs
@@ -72,7 +72,7 @@ namespace Volo.Abp.Account.Emailing
             );
         }
 
-        private string NormalizeReturnUrl(string returnUrl)
+        protected string NormalizeReturnUrl(string returnUrl)
         {
             if (returnUrl.IsNullOrEmpty())
             {

--- a/modules/account/src/Volo.Abp.Account.Application/Volo/Abp/Account/Emailing/AccountEmailer.cs
+++ b/modules/account/src/Volo.Abp.Account.Application/Volo/Abp/Account/Emailing/AccountEmailer.cs
@@ -72,7 +72,7 @@ namespace Volo.Abp.Account.Emailing
             );
         }
 
-        protected string NormalizeReturnUrl(string returnUrl)
+        protected virtual string NormalizeReturnUrl(string returnUrl)
         {
             if (returnUrl.IsNullOrEmpty())
             {


### PR DESCRIPTION
This will allow the `SendPasswordResetLinkAsync` method to be overridden but still use the base `NormalizeReturnUrl` method.
Also consider making this `virtual` if you would like.