### PR TITLE
Add Entity Framework Core tools CLI

### DIFF
--- a/docs/en/Getting-Started-Setup-Environment.md
+++ b/docs/en/Getting-Started-Setup-Environment.md
@@ -37,6 +37,12 @@ The following tools should be installed on your development machine:
 
 {{ end }}
 
+### Install the Entity Framework Core tools CLI
+
+````shell
+dotnet tool install --global dotnet-ef
+````
+
 ### Install the ABP CLI
 
 [ABP CLI](./CLI.md) is a command line interface that is used to automate some common tasks for ABP based solutions. First, you need to install the ABP CLI using the following command:


### PR DESCRIPTION
So that other users don't run into the same problem as I did, I think it's worth mentioning that the installation of Entity Framework Core tools is mandatory in order to run the application.