### PR TITLE
Make IInitLogger inherit ILogger.

### DIFF
--- a/framework/src/Volo.Abp.Core/Microsoft/Extensions/DependencyInjection/ServiceCollectionLoggingExtensions.cs
+++ b/framework/src/Volo.Abp.Core/Microsoft/Extensions/DependencyInjection/ServiceCollectionLoggingExtensions.cs
@@ -1,12 +1,13 @@
-﻿using Volo.Abp.Logging;
+﻿using Microsoft.Extensions.Logging;
+using Volo.Abp.Logging;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
     public static class ServiceCollectionLoggingExtensions
     {
-        public static IInitLogger GetInitLogger(this IServiceCollection services)
+        public static ILogger<T> GetInitLogger<T>(this IServiceCollection services)
         {
-            return services.GetSingletonInstance<IInitLogger>();
+            return services.GetSingletonInstance<IInitLoggerFactory>().Create<T>();
         }
     }
 }

--- a/framework/src/Volo.Abp.Core/Volo/Abp/AbpApplicationBase.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/AbpApplicationBase.cs
@@ -62,7 +62,7 @@ namespace Volo.Abp
         {
             //TODO: Shutdown if not done before?
         }
-        
+
         protected virtual void SetServiceProvider(IServiceProvider serviceProvider)
         {
             ServiceProvider = serviceProvider;
@@ -79,7 +79,7 @@ namespace Volo.Abp
                     .InitializeModules(new ApplicationInitializationContext(scope.ServiceProvider));
             }
         }
-        
+
         protected virtual void WriteInitLogs(IServiceProvider serviceProvider)
         {
             var logger = serviceProvider.GetService<ILogger<AbpApplicationBase>>();
@@ -87,14 +87,14 @@ namespace Volo.Abp
             {
                 return;
             }
-            
-            var initLogger = serviceProvider.GetRequiredService<IInitLogger>();
-            
+
+            var initLogger = serviceProvider.GetRequiredService<IInitLoggerFactory>().Create<AbpApplicationBase>();
+
             foreach (var entry in initLogger.Entries)
             {
-                logger.LogWithLevel(entry.Level, entry.Message, entry.Exception);
+                logger.Log(entry.LogLevel, entry.EventId, entry.State, entry.Exception, entry.Formatter);
             }
-            
+
             initLogger.Entries.Clear();
         }
 
@@ -108,7 +108,7 @@ namespace Volo.Abp
                     options.PlugInSources
                 );
         }
