### PR TITLE
Introduce ICacheNameProvider.

### DIFF
--- a/framework/src/Volo.Abp.Caching/Volo/Abp/Caching/CacheNameAttribute.cs
+++ b/framework/src/Volo.Abp.Caching/Volo/Abp/Caching/CacheNameAttribute.cs
@@ -18,6 +18,18 @@ namespace Volo.Abp.Caching
 
         public static string GetCacheName(Type cacheItemType)
         {
+            if (typeof(ICacheNameProvider).IsAssignableFrom(cacheItemType))
+            {
+                try
+                {
+                    return ((ICacheNameProvider)Activator.CreateInstance(cacheItemType)).GetCacheName();
+                }
+                catch (Exception ex)
+                {
+                    throw new AbpException($"Cannot create an instance of type {cacheItemType.FullName}.", ex);
+                }
+            }
+
             var cacheNameAttribute = cacheItemType
                 .GetCustomAttributes(true)
                 .OfType<CacheNameAttribute>()

--- a/framework/src/Volo.Abp.Caching/Volo/Abp/Caching/ICacheNameProvider.cs
+++ b/framework/src/Volo.Abp.Caching/Volo/Abp/Caching/ICacheNameProvider.cs
@@ -1,0 +1,7 @@
+﻿namespace Volo.Abp.Caching
+{
+    public interface ICacheNameProvider
+    {
+        string GetCacheName();
+    }
+}

--- a/framework/test/Volo.Abp.Caching.Tests/Volo/Abp/Caching/CacheNameAttribute_Tests.cs
+++ b/framework/test/Volo.Abp.Caching.Tests/Volo/Abp/Caching/CacheNameAttribute_Tests.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using Shouldly;
+using Xunit;
+
+namespace Volo.Abp.Caching
+{
+    public class CacheNameAttribute_Tests
+    {
+        [Fact]
+        public void CacheNameAttribute_Test()
+        {
+            CacheNameAttribute.GetCacheName(typeof(MyCacheItem)).ShouldBe("My_Cache_Item");
+        }
+
+        [Fact]
+        public void ICacheNameProvider_Test()
+        {
+            CacheNameAttribute.GetCacheName(typeof(MyCacheItem2<MyCacheItem>)).ShouldBe(nameof(MyCacheItem2<MyCacheItem>) + typeof(MyCacheItem).Name);
+        }
+
+        [Fact]
+        public void ICacheNameProvider_Exception_Test()
+        {
+            var exception = Assert.Throws<AbpException>(() => CacheNameAttribute.GetCacheName(typeof(ICacheNameProvider)));
+            exception.Message.ShouldContain($"Cannot create an instance of type {typeof(ICacheNameProvider).FullName}.");
+        }
+
+        [Serializable]
+        [CacheName("My_Cache_Item")]
+        public class MyCacheItem
+        {
+            public string Value { get; set; }
+
+            public MyCacheItem()
+            {
+
+            }
+
+            public MyCacheItem(string value)
+            {
+                Value = value;
+            }
+        }
+
+        [Serializable]
+        public class MyCacheItem2<T> : ICacheNameProvider
+        {
+            public T Value { get; set; }
+
+            public MyCacheItem2()
+            {
+
+            }
+
+            public MyCacheItem2(T value)
+            {
+                Value = value;
+            }
+
+            public string GetCacheName()
+            {
+                return nameof(MyCacheItem2<T>) + typeof(T).Name;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This way we can dynamically set the name for the cache item. For example, a generic cache item.

```cs
[Serializable]
public class MyCacheItem<T> : ICacheNameProvider
{
    public T Value { get; set; }

    public string GetCacheName()
    {
        return typeof(T).Name;
    }
}
```