### PR TITLE
Use application service provider in AbpDbContextConfigurationContext

### DIFF
--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/DependencyInjection/AbpDbContextConfigurationContext.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/DependencyInjection/AbpDbContextConfigurationContext.cs
@@ -32,7 +32,8 @@ namespace Volo.Abp.EntityFrameworkCore.DependencyInjection
             ExistingConnection = existingConnection;
 
             DbContextOptions = new DbContextOptionsBuilder()
-                .UseLoggerFactory(serviceProvider.GetRequiredService<ILoggerFactory>());
+                .UseLoggerFactory(serviceProvider.GetRequiredService<ILoggerFactory>())
+                .UseApplicationServiceProvider(serviceProvider);
         }
     }
 
@@ -47,13 +48,14 @@ namespace Volo.Abp.EntityFrameworkCore.DependencyInjection
             [CanBeNull] string connectionStringName,
             [CanBeNull] DbConnection existingConnection)
             : base(
-                  connectionString, 
-                  serviceProvider, 
-                  connectionStringName, 
+                  connectionString,
+                  serviceProvider,
+                  connectionStringName,
                   existingConnection)
         {
             base.DbContextOptions = new DbContextOptionsBuilder<TDbContext>()
-                .UseLoggerFactory(serviceProvider.GetRequiredService<ILoggerFactory>());
+                .UseLoggerFactory(serviceProvider.GetRequiredService<ILoggerFactory>())
+                .UseApplicationServiceProvider(serviceProvider);;
         }
     }
 }


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.dbcontextoptionsbuilder.useapplicationserviceprovider?view=efcore-5.0

> This is done automatically when using 'AddDbContext' or 'AddDbContextPool', so it is rare that this method needs to be called.

https://github.com/dotnet/efcore/blob/efc2924e6e36db17611c7da480d5bc97a4514cb8/src/EFCore/Extensions/EntityFrameworkServiceCollectionExtensions.cs#L952

In this way, We can use `IServiceProvider `in `OnModelCreating `and `OnConfiguring `methods of `DbContext`.

