### PR TITLE
Use $.fn.dataTable.render.text() as default render.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/wwwroot/libs/abp/aspnetcore-mvc-ui-theme-shared/datatables/datatables-extensions.js
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/wwwroot/libs/abp/aspnetcore-mvc-ui-theme-shared/datatables/datatables-extensions.js
@@ -408,6 +408,10 @@
                     }
                 }
 
+                if (!column.render) {
+                    column.render = $.fn.dataTable.render.text();
+                }
+
                 if (column.rowAction) {
                     customizeRowActionColumn(column);
                 }


### PR DESCRIPTION
Resolve #8114

![image](https://user-images.githubusercontent.com/6908465/111567036-40d0a280-87d9-11eb-9f07-db7868554e49.png)
