### PR TITLE
Adding JsonName to PropertyApiDescriptionModel for handling JsonProperty attribute names

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AspNetCoreApiDescriptionModelProvider.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AspNetCoreApiDescriptionModelProvider.cs
@@ -272,6 +272,7 @@ namespace Volo.Abp.AspNetCore.Mvc
 
                 actionModel.AddParameter(ParameterApiDescriptionModel.Create(
                         parameterDescription.Name,
+                        _options.ApiParameterNameGenerator?.Invoke(parameterDescription),
                         matchedMethodParamName,
                         parameterDescription.Type,
                         parameterDescription.RouteInfo?.IsOptional ?? false,

--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AspNetCoreApiDescriptionModelProviderOptions.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AspNetCoreApiDescriptionModelProviderOptions.cs
@@ -2,6 +2,9 @@
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Volo.Abp.Application.Services;
 using Volo.Abp.AspNetCore.Mvc.Conventions;
 
@@ -12,6 +15,8 @@ namespace Volo.Abp.AspNetCore.Mvc
         public Func<Type, ConventionalControllerSetting, string> ControllerNameGenerator { get; set; }
 
         public Func<MethodInfo, string> ActionNameGenerator { get; set; }
+
+        public Func<ApiParameterDescription, string> ApiParameterNameGenerator { get; set; }
 
         public AspNetCoreApiDescriptionModelProviderOptions()
         {
@@ -51,6 +56,28 @@ namespace Volo.Abp.AspNetCore.Mvc
                 }
 
                 return methodNameBuilder.ToString();
+            };
+
+            ApiParameterNameGenerator = (apiParameterDescription) =>
+            {
+                if (apiParameterDescription.ModelMetadata is DefaultModelMetadata defaultModelMetadata)
+                {
+                    var jsonPropertyNameAttribute = (System.Text.Json.Serialization.JsonPropertyNameAttribute)
+                        defaultModelMetadata.Attributes.PropertyAttributes.FirstOrDefault(x => x is System.Text.Json.Serialization.JsonPropertyNameAttribute);
+                    if (jsonPropertyNameAttribute != null)
+                    {
+                        return jsonPropertyNameAttribute.Name;
+                    }
+
+                    var jsonPropertyAttribute = (Newtonsoft.Json.JsonPropertyAttribute)
+                        defaultModelMetadata.Attributes.PropertyAttributes.FirstOrDefault(x => x is Newtonsoft.Json.JsonPropertyAttribute);
+                    if (jsonPropertyAttribute != null)
+                    {
+                        return jsonPropertyAttribute.PropertyName;
+                    }
+                }
+
+                return null;
             };
         }
     }

