### PR TITLE
docs: Fix incorrect text templating instructions

### DIFF
--- a/docs/en/Text-Templating.md
+++ b/docs/en/Text-Templating.md
@@ -423,7 +423,7 @@ This example simply adds a header and footer to the template and renders the con
 **3)** Configure the embedded resources in the `.csproj` file
 
 * Add [Microsoft.Extensions.FileProviders.Embedded](https://www.nuget.org/packages/Microsoft.Extensions.FileProviders.Embedded) NuGet package to the project.
-* Add `<GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>` into the `<PropertyConfig>...</PropertyConfig>` section of your `.csproj` file.
+* Add `<GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>` into the `<PropertyGroup>...</PropertyGroup>` section of your `.csproj` file.
 * Add the following code into your `.csproj` file:
 
 ````xml


### PR DESCRIPTION
"< PropertyConfig >" doesn't exist in the project file schema: https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-project-file-schema-reference?view=vs-2019