### PR TITLE
Fix ModelMetadata is required by default for validator localization

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/DataAnnotations/AbpValidationAttributeAdapterProvider.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/DataAnnotations/AbpValidationAttributeAdapterProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc.DataAnnotations;
 using Microsoft.Extensions.Localization;
+using Volo.Abp.AspNetCore.Mvc.Validation;
 using Volo.Abp.Validation;
 
 namespace Volo.Abp.AspNetCore.Mvc.DataAnnotations
@@ -31,6 +32,12 @@ namespace Volo.Abp.AspNetCore.Mvc.DataAnnotations
             if (type == typeof(DynamicRangeAttribute))
             {
                 return new DynamicRangeAttributeAdapter((DynamicRangeAttribute) attribute, stringLocalizer);
+            }
+
+            //DataAnnotationsClientModelValidatorProvider wiil add a default '[Required]' validator for generating HTML if necessary.
+            if (type == typeof(RequiredAttribute))
+            {
+                ValidationAttributeHelper.SetDefaultErrorMessage(attribute);
             }
 
             return _defaultAdapter.GetAttributeAdapter(attribute, stringLocalizer);

--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/DataAnnotations/AbpValidationAttributeAdapterProvider.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/DataAnnotations/AbpValidationAttributeAdapterProvider.cs
@@ -34,8 +34,8 @@ namespace Volo.Abp.AspNetCore.Mvc.DataAnnotations
                 return new DynamicRangeAttributeAdapter((DynamicRangeAttribute) attribute, stringLocalizer);
             }
 
-            //DataAnnotationsClientModelValidatorProvider wiil add a default '[Required]' validator for generating HTML if necessary.
-            if (type == typeof(RequiredAttribute))
+            //DataAnnotationsClientModelValidatorProvider will add a default '[Required]' validator for generating HTML if necessary.
+            if (type == typeof(RequiredAttribute) && attribute.ErrorMessage == null)
             {
                 ValidationAttributeHelper.SetDefaultErrorMessage(attribute);
             }


### PR DESCRIPTION
> DataAnnotationsClientModelValidatorProvider will add a default '[Required]' validator for generating HTML if necessary.

https://github.com/dotnet/aspnetcore/blob/e7b5aa6f713e9f040ba0730b915ae407d35971c1/src/Mvc/Mvc.DataAnnotations/src/DataAnnotationsClientModelValidatorProvider.cs#L99-L109