### PR TITLE
Page header updates

### DIFF
--- a/docs/en/Migration-Guides/Abp-4_3.md
+++ b/docs/en/Migration-Guides/Abp-4_3.md
@@ -1,3 +1,6 @@
 # ABP Framework 4.x to 4.3 Migration Guide
 
-TODO
+## Blazor UI
+
+- `PageHeader` component has been moved to the`Volo.Abp.AspNetCore.Components.Web.Theming.Layout` namespace.
+

--- a/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Layout/PageHeader.razor
+++ b/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Layout/PageHeader.razor
@@ -32,6 +32,11 @@
     }
     <Column>
         <Row Class="justify-content-end mx-n1">
+            @if (Toolbar == null)
+            {
+                @ChildContent
+            }
+            
             @foreach (var toolbarItemRender in ToolbarItemRenders)
             {
                 <Column ColumnSize="ColumnSize.IsAuto" Class="px-1 pt-2">

--- a/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Layout/PageHeader.razor.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Layout/PageHeader.razor.cs
@@ -31,9 +31,6 @@ namespace Volo.Abp.AspNetCore.Components.Web.Theming.Layout
         [Parameter] 
         public PageToolbar Toolbar { get; set; }
 
-        [Parameter]
-        public string PageName { get; set; }
-
         public PageHeader()
         {
             BreadcrumbItems = new List<BreadcrumbItem>();


### PR DESCRIPTION
- Render `PageHeader` Child Content To Avoid Breaking Changes
- Add `PageHeader` Namespace Change To The Migration Guide