### PR TITLE
UPDATE es.json Misspelling "Actions"

### DIFF
--- a/framework/src/Volo.Abp.UI/Localization/Resources/AbpUi/es.json
+++ b/framework/src/Volo.Abp.UI/Localization/Resources/AbpUi/es.json
@@ -11,7 +11,7 @@
     "Close": "Cerrar",
     "Save": "Guardar",
     "SavingWithThreeDot": "Guardando...",
-    "Actions": "Actiones",
+    "Actions": "Acciones",
     "Delete": "Borrar",
     "Edit": "Editar",
     "Refresh": "Actualizar",


### PR DESCRIPTION
Actions Menu Title is misspelling in  spanish, it's must be "Acciones" but now is written like "Actiones".