### PR TITLE
Fixing IsExternal flag for external users

### DIFF
--- a/modules/account/src/Volo.Abp.Account.Web/Pages/Account/Login.cshtml.cs
+++ b/modules/account/src/Volo.Abp.Account.Web/Pages/Account/Login.cshtml.cs
@@ -265,7 +265,7 @@ namespace Volo.Abp.Account.Web.Pages.Account
 
             var emailAddress = info.Principal.FindFirstValue(AbpClaimTypes.Email);
 
-            var user = new IdentityUser(GuidGenerator.Create(), emailAddress, emailAddress, CurrentTenant.Id);
+            var user = new IdentityUser(GuidGenerator.Create(), emailAddress, emailAddress, CurrentTenant.Id) { IsExternal = true };
 
             CheckIdentityErrors(await UserManager.CreateAsync(user));
             CheckIdentityErrors(await UserManager.SetEmailAsync(user, emailAddress));


### PR DESCRIPTION
External users created with the method CreateExternalUserAsync was not setting the IsExternal flag for the user.