### PR TITLE
CLI: Remove illegal char check for project creation

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Utils/ProjectNameValidator.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Utils/ProjectNameValidator.cs
@@ -17,38 +17,9 @@ namespace Volo.Abp.Cli.Utils
             "LPT2"
         };
 
-        private static readonly char[] IllegalChars = new[]
-        {
-            '/',
-            '?',
-            ':',
-            '&',
-            '\\',
-            '*',
-            '\'',
-            '<',
-            '>',
-            '|',
-            '#',
-            '%',
-        };
-
         private static bool HasParentDirectoryString(string projectName)
         {
             return projectName.Contains("..");
-        }
-
-        private static bool HasIllegalChar(string projectName)
-        {
-            foreach (var illegalChar in IllegalChars)
-            {
-                if (projectName.Contains(illegalChar))
-                {
-                    return true;
-                }
-            }
-
-            return false;
         }
 
         private static bool HasSurrogateOrControlChar(string projectName)
@@ -74,11 +45,6 @@ namespace Volo.Abp.Cli.Utils
             if (projectName == null)
             {
                 throw new CliUsageException("Project name cannot be empty!");
-            }
-
-            if (HasIllegalChar(projectName))
-            {
-                return false;
             }
 
             if (HasSurrogateOrControlChar(projectName))

--- a/framework/test/Volo.Abp.Cli.Core.Tests/Volo/Abp/Cli/ProjectNameValidation_Tests.cs
+++ b/framework/test/Volo.Abp.Cli.Core.Tests/Volo/Abp/Cli/ProjectNameValidation_Tests.cs
@@ -39,32 +39,6 @@ namespace Volo.Abp.Cli
         }
 
         [Fact]
-        public async Task ContainsIllegalChar_Test()
-        {
-            var illegalChars = new[]
-            {
-                '/',
-                '?',
-                ':',
-                '&',
-                '\\',
-                '*',
-                '\'',
-                '<',
-                '>',
-                '|',
-                '#',
-                '%',
-            };
-
-            foreach (var illegalChar in illegalChars)
-            {
-                var args = new CommandLineArgs("new", "Test" + illegalChar);
-                await _newCommand.ExecuteAsync(args).ShouldThrowAsync<CliUsageException>();
-            }
-        }
-
-        [Fact]
         public async Task ParentDirectoryContain_Test()
         {
 


### PR DESCRIPTION
All illegal characters (/, ?, :, &, \, *, ', <, >, |, #, %) [replaces](https://github.com/abpframework/abp/blob/dev/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Utils/NamespaceHelper.cs) with **"_"**, so we don't need to check these characters.