### PR TITLE
Provide an option to DataTables to cancel the previous requests.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/wwwroot/libs/abp/aspnetcore-mvc-ui-theme-shared/datatables/datatables-extensions.js
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/wwwroot/libs/abp/aspnetcore-mvc-ui-theme-shared/datatables/datatables-extensions.js
@@ -373,8 +373,9 @@ var abp = abp || {};
                         promise.jqXHR.abort();
                     }
                     promise = serverMethod(input);
-                    promise.then(function (result) {
+                    promise.always(function () {
                         promise = null;
+                    }).then(function (result) {
                         callback(responseCallback(result));
                     });
                 }


### PR DESCRIPTION
It will cancel the previous request when a new request created. eg: page index or page count change.

```cs
  _dataTable = _$wrapper.find('table').DataTable(
      abp.libs.datatables.normalizeConfiguration({
          ajax: abp.libs.datatables.createAjax(_tenantAppService.getList, null, null, true)
      })
  );
```

![image](https://user-images.githubusercontent.com/6908465/112085848-3261fc80-8bc6-11eb-82ce-0d54aaaa509a.png)

