### PR TITLE
Improve flexibility of email validation in the ValidationHelper

### DIFF
--- a/framework/src/Volo.Abp.Validation/Volo/Abp/Validation/ValidationHelper.cs
+++ b/framework/src/Volo.Abp.Validation/Volo/Abp/Validation/ValidationHelper.cs
@@ -4,7 +4,9 @@ namespace Volo.Abp.Validation
 {
     public class ValidationHelper
     {
-        private const string EmailRegEx = @"[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?";
+        // Taken from W3C as an alternative to the RFC5322 specification: https://html.spec.whatwg.org/#valid-e-mail-address
+        // The RFC5322 regex can be found here: https://emailregex.com/
+        public static string EmailRegEx { get; set; } = @"^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$";
 
         public static bool IsValidEmailAddress(string email)
         {
@@ -13,7 +15,6 @@ namespace Volo.Abp.Validation
                 return false;
             }
 
-            /*RFC 2822 (simplified)*/
             return Regex.IsMatch(email, EmailRegEx, RegexOptions.Compiled | RegexOptions.IgnoreCase);
         }
     }

--- a/framework/test/Volo.Abp.Validation.Tests/Volo/Abp/Validation/ApplicationService_Validation_Tests.cs
+++ b/framework/test/Volo.Abp.Validation.Tests/Volo/Abp/Validation/ApplicationService_Validation_Tests.cs
@@ -180,15 +180,19 @@ namespace Volo.Abp.Validation
         {
             //Valid
             ValidationHelper.IsValidEmailAddress("john.doe@domain.com").ShouldBe(true);
+            ValidationHelper.IsValidEmailAddress("john-doe1@domain.co").ShouldBe(true);
             ValidationHelper.IsValidEmailAddress("ip@1.2.3.123").ShouldBe(true);
             ValidationHelper.IsValidEmailAddress("pharaoh@egyptian.museum").ShouldBe(true);
             ValidationHelper.IsValidEmailAddress("john.doe+regexbuddy@gmail.com").ShouldBe(true);
             ValidationHelper.IsValidEmailAddress("Mike.O'Dell@ireland.com").ShouldBe(true);
+            ValidationHelper.IsValidEmailAddress("admin@localhost").ShouldBe(true);
+            ValidationHelper.IsValidEmailAddress("j@h.c").ShouldBe(true);
 
             //Invalid
-            ValidationHelper.IsValidEmailAddress("1024x768@60Hz").ShouldBe(false);
             ValidationHelper.IsValidEmailAddress("not.a.valid.email").ShouldBe(false);
             ValidationHelper.IsValidEmailAddress("john@aol...com").ShouldBe(false);
+            ValidationHelper.IsValidEmailAddress("john@aol@domain.com").ShouldBe(false);
+            ValidationHelper.IsValidEmailAddress("jack@domain.").ShouldBe(false);
         }
 
         [DependsOn(typeof(AbpAutofacModule))]


### PR DESCRIPTION
Resolves https://github.com/abpframework/abp/issues/7265

* ValidationHelper.EmailRegEx can now be modified to suit the users needs
* Regex updated to be more inclusive. Taken from the WHATWG specification https://html.spec.whatwg.org/#valid-e-mail-address

WHATWG state that the rules defined by RFC5322 are not good enough. They offer an alternative regex which they say violates the standard, but it works better. See https://html.spec.whatwg.org/#valid-e-mail-address

Instead of using two properties `EmailRegex` and `StrictEmailRegex`, I propose we simply update the current regex and use a more inclusive regex. If you think we should include both then I will update the PR to include both and use the W3C regex for the less strict one. I have updated the tests to include a test for `admin@localhost`, which now passes. The old `1024x768@60hz` test would have passed for the same reason so I remove it.