--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AspNetCoreApiDescriptionModelProviderOptions.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AspNetCoreApiDescriptionModelProviderOptions.cs
@@ -63,14 +63,14 @@ namespace Volo.Abp.AspNetCore.Mvc
                 if (apiParameterDescription.ModelMetadata is DefaultModelMetadata defaultModelMetadata)
                 {
                     var jsonPropertyNameAttribute = (System.Text.Json.Serialization.JsonPropertyNameAttribute)
-                        defaultModelMetadata.Attributes.PropertyAttributes.FirstOrDefault(x => x is System.Text.Json.Serialization.JsonPropertyNameAttribute);
+                        defaultModelMetadata?.Attributes?.PropertyAttributes?.FirstOrDefault(x => x is System.Text.Json.Serialization.JsonPropertyNameAttribute);
                     if (jsonPropertyNameAttribute != null)
                     {
                         return jsonPropertyNameAttribute.Name;
                     }
 
                     var jsonPropertyAttribute = (Newtonsoft.Json.JsonPropertyAttribute)
-                        defaultModelMetadata.Attributes.PropertyAttributes.FirstOrDefault(x => x is Newtonsoft.Json.JsonPropertyAttribute);
+                        defaultModelMetadata?.Attributes?.PropertyAttributes?.FirstOrDefault(x => x is Newtonsoft.Json.JsonPropertyAttribute);
                     if (jsonPropertyAttribute != null)
                     {
                         return jsonPropertyAttribute.PropertyName;

--- a/framework/src/Volo.Abp.Http/Volo/Abp/Http/Modeling/ParameterApiDescriptionModel.cs
+++ b/framework/src/Volo.Abp.Http/Volo/Abp/Http/Modeling/ParameterApiDescriptionModel.cs
@@ -10,6 +10,8 @@ namespace Volo.Abp.Http.Modeling
 
         public string Name { get; set; }
 
+        public string JsonName { get; set; }
+
         public string Type { get; set; }
 
         public string TypeSimple { get; set; }
@@ -29,11 +31,12 @@ namespace Volo.Abp.Http.Modeling
 
         }
 
-        public static ParameterApiDescriptionModel Create(string name, string nameOnMethod, Type type, bool isOptional = false, object defaultValue = null, string[] constraintTypes = null, string bindingSourceId = null, string descriptorName = null)
+        public static ParameterApiDescriptionModel Create(string name, string jsonName, string nameOnMethod, Type type, bool isOptional = false, object defaultValue = null, string[] constraintTypes = null, string bindingSourceId = null, string descriptorName = null)
         {
             return new ParameterApiDescriptionModel
             {
                 Name = name,
+                JsonName = jsonName,
                 NameOnMethod = nameOnMethod,
                 Type = type != null ? TypeHelper.GetFullNameHandlingNullableAndGenerics(type) : null,
                 TypeSimple = type != null ? ApiTypeNameHelper.GetSimpleTypeName(type) : null,

--- a/framework/src/Volo.Abp.Http/Volo/Abp/Http/Modeling/PropertyApiDescriptionModel.cs
+++ b/framework/src/Volo.Abp.Http/Volo/Abp/Http/Modeling/PropertyApiDescriptionModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.Reflection;
+using Volo.Abp.Http.ProxyScripting.Configuration;
 
 namespace Volo.Abp.Http.Modeling
 {
@@ -9,6 +10,8 @@ namespace Volo.Abp.Http.Modeling
     {
         public string Name { get; set; }
 
+        public string JsonName { get; set; }
+        
         public string Type { get; set; }
 
         public string TypeSimple { get; set; }
@@ -21,6 +24,7 @@ namespace Volo.Abp.Http.Modeling
             return new PropertyApiDescriptionModel
             {
                 Name = propertyInfo.Name,
+                JsonName = AbpApiProxyScriptingOptions.PropertyNameGenerator.Invoke(propertyInfo),
                 Type = ApiTypeNameHelper.GetTypeName(propertyInfo.PropertyType),
                 TypeSimple = ApiTypeNameHelper.GetSimpleTypeName(propertyInfo.PropertyType),
                 IsRequired = propertyInfo.IsDefined(typeof(RequiredAttribute), true)

--- a/framework/src/Volo.Abp.Http/Volo/Abp/Http/ProxyScripting/Configuration/AbpApiProxyScriptingOptions.cs
+++ b/framework/src/Volo.Abp.Http/Volo/Abp/Http/ProxyScripting/Configuration/AbpApiProxyScriptingOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace Volo.Abp.Http.ProxyScripting.Configuration
 {
@@ -7,9 +8,30 @@ namespace Volo.Abp.Http.ProxyScripting.Configuration
     {
         public IDictionary<string, Type> Generators { get; }
 
+        public Func<PropertyInfo, string> PropertyNameGenerator { get; set; }
+
         public AbpApiProxyScriptingOptions()
         {
             Generators = new Dictionary<string, Type>();
+            
+            PropertyNameGenerator = propertyInfo =>
+            {
+                var jsonPropertyNameAttribute = propertyInfo.GetSingleAttributeOrNull<System.Text.Json.Serialization.JsonPropertyNameAttribute>(true);
+
+                if (jsonPropertyNameAttribute != null)
+                {
+                    return jsonPropertyNameAttribute.Name;
+                }
+                
+                var jsonPropertyAttribute = propertyInfo.GetSingleAttributeOrNull<Newtonsoft.Json.JsonPropertyAttribute>(true);
+
+                if (jsonPropertyAttribute != null)
+                {
+                    return jsonPropertyAttribute.PropertyName;
+                }
+
+                return null;
+            };
         }
     }
 }

--- a/framework/src/Volo.Abp.Http/Volo/Abp/Http/ProxyScripting/Configuration/AbpApiProxyScriptingOptions.cs
+++ b/framework/src/Volo.Abp.Http/Volo/Abp/Http/ProxyScripting/Configuration/AbpApiProxyScriptingOptions.cs
@@ -8,7 +8,7 @@ namespace Volo.Abp.Http.ProxyScripting.Configuration
     {
         public IDictionary<string, Type> Generators { get; }
 
-        public Func<PropertyInfo, string> PropertyNameGenerator { get; set; }
+        public static Func<PropertyInfo, string> PropertyNameGenerator { get; set; }
 
         public AbpApiProxyScriptingOptions()
         {


### PR DESCRIPTION
Ref: https://github.com/abpframework/abp/issues/7776

With this attribute, `api-definition` can show properties with their manually typed json names.

![image](https://user-images.githubusercontent.com/20099739/108821409-9e087800-75ce-11eb-9367-9bcbd5500961.png)
