### PR TITLE
Add ConfigureAll method to Bundle system

### DIFF
--- a/docs/en/UI/AspNetCore/Bundling-Minification.md
+++ b/docs/en/UI/AspNetCore/Bundling-Minification.md
@@ -165,7 +165,27 @@ public class MyWebExtensionModule : AbpModule
 }
 ````
 
-> It's not possible to configure unnamed bundle tag helpers by code, because their name are not known at the development time. It's suggested to always use a name for a bundle tag helper.
+You can also use the `ConfigureAll` method to configure all existing bundles:
+
+````C#
+[DependsOn(typeof(MyWebModule))]
+public class MyWebExtensionModule : AbpModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        Configure<AbpBundlingOptions>(options =>
+        {
+            options
+                .ScriptBundles
+                .ConfigureAll(bundle => {
+                    bundle.AddFiles(
+                        "/scripts/my-extension-script.js"
+                    );
+                });
+        });
+    }
+}
+````
 
 ## Bundle Contributors
 

--- a/docs/zh-Hans/UI/AspNetCore/Bundling-Minification.md
+++ b/docs/zh-Hans/UI/AspNetCore/Bundling-Minification.md
@@ -167,7 +167,27 @@ public class MyWebExtensionModule : AbpModule
 }
 ````
 
-> 无法通过代码配置未命名的bundle tag helpers, 因为它们的名称在开发时是未知的. 建议始终使用bundle tag helper的名称.
+你也可以使用 `ConfigureAll` 方法配置所有现有的捆绑包:
+
+````C#
+[DependsOn(typeof(MyWebModule))]
+public class MyWebExtensionModule : AbpModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        Configure<AbpBundlingOptions>(options =>
+        {
+            options
+                .ScriptBundles
+                .ConfigureAll(bundle => {
+                    bundle.AddFiles(
+                        "/scripts/my-extension-script.js"
+                    );
+                });
+        });
+    }
+}
+````
 
 ### Bundle 贡献者
 

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/BundleConfigurationCollection.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/BundleConfigurationCollection.cs
@@ -92,7 +92,11 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bundling
                 }
             }
 
-            _lazyAllBundleConfigurationActions.ForEach(c => c.Invoke(bundle));
+            lock (_lazyAllBundleConfigurationActions)
+            {
+                _lazyAllBundleConfigurationActions.ForEach(c => c.Invoke(bundle));
+            }
+
 
             return bundle;
         }
@@ -142,7 +146,10 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bundling
                 configureAction.Invoke(bundle.Value);
             }
 
-            _lazyAllBundleConfigurationActions.Add(configureAction);
+            lock (_lazyAllBundleConfigurationActions)
+            {
+                _lazyAllBundleConfigurationActions.Add(configureAction);
+            }
 
             return this;
         }


### PR DESCRIPTION
Allow configuration of all bundled packages(Including dynamically created by Tag helper)

Example:

```csharp
public class RemoveJqueryScriptContributor : BundleContributor
{
   public override void ConfigureBundle(BundleConfigurationContext context)
   {
       context.Files.RemoveAll(x => x.StartsWith("/libs/jquery/jquery.js", StringComparison.InvariantCultureIgnoreCase));
   }
}

Configure<AbpBundlingOptions>(options =>
{
    options.ScriptBundles.ConfigureAll(bundle =>
    {
        bundle.AddContributors(typeof(RemoveJqueryScriptContributor));
    });
});
```