### PR TITLE
Cms Kit - Refactoing on CommentMongoRepository

### DIFF
--- a/modules/cms-kit/src/Volo.CmsKit.MongoDB/Volo/CmsKit/MongoDB/Comments/MongoCommentRepository.cs
+++ b/modules/cms-kit/src/Volo.CmsKit.MongoDB/Volo/CmsKit/MongoDB/Comments/MongoCommentRepository.cs
@@ -23,10 +23,6 @@ namespace Volo.CmsKit.MongoDB.Comments
 
         public async Task<CommentWithAuthorQueryResultItem> GetWithAuthorAsync(Guid id, CancellationToken cancellationToken = default)
         {
-            var dbContext = await GetDbContextAsync();
-            var commentQueryable = await GetMongoQueryableAsync(cancellationToken);
-            var userQueryable = dbContext.Collection<CmsUser>();
-
             var query = from comment in (await GetMongoQueryableAsync(cancellationToken))
                         join user in (await GetDbContextAsync(cancellationToken)).CmsUsers on comment.CreatorId equals user.Id
                         where id == comment.Id


### PR DESCRIPTION
## Summary
There are a couple of unnecessary lines left in **CommentMongoRepository** after reverted LINQ usage at #8588
