### PR TITLE
Add MenuContributorBase to check permissions in advance.

### DIFF
--- a/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/MenuContributorBase.cs
+++ b/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/MenuContributorBase.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+
+namespace Volo.Abp.UI.Navigation
+{
+    public abstract class MenuContributorBase : IMenuContributor
+    {
+        public List<string> PreCheckPermissions { get; }
+        public IReadOnlyList<string> GrantedPermissions => _grantedPermissions.ToImmutableList();
+        private readonly List<string> _grantedPermissions;
+
+        protected MenuContributorBase()
+        {
+            PreCheckPermissions = new List<string>();
+            _grantedPermissions = new List<string>();
+        }
+
+        public void AddGrantedPermission(string permission)
+        {
+            _grantedPermissions.Add(permission);
+        }
+
+        public abstract Task ConfigureMenuAsync(MenuConfigurationContext context);
+    }
+}

--- a/framework/test/Volo.Abp.Authorization.Tests/Volo.Abp.Authorization.Tests.csproj
+++ b/framework/test/Volo.Abp.Authorization.Tests/Volo.Abp.Authorization.Tests.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Volo.Abp.Autofac\Volo.Abp.Autofac.csproj" />
     <ProjectReference Include="..\..\src\Volo.Abp.ExceptionHandling\Volo.Abp.ExceptionHandling.csproj" />
+    <ProjectReference Include="..\..\src\Volo.Abp.UI.Navigation\Volo.Abp.UI.Navigation.csproj" />
     <ProjectReference Include="..\AbpTestBase\AbpTestBase.csproj" />
     <ProjectReference Include="..\..\src\Volo.Abp.Authorization\Volo.Abp.Authorization.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />

--- a/framework/test/Volo.Abp.Authorization.Tests/Volo/Abp/Authorization/AbpAuthorizationTestModule.cs
+++ b/framework/test/Volo.Abp.Authorization.Tests/Volo/Abp/Authorization/AbpAuthorizationTestModule.cs
@@ -4,12 +4,14 @@ using Volo.Abp.Autofac;
 using Volo.Abp.DynamicProxy;
 using Volo.Abp.ExceptionHandling;
 using Volo.Abp.Modularity;
