### PR TITLE
AbpLdapOptions never be configured

### DIFF
--- a/framework/src/Volo.Abp.Ldap/Volo/Abp/Ldap/AbpLdapModule.cs
+++ b/framework/src/Volo.Abp.Ldap/Volo/Abp/Ldap/AbpLdapModule.cs
@@ -21,11 +21,12 @@ namespace Volo.Abp.Ldap
             context.Services.AddAbpDynamicOptions<AbpLdapOptions, AbpAbpLdapOptionsManager>();
 
             var configuration = context.Services.GetConfiguration();
-            var ldapConfiguration = configuration["Ldap"];
+            Configure<AbpLdapOptions>(configuration.GetSection("Ldap"));
+            /*var ldapConfiguration = configuration["Ldap"];
             if (!ldapConfiguration.IsNullOrEmpty())
             {
                 Configure<AbpLdapOptions>(configuration.GetSection("Ldap"));
-            }
+            }*/
 
             Configure<AbpVirtualFileSystemOptions>(options =>
             {


### PR DESCRIPTION
`configuration["Ldap"]` always return null, even set the "Ldap" section in appsettings.json.
so `Configure<AbpLdapOptions>(configuration.GetSection("Ldap"));`   does not execute,i think its a bug..