### PR TITLE
chore(deps): bump Swashbuckle.AspNetCore from 6.1.1 to 6.1.3

### DIFF
--- a/framework/src/Volo.Abp.Swashbuckle/Volo.Abp.Swashbuckle.csproj
+++ b/framework/src/Volo.Abp.Swashbuckle/Volo.Abp.Swashbuckle.csproj
@@ -15,7 +15,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.1" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.3" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
I've met a swagger bug which already have been fixed in https://github.com/swagger-api/swagger-ui/pull/7003 and https://github.com/swagger-api/swagger-ui/pull/7112

It's also included in the latest release of Swashbuckle.AspNetCore. But Abp used an older version.

I know I can depend the latest Swashbuckle.AspNetCore directly in my project. But it's only a temporary solution.

It also should be fixed in abp framework.