### PR TITLE
fix:  FileNotFoundException when folder include multiple dll file

### DIFF
--- a/framework/src/Volo.Abp.Core/Volo/Abp/Modularity/PlugIns/FolderPlugInSource.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/Modularity/PlugIns/FolderPlugInSource.cs
@@ -30,8 +30,8 @@ namespace Volo.Abp.Modularity.PlugIns
         public Type[] GetModules()
         {
             var modules = new List<Type>();
-
-            foreach (var assembly in GetAssemblies())
+            var assemblies = GetAssemblies().ToList();
+            foreach (var assembly in assemblies)
             {
                 try
                 {


### PR DESCRIPTION
fix  FileNotFoundException when folder include multiple dll file. example:
- plugin_folder
- - module_1_folder
- - - Abc.Module.Payment.dll
- - module_2_folder
- - - Abc.Module.Order.dll
- - - Abc.Module.Order.Domain.dll

`Abc.Module.Order.dll` dependency `Abc.Module.Order.Domain.dll`

Because `IEnumerable<T>` is lazy load assembly.