### PR TITLE
Set specific version for tui-code-snippet

### DIFF
--- a/npm/packs/tui-editor/package.json
+++ b/npm/packs/tui-editor/package.json
@@ -10,7 +10,7 @@
     "@abp/jquery": "~4.2.2",
     "@abp/markdown-it": "~4.2.2",
     "tui-editor": "^1.4.10",
-    "tui-code-snippet": "^2.3.2"
+    "tui-code-snippet": "1.5.2"
   },
   "gitHead": "bb4ea17d5996f01889134c138d00b6c8f858a431"
 }


### PR DESCRIPTION
## Summary

We're using `tui-editor` with version *v1.4.10*. Also tui-editor is changed as `toast-ui-editor` in v2.x version. 

So v2.x of `tui-code-snippet` library targets `toast-ui-editor` but we're using `tui-editor`. So we need to use latest *v1.x* version of `tui-code-snippet` library.

This is temporary solution until resolution of #7964 