-        
+
         //TODO: We can extract a new class for this
         protected virtual void ConfigureServices()
         {

--- a/framework/src/Volo.Abp.Core/Volo/Abp/Internal/InternalServiceCollectionExtensions.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/Internal/InternalServiceCollectionExtensions.cs
@@ -17,7 +17,7 @@ namespace Volo.Abp.Internal
         }
 
         internal static void AddCoreAbpServices(this IServiceCollection services,
-            IAbpApplication abpApplication, 
+            IAbpApplication abpApplication,
             AbpApplicationCreationOptions applicationCreationOptions)
         {
             var moduleLoader = new ModuleLoader();
@@ -36,7 +36,7 @@ namespace Volo.Abp.Internal
             services.TryAddSingleton<IModuleLoader>(moduleLoader);
             services.TryAddSingleton<IAssemblyFinder>(assemblyFinder);
             services.TryAddSingleton<ITypeFinder>(typeFinder);
-            services.TryAddSingleton<IInitLogger>(new DefaultInitLogger());
+            services.TryAddSingleton<IInitLoggerFactory>(new InitLoggerFactory());
 
             services.AddAssemblyOf<IAbpApplication>();
 

--- a/framework/src/Volo.Abp.Core/Volo/Abp/Internal/InternalServiceCollectionExtensions.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/Internal/InternalServiceCollectionExtensions.cs
@@ -36,7 +36,7 @@ namespace Volo.Abp.Internal
             services.TryAddSingleton<IModuleLoader>(moduleLoader);
             services.TryAddSingleton<IAssemblyFinder>(assemblyFinder);
             services.TryAddSingleton<ITypeFinder>(typeFinder);
-            services.TryAddSingleton<IInitLoggerFactory>(new InitLoggerFactory());
+            services.TryAddSingleton<IInitLoggerFactory>(new DefaultInitLoggerFactory());
 
             services.AddAssemblyOf<IAbpApplication>();
 

--- a/framework/src/Volo.Abp.Core/Volo/Abp/Logging/AbpInitLogEntry.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/Logging/AbpInitLogEntry.cs
@@ -1,26 +1,20 @@
 ﻿using System;
-using JetBrains.Annotations;
 using Microsoft.Extensions.Logging;
 
 namespace Volo.Abp.Logging
 {
     public class AbpInitLogEntry
     {
-        public LogLevel Level { get; }
-        
-        public string Message { get; }
-        
-        [CanBeNull]
-        public Exception Exception { get; }
-        
-        public AbpInitLogEntry(
-            LogLevel level,
-            string message,
-            Exception exception)
-        {
-            Level = level;
-            Message = message;
-            Exception = exception;
-        }
+        public LogLevel LogLevel { get; set; }
+
+        public EventId EventId { get; set; }
+
+        public object State { get; set; }
+
+        public Exception Exception { get; set; }
+
+        public Func<object, Exception, string> Formatter { get; set; }
+
+        public string Message => Formatter(State, Exception);
     }
 }

--- a/framework/src/Volo.Abp.Core/Volo/Abp/Logging/DefaultInitLogger.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/Logging/DefaultInitLogger.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Volo.Abp.Logging
 {
-    public class DefaultInitLogger : IInitLogger
+    public class DefaultInitLogger<T> : IInitLogger<T>
     {
         public List<AbpInitLogEntry> Entries { get; }
 
@@ -12,13 +12,27 @@ namespace Volo.Abp.Logging
         {
             Entries = new List<AbpInitLogEntry>();
         }
-        
-        public void Log(
-            LogLevel logLevel,
-            string message,
-            Exception exception = null)
+
+        public virtual void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {
-            Entries.Add(new AbpInitLogEntry(logLevel, message, exception));
+            Entries.Add(new AbpInitLogEntry
+            {
+                LogLevel = logLevel,
+                EventId = eventId,
+                State = state,
+                Exception = exception,
+                Formatter = (s, e) => formatter((TState)s, e),
+            });
+        }
+
+        public virtual bool IsEnabled(LogLevel logLevel)
+        {
+            return logLevel != LogLevel.None;
+        }
+
+        public virtual IDisposable BeginScope<TState>(TState state)
+        {
+            return NullDisposable.Instance;
         }
     }
 }

--- a/framework/src/Volo.Abp.Core/Volo/Abp/Logging/DefaultInitLoggerFactory.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/Logging/DefaultInitLoggerFactory.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Volo.Abp.Logging
 {
-    public class InitLoggerFactory : IInitLoggerFactory
+    public class DefaultInitLoggerFactory : IInitLoggerFactory
     {
         private readonly Dictionary<Type, object> _cache = new Dictionary<Type, object>();
 

--- a/framework/src/Volo.Abp.Core/Volo/Abp/Logging/IInitLogger.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/Logging/IInitLogger.cs
@@ -1,16 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 
 namespace Volo.Abp.Logging
 {
-    public interface IInitLogger
+    public interface IInitLogger<out T> : ILogger<T>
     {
         public List<AbpInitLogEntry> Entries { get; }
-
-        void Log(
-            LogLevel logLevel,
-            string message,
-            Exception exception = null);
     }
 }

--- a/framework/src/Volo.Abp.Core/Volo/Abp/Logging/IInitLoggerFactory.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/Logging/IInitLoggerFactory.cs
@@ -1,0 +1,7 @@
+﻿namespace Volo.Abp.Logging
+{
+    public interface IInitLoggerFactory
+    {
+        IInitLogger<T> Create<T>();
+    }
+}

--- a/framework/src/Volo.Abp.Core/Volo/Abp/Logging/InitLoggerFactory.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/Logging/InitLoggerFactory.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Volo.Abp.Logging
+{
+    public class InitLoggerFactory : IInitLoggerFactory
+    {
+        private readonly Dictionary<Type, object> _cache = new Dictionary<Type, object>();
+
+        public virtual IInitLogger<T> Create<T>()
+        {
+            return (IInitLogger<T>)_cache.GetOrAdd(typeof(T), () => new DefaultInitLogger<T>());;
+        }
+    }
+}

--- a/framework/src/Volo.Abp.Core/Volo/Abp/Modularity/AbpModuleHelper.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/Modularity/AbpModuleHelper.cs
@@ -3,13 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
-using Volo.Abp.Logging;
 
 namespace Volo.Abp.Modularity
 {
     internal static class AbpModuleHelper
     {
-        public static List<Type> FindAllModuleTypes(Type startupModuleType, IInitLogger logger)
+        public static List<Type> FindAllModuleTypes(Type startupModuleType, ILogger logger)
         {
             var moduleTypes = new List<Type>();
             logger.Log(LogLevel.Information, "Loaded ABP modules:");
@@ -41,7 +40,7 @@ namespace Volo.Abp.Modularity
         private static void AddModuleAndDependenciesResursively(
             List<Type> moduleTypes,
             Type moduleType,
-            IInitLogger logger,
+            ILogger logger,
             int depth = 0)
         {
             AbpModule.CheckAbpModuleType(moduleType);

--- a/framework/src/Volo.Abp.Core/Volo/Abp/Modularity/ModuleLoader.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/Modularity/ModuleLoader.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
-using Volo.Abp.Logging;
 using Volo.Abp.Modularity.PlugIns;
 
 namespace Volo.Abp.Modularity
@@ -26,7 +25,7 @@ namespace Volo.Abp.Modularity
         }
 
         private List<IAbpModuleDescriptor> GetDescriptors(
-            IServiceCollection services, 
+            IServiceCollection services,
             Type startupModuleType,
             PlugInSourceList plugInSources)
         {
@@ -44,16 +43,16 @@ namespace Volo.Abp.Modularity
             Type startupModuleType,
             PlugInSourceList plugInSources)
         {
-            var initLogger = services.GetInitLogger();
-            
+            var logger = services.GetInitLogger<AbpApplicationBase>();
+
             //All modules starting from the startup module
-            foreach (var moduleType in AbpModuleHelper.FindAllModuleTypes(startupModuleType, initLogger))
+            foreach (var moduleType in AbpModuleHelper.FindAllModuleTypes(startupModuleType, logger))
             {
                 modules.Add(CreateModuleDescriptor(services, moduleType));
             }
 
             //Plugin modules
-            foreach (var moduleType in plugInSources.GetAllModules(initLogger))
+            foreach (var moduleType in plugInSources.GetAllModules(logger))
             {
                 if (modules.Any(m => m.Type == moduleType))
                 {

--- a/framework/src/Volo.Abp.Core/Volo/Abp/Modularity/PlugIns/PlugInSourceExtensions.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/Modularity/PlugIns/PlugInSourceExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using JetBrains.Annotations;
+using Microsoft.Extensions.Logging;
 using Volo.Abp.Logging;
 
 namespace Volo.Abp.Modularity.PlugIns
@@ -8,7 +9,7 @@ namespace Volo.Abp.Modularity.PlugIns
     public static class PlugInSourceExtensions
     {
         [NotNull]
-        public static Type[] GetModulesWithAllDependencies([NotNull] this IPlugInSource plugInSource, IInitLogger logger)
+        public static Type[] GetModulesWithAllDependencies([NotNull] this IPlugInSource plugInSource, ILogger logger)
         {
             Check.NotNull(plugInSource, nameof(plugInSource));
 

--- a/framework/src/Volo.Abp.Core/Volo/Abp/Modularity/PlugIns/PlugInSourceList.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/Modularity/PlugIns/PlugInSourceList.cs
@@ -2,14 +2,14 @@
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
-using Volo.Abp.Logging;
+using Microsoft.Extensions.Logging;
 
 namespace Volo.Abp.Modularity.PlugIns
 {
     public class PlugInSourceList : List<IPlugInSource>
     {
         [NotNull]
-        internal Type[] GetAllModules(IInitLogger logger)
+        internal Type[] GetAllModules(ILogger logger)
         {
             return this
                 .SelectMany(pluginSource => pluginSource.GetModulesWithAllDependencies(logger))

--- a/framework/test/Volo.Abp.Core.Tests/Volo/Abp/Modularity/ModuleLoader_Tests.cs
+++ b/framework/test/Volo.Abp.Core.Tests/Volo/Abp/Modularity/ModuleLoader_Tests.cs
@@ -14,7 +14,7 @@ namespace Volo.Abp.Modularity
             var moduleLoader = new ModuleLoader();
             var modules = moduleLoader.LoadModules(
                 new ServiceCollection()
-                    .AddSingleton<IInitLoggerFactory>(new InitLoggerFactory()),
+                    .AddSingleton<IInitLoggerFactory>(new DefaultInitLoggerFactory()),
                 typeof(MyStartupModule),
                 new PlugInSourceList()
             );

--- a/framework/test/Volo.Abp.Core.Tests/Volo/Abp/Modularity/ModuleLoader_Tests.cs
+++ b/framework/test/Volo.Abp.Core.Tests/Volo/Abp/Modularity/ModuleLoader_Tests.cs
@@ -14,7 +14,7 @@ namespace Volo.Abp.Modularity
             var moduleLoader = new ModuleLoader();
             var modules = moduleLoader.LoadModules(
                 new ServiceCollection()
-                    .AddSingleton<IInitLogger>(new DefaultInitLogger()),
+                    .AddSingleton<IInitLoggerFactory>(new InitLoggerFactory()),
                 typeof(MyStartupModule),
                 new PlugInSourceList()
             );
@@ -28,7 +28,7 @@ namespace Volo.Abp.Modularity
         {
             public override void ConfigureServices(ServiceConfigurationContext context)
             {
-                
+
             }
         }
     }


### PR DESCRIPTION
https://github.com/abpframework/abp/issues/7965

```cs
ILogger logger = services.GetInitLogger<AbpApplicationBase>();
ILogger<AbpApplicationBase> logger = services.GetInitLogger<AbpApplicationBase>();
//Then use LoggerExtensions.
```