### PR TITLE
Fix code sample in Environment doc page

### DIFF
--- a/docs/en/UI/Angular/Environment.md
+++ b/docs/en/UI/Angular/Environment.md
@@ -138,10 +138,10 @@ You can use the `getEnvironment` or `getEnvironment$` method of `EnvironmentServ
 ```js
 // this.environment is instance of EnvironmentService
 
-const environment = this.environment.getAll();
+const environment = this.environment.getEnvironment();
 
 // or
-this.environment.getAll$().subscribe(environment => {
+this.environment.getEnvironment$().subscribe(environment => {
    // use environment here
 })
 ```
@@ -166,7 +166,7 @@ This method returns the `url` of a specific API based on the key given as its on
 
 #### How to Set the Environment
 
-`EnvironmentService` has a method named `setState` which allow you to set the state value.
+`EnvironmentService` has a method named `setState` which allows you to set the state value.
 
 ```js
 // this.environment is instance of EnvironmentService


### PR DESCRIPTION
Hi,

I believe there is a mistake in the Environment doc page in the code sample. `EnvironemntService` doesn't have `getAll()` and `getAll$()` methods. This PR fixes it. There is also a small grama fix. 