### PR TITLE
refactor: change Initialize in VirtualFileLocalization to virutal

### DIFF
--- a/framework/src/Volo.Abp.Localization/Volo/Abp/Localization/VirtualFiles/VirtualFileLocalizationResourceContributorBase.cs
+++ b/framework/src/Volo.Abp.Localization/Volo/Abp/Localization/VirtualFiles/VirtualFileLocalizationResourceContributorBase.cs
@@ -22,17 +22,17 @@ namespace Volo.Abp.Localization.VirtualFiles
             _virtualPath = virtualPath;
         }
 
-        public virtual void  Initialize(LocalizationResourceInitializationContext context)
+        public virtual void Initialize(LocalizationResourceInitializationContext context)
         {
             _virtualFileProvider = context.ServiceProvider.GetRequiredService<IVirtualFileProvider>();
         }
 
-        public LocalizedString GetOrNull(string cultureName, string name)
+        public virtual LocalizedString GetOrNull(string cultureName, string name)
         {
             return GetDictionaries().GetOrDefault(cultureName)?.GetOrNull(name);
         }
 
-        public void Fill(string cultureName, Dictionary<string, LocalizedString> dictionary)
+        public virtual void Fill(string cultureName, Dictionary<string, LocalizedString> dictionary)
         {
             GetDictionaries().GetOrDefault(cultureName)?.Fill(dictionary);
         }

--- a/framework/src/Volo.Abp.Localization/Volo/Abp/Localization/VirtualFiles/VirtualFileLocalizationResourceContributorBase.cs
+++ b/framework/src/Volo.Abp.Localization/Volo/Abp/Localization/VirtualFiles/VirtualFileLocalizationResourceContributorBase.cs
@@ -22,7 +22,7 @@ namespace Volo.Abp.Localization.VirtualFiles
             _virtualPath = virtualPath;
         }
 
-        public void Initialize(LocalizationResourceInitializationContext context)
+        public virtual void  Initialize(LocalizationResourceInitializationContext context)
         {
             _virtualFileProvider = context.ServiceProvider.GetRequiredService<IVirtualFileProvider>();
         }


### PR DESCRIPTION
i need to inherit from (VirtualFileLocalizationResourceContributorBase) and apply some database logic to extract field localization 
i can copy the full code but it better if initialize function is virutal that way i can  replace and get the service that i need