### PR TITLE
Standardize passing and setting of content in Tag Helpers

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Collapse/AbpAccordionItemTagHelperService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Collapse/AbpAccordionItemTagHelperService.cs
@@ -13,9 +13,9 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Collapse
         {
             SetRandomIdIfNotProvided();
 
-            var innerContent = (await output.GetChildContentAsync()).GetContent();
+            var childContent = await output.GetChildContentAsync();
 
-            var html = GetAccordionHeaderItem(context, output) + GetAccordionContentItem(context, output, innerContent);
+            var html = GetAccordionHeaderItem(context, output) + GetAccordionContentItem(context, output, childContent);
 
             var tabHeaderItems = context.GetValue<List<string>>(AccordionItems);
             tabHeaderItems.Add(html);
@@ -46,7 +46,7 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Collapse
             return header.ToHtmlString();
         }
 
-        protected virtual string GetAccordionContentItem(TagHelperContext context, TagHelperOutput output, string content)
+        protected virtual string GetAccordionContentItem(TagHelperContext context, TagHelperOutput output, TagHelperContent content)
         {
             var show = (TagHelper.Active ?? false) ? " show" : "";
 

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Collapse/AbpCollapseBodyTagHelperService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Collapse/AbpCollapseBodyTagHelperService.cs
@@ -22,9 +22,9 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Collapse
                 output.Attributes.AddClass("multi-collapse");
             }
 
-            var innerContent = (await output.GetChildContentAsync()).GetContent();
+            var childContent = await output.GetChildContentAsync();
 
-            output.Content.SetHtmlContent(innerContent);
+            output.Content.SetHtmlContent(childContent);
         }
     }
 }

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Dropdown/AbpDropdownButtonTagHelperService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Dropdown/AbpDropdownButtonTagHelperService.cs
@@ -70,7 +70,7 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Dropdown
 
             var buttonTag = await abpButtonTagHelper.ProcessAndGetOutputAsync(attributes, context, "button", TagMode.StartTagAndEndTag);
 
-            buttonTag.PreContent.SetHtmlContent(content.GetContent());
+            buttonTag.PreContent.SetHtmlContent(content);
 
             if ((TagHelper.NavLink ?? false) || (TagHelper.Link ?? false))
             {

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpDynamicformTagHelperService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpDynamicformTagHelperService.cs
@@ -78,8 +78,8 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Form
 
             await formTagOutput.GetChildContentAsync();
 
-            output.PostContent.SetHtmlContent(output.PostContent.GetContent() + formTagOutput.PostContent.GetContent());
-            output.PreContent.SetHtmlContent(output.PreContent.GetContent() + formTagOutput.PreContent.GetContent());
+            output.PostContent.AppendHtml(formTagOutput.PostContent);
+            output.PreContent.AppendHtml(formTagOutput.PreContent);
         }
 
         protected virtual void NormalizeTagMode(TagHelperContext context, TagHelperOutput output)
@@ -123,7 +123,7 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Form
 
             var buttonHtml = await ProcessSubmitButtonAndGetContentAsync(context, output);
 
-            output.PostContent.SetHtmlContent(output.PostContent.GetContent() + buttonHtml);
+            output.PostContent.AppendHtml(buttonHtml);
         }
 
         protected virtual List<FormGroupItem> InitilizeFormGroupContentsContext(TagHelperContext context, TagHelperOutput output)

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpDynamicformTagHelperService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpDynamicformTagHelperService.cs
@@ -102,16 +102,17 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Form
                 contentBuilder.AppendLine(item.HtmlContent);
             }
 
-            if (childContent.Contains(AbpFormContentPlaceHolder))
+            var content = childContent.GetContent();
+            if (content.Contains(AbpFormContentPlaceHolder))
             {
-                childContent = childContent.Replace(AbpFormContentPlaceHolder, contentBuilder.ToString());
+                content = content.Replace(AbpFormContentPlaceHolder, contentBuilder.ToString());
             }
             else
             {
-                childContent = contentBuilder + childContent;
+                content = contentBuilder + content;
             }
 
-            output.Content.SetHtmlContent(childContent);
+            output.Content.SetHtmlContent(content);
         }
 
         protected virtual async Task SetSubmitButton(TagHelperContext context, TagHelperOutput output)

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpDynamicformTagHelperService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpDynamicformTagHelperService.cs
@@ -42,7 +42,7 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Form
 
             NormalizeTagMode(context, output);
 
-            var childContent = (await output.GetChildContentAsync()).GetContent();
+            var childContent = await output.GetChildContentAsync();
 
             await ConvertToMvcForm(context, output);
 
@@ -93,7 +93,7 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Form
             output.Attributes.AddIfNotContains("method", "post");
         }
 
-        protected virtual void SetContent(TagHelperContext context, TagHelperOutput output, List<FormGroupItem> items, string childContent)
+        protected virtual void SetContent(TagHelperContext context, TagHelperOutput output, List<FormGroupItem> items, TagHelperContent childContent)
         {
             var contentBuilder = new StringBuilder("");
 

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpInputTagHelperService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpInputTagHelperService.cs
@@ -52,7 +52,7 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Form
                 output.Attributes.AddClass(isCheckBox ? "custom-checkbox" : "form-group");
                 output.Attributes.AddClass(isCheckBox ? "custom-control" : "");
                 output.Attributes.AddClass(isCheckBox ? "mb-2" : "");
-                output.Content.SetHtmlContent(output.Content.GetContent() + innerHtml);
+                output.Content.AppendHtml(innerHtml);
             }
         }
 

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Tab/AbpTabTagHelperService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Tab/AbpTabTagHelperService.cs
@@ -13,9 +13,9 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Tab
         {
             SetPlaceholderForNameIfNotProvided();
 
-            var innerContent = await output.GetChildContentAsync();
+            var childContent = await output.GetChildContentAsync();
             var tabHeader = GetTabHeaderItem(context, output);
-            var tabContent = GetTabContentItem(context, output, innerContent.GetContent());
+            var tabContent = GetTabContentItem(context, output, childContent);
 
             var tabHeaderItems = context.GetValue<List<TabItem>>(TabItems);
 
@@ -83,7 +83,7 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Tab
             }
         }
 
-        protected virtual string GetTabContentItem(TagHelperContext context, TagHelperOutput output, string content)
+        protected virtual string GetTabContentItem(TagHelperContext context, TagHelperOutput output, TagHelperContent content)
         {
             var headerId = TagHelper.Name + "-tab";
             var id = TagHelper.Name;


### PR DESCRIPTION
Purely refactoring.

Changes:
1. Standardize passing of child content.
   - Pass child content as `TagHelperContent` instead of `string` from unnecessary call to `.GetContent()`.
   - Rename `innerContent` to `childContent`.
2. Simplify usage of `SetHtmlContent`  to `AppendHtml` instead of `.GetContent()` and string concatenation.