### PR TITLE
Extend DataFilter implementation

### DIFF
--- a/framework/src/Volo.Abp.Core/System/AbpTypeExtensions.cs
+++ b/framework/src/Volo.Abp.Core/System/AbpTypeExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Text;
 using JetBrains.Annotations;
 using Volo.Abp;
 
@@ -9,6 +10,40 @@ namespace System
         public static string GetFullNameWithAssemblyName(this Type type)
         {
             return type.FullName + ", " + type.Assembly.GetName().Name;
+        }
+
+        /// <summary>
+        /// Generates a friendly name which includes generic type parameters.
+        /// <br/>See original: https://stackoverflow.com/a/56756010/2634818
+        /// </summary>
+        /// <returns>A string representation of the Type including generic type parameters. </returns>
+        public static string GetFriendlyName(this Type type)
+        {
+            if (type.IsGenericType)
+            {
+                return GetTypeString(type);
+            }
+            return type.FullName;
+        }
+
+        private static string GetTypeString(Type type)
+        {
+            var t = type.AssemblyQualifiedName;
+
+            var output = new StringBuilder();
+            List<string> typeStrings = new List<string>();
+
+            int iAssyBackTick = t.IndexOf('`') + 1;
+            output.Append(t.Substring(0, iAssyBackTick - 1).Replace("[", string.Empty));
+            var genericTypes = type.GetGenericArguments();
+
+            foreach (var genType in genericTypes)
+            {
+                typeStrings.Add(genType.IsGenericType ? GetTypeString(genType) : genType.ToString());
+            }
+
+            output.Append($"<{string.Join(",", typeStrings)}>");
+            return output.ToString();
         }
 
         /// <summary>

