### PR TITLE
angular: Fix AuthGuard returning 'true' when user not authorized

### DIFF
--- a/npm/ng-packs/packages/core/src/lib/guards/auth.guard.ts
+++ b/npm/ng-packs/packages/core/src/lib/guards/auth.guard.ts
@@ -17,6 +17,6 @@ export class AuthGuard implements CanActivate {
     }
 
     this.authService.initLogin();
-    return true;
+    return false;
   }
 }

--- a/npm/ng-packs/packages/core/src/lib/tests/auth.guard.spec.ts
+++ b/npm/ng-packs/packages/core/src/lib/tests/auth.guard.spec.ts
@@ -26,7 +26,7 @@ describe('AuthGuard', () => {
     spectator.inject(OAuthService).hasValidAccessToken.andReturn(false);
     const initLoginSpy = jest.spyOn(authService, 'initLogin');
 
-    expect(guard.canActivate()).toBe(true);
+    expect(guard.canActivate()).toBe(false);
     expect(initLoginSpy).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
I believe this is a bug? By returning false the page doesn't continue to load, and the user is redirected to the '/Account/Login' page as expected without causing permission errors to appear on my app.