+using Volo.Abp.UI.Navigation;
 
 namespace Volo.Abp.Authorization
 {
     [DependsOn(typeof(AbpAutofacModule))]
     [DependsOn(typeof(AbpAuthorizationModule))]
     [DependsOn(typeof(AbpExceptionHandlingModule))]
+    [DependsOn(typeof(AbpUiNavigationModule))]
     public class AbpAuthorizationTestModule : AbpModule
     {
         public override void PreConfigureServices(ServiceConfigurationContext context)

--- a/framework/test/Volo.Abp.Authorization.Tests/Volo/Abp/Authorization/FakePermissionStore.cs
+++ b/framework/test/Volo.Abp.Authorization.Tests/Volo/Abp/Authorization/FakePermissionStore.cs
@@ -1,0 +1,28 @@
+﻿using System.Threading.Tasks;
+using Volo.Abp.Authorization.Permissions;
+using Volo.Abp.DependencyInjection;
+
+namespace Volo.Abp.Authorization
+{
+    public class FakePermissionStore : IPermissionStore, ITransientDependency
+    {
+        public Task<bool> IsGrantedAsync(string name, string providerName, string providerKey)
+        {
+            var result = name == "MenuPermission1" || name == "MenuPermission4";
+            return Task.FromResult(result);
+        }
+
+        public Task<MultiplePermissionGrantResult> IsGrantedAsync(string[] names, string providerName, string providerKey)
+        {
+            var result = new MultiplePermissionGrantResult();
+            foreach (var name in names)
+            {
+                result.Result.Add(name, name == "MenuPermission1" || name == "MenuPermission4"
+                    ? PermissionGrantResult.Granted
+                    : PermissionGrantResult.Prohibited);
+            }
+
+            return Task.FromResult(result);
+        }
+    }
+}

--- a/framework/test/Volo.Abp.Authorization.Tests/Volo/Abp/Authorization/MenuContributorPermission_Test.cs
+++ b/framework/test/Volo.Abp.Authorization.Tests/Volo/Abp/Authorization/MenuContributorPermission_Test.cs
@@ -1,0 +1,73 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Volo.Abp.UI.Navigation;
+using Xunit;
+
+namespace Volo.Abp.Authorization
+{
+    public class MenuContributorPermission_Test : AuthorizationTestBase
+    {
+        public static readonly List<string> GrantedPermissions = new List<string>();
+        private readonly IMenuManager _menuManager;
+
+        public MenuContributorPermission_Test()
+        {
+            _menuManager = GetRequiredService<IMenuManager>();
+        }
+
+        protected override void AfterAddApplication(IServiceCollection services)
+        {
+            services.Configure<AbpNavigationOptions>(options =>
+            {
+                options.MenuContributors.Add(new TestMenuContributor1());
+                options.MenuContributors.Add(new TestMenuContributor2());
+            });
+
+            base.AfterAddApplication(services);
+        }
+
+        [Fact]
+        public async Task Should_Check_MenuContributor_PreCheckPermissions()
+        {
+            await _menuManager.GetAsync(StandardMenus.Main);
+
+            GrantedPermissions.Count.ShouldBe(2);
+            GrantedPermissions.ShouldContain("MenuPermission1");
+            GrantedPermissions.ShouldContain("MenuPermission4");
+        }
+
+        class TestMenuContributor1 : MenuContributorBase
+        {
+            public TestMenuContributor1()
+            {
+                PreCheckPermissions.Add("MenuPermission1");
+                PreCheckPermissions.Add("MenuPermission2");
+            }
+
+            public override Task ConfigureMenuAsync(MenuConfigurationContext context)
+            {
+                MenuContributorPermission_Test.GrantedPermissions.AddRange(GrantedPermissions);
+
+                return Task.CompletedTask;
+            }
+        }
+
+        class TestMenuContributor2 : MenuContributorBase
+        {
+            public TestMenuContributor2()
+            {
+                PreCheckPermissions.Add("MenuPermission3");
+                PreCheckPermissions.Add("MenuPermission4");
+            }
+
+            public override Task ConfigureMenuAsync(MenuConfigurationContext context)
+            {
+                MenuContributorPermission_Test.GrantedPermissions.AddRange(GrantedPermissions);
+
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/framework/test/Volo.Abp.Authorization.Tests/Volo/Abp/Authorization/TestServices/AuthorizationTestPermissionDefinitionProvider.cs
+++ b/framework/test/Volo.Abp.Authorization.Tests/Volo/Abp/Authorization/TestServices/AuthorizationTestPermissionDefinitionProvider.cs
@@ -12,10 +12,15 @@ namespace Volo.Abp.Authorization.TestServices
             {
                 getGroup = context.AddGroup("TestGetGroup");
             }
-            
+
             var group = context.AddGroup("TestGroup");
 
             group.AddPermission("MyAuthorizedService1");
+
+            group.AddPermission("MenuPermission1");
+            group.AddPermission("MenuPermission2");
+            group.AddPermission("MenuPermission3");
+            group.AddPermission("MenuPermission4");
 
             group.GetPermissionOrNull("MyAuthorizedService1").ShouldNotBeNull();
 


### PR DESCRIPTION
Resolve #7788

Usage:
Use **GrantedPermissions** to check the permissions.
```cs
public class TestMenuContributor1 : MenuContributorBase
{
    public TestMenuContributor1()
    {
        PreCheckPermissions.Add("MenuPermission1");
        PreCheckPermissions.Add("MenuPermission2");
    }

    public override Task ConfigureMenuAsync(MenuConfigurationContext context)
    {
        if (GrantedPermissions.Contains("MenuPermission1"))
        {
            //context.Menu.AddItem()
        }

        return Task.CompletedTask;
    }
}
```