### PR TITLE
Add abp-data-datepicker attribute to ignore initialize Datepickers.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/wwwroot/libs/abp/aspnetcore-mvc-ui-theme-shared/bootstrap/dom-event-handlers.js
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/wwwroot/libs/abp/aspnetcore-mvc-ui-theme-shared/bootstrap/dom-event-handlers.js
@@ -159,7 +159,7 @@
 
     abp.dom.initializers.initializeDatepickers = function ($rootElement) {
         $rootElement
-            .findWithSelf('input.datepicker,input[type=date]')
+            .findWithSelf('input.datepicker,input[type=date][data-datepicker!=false]')
             .each(function () {
                 var $input = $(this);
                 $input

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/wwwroot/libs/abp/aspnetcore-mvc-ui-theme-shared/bootstrap/dom-event-handlers.js
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/wwwroot/libs/abp/aspnetcore-mvc-ui-theme-shared/bootstrap/dom-event-handlers.js
@@ -159,7 +159,7 @@
 
     abp.dom.initializers.initializeDatepickers = function ($rootElement) {
         $rootElement
-            .findWithSelf('input.datepicker,input[type=date][data-datepicker!=false]')
+            .findWithSelf('input.datepicker,input[type=date][abp-data-datepicker!=false]')
             .each(function () {
                 var $input = $(this);
                 $input


### PR DESCRIPTION
Resolve #7571

```html
<input type="date" class="form-control" abp-data-datepicker="false"/>
```