--- a/framework/src/Volo.Abp.Data/Volo/Abp/Data/AbpDataFilterOptions.cs
+++ b/framework/src/Volo.Abp.Data/Volo/Abp/Data/AbpDataFilterOptions.cs
@@ -5,6 +5,8 @@ namespace Volo.Abp.Data
 {
     public class AbpDataFilterOptions
     {
+        public bool DefaultFilterState { get; set; } = true;
+
         public Dictionary<Type, DataFilterState> DefaultStates { get; }
 
         public AbpDataFilterOptions()

--- a/framework/src/Volo.Abp.Data/Volo/Abp/Data/DataFilter.cs
+++ b/framework/src/Volo.Abp.Data/Volo/Abp/Data/DataFilter.cs
@@ -1,108 +1,177 @@
-﻿using System;
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
-using Volo.Abp.DependencyInjection;
 
 namespace Volo.Abp.Data
 {
     //TODO: Create a Volo.Abp.Data.Filtering namespace?
     public class DataFilter : IDataFilter, ISingletonDependency
     {
-        private readonly ConcurrentDictionary<Type, object> _filters;
+        public IReadOnlyDictionary<Type, IBasicDataFilter> ReadOnlyFilters => Filters;
 
-        private readonly IServiceProvider _serviceProvider;
+        protected readonly ConcurrentDictionary<Type, IBasicDataFilter> Filters = new();
+
+        protected readonly IServiceProvider ServiceProvider;
 
         public DataFilter(IServiceProvider serviceProvider)
         {
-            _serviceProvider = serviceProvider;
-            _filters = new ConcurrentDictionary<Type, object>();
+            ServiceProvider = serviceProvider;
         }
 
-        public IDisposable Enable<TFilter>()
+        public virtual IDisposable Enable<TFilter>()
             where TFilter : class
         {
-            return GetFilter<TFilter>().Enable();
+            return GetOrAddFilter<TFilter>().Enable();
         }
 
-        public IDisposable Disable<TFilter>()
+        public virtual IDisposable Disable<TFilter>()
             where TFilter : class
         {
-            return GetFilter<TFilter>().Disable();
+            return GetOrAddFilter<TFilter>().Disable();
         }
 
-        public bool IsEnabled<TFilter>()
+        public virtual bool IsActive<TFilter>()
             where TFilter : class
         {
-            return GetFilter<TFilter>().IsEnabled;
+            return GetOrAddFilter<TFilter>().IsActive;
         }
 
-        private IDataFilter<TFilter> GetFilter<TFilter>()
+        public virtual bool IsActive(Type filterType)
+        {
+            return GetOrAddFilter(filterType).IsActive;
+        }
+
+        public virtual bool IsEnabled<TFilter>()
             where TFilter : class
         {
-            return _filters.GetOrAdd(
+            return GetOrAddFilter<TFilter>().IsEnabled;
+        }
+
+        public virtual bool IsEnabled(Type filterType)
+        {
+            return GetOrAddFilter(filterType).IsEnabled;
+        }
+
+        public virtual IDataFilter<TFilter> GetOrAddFilter<TFilter>()
+            where TFilter : class
+        {
+            return Filters.GetOrAdd(
                 typeof(TFilter),
-                () => _serviceProvider.GetRequiredService<IDataFilter<TFilter>>()
+                () => ServiceProvider.GetRequiredService<IDataFilter<TFilter>>()
             ) as IDataFilter<TFilter>;
+        }
+
+        public virtual IBasicDataFilter GetOrAddFilter(Type filterType)
+        {
+            if (filterType == null
+                // Should have no more than 1 interface type argument
+                || filterType.GenericTypeArguments.Length > 1
+                // Should be a generic filter interface e.g. ISoftDelete without unbound generic parameters e.g. ISoftDelete<>
+                || (filterType.GenericTypeArguments.Length == 0 && (!filterType.IsInterface || filterType.ContainsGenericParameters))
+                // Should be a filter interface with a concrete parameter e.g. Blog (filter == ISoftDelete<Blog>)
+                || (filterType.GenericTypeArguments.Length == 1 && filterType.GenericTypeArguments[0].IsGenericType))
+            {
+                throw new AbpException($"The {nameof(filterType)} \"{(filterType == null ? "<null>" : filterType.GetFriendlyName())}\"" +
+                    " is not a valid data filter type");
+            }
+
+            return Filters.GetOrAdd(
+                filterType,
+                (type) => ServiceProvider.GetRequiredService(
+                    typeof(IDataFilter<>).MakeGenericType(type)) as IBasicDataFilter
+            );
         }
     }
 
     public class DataFilter<TFilter> : IDataFilter<TFilter>
         where TFilter : class
     {
-        public bool IsEnabled
+        public virtual bool IsActive => Filter.Value != null && Filter.Value.IsActive;
+
+        public virtual bool IsEnabled
         {
             get
             {
                 EnsureInitialized();
-                return _filter.Value.IsEnabled;
+                return Filter.Value.IsEnabled;
             }
         }
 
-        private readonly AbpDataFilterOptions _options;
+        protected readonly AbpDataFilterOptions Options;
 
-        private readonly AsyncLocal<DataFilterState> _filter;
+        protected readonly AsyncLocal<DataFilterState> Filter;
 
         public DataFilter(IOptions<AbpDataFilterOptions> options)
         {
-            _options = options.Value;
-            _filter = new AsyncLocal<DataFilterState>();
+            Options = options.Value;
+            Filter = new AsyncLocal<DataFilterState>();
         }
 
-        public IDisposable Enable()
+        public virtual IDisposable Enable()
         {
-            if (IsEnabled)
-            {
-                return NullDisposable.Instance;
-            }
+            EnsureInitialized();
 
-            _filter.Value.IsEnabled = true;
-
-            return new DisposeAction(() => Disable());
-        }
-
-        public IDisposable Disable()
-        {
             if (!IsEnabled)
             {
-                return NullDisposable.Instance;
+                Filter.Value.IsEnabled = true;
             }
 
-            _filter.Value.IsEnabled = false;
+            if (IsActive)
+            {
+                return new DisposeAction(() => {
+                    if (IsEnabled) Filter.Value.IsEnabled = false;
+                });
+            }
+            else
+            {
+                Filter.Value.IsActive = true;
 
-            return new DisposeAction(() => Enable());
+                return new DisposeAction(() => {
+                    Filter.Value.IsActive = false;
+                    if (IsEnabled) Filter.Value.IsEnabled = false;
+                });
+            }
         }
 
-        private void EnsureInitialized()
+        public virtual IDisposable Disable()
         {
-            if (_filter.Value != null)
+            EnsureInitialized();
+
+            if (IsEnabled)
+            {
+                Filter.Value.IsEnabled = false;
+            }
+
+            if (IsActive)
+            {
+                return new DisposeAction(() => {
+                    if (!IsEnabled) Filter.Value.IsEnabled = true;
+                });
+            }
+            else
+            {
+                Filter.Value.IsActive = true;
+
+                return new DisposeAction(() => {
+                    Filter.Value.IsActive = false;
+                    if (!IsEnabled) Filter.Value.IsEnabled = true;
+                });
+            }
+        }
+
+        protected virtual void EnsureInitialized()
+        {
+            if (Filter.Value != null)
             {
                 return;
             }
 
-            _filter.Value = _options.DefaultStates.GetOrDefault(typeof(TFilter))?.Clone() ?? new DataFilterState(true);
+            Filter.Value = Options.DefaultStates.GetOrDefault(typeof(TFilter))?.Clone()
+                ?? new DataFilterState(Options.DefaultFilterState, false);
         }
     }
 }

--- a/framework/src/Volo.Abp.Data/Volo/Abp/Data/DataFilter.cs
+++ b/framework/src/Volo.Abp.Data/Volo/Abp/Data/DataFilter.cs
@@ -3,8 +3,8 @@ using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
+using Volo.Abp.DependencyInjection;
 
 namespace Volo.Abp.Data
 {

--- a/framework/src/Volo.Abp.Data/Volo/Abp/Data/DataFilterState.cs
+++ b/framework/src/Volo.Abp.Data/Volo/Abp/Data/DataFilterState.cs
@@ -2,16 +2,18 @@
 {
     public class DataFilterState
     {
+        public bool IsActive { get; set; }
         public bool IsEnabled { get; set; }
 
-        public DataFilterState(bool isEnabled)
+        public DataFilterState(bool isEnabled, bool isActive = false)
         {
             IsEnabled = isEnabled;
+            IsActive = isActive;
         }
-        
+
         public DataFilterState Clone()
         {
-            return new DataFilterState(IsEnabled);
+            return new DataFilterState(IsEnabled, IsActive);
         }
     }
 }

--- a/framework/src/Volo.Abp.Data/Volo/Abp/Data/IDataFilter.cs
+++ b/framework/src/Volo.Abp.Data/Volo/Abp/Data/IDataFilter.cs
@@ -1,26 +1,151 @@
 ﻿using System;
+using System.Collections.Generic;
+using Volo.Abp.DependencyInjection;
 
 namespace Volo.Abp.Data
 {
-    public interface IDataFilter<TFilter>
+    public interface IDataFilter<TFilter> : IBasicDataFilter
         where TFilter : class
+    { }
+
+    public interface IBasicDataFilter
     {
         IDisposable Enable();
-
         IDisposable Disable();
-
+        bool IsActive { get; }
         bool IsEnabled { get; }
     }
 
-    public interface IDataFilter
+    public interface IDataFilter : ISingletonDependency
     {
-        IDisposable Enable<TFilter>()
-            where TFilter : class;
-        
-        IDisposable Disable<TFilter>()
-            where TFilter : class;
+        /// <summary>
+        /// The filters that have been cached. These can be filtered by <see cref="IBasicDataFilter.IsActive"/> to find the filters that are in active use.
+        /// <para>
+        ///     This contains filters which have previously been cached for example when reading or updating a filter using <see cref="IsEnabled{TFilter}"/> or <see cref="Enable{TFilter}"/>.
+        ///     <br/>As such, this can only be used as a reference. To fetch a single result, please use <see cref="IsActive{TFilter}"/> or <see cref="IsEnabled{TFilter}"/>.
+        /// </para>
+        /// </summary>
+        IReadOnlyDictionary<Type, IBasicDataFilter> ReadOnlyFilters { get; }
 
-        bool IsEnabled<TFilter>()
-            where TFilter : class;
+        /// <summary>
+        /// <para>
+        ///     Enables the given filter. This should be disposed of after use to reset the filter to its previous state.
+        /// </para>
+        /// <example>
+        ///     <b>Example:</b> <c>using(DataFilter.Enable&lt;ISoftDelete&gt;) { /* code here */ }</c>
+        /// </example>
+        /// </summary>
+        /// <typeparam name="TFilter">The filter to enable. </typeparam>
+        /// <returns>A disposable which resets the filter after use. </returns>
+        IDisposable Enable<TFilter>() where TFilter : class;
+
+        /// <summary>
+        /// <para>
+        ///     Disables the given filter. This should be disposed of after use to reset the filter to its previous state.
+        /// </para>
+        /// <example>
+        ///     <b>Example:</b> <c>using(DataFilter.Disable&lt;ISoftDelete&gt;) { /* code here */ }</c>
+        /// </example>
+        /// </summary>
+        /// <typeparam name="TFilter">The filter to disable. </typeparam>
+        /// <returns>A disposable which resets the filter after use. </returns>
+        IDisposable Disable<TFilter>() where TFilter : class;
+
+        /// <summary>
+        /// <para>
+        ///     Determines if the <see cref="IDataFilter{TFilter}"/> is active for the given <typeparamref name="TFilter"/>.
+        ///     <br/>A filter is active when <see cref="Enable{TFilter}"/> or <see cref="Disable{TFilter}"/> has been called and is in active use.
+        ///     <br/>When the filter is disposed, it will be set to inactive again.
+        /// </para>
+        /// <example>
+        ///     Example usage: <see cref="DataFilter.IsActive{TFilter}"/>
+        /// </example>
+        /// </summary>
+        /// <typeparam name="TFilter">The <see cref="Type"/> of filter to find i.e. <see cref="ISoftDelete"/>. </typeparam>
+        /// <returns>
+        ///     <see langword="true"/> if the filter is active for the given <typeparamref name="TFilter"/>, 
+        ///     otherwise <see langword="false"/>.
+        /// </returns>
+        bool IsActive<TFilter>() where TFilter : class;
+
+        /// <summary>
+        /// <para>
+        ///     Determines if the <see cref="IDataFilter{TFilter}"/> is active for the given <paramref name="filterType"/>.
+        ///     <br/>A filter is active when <see cref="Enable{TFilter}"/> or <see cref="Disable{TFilter}"/> has been called and is in active use.
+        ///     <br/>When the filter is disposed, it will be set to inactive again.
+        /// </para>
+        /// <para>
+        ///     <b>Note</b>: This method should only be used when the <see cref="IDataFilter{TFilter}"/> type is not known until runtime as there is a performance penalty for using it.
+        ///     <br/>Please use <see cref="IsActive{TFilter}"/> if the filter type is known at compile-time e.g. when using the generic <see cref="ISoftDelete"/>.
+        /// </para>
+        /// <example>
+        ///     Example usage: <c>DataFilter.IsActive(typeof(myDynamicFilter))</c>
+        /// </example>
+        /// </summary>
+        /// <param name="filterType">The <see cref="Type"/> of filter to find. </param>
+        /// <returns>
+        ///     <see langword="true"/> if the filter is active for the given <paramref name="filterType"/>, 
+        ///     otherwise <see langword="false"/>.
+        /// </returns>
+        bool IsActive(Type filterType);
+
+        /// <summary>
+        /// <para>
+        ///     Determines if the <see cref="IDataFilter{TFilter}"/> is enabled for the given <typeparamref name="TFilter"/>.
+        /// </para>
+        /// <example>
+        ///     Example usage: <see cref="DataFilter.IsEnabled{TFilter}"/>
+        /// </example>
+        /// </summary>
+        /// <typeparam name="TFilter">The <see cref="Type"/> of filter to find i.e. <see cref="ISoftDelete"/>. </typeparam>
+        /// <returns>
+        ///     <see langword="true"/> if the filter is enabled for the given <typeparamref name="TFilter"/>, 
+        ///     otherwise the default value for this filter defined in <see cref="AbpDataFilterOptions.DefaultStates"/> or the <see cref="AbpDataFilterOptions.DefaultFilterState"/>.
+        /// </returns>
+        bool IsEnabled<TFilter>() where TFilter : class;
+
+        /// <summary>
+        /// Determines if the <see cref="IDataFilter{TFilter}"/> is enabled for the given <paramref name="filterType"/>.
+        /// <para>
+        ///     <b>Note</b>: This method should only be used when the <see cref="IDataFilter{TFilter}"/> type is not known until runtime as there is a performance penalty for using it.
+        ///     <br/>Please use <see cref="IsEnabled{TFilter}"/> if the filter type is known at compile-time e.g. when using the generic <see cref="ISoftDelete"/>.
+        /// </para>
+        /// <example>
+        ///     Example usage: <c>DataFilter.IsEnabled(typeof(myDynamicFilter))</c>
+        /// </example>
+        /// </summary>
+        /// <param name="filterType">The <see cref="Type"/> of filter to find. </param>
+        /// <returns>
+        ///     <see langword="true"/> if the filter is enabled for the given <paramref name="filterType"/>, 
+        ///     otherwise the default value for this filter defined in <see cref="AbpDataFilterOptions.DefaultStates"/> or the <see cref="AbpDataFilterOptions.DefaultFilterState"/>. 
+        /// </returns>
+        bool IsEnabled(Type filterType);
+
+        /// <summary>
+        /// Gets the <see cref="IDataFilter{TFilter}"/> representing the <typeparamref name="TFilter"/>.
+        /// If the filter doesn't exist then a new instance will be created.
+        /// </summary>
+        /// <typeparam name="TFilter">The type of filter e.g. <see cref="ISoftDelete"/>. </typeparam>
+        IDataFilter<TFilter> GetOrAddFilter<TFilter>() where TFilter : class;
+
+        /// <summary>
+        /// Gets the <see cref="IBasicDataFilter"/> representing the <paramref name="filterType"/>.
+        /// If the filter doesn't exist then a new instance will be created.
+        /// <para>
+        ///     <b>Note</b>: This method should only be used when the <see cref="IDataFilter{TFilter}"/> type is not known until runtime as there is a performance penalty for using it.
+        ///     <br/>Please use <see cref="GetOrAddFilter{TFilter}"/> if the filter type is known at compile-time e.g. when using the generic <see cref="ISoftDelete"/>.
+        /// </para>
+        /// <para>
+        ///     It should be possible to cast the <see cref="IBasicDataFilter"/> to your custom type.
+        ///     <br/>Example: <c>(myDynamicFilter as IDataFilter&lt;ICustomFilter&lt;MyClass&gt;&gt;)</c>
+        /// </para>
+        /// <para>
+        ///     This will throw an <see cref="AbpException"/> when the <see cref="Type"/> cannot be used as a <see cref="IDataFilter{TFilter}"/>.
+        ///     <br/>For example when using nested interfaces <c>IDataFilter&lt;ISoftDelete&lt;ISoftDelete&gt;&gt;</c> or interfaces with multiple type parameters.
+        /// </para>
+        /// </summary>
+        /// <param name="filterType">The type of filter e.g. <c>typeof(myDynamicFilter)</c>. </param>
+        /// <exception cref="AbpException"/>
+        IBasicDataFilter GetOrAddFilter(Type filterType);
     }
 }

--- a/framework/test/Volo.Abp.Data.Tests/Volo/Abp/Data/DataFilter_Tests.cs
+++ b/framework/test/Volo.Abp.Data.Tests/Volo/Abp/Data/DataFilter_Tests.cs
@@ -1,0 +1,208 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using System.Threading.Tasks;
+using Volo.Abp.Modularity;
+using Volo.Abp.Testing;
+using Xunit;
+
+namespace Volo.Abp.Data
+{
+    public class DataFilter_Tests : AbpIntegratedTest<DataFilter_Tests.TestModule>
+    {
+        private readonly IDataFilter _dataFilter;
+        private readonly AbpDataFilterOptions _dataFilterOptions;
+
+        public DataFilter_Tests()
+        {
+            _dataFilter = ServiceProvider.GetRequiredService<IDataFilter>();
+            _dataFilterOptions = ServiceProvider
+                .GetRequiredService<IOptions<AbpDataFilterOptions>>().Value;
+        }
+
+        [Fact]
+        public void Should_Allow_Default_Filter_State_To_Be_Updated()
+        {
+            _dataFilter.ReadOnlyFilters.ContainsKey(typeof(ISoftDelete)).ShouldBe(false);
+            _dataFilter.ReadOnlyFilters.ContainsKey(typeof(IGenericDataFilter1)).ShouldBe(false);
+
+            _dataFilterOptions.DefaultFilterState = false;
+            _dataFilter.IsEnabled<ISoftDelete>().ShouldBe(false);
+
+            _dataFilterOptions.DefaultFilterState = true;
+            _dataFilter.IsEnabled<IGenericDataFilter1>().ShouldBe(true);
+
+            _dataFilter.IsEnabled<IDefaultDisabledFilter>().ShouldBe(false);
+        }
+
+        [Fact]
+        public void Should_Correctly_Dispose_Filter_State()
+        {
+            void task()
+            {
+                _dataFilter.IsActive<IGenericDataFilter1>().ShouldBe(false);
+                _dataFilter.IsEnabled<IGenericDataFilter1>().ShouldBe(true);
+
+                // filter now cached, is it still marked IsActive == false?
+                _dataFilter.IsActive<IGenericDataFilter1>().ShouldBe(false);
+
+                using (_dataFilter.Disable<IGenericDataFilter1>())
+                {
+                    _dataFilter.IsEnabled<IGenericDataFilter1>().ShouldBe(false);
+                    _dataFilter.IsActive<IGenericDataFilter1>().ShouldBe(true);
+                }
+
+                _dataFilter.IsActive<IGenericDataFilter1>().ShouldBe(false);
+                _dataFilter.IsEnabled<IGenericDataFilter1>().ShouldBe(true);
+            }
+
+            // Simulate multiple 'requests' happening at once.
+            // The filter state should not be contaminated between requests.
+            Parallel.Invoke(task, task, task, task);
+        }
+
+        [Fact]
+        public void Should_Override_Default_Filter_State_For_Single_Filter()
+        {
+            _dataFilterOptions.DefaultFilterState.ShouldBe(true);
+
+            _dataFilterOptions.DefaultStates.ContainsKey(typeof(IGenericDataFilter1)).ShouldBe(false);
+
+            _dataFilterOptions.DefaultStates.Add(typeof(IGenericDataFilter1), new DataFilterState(false));
+
+            _dataFilter.IsEnabled<IGenericDataFilter1>().ShouldBe(false);
+            _dataFilter.IsEnabled<ISoftDelete>().ShouldBe(true);
+        }
+
+        [Fact]
+        public void Should_Disable_Filter()
+        {
+            _dataFilter.IsEnabled<ISoftDelete>().ShouldBe(true);
+
+            using (_dataFilter.Disable<ISoftDelete>())
+            {
+                _dataFilter.IsEnabled<ISoftDelete>().ShouldBe(false);
+            }
+
+            _dataFilter.IsEnabled<ISoftDelete>().ShouldBe(true);
+        }
+
+        [Fact]
+        public async Task Should_Handle_Nested_Filters()
+        {
+            _dataFilter.IsEnabled<ISoftDelete>().ShouldBe(true);
+
+            using (_dataFilter.Disable<ISoftDelete>())
+            {
+                await Task.Run(() =>
+                {
+                    using (_dataFilter.Enable<ISoftDelete>())
+                    {
+                        _dataFilter.IsEnabled<ISoftDelete>().ShouldBe(true);
+                    }
+                });
+
+                _dataFilter.IsEnabled<ISoftDelete>().ShouldBe(false);
+            }
+
+            _dataFilter.IsEnabled<ISoftDelete>().ShouldBe(true);
+        }
+
+        [Fact]
+        public void Should_Handle_Dynamic_Filters()
+        {
+            _dataFilter.IsActive(typeof(ICustomFilter<TestSoftDeleteClass>)).ShouldBe(false);
+            _dataFilter.IsEnabled(typeof(ICustomFilter<TestSoftDeleteClass>)).ShouldBe(true);
+
+            using (_dataFilter.Disable<ICustomFilter<TestSoftDeleteClass>>())
+            {
+                _dataFilter.IsActive(typeof(ICustomFilter<TestSoftDeleteClass>)).ShouldBe(true);
+                _dataFilter.IsEnabled(typeof(ICustomFilter<TestSoftDeleteClass>)).ShouldBe(false);
+            }
+
+            _dataFilter.IsEnabled<ICustomFilter<TestSoftDeleteClass>>().ShouldBe(true);
+
+            // null
+            ShouldThrowExtensions.ShouldThrow(
+                () => _dataFilter.GetOrAddFilter(null),
+                typeof(AbpException)
+            );
+            // Not an interface
+            ShouldThrowExtensions.ShouldThrow(
+                () => _dataFilter.GetOrAddFilter(typeof(TestSoftDeleteClass)),
+                typeof(AbpException)
+            );
+            // No type parameter defined
+            ShouldThrowExtensions.ShouldThrow(
+                () => _dataFilter.GetOrAddFilter(typeof(ICustomFilter<>)),
+                typeof(AbpException)
+            );
+            // Nested generics
+            ShouldThrowExtensions.ShouldThrow(
+                () => _dataFilter.GetOrAddFilter(typeof(ICustomFilter<ICustomFilter<TestSoftDeleteClass>>)),
+                typeof(AbpException)
+            );
+            // Multiple type parameters
+            ShouldThrowExtensions.ShouldThrow(
+                () => _dataFilter.GetOrAddFilter(typeof(ICustomFilter<SimpleClass, SimpleClass>)),
+                typeof(AbpException)
+            );
+        }
+
+        [Fact]
+        public void Should_Work_Without_DataFilter_Container()
+        {
+            var genericDataFilter2 = ServiceProvider.GetRequiredService<IDataFilter<IGenericDataFilter2>>();
+
+            genericDataFilter2.IsActive.ShouldBe(false);
+            genericDataFilter2.IsEnabled.ShouldBe(true);
+
+            using (genericDataFilter2.Disable())
+            {
+                genericDataFilter2.IsActive.ShouldBe(true);
+                genericDataFilter2.IsEnabled.ShouldBe(false);
+
+                using (genericDataFilter2.Enable())
+                {
+                    genericDataFilter2.IsActive.ShouldBe(true);
+                    genericDataFilter2.IsEnabled.ShouldBe(true);
+                }
+
+                genericDataFilter2.IsActive.ShouldBe(true);
+            }
+
+            genericDataFilter2.IsActive.ShouldBe(false);
+            genericDataFilter2.IsEnabled.ShouldBe(true);
+        }
+
+        class TestSoftDeleteClass : ISoftDelete, ITestMarkerInterface
+        {
+            public bool IsDeleted { get; set; }
+        }
+        interface ITestMarkerInterface { }
+
+        interface ICustomFilter<T> { }
+        interface ICustomFilter<T,T2> { }
+        class SimpleClass { }
+
+        interface IDefaultDisabledFilter { }
+        interface IGenericDataFilter1 { }
+        interface IGenericDataFilter2 { }
+
+
+        [DependsOn(typeof(AbpDataModule))]
+        public class TestModule : AbpModule
+        {
+            public override void ConfigureServices(ServiceConfigurationContext context)
+            {
+                base.ConfigureServices(context);
+
+                Configure<AbpDataFilterOptions>(options =>
+                {
+                    options.DefaultStates.Add(typeof(IDefaultDisabledFilter), new DataFilterState(false));
+                });
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
I would like to propose some updates to the DataFilter implementation. The changes should be non-breaking as the base functionality remains the same, with an additional `IsActive` attribute along with some additional useful methods.
I have made a number of changes but my main motivation is to know which filters are currently 'active' (being used within a disposable scope). Having access to information about the filters is also very useful.

Because DataFilter is `ISingletonDependency` the cached filters are kept in memory after their first use. The `IsEnabled` property isn't a reliable source because the default `IsEnabled` value can be changed per filter with `AbpDataFilterOptions`. I tried making the `DataFilter` Scoped; but the scope can change within a request so the filters reset.

I have added various tests to ensure these work within all common scenarios and I've added documentation to guide developers for the correct use of each method.

Initially, I intend to use this in conjunction with the [abp-queryfilter-test](https://github.com/olicooper/abp-queryfilter-test) project I am working on ([mentioned here](https://github.com/abpframework/abp/issues/7690)) - where you can the proposed changes in use.

Changes include:
* Add new methods (GetOrAddFilter, IsActive) and add ReadOnlyFilters property to DataFilter
* Make DataFilter extensible (virtual methods etc.)
* Add ability to set the DefaultFilterState in AbpDataFilterOptions
* Add test suite
* Improve method XML descriptions