### PR TITLE
Store jqXHR in promise object.

### DIFF
--- a/npm/packs/jquery/src/abp.jquery.js
+++ b/npm/packs/jquery/src/abp.jquery.js
@@ -1,4 +1,4 @@
-﻿var abp = abp || {};
+var abp = abp || {};
 (function($) {
 
     if (!$) {
@@ -99,19 +99,28 @@
         options.success = undefined;
         options.error = undefined;
 
-        return $.Deferred(function ($dfd) {
-            $.ajax(options)
+        var xhr = null;
+        var promise = $.Deferred(function ($dfd) {
+            xhr = $.ajax(options)
                 .done(function (data, textStatus, jqXHR) {
                     $dfd.resolve(data);
                     userOptions.success && userOptions.success(data);
                 }).fail(function (jqXHR) {
+                    if(jqXHR.status === 0 || jqXHR.statusText === 'abort') {
+                        //ajax request is abort, ignore error handle.
+                        return;
+                    }
                     if (jqXHR.getResponseHeader('_AbpErrorFormat') === 'true') {
                         abp.ajax.handleAbpErrorResponse(jqXHR, userOptions, $dfd);
                     } else {
                         abp.ajax.handleNonAbpErrorResponse(jqXHR, userOptions, $dfd);
                     }
                 });
-        });
+        }).promise();
+
+        promise['jqXHR'] = xhr;
+
+        return promise;
     };
 
     $.extend(abp.ajax, {


### PR DESCRIPTION
Resolve #8139

```js
var req = abp.ajax({
  type: 'GET',
  url: '/api/identity/users'
});

req.then(function(result){
  console.log(result);
});

req.jqXHR.abort();
```

`req.then()` will create a new **Deferred** which will lost **jqXHR**. Must be saving return value first.

```js
var req = abp.ajax({
  type: 'GET',
  url: '/api/identity/users'
}).then(function(result){
  console.log(result);
});

//Not working.
req.jqXHR.abort();
```

![image](https://user-images.githubusercontent.com/6908465/111799637-2b0ccb80-8906-11eb-9311-1085b9c36b1d.png)
