### PR TITLE
Fix EF warning in EfCoreTenantRepository

### DIFF
--- a/modules/tenant-management/src/Volo.Abp.TenantManagement.EntityFrameworkCore/Volo/Abp/TenantManagement/EntityFrameworkCore/EfCoreTenantRepository.cs
+++ b/modules/tenant-management/src/Volo.Abp.TenantManagement.EntityFrameworkCore/Volo/Abp/TenantManagement/EntityFrameworkCore/EfCoreTenantRepository.cs
@@ -25,7 +25,7 @@ namespace Volo.Abp.TenantManagement.EntityFrameworkCore
         {
             return await (await GetDbSetAsync())
                 .IncludeDetails(includeDetails)
-                .OrderBy(x => x.Id)
+                .OrderBy(t => t.Id)
                 .FirstOrDefaultAsync(t => t.Name == name, GetCancellationToken(cancellationToken));
         }
 
@@ -34,7 +34,7 @@ namespace Volo.Abp.TenantManagement.EntityFrameworkCore
         {
             return DbSet
                 .IncludeDetails(includeDetails)
-                .OrderBy(x => x.Id)
+                .OrderBy(t => t.Id)
                 .FirstOrDefault(t => t.Name == name);
         }
 
@@ -43,7 +43,7 @@ namespace Volo.Abp.TenantManagement.EntityFrameworkCore
         {
             return DbSet
                 .IncludeDetails(includeDetails)
-                .OrderBy(x => x.Id)
+                .OrderBy(t => t.Id)
                 .FirstOrDefault(t => t.Id == id);
         }
 

--- a/modules/tenant-management/src/Volo.Abp.TenantManagement.EntityFrameworkCore/Volo/Abp/TenantManagement/EntityFrameworkCore/EfCoreTenantRepository.cs
+++ b/modules/tenant-management/src/Volo.Abp.TenantManagement.EntityFrameworkCore/Volo/Abp/TenantManagement/EntityFrameworkCore/EfCoreTenantRepository.cs
@@ -25,6 +25,7 @@ namespace Volo.Abp.TenantManagement.EntityFrameworkCore
         {
             return await (await GetDbSetAsync())
                 .IncludeDetails(includeDetails)
+                .OrderBy(x => x.Name)
                 .FirstOrDefaultAsync(t => t.Name == name, GetCancellationToken(cancellationToken));
         }
 
@@ -33,6 +34,7 @@ namespace Volo.Abp.TenantManagement.EntityFrameworkCore
         {
             return DbSet
                 .IncludeDetails(includeDetails)
+                .OrderBy(x => x.Name)
                 .FirstOrDefault(t => t.Name == name);
         }
 
@@ -41,6 +43,7 @@ namespace Volo.Abp.TenantManagement.EntityFrameworkCore
         {
             return DbSet
                 .IncludeDetails(includeDetails)
+                .OrderBy(x => x.Id)
                 .FirstOrDefault(t => t.Id == id);
         }
 

--- a/modules/tenant-management/src/Volo.Abp.TenantManagement.EntityFrameworkCore/Volo/Abp/TenantManagement/EntityFrameworkCore/EfCoreTenantRepository.cs
+++ b/modules/tenant-management/src/Volo.Abp.TenantManagement.EntityFrameworkCore/Volo/Abp/TenantManagement/EntityFrameworkCore/EfCoreTenantRepository.cs
@@ -25,7 +25,7 @@ namespace Volo.Abp.TenantManagement.EntityFrameworkCore
         {
             return await (await GetDbSetAsync())
                 .IncludeDetails(includeDetails)
-                .OrderBy(x => x.Name)
+                .OrderBy(x => x.Id)
                 .FirstOrDefaultAsync(t => t.Name == name, GetCancellationToken(cancellationToken));
         }
 
@@ -34,7 +34,7 @@ namespace Volo.Abp.TenantManagement.EntityFrameworkCore
         {
             return DbSet
                 .IncludeDetails(includeDetails)
-                .OrderBy(x => x.Name)
+                .OrderBy(x => x.Id)
                 .FirstOrDefault(t => t.Name == name);
         }
 


### PR DESCRIPTION
Fixes 'The query uses a row limiting operator' errors In EfCoreTenantRepository
Related: https://github.com/abpframework/abp/issues/7188