### PR TITLE
Multi tenancy & default localization patch

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.MultiTenancy/Volo/Abp/AspNetCore/MultiTenancy/MultiTenancyMiddleware.cs
+++ b/framework/src/Volo.Abp.AspNetCore.MultiTenancy/Volo/Abp/AspNetCore/MultiTenancy/MultiTenancyMiddleware.cs
@@ -1,7 +1,15 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Globalization;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Localization;
+using Microsoft.AspNetCore.RequestLocalization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Volo.Abp.DependencyInjection;
+using Volo.Abp.Localization;
 using Volo.Abp.MultiTenancy;
+using Volo.Abp.Settings;
 
 namespace Volo.Abp.AspNetCore.MultiTenancy
 {
@@ -23,8 +31,62 @@ namespace Volo.Abp.AspNetCore.MultiTenancy
             var tenant = await _tenantConfigurationProvider.GetAsync(saveResolveResult: true);
             using (_currentTenant.Change(tenant?.Id, tenant?.Name))
             {
+                var requestCulture = await TryGetRequestCultureAsync(context);
+                if (requestCulture != null)
+                {
+                    CultureInfo.CurrentCulture = requestCulture.Culture;
+                    CultureInfo.CurrentUICulture = requestCulture.UICulture;
+                    AbpRequestCultureCookieHelper.SetCultureCookie(
+                        context,
+                        requestCulture
+                    );
+                }
+
                 await next(context);
             }
+        }
+
+        private async Task<RequestCulture> TryGetRequestCultureAsync(HttpContext httpContext)
+        {
+            var requestCultureFeature = httpContext.Features.Get<IRequestCultureFeature>();
+
+            /* If requestCultureFeature == null, that means the RequestLocalizationMiddleware was not used
+             * and we don't want to set the culture. */
+            if (requestCultureFeature == null)
+            {
+                return null;
+            }
+
+            /* If requestCultureFeature.Provider is not null, that means RequestLocalizationMiddleware
+             * already picked a language, so we don't need to set the default. */
+            if (requestCultureFeature.Provider != null)
+            {
+                return null;
+            }
+
+            var settingProvider = httpContext.RequestServices.GetRequiredService<ISettingProvider>();
+            var defaultLanguage = await settingProvider.GetOrNullAsync(LocalizationSettingNames.DefaultLanguage);
+            if (defaultLanguage.IsNullOrWhiteSpace())
+            {
+                return null;
+            }
+
+            string culture;
+            string uiCulture;
+
+            if (defaultLanguage.Contains(';'))
+            {
+                var splitted = defaultLanguage.Split(';');
+                culture = splitted[0];
+                uiCulture = splitted[1];
+            }
+            else
+            {
+                culture = defaultLanguage;
+                uiCulture = defaultLanguage;
+            }
+
+            return new RequestCulture(CultureInfo.GetCultureInfo(culture), CultureInfo.GetCultureInfo(uiCulture));
         }
     }
 }

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.Client/Volo/Abp/AspNetCore/Mvc/Client/MvcCachedApplicationConfigurationClientHelper.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.Client/Volo/Abp/AspNetCore/Mvc/Client/MvcCachedApplicationConfigurationClientHelper.cs
@@ -7,7 +7,8 @@ namespace Volo.Abp.AspNetCore.Mvc.Client
     {
         public static string CreateCacheKey(ICurrentUser currentUser)
         {
-            return $"ApplicationConfiguration_{currentUser.Id?.ToString("N") ?? "Anonymous"}_{CultureInfo.CurrentUICulture.Name}";
+            var userKey = currentUser.Id?.ToString("N") ?? "Anonymous";
+            return $"ApplicationConfiguration_{userKey}_{CultureInfo.CurrentUICulture.Name}";
         }
     }
 }

--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/Localization/AbpLanguagesController.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/Localization/AbpLanguagesController.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Localization;
+﻿using Microsoft.AspNetCore.Localization;
 using Microsoft.AspNetCore.Mvc;
 using System;
+using Microsoft.AspNetCore.RequestLocalization;
 using Volo.Abp.Localization;
 
 namespace Volo.Abp.AspNetCore.Mvc.Localization
@@ -20,12 +20,10 @@ namespace Volo.Abp.AspNetCore.Mvc.Localization
                 throw new AbpException("Unknown language: " + culture + ". It must be a valid culture!");
             }
 
