### PR TITLE
CmsKit - Model creating fix

### DIFF
--- a/modules/cms-kit/src/Volo.CmsKit.EntityFrameworkCore/Volo/CmsKit/EntityFrameworkCore/CmsKitDbContextModelCreatingExtensions.cs
+++ b/modules/cms-kit/src/Volo.CmsKit.EntityFrameworkCore/Volo/CmsKit/EntityFrameworkCore/CmsKitDbContextModelCreatingExtensions.cs
@@ -62,6 +62,10 @@ namespace Volo.CmsKit.EntityFrameworkCore
                     b.HasIndex(x => new {x.TenantId, x.CreatorId, x.EntityType, x.EntityId, x.ReactionName});
                 });
             }
+            else
+            {
+                builder.Ignore<UserReaction>();
+            }
 
             if (GlobalFeatureManager.Instance.IsEnabled<CommentsFeature>())
             {
@@ -80,6 +84,10 @@ namespace Volo.CmsKit.EntityFrameworkCore
                     b.HasIndex(x => new {x.TenantId, x.RepliedCommentId});
                 });
             }
+            else
+            {
+                builder.Ignore<Comment>();
+            }
 
             if (GlobalFeatureManager.Instance.IsEnabled<RatingsFeature>())
             {
@@ -96,6 +104,10 @@ namespace Volo.CmsKit.EntityFrameworkCore
                     r.HasIndex(x => new { x.TenantId, x.EntityType, x.EntityId, x.CreatorId });
                 });
             }
+            else
+            {
+                builder.Ignore<Rating>();
+            }
 
             if (GlobalFeatureManager.Instance.IsEnabled<ContentsFeature>())
             {
@@ -111,6 +123,10 @@ namespace Volo.CmsKit.EntityFrameworkCore
 
                     b.HasIndex(x => new { x.TenantId, x.EntityType, x.EntityId });
                 });
+            }
+            else
+            {
+                builder.Ignore<Content>();
             }
 
             if (GlobalFeatureManager.Instance.IsEnabled<TagsFeature>())
@@ -145,50 +161,10 @@ namespace Volo.CmsKit.EntityFrameworkCore
                     b.HasIndex(x => new { x.TenantId, x.EntityId, x.TagId });
                 });
             }
-
-            if (GlobalFeatureManager.Instance.IsEnabled<PagesFeature>())
+            else
             {
-                builder.Entity<Page>(b =>
-                {
-                    b.ToTable(options.TablePrefix + "Pages", options.Schema);
-
-                    b.ConfigureByConvention();
-
-                    b.Property(x => x.Title).IsRequired().HasMaxLength(PageConsts.MaxTitleLength);
-                    b.Property(x => x.Url).IsRequired().HasMaxLength(PageConsts.MaxUrlLength);
-                    b.Property(x => x.Description).HasMaxLength(PageConsts.MaxDescriptionLength);
-
-                    b.HasIndex(x => new { x.TenantId, x.Url });
-                });
-            }
-
-            if (GlobalFeatureManager.Instance.IsEnabled<TagsFeature>())
-            {
-                builder.Entity<Tag>(b =>
-                {
-                    b.ToTable(options.TablePrefix + "Tags", options.Schema);
-
-                    b.ConfigureByConvention();
-
-                    b.Property(x => x.EntityType).IsRequired().HasMaxLength(TagConsts.MaxEntityTypeLength);
-                    b.Property(x => x.Name).IsRequired().HasMaxLength(TagConsts.MaxNameLength);
-
-                    b.HasIndex(x => new {x.TenantId, x.Name});
-                });
-
-                builder.Entity<EntityTag>(b =>
-                {
-                    b.ToTable(options.TablePrefix + "EntityTags", options.Schema);
-
-                    b.ConfigureByConvention();
-
-                    b.HasKey(x => new {x.EntityId, x.TagId});
-
-                    b.Property(x => x.EntityId).IsRequired();
-                    b.Property(x => x.TagId).IsRequired();
-
-                    b.HasIndex(x => new {x.TenantId, x.EntityId, x.TagId});
-                });
+                builder.Ignore<EntityTag>();
+                builder.Ignore<Tag>();
             }
 
             if (GlobalFeatureManager.Instance.IsEnabled<PagesFeature>())
@@ -205,6 +181,10 @@ namespace Volo.CmsKit.EntityFrameworkCore
 
                     b.HasIndex(x => new {x.TenantId, x.Url});
                 });
+            }
+            else
+            {
+                builder.Ignore<Page>();
             }
         }
     }


### PR DESCRIPTION
## Summary

Entity Framework configures all **DbSet**s even you haven't configured in **OnModelCreating** method. So if a feature isn't enabled, we have to call `Ignore()` method to ignore default configuring by EF Core.

Also there are some duplicated configurations. I've just removed them too.