### PR TITLE
Add ConcurrentDictionary GetOrAdd extension methods

### DIFF
--- a/framework/src/Volo.Abp.Core/System/Collections/Generic/AbpDictionaryExtensions.cs
+++ b/framework/src/Volo.Abp.Core/System/Collections/Generic/AbpDictionaryExtensions.cs
@@ -67,7 +67,7 @@ namespace System.Collections.Generic
         {
             return dictionary.TryGetValue(key, out var obj) ? obj : default;
         }
-        
+
         /// <summary>
         /// Gets a value from the dictionary with given key. Returns default value if can not find.
         /// </summary>
@@ -100,7 +100,7 @@ namespace System.Collections.Generic
 
             return dictionary[key] = factory(key);
         }
-        
+
         /// <summary>
         /// Gets a value from the dictionary with given key. Returns default value if can not find.
         /// </summary>
@@ -111,6 +111,20 @@ namespace System.Collections.Generic
         /// <typeparam name="TValue">Type of the value</typeparam>
         /// <returns>Value if found, default if can not found.</returns>
         public static TValue GetOrAdd<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, Func<TValue> factory)
+        {
+            return dictionary.GetOrAdd(key, k => factory());
+        }
+
+        /// <summary>
+        /// Gets a value from the concurrent dictionary with given key. Returns default value if can not find.
+        /// </summary>
+        /// <param name="dictionary">Concurrent dictionary to check and get</param>
+        /// <param name="key">Key to find the value</param>
+        /// <param name="factory">A factory method used to create the value if not found in the dictionary</param>
+        /// <typeparam name="TKey">Type of the key</typeparam>
+        /// <typeparam name="TValue">Type of the value</typeparam>
+        /// <returns>Value if found, default if can not found.</returns>
+        public static TValue GetOrAdd<TKey, TValue>(this ConcurrentDictionary<TKey, TValue> dictionary, TKey key, Func<TValue> factory)
         {
             return dictionary.GetOrAdd(key, k => factory());
         }


### PR DESCRIPTION
Avoid using the wrong `GetOrAdd` extension method when using `ConcurrentDictionary`

https://github.com/abpframework/abp/blob/3fcdeeeb05810b7a2e162f212ef435b81d412aa5/framework/src/Volo.Abp.Core/System/Collections/Generic/AbpDictionaryExtensions.cs#L93