-            string cookieValue = CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(culture, uiCulture));
-
-            Response.Cookies.Append(CookieRequestCultureProvider.DefaultCookieName, cookieValue, new CookieOptions
-            {
-                Expires = Clock.Now.AddYears(2)
-            });
+            AbpRequestCultureCookieHelper.SetCultureCookie(
+                HttpContext,
+                new RequestCulture(culture, uiCulture)
+            );
 
             if (!string.IsNullOrWhiteSpace(returnUrl))
             {

--- a/framework/src/Volo.Abp.AspNetCore/Microsoft/AspNetCore/RequestLocalization/AbpRequestCultureCookieHelper.cs
+++ b/framework/src/Volo.Abp.AspNetCore/Microsoft/AspNetCore/RequestLocalization/AbpRequestCultureCookieHelper.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Localization;
+
+namespace Microsoft.AspNetCore.RequestLocalization
+{
+    public static class AbpRequestCultureCookieHelper
+    {
+        public static void SetCultureCookie(
+            HttpContext httpContext,
+            RequestCulture requestCulture)
+        {
+            httpContext.Response.Cookies.Append(
+                CookieRequestCultureProvider.DefaultCookieName,
+                CookieRequestCultureProvider.MakeCookieValue(requestCulture),
+                new CookieOptions
+                {
+                    Expires = DateTime.Now.AddYears(2)
+                }
+            );
+        }
+    }
+}

--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Entities/EntityHelper.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Entities/EntityHelper.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
@@ -15,6 +13,17 @@ namespace Volo.Abp.Domain.Entities
     /// </summary>
     public static class EntityHelper
     {
+        public static bool IsMultiTenant<TEntity>()
+            where TEntity : IEntity
+        {
+            return IsMultiTenant(typeof(TEntity));
+        }
+
+        public static bool IsMultiTenant(Type type)
+        {
+            return typeof(IMultiTenant).IsAssignableFrom(type);
+        }
+
         public static bool EntityEquals(IEntity entity1, IEntity entity2)
         {
             if (entity1 == null || entity2 == null)

--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/Domain/Repositories/EntityFrameworkCore/EfCoreRepository.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/Domain/Repositories/EntityFrameworkCore/EfCoreRepository.cs
@@ -13,6 +13,7 @@ using Volo.Abp.Domain.Entities;
 using Volo.Abp.EntityFrameworkCore;
 using Volo.Abp.EntityFrameworkCore.DependencyInjection;
 using Volo.Abp.Guids;
+using Volo.Abp.MultiTenancy;
 
 namespace Volo.Abp.Domain.Repositories.EntityFrameworkCore
 {
@@ -21,18 +22,42 @@ namespace Volo.Abp.Domain.Repositories.EntityFrameworkCore
         where TEntity : class, IEntity
     {
         [Obsolete("Use GetDbContextAsync() method.")]
-        protected virtual TDbContext DbContext => _dbContextProvider.GetDbContext();
+        protected virtual TDbContext DbContext => GetDbContext();
 
         [Obsolete("Use GetDbContextAsync() method.")]
-        DbContext IEfCoreRepository<TEntity>.DbContext => DbContext.As<DbContext>();
+        DbContext IEfCoreRepository<TEntity>.DbContext => GetDbContext() as DbContext;
 
         async Task<DbContext> IEfCoreRepository<TEntity>.GetDbContextAsync()
         {
             return await GetDbContextAsync() as DbContext;
         }
 
+        [Obsolete("Use GetDbContextAsync() method.")]
+        private TDbContext GetDbContext()
+        {
+            // Multi-tenancy unaware entities should always use the host connection string
+            if (!EntityHelper.IsMultiTenant<TEntity>())
+            {
+                using (CurrentTenant.Change(null))
+                {
+                    return _dbContextProvider.GetDbContext();
+                }
+            }
+
+            return _dbContextProvider.GetDbContext();
+        }
+
         protected virtual Task<TDbContext> GetDbContextAsync()
         {
+            // Multi-tenancy unaware entities should always use the host connection string
+            if (!EntityHelper.IsMultiTenant<TEntity>())
+            {
+                using (CurrentTenant.Change(null))
+                {
+                    return _dbContextProvider.GetDbContextAsync();
+                }
+            }
+
             return _dbContextProvider.GetDbContextAsync();
         }
 

--- a/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/DynamicProxying/ApiDescriptionFinder.cs
+++ b/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/DynamicProxying/ApiDescriptionFinder.cs
@@ -1,24 +1,38 @@
 ﻿using System;
+using System.Globalization;
 using System.Linq;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Reflection;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Http.Modeling;
+using Volo.Abp.MultiTenancy;
 using Volo.Abp.Threading;
+using Volo.Abp.Tracing;
 
 namespace Volo.Abp.Http.Client.DynamicProxying
 {
     public class ApiDescriptionFinder : IApiDescriptionFinder, ITransientDependency
     {
         public ICancellationTokenProvider CancellationTokenProvider { get; set; }
-
         protected IApiDescriptionCache Cache { get; }
+        protected AbpCorrelationIdOptions AbpCorrelationIdOptions { get; }
+        protected ICorrelationIdProvider CorrelationIdProvider { get; }
+        protected ICurrentTenant CurrentTenant { get; }
 
-        public ApiDescriptionFinder(IApiDescriptionCache cache)
+        public ApiDescriptionFinder(
+            IApiDescriptionCache cache,
+            IOptions<AbpCorrelationIdOptions> abpCorrelationIdOptions,
+            ICorrelationIdProvider correlationIdProvider,
+            ICurrentTenant currentTenant)
         {
             Cache = cache;
+            AbpCorrelationIdOptions = abpCorrelationIdOptions.Value;
+            CorrelationIdProvider = correlationIdProvider;
+            CurrentTenant = currentTenant;
             CancellationTokenProvider = NullCancellationTokenProvider.Instance;
         }
 
@@ -71,10 +85,19 @@ namespace Volo.Abp.Http.Client.DynamicProxying
             return await Cache.GetAsync(baseUrl, () => GetApiDescriptionFromServerAsync(client, baseUrl));
         }
 
-        protected virtual async Task<ApplicationApiDescriptionModel> GetApiDescriptionFromServerAsync(HttpClient client, string baseUrl)
+        protected virtual async Task<ApplicationApiDescriptionModel> GetApiDescriptionFromServerAsync(
+            HttpClient client,
+            string baseUrl)
         {
-            var response = await client.GetAsync(
-                baseUrl.EnsureEndsWith('/') + "api/abp/api-definition",
+            var requestMessage = new HttpRequestMessage(
+                HttpMethod.Get,
+                baseUrl.EnsureEndsWith('/') + "api/abp/api-definition"
+            );
+
+            AddHeaders(requestMessage);
+
+            var response = await client.SendAsync(
+                requestMessage,
                 CancellationTokenProvider.Token
             );
 
@@ -91,6 +114,30 @@ namespace Volo.Abp.Http.Client.DynamicProxying
             });
 
             return (ApplicationApiDescriptionModel)result;
+        }
+
+        protected virtual void AddHeaders(HttpRequestMessage requestMessage)
+        {
+            //CorrelationId
+            requestMessage.Headers.Add(AbpCorrelationIdOptions.HttpHeaderName, CorrelationIdProvider.Get());
+
+            //TenantId
+            if (CurrentTenant.Id.HasValue)
+            {
+                //TODO: Use AbpAspNetCoreMultiTenancyOptions to get the key
+                requestMessage.Headers.Add(TenantResolverConsts.DefaultTenantKey, CurrentTenant.Id.Value.ToString());
+            }
+
+            //Culture
+            //TODO: Is that the way we want? Couldn't send the culture (not ui culture)
+            var currentCulture = CultureInfo.CurrentUICulture.Name ?? CultureInfo.CurrentCulture.Name;
+            if (!currentCulture.IsNullOrEmpty())
+            {
+                requestMessage.Headers.AcceptLanguage.Add(new StringWithQualityHeaderValue(currentCulture));
+            }
+
+            //X-Requested-With
+            requestMessage.Headers.Add("X-Requested-With", "XMLHttpRequest");
         }
 
         protected virtual bool TypeMatches(MethodParameterApiDescriptionModel actionParameter, ParameterInfo methodParameter)

--- a/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/DynamicProxying/DynamicHttpProxyInterceptor.cs
+++ b/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/DynamicProxying/DynamicHttpProxyInterceptor.cs
@@ -136,7 +136,13 @@ namespace Volo.Abp.Http.Client.DynamicProxying
 
             var client = HttpClientFactory.Create(clientConfig.RemoteServiceName);
 
-            var action = await ApiDescriptionFinder.FindActionAsync(client, remoteServiceConfig.BaseUrl, typeof(TService), invocation.Method);
+            var action = await ApiDescriptionFinder.FindActionAsync(
+                client,
+                remoteServiceConfig.BaseUrl,
+                typeof(TService),
+                invocation.Method
+            );
+
             var apiVersion = GetApiVersionInfo(action);
             var url = remoteServiceConfig.BaseUrl.EnsureEndsWith('/') + UrlBuilder.GenerateUrlWithParameters(action, invocation.ArgumentsDictionary, apiVersion);
 
@@ -156,9 +162,11 @@ namespace Volo.Abp.Http.Client.DynamicProxying
                 )
             );
 
-            var response = await client.SendAsync(requestMessage,
+            var response = await client.SendAsync(
+                requestMessage,
                 HttpCompletionOption.ResponseHeadersRead /*this will buffer only the headers, the content will be used as a stream*/,
-                GetCancellationToken());
+                GetCancellationToken()
+            );
 
             if (!response.IsSuccessStatusCode)
             {
@@ -196,7 +204,11 @@ namespace Volo.Abp.Http.Client.DynamicProxying
             return action.SupportedVersions.Last(); //TODO: Ensure to get the latest version!
         }
 
-        protected virtual void AddHeaders(IAbpMethodInvocation invocation, ActionApiDescriptionModel action, HttpRequestMessage requestMessage, ApiVersionInfo apiVersion)
+        protected virtual void AddHeaders(
+            IAbpMethodInvocation invocation,
+            ActionApiDescriptionModel action,
+            HttpRequestMessage requestMessage,
+            ApiVersionInfo apiVersion)
         {
             //API Version
             if (!apiVersion.Version.IsNullOrEmpty())

--- a/framework/src/Volo.Abp.MongoDB/Volo/Abp/Domain/Repositories/MongoDB/MongoDbRepository.cs
+++ b/framework/src/Volo.Abp.MongoDB/Volo/Abp/Domain/Repositories/MongoDB/MongoDbRepository.cs
@@ -51,10 +51,34 @@ namespace Volo.Abp.Domain.Repositories.MongoDB
         }
 
         [Obsolete("Use GetDbContextAsync method.")]
-        protected virtual TMongoDbContext DbContext => DbContextProvider.GetDbContext();
+        protected virtual TMongoDbContext DbContext => GetDbContext();
+
+        [Obsolete("Use GetDbContextAsync method.")]
+        private TMongoDbContext GetDbContext()
+        {
+            // Multi-tenancy unaware entities should always use the host connection string
+            if (!EntityHelper.IsMultiTenant<TEntity>())
+            {
+                using (CurrentTenant.Change(null))
+                {
+                    return DbContextProvider.GetDbContext();
+                }
+            }
+
+            return DbContextProvider.GetDbContext();
+        }
 
         protected Task<TMongoDbContext> GetDbContextAsync(CancellationToken cancellationToken = default)
         {
+            // Multi-tenancy unaware entities should always use the host connection string
+            if (!EntityHelper.IsMultiTenant<TEntity>())
+            {
+                using (CurrentTenant.Change(null))
+                {
+                    return DbContextProvider.GetDbContextAsync(GetCancellationToken(cancellationToken));
+                }
+            }
+
             return DbContextProvider.GetDbContextAsync(GetCancellationToken(cancellationToken));
         }
 

--- a/modules/background-jobs/src/Volo.Abp.BackgroundJobs.EntityFrameworkCore/Volo/Abp/BackgroundJobs/EntityFrameworkCore/BackgroundJobsDbContext.cs
+++ b/modules/background-jobs/src/Volo.Abp.BackgroundJobs.EntityFrameworkCore/Volo/Abp/BackgroundJobs/EntityFrameworkCore/BackgroundJobsDbContext.cs
@@ -1,15 +1,17 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Volo.Abp.Data;
 using Volo.Abp.EntityFrameworkCore;
+using Volo.Abp.MultiTenancy;
 
 namespace Volo.Abp.BackgroundJobs.EntityFrameworkCore
 {
+    [IgnoreMultiTenancy]
     [ConnectionStringName(BackgroundJobsDbProperties.ConnectionStringName)]
     public class BackgroundJobsDbContext : AbpDbContext<BackgroundJobsDbContext>, IBackgroundJobsDbContext
     {
         public DbSet<BackgroundJobRecord> BackgroundJobs { get; set; }
 
-        public BackgroundJobsDbContext(DbContextOptions<BackgroundJobsDbContext> options) 
+        public BackgroundJobsDbContext(DbContextOptions<BackgroundJobsDbContext> options)
             : base(options)
         {
 

--- a/modules/background-jobs/src/Volo.Abp.BackgroundJobs.EntityFrameworkCore/Volo/Abp/BackgroundJobs/EntityFrameworkCore/IBackgroundJobsDbContext.cs
+++ b/modules/background-jobs/src/Volo.Abp.BackgroundJobs.EntityFrameworkCore/Volo/Abp/BackgroundJobs/EntityFrameworkCore/IBackgroundJobsDbContext.cs
@@ -1,9 +1,11 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Volo.Abp.Data;
 using Volo.Abp.EntityFrameworkCore;
+using Volo.Abp.MultiTenancy;
 
 namespace Volo.Abp.BackgroundJobs.EntityFrameworkCore
 {
+    [IgnoreMultiTenancy]
     [ConnectionStringName(BackgroundJobsDbProperties.ConnectionStringName)]
     public interface IBackgroundJobsDbContext : IEfCoreDbContext
     {

--- a/modules/background-jobs/src/Volo.Abp.BackgroundJobs.MongoDB/Volo/Abp/BackgroundJobs/MongoDB/BackgroundJobsMongoDbContext.cs
+++ b/modules/background-jobs/src/Volo.Abp.BackgroundJobs.MongoDB/Volo/Abp/BackgroundJobs/MongoDB/BackgroundJobsMongoDbContext.cs
@@ -1,9 +1,11 @@
 ﻿using MongoDB.Driver;
 using Volo.Abp.Data;
 using Volo.Abp.MongoDB;
+using Volo.Abp.MultiTenancy;
 
 namespace Volo.Abp.BackgroundJobs.MongoDB
 {
+    [IgnoreMultiTenancy]
     [ConnectionStringName(BackgroundJobsDbProperties.ConnectionStringName)]
     public class BackgroundJobsMongoDbContext : AbpMongoDbContext, IBackgroundJobsMongoDbContext
     {

--- a/modules/background-jobs/src/Volo.Abp.BackgroundJobs.MongoDB/Volo/Abp/BackgroundJobs/MongoDB/IBackgroundJobsMongoDbContext.cs
+++ b/modules/background-jobs/src/Volo.Abp.BackgroundJobs.MongoDB/Volo/Abp/BackgroundJobs/MongoDB/IBackgroundJobsMongoDbContext.cs
@@ -1,9 +1,11 @@
 ﻿using MongoDB.Driver;
 using Volo.Abp.Data;
 using Volo.Abp.MongoDB;
+using Volo.Abp.MultiTenancy;
 
 namespace Volo.Abp.BackgroundJobs.MongoDB
 {
+    [IgnoreMultiTenancy]
     [ConnectionStringName(BackgroundJobsDbProperties.ConnectionStringName)]
     public interface IBackgroundJobsMongoDbContext : IAbpMongoDbContext
     {

--- a/modules/blob-storing-database/src/Volo.Abp.BlobStoring.Database.Domain/Volo/Abp/BlobStoring/Database/DatabaseBlobContainer.cs
+++ b/modules/blob-storing-database/src/Volo.Abp.BlobStoring.Database.Domain/Volo/Abp/BlobStoring/Database/DatabaseBlobContainer.cs
@@ -5,13 +5,13 @@ using Volo.Abp.MultiTenancy;
 
 namespace Volo.Abp.BlobStoring.Database
 {
-    public class DatabaseBlobContainer : AggregateRoot<Guid>, IMultiTenant //TODO: Rename to BlobContainer
+    public class DatabaseBlobContainer : AggregateRoot<Guid>, IMultiTenant
     {
         public virtual Guid? TenantId { get; protected set; }
 
         public virtual string Name { get; protected set; }
 
-        public DatabaseBlobContainer(Guid id, [NotNull] string name, Guid? tenantId = null) 
+        public DatabaseBlobContainer(Guid id, [NotNull] string name, Guid? tenantId = null)
             : base(id)
         {
             Name = Check.NotNullOrWhiteSpace(name, nameof(name), DatabaseContainerConsts.MaxNameLength);

--- a/modules/blogging/src/Volo.Blogging.EntityFrameworkCore/Volo/Blogging/EntityFrameworkCore/BloggingDbContext.cs
+++ b/modules/blogging/src/Volo.Blogging.EntityFrameworkCore/Volo/Blogging/EntityFrameworkCore/BloggingDbContext.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Volo.Abp.Data;
 using Volo.Abp.EntityFrameworkCore;
+using Volo.Abp.MultiTenancy;
 using Volo.Blogging.Blogs;
 using Volo.Blogging.Comments;
 using Volo.Blogging.Posts;
@@ -9,6 +10,7 @@ using Volo.Blogging.Users;
 
 namespace Volo.Blogging.EntityFrameworkCore
 {
+    [IgnoreMultiTenancy]
     [ConnectionStringName(BloggingDbProperties.ConnectionStringName)]
     public class BloggingDbContext : AbpDbContext<BloggingDbContext>, IBloggingDbContext
     {
@@ -23,7 +25,7 @@ namespace Volo.Blogging.EntityFrameworkCore
         public DbSet<PostTag> PostTags { get; set; }
 
         public DbSet<Comment> Comments { get; set; }
-        
+
         public BloggingDbContext(DbContextOptions<BloggingDbContext> options)
             : base(options)
         {

--- a/modules/blogging/src/Volo.Blogging.EntityFrameworkCore/Volo/Blogging/EntityFrameworkCore/IBloggingDbContext.cs
+++ b/modules/blogging/src/Volo.Blogging.EntityFrameworkCore/Volo/Blogging/EntityFrameworkCore/IBloggingDbContext.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Volo.Abp.Data;
 using Volo.Abp.EntityFrameworkCore;
+using Volo.Abp.MultiTenancy;
 using Volo.Blogging.Blogs;
 using Volo.Blogging.Comments;
 using Volo.Blogging.Posts;
@@ -9,6 +10,7 @@ using Volo.Blogging.Users;
 
 namespace Volo.Blogging.EntityFrameworkCore
 {
+    [IgnoreMultiTenancy]
     [ConnectionStringName(BloggingDbProperties.ConnectionStringName)]
     public interface IBloggingDbContext : IEfCoreDbContext
     {

--- a/modules/blogging/src/Volo.Blogging.MongoDB/Volo/Blogging/MongoDB/BloggingMongoDbContext.cs
+++ b/modules/blogging/src/Volo.Blogging.MongoDB/Volo/Blogging/MongoDB/BloggingMongoDbContext.cs
@@ -1,6 +1,7 @@
 ﻿using MongoDB.Driver;
 using Volo.Abp.Data;
 using Volo.Abp.MongoDB;
+using Volo.Abp.MultiTenancy;
 using Volo.Blogging.Blogs;
 using Volo.Blogging.Comments;
 using Volo.Blogging.Posts;
@@ -8,6 +9,7 @@ using Volo.Blogging.Users;
 
 namespace Volo.Blogging.MongoDB
 {
+    [IgnoreMultiTenancy]
     [ConnectionStringName(BloggingDbProperties.ConnectionStringName)]
     public class BloggingMongoDbContext : AbpMongoDbContext, IBloggingMongoDbContext
     {

--- a/modules/blogging/src/Volo.Blogging.MongoDB/Volo/Blogging/MongoDB/IBloggingMongoDbContext.cs
+++ b/modules/blogging/src/Volo.Blogging.MongoDB/Volo/Blogging/MongoDB/IBloggingMongoDbContext.cs
@@ -1,6 +1,7 @@
 ﻿using MongoDB.Driver;
 using Volo.Abp.Data;
 using Volo.Abp.MongoDB;
+using Volo.Abp.MultiTenancy;
 using Volo.Blogging.Blogs;
 using Volo.Blogging.Comments;
 using Volo.Blogging.Posts;
@@ -8,6 +9,7 @@ using Volo.Blogging.Users;
 
 namespace Volo.Blogging.MongoDB
 {
+    [IgnoreMultiTenancy]
     [ConnectionStringName(BloggingDbProperties.ConnectionStringName)]
     public interface IBloggingMongoDbContext : IAbpMongoDbContext
     {

--- a/modules/docs/src/Volo.Docs.Domain/Volo/Docs/Projects/Project.cs
+++ b/modules/docs/src/Volo.Docs.Domain/Volo/Docs/Projects/Project.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using JetBrains.Annotations;
 using Volo.Abp;
 using Volo.Abp.Domain.Entities;

--- a/modules/docs/src/Volo.Docs.EntityFrameworkCore/Volo/Docs/EntityFrameworkCore/DocsDbContext.cs
+++ b/modules/docs/src/Volo.Docs.EntityFrameworkCore/Volo/Docs/EntityFrameworkCore/DocsDbContext.cs
@@ -1,11 +1,13 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Volo.Abp.Data;
 using Volo.Abp.EntityFrameworkCore;
+using Volo.Abp.MultiTenancy;
 using Volo.Docs.Documents;
 using Volo.Docs.Projects;
 
 namespace Volo.Docs.EntityFrameworkCore
 {
+    [IgnoreMultiTenancy]
     [ConnectionStringName(DocsDbProperties.ConnectionStringName)]
     public class DocsDbContext: AbpDbContext<DocsDbContext>, IDocsDbContext
     {
@@ -15,7 +17,7 @@ namespace Volo.Docs.EntityFrameworkCore
 
         public DbSet<DocumentContributor> DocumentContributors { get; set; }
 
-        public DocsDbContext(DbContextOptions<DocsDbContext> options) 
+        public DocsDbContext(DbContextOptions<DocsDbContext> options)
             : base(options)
         {
 

--- a/modules/docs/src/Volo.Docs.EntityFrameworkCore/Volo/Docs/EntityFrameworkCore/IDocsDbContext.cs
+++ b/modules/docs/src/Volo.Docs.EntityFrameworkCore/Volo/Docs/EntityFrameworkCore/IDocsDbContext.cs
@@ -1,11 +1,13 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Volo.Abp.Data;
 using Volo.Abp.EntityFrameworkCore;
+using Volo.Abp.MultiTenancy;
 using Volo.Docs.Documents;
 using Volo.Docs.Projects;
 
 namespace Volo.Docs.EntityFrameworkCore
 {
+    [IgnoreMultiTenancy]
     [ConnectionStringName(DocsDbProperties.ConnectionStringName)]
     public interface IDocsDbContext : IEfCoreDbContext
     {

--- a/modules/docs/src/Volo.Docs.MongoDB/Volo/Docs/MongoDB/DocsMongoDbContext.cs
+++ b/modules/docs/src/Volo.Docs.MongoDB/Volo/Docs/MongoDB/DocsMongoDbContext.cs
@@ -2,10 +2,12 @@
 using Volo.Abp.Data;
 using Volo.Docs.Projects;
 using Volo.Abp.MongoDB;
+using Volo.Abp.MultiTenancy;
 using Volo.Docs.Documents;
 
 namespace Volo.Docs.MongoDB
 {
+    [IgnoreMultiTenancy]
     [ConnectionStringName(DocsDbProperties.ConnectionStringName)]
     public class DocsMongoDbContext : AbpMongoDbContext, IDocsMongoDbContext
     {

--- a/modules/docs/src/Volo.Docs.MongoDB/Volo/Docs/MongoDB/IDocsMongoDbContext.cs
+++ b/modules/docs/src/Volo.Docs.MongoDB/Volo/Docs/MongoDB/IDocsMongoDbContext.cs
@@ -1,11 +1,13 @@
 ﻿using MongoDB.Driver;
 using Volo.Abp.Data;
 using Volo.Abp.MongoDB;
+using Volo.Abp.MultiTenancy;
 using Volo.Docs.Documents;
 using Volo.Docs.Projects;
 
 namespace Volo.Docs.MongoDB
 {
+    [IgnoreMultiTenancy]
     [ConnectionStringName(DocsDbProperties.ConnectionStringName)]
     public interface IDocsMongoDbContext : IAbpMongoDbContext
     {

--- a/modules/feature-management/src/Volo.Abp.FeatureManagement.EntityFrameworkCore/Volo/Abp/FeatureManagement/EntityFrameworkCore/FeatureManagementDbContext.cs
+++ b/modules/feature-management/src/Volo.Abp.FeatureManagement.EntityFrameworkCore/Volo/Abp/FeatureManagement/EntityFrameworkCore/FeatureManagementDbContext.cs
@@ -1,15 +1,17 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Volo.Abp.Data;
 using Volo.Abp.EntityFrameworkCore;
+using Volo.Abp.MultiTenancy;
 
 namespace Volo.Abp.FeatureManagement.EntityFrameworkCore
 {
+    [IgnoreMultiTenancy]
     [ConnectionStringName(FeatureManagementDbProperties.ConnectionStringName)]
     public class FeatureManagementDbContext : AbpDbContext<FeatureManagementDbContext>, IFeatureManagementDbContext
     {
         public DbSet<FeatureValue> FeatureValues { get; set; }
 
-        public FeatureManagementDbContext(DbContextOptions<FeatureManagementDbContext> options) 
+        public FeatureManagementDbContext(DbContextOptions<FeatureManagementDbContext> options)
             : base(options)
         {
 

--- a/modules/feature-management/src/Volo.Abp.FeatureManagement.EntityFrameworkCore/Volo/Abp/FeatureManagement/EntityFrameworkCore/IFeatureManagementDbContext.cs
+++ b/modules/feature-management/src/Volo.Abp.FeatureManagement.EntityFrameworkCore/Volo/Abp/FeatureManagement/EntityFrameworkCore/IFeatureManagementDbContext.cs
@@ -1,9 +1,11 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Volo.Abp.Data;
 using Volo.Abp.EntityFrameworkCore;
+using Volo.Abp.MultiTenancy;
 
 namespace Volo.Abp.FeatureManagement.EntityFrameworkCore
 {
+    [IgnoreMultiTenancy]
     [ConnectionStringName(FeatureManagementDbProperties.ConnectionStringName)]
     public interface IFeatureManagementDbContext : IEfCoreDbContext
     {

--- a/modules/feature-management/src/Volo.Abp.FeatureManagement.MongoDB/Volo/Abp/FeatureManagement/MongoDB/FeatureManagementMongoDbContext.cs
+++ b/modules/feature-management/src/Volo.Abp.FeatureManagement.MongoDB/Volo/Abp/FeatureManagement/MongoDB/FeatureManagementMongoDbContext.cs
@@ -1,9 +1,11 @@
 ﻿using MongoDB.Driver;
 using Volo.Abp.Data;
 using Volo.Abp.MongoDB;
+using Volo.Abp.MultiTenancy;
 
 namespace Volo.Abp.FeatureManagement.MongoDB
 {
+    [IgnoreMultiTenancy]
     [ConnectionStringName(FeatureManagementDbProperties.ConnectionStringName)]
     public class FeatureManagementMongoDbContext : AbpMongoDbContext, IFeatureManagementMongoDbContext
     {

--- a/modules/feature-management/src/Volo.Abp.FeatureManagement.MongoDB/Volo/Abp/FeatureManagement/MongoDB/IFeatureManagementMongoDbContext.cs
+++ b/modules/feature-management/src/Volo.Abp.FeatureManagement.MongoDB/Volo/Abp/FeatureManagement/MongoDB/IFeatureManagementMongoDbContext.cs
@@ -1,9 +1,11 @@
 ﻿using MongoDB.Driver;
 using Volo.Abp.Data;
 using Volo.Abp.MongoDB;
+using Volo.Abp.MultiTenancy;
 
 namespace Volo.Abp.FeatureManagement.MongoDB
 {
+    [IgnoreMultiTenancy]
     [ConnectionStringName(FeatureManagementDbProperties.ConnectionStringName)]
     public interface IFeatureManagementMongoDbContext : IAbpMongoDbContext
     {

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.EntityFrameworkCore/Volo/Abp/SettingManagement/EntityFrameworkCore/ISettingManagementDbContext.cs
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.EntityFrameworkCore/Volo/Abp/SettingManagement/EntityFrameworkCore/ISettingManagementDbContext.cs
@@ -1,9 +1,11 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Volo.Abp.Data;
 using Volo.Abp.EntityFrameworkCore;
+using Volo.Abp.MultiTenancy;
 
 namespace Volo.Abp.SettingManagement.EntityFrameworkCore
 {
+    [IgnoreMultiTenancy]
     [ConnectionStringName(AbpSettingManagementDbProperties.ConnectionStringName)]
     public interface ISettingManagementDbContext : IEfCoreDbContext
     {

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.EntityFrameworkCore/Volo/Abp/SettingManagement/EntityFrameworkCore/SettingManagementDbContext.cs
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.EntityFrameworkCore/Volo/Abp/SettingManagement/EntityFrameworkCore/SettingManagementDbContext.cs
@@ -1,9 +1,11 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Volo.Abp.Data;
 using Volo.Abp.EntityFrameworkCore;
+using Volo.Abp.MultiTenancy;
 
 namespace Volo.Abp.SettingManagement.EntityFrameworkCore
 {
+    [IgnoreMultiTenancy]
     [ConnectionStringName(AbpSettingManagementDbProperties.ConnectionStringName)]
     public class SettingManagementDbContext : AbpDbContext<SettingManagementDbContext>, ISettingManagementDbContext
     {

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.MongoDB/Volo/Abp/SettingManagement/MongoDB/ISettingManagementMongoDbContext.cs
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.MongoDB/Volo/Abp/SettingManagement/MongoDB/ISettingManagementMongoDbContext.cs
@@ -1,9 +1,11 @@
 using MongoDB.Driver;
 using Volo.Abp.Data;
 using Volo.Abp.MongoDB;
+using Volo.Abp.MultiTenancy;
 
 namespace Volo.Abp.SettingManagement.MongoDB
 {
+    [IgnoreMultiTenancy]
     [ConnectionStringName(AbpSettingManagementDbProperties.ConnectionStringName)]
     public interface ISettingManagementMongoDbContext : IAbpMongoDbContext
     {

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.MongoDB/Volo/Abp/SettingManagement/MongoDB/SettingManagementMongoDbContext.cs
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.MongoDB/Volo/Abp/SettingManagement/MongoDB/SettingManagementMongoDbContext.cs
@@ -1,9 +1,11 @@
 using MongoDB.Driver;
 using Volo.Abp.Data;
 using Volo.Abp.MongoDB;
+using Volo.Abp.MultiTenancy;
 
 namespace Volo.Abp.SettingManagement.MongoDB
 {
+    [IgnoreMultiTenancy]
     [ConnectionStringName(AbpSettingManagementDbProperties.ConnectionStringName)]
     public class SettingManagementMongoDbContext : AbpMongoDbContext, ISettingManagementMongoDbContext
     {

--- a/modules/tenant-management/src/Volo.Abp.TenantManagement.EntityFrameworkCore/Volo/Abp/TenantManagement/EntityFrameworkCore/ITenantManagementDbContext.cs
+++ b/modules/tenant-management/src/Volo.Abp.TenantManagement.EntityFrameworkCore/Volo/Abp/TenantManagement/EntityFrameworkCore/ITenantManagementDbContext.cs
@@ -1,9 +1,11 @@
 using Microsoft.EntityFrameworkCore;
 using Volo.Abp.Data;
 using Volo.Abp.EntityFrameworkCore;
+using Volo.Abp.MultiTenancy;
 
 namespace Volo.Abp.TenantManagement.EntityFrameworkCore
 {
+    [IgnoreMultiTenancy]
     [ConnectionStringName(AbpTenantManagementDbProperties.ConnectionStringName)]
     public interface ITenantManagementDbContext : IEfCoreDbContext
     {

--- a/modules/tenant-management/src/Volo.Abp.TenantManagement.EntityFrameworkCore/Volo/Abp/TenantManagement/EntityFrameworkCore/TenantManagementDbContext.cs
+++ b/modules/tenant-management/src/Volo.Abp.TenantManagement.EntityFrameworkCore/Volo/Abp/TenantManagement/EntityFrameworkCore/TenantManagementDbContext.cs
@@ -1,9 +1,11 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Volo.Abp.Data;
 using Volo.Abp.EntityFrameworkCore;
+using Volo.Abp.MultiTenancy;
 
 namespace Volo.Abp.TenantManagement.EntityFrameworkCore
 {
+    [IgnoreMultiTenancy]
     [ConnectionStringName(AbpTenantManagementDbProperties.ConnectionStringName)]
     public class TenantManagementDbContext : AbpDbContext<TenantManagementDbContext>, ITenantManagementDbContext
     {

--- a/modules/tenant-management/src/Volo.Abp.TenantManagement.MongoDB/Volo/Abp/TenantManagement/MongoDb/ITenantManagementMongoDbContext.cs
+++ b/modules/tenant-management/src/Volo.Abp.TenantManagement.MongoDB/Volo/Abp/TenantManagement/MongoDb/ITenantManagementMongoDbContext.cs
@@ -1,9 +1,11 @@
 ﻿using MongoDB.Driver;
 using Volo.Abp.Data;
 using Volo.Abp.MongoDB;
+using Volo.Abp.MultiTenancy;
 
 namespace Volo.Abp.TenantManagement.MongoDB
 {
+    [IgnoreMultiTenancy]
     [ConnectionStringName(AbpTenantManagementDbProperties.ConnectionStringName)]
     public interface ITenantManagementMongoDbContext : IAbpMongoDbContext
     {

--- a/modules/tenant-management/src/Volo.Abp.TenantManagement.MongoDB/Volo/Abp/TenantManagement/MongoDb/TenantManagementMongoDbContext.cs
+++ b/modules/tenant-management/src/Volo.Abp.TenantManagement.MongoDB/Volo/Abp/TenantManagement/MongoDb/TenantManagementMongoDbContext.cs
@@ -1,9 +1,11 @@
 ﻿using MongoDB.Driver;
 using Volo.Abp.Data;
 using Volo.Abp.MongoDB;
+using Volo.Abp.MultiTenancy;
 
 namespace Volo.Abp.TenantManagement.MongoDB
 {
+    [IgnoreMultiTenancy]
     [ConnectionStringName(AbpTenantManagementDbProperties.ConnectionStringName)]
     public class TenantManagementMongoDbContext : AbpMongoDbContext, ITenantManagementMongoDbContext
     {


### PR DESCRIPTION
- Resolves #7508
- Resolves #5215

Some new enhancements to solve the problems;

* `[IgnoreMultiTenancy]` now can be added to a DbContext class (and to interface of the DbContext) to indicate that this DbContext should always use the host connection string because it's entities can't be stored in the tenant databases. This is important when we use separate db for tenants. Declare this attribute for a dbcontext that has no entity implements `IMultiTenant`. Even if only one entity implements `IMultiTenant`, do not use this attribute and see the next item. This was actually done with https://github.com/abpframework/abp/commit/16fdc527cc85f6fd3c2565df30753b5b9a2f80f2 and I had implemented it for the IdentityServer
* If an entity doesn't implement `IMultiTenant` interface and you use the repository of that entity, it guarantees that it always use the host database. This is also useful if a dbcontext has some entities multi-tenant while some others are not and you couldn't add `IgnoreMultiTenancy` attribute to it.

I updated related modules based on that. This PR will solve the separate tenant database problems.