### PR TITLE
Refactor RequestLocalizationOptionsProvider.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore/Microsoft/AspNetCore/Builder/AbpApplicationBuilderExtensions.cs
+++ b/framework/src/Volo.Abp.AspNetCore/Microsoft/AspNetCore/Builder/AbpApplicationBuilderExtensions.cs
@@ -58,13 +58,8 @@ namespace Microsoft.AspNetCore.Builder
                 .UseMiddleware<AbpCorrelationIdMiddleware>();
         }
 
-        public static IApplicationBuilder UseAbpRequestLocalization(this IApplicationBuilder app,
-            Action<RequestLocalizationOptions> optionsAction = null)
+        public static IApplicationBuilder UseAbpRequestLocalization(this IApplicationBuilder app)
         {
-            app.ApplicationServices
-                .GetRequiredService<IAbpRequestLocalizationOptionsProvider>()
-                .InitLocalizationOptions(optionsAction);
-
             return app.UseMiddleware<AbpRequestLocalizationMiddleware>();
         }
 

--- a/framework/src/Volo.Abp.AspNetCore/Microsoft/AspNetCore/RequestLocalization/AbpRequestLocalizationMiddleware.cs
+++ b/framework/src/Volo.Abp.AspNetCore/Microsoft/AspNetCore/RequestLocalization/AbpRequestLocalizationMiddleware.cs
@@ -23,9 +23,10 @@ namespace Microsoft.AspNetCore.RequestLocalization
 
         public async Task InvokeAsync(HttpContext context, RequestDelegate next)
         {
+            var requestLocalizationOptions = await _requestLocalizationOptionsProvider.GetLocalizationOptionsAsync();
             var middleware = new RequestLocalizationMiddleware(
                 next,
-                new OptionsWrapper<RequestLocalizationOptions>(await _requestLocalizationOptionsProvider.GetLocalizationOptionsAsync()),
+                new OptionsWrapper<RequestLocalizationOptions>(requestLocalizationOptions),
                 _loggerFactory
             );
 

--- a/framework/src/Volo.Abp.AspNetCore/Microsoft/AspNetCore/RequestLocalization/DefaultAbpRequestLocalizationOptionsProvider.cs
+++ b/framework/src/Volo.Abp.AspNetCore/Microsoft/AspNetCore/RequestLocalization/DefaultAbpRequestLocalizationOptionsProvider.cs
@@ -1,8 +1,6 @@
-using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Localization;
@@ -11,90 +9,68 @@ using Microsoft.Extensions.Options;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Localization;
 using Volo.Abp.Settings;
-using Volo.Abp.Threading;
 
 namespace Microsoft.AspNetCore.RequestLocalization
 {
-    public class DefaultAbpRequestLocalizationOptionsProvider : IAbpRequestLocalizationOptionsProvider, ISingletonDependency
+    public class DefaultAbpRequestLocalizationOptionsProvider : IAbpRequestLocalizationOptionsProvider, ITransientDependency
     {
-        private readonly IServiceScopeFactory _serviceProviderFactory;
-        private readonly SemaphoreSlim _syncSemaphore;
-        private Action<RequestLocalizationOptions> _optionsAction;
-        private RequestLocalizationOptions _requestLocalizationOptions;
+        protected readonly IServiceScopeFactory ServiceProviderFactory;
 
         public DefaultAbpRequestLocalizationOptionsProvider(IServiceScopeFactory serviceProviderFactory)
         {
-            _serviceProviderFactory = serviceProviderFactory;
-            _syncSemaphore = new SemaphoreSlim(1, 1);
-        }
-
-        public void InitLocalizationOptions(Action<RequestLocalizationOptions> optionsAction = null)
-        {
-            _optionsAction = optionsAction;
+            ServiceProviderFactory = serviceProviderFactory;
         }
 
         public async Task<RequestLocalizationOptions> GetLocalizationOptionsAsync()
         {
-            if (_requestLocalizationOptions == null)
+            using (var serviceScope = ServiceProviderFactory.CreateScope())
             {
-                using (await _syncSemaphore.LockAsync())
-                {
-                    if (_requestLocalizationOptions == null)
+                var languageProvider = serviceScope.ServiceProvider.GetRequiredService<ILanguageProvider>();
+                var settingProvider = serviceScope.ServiceProvider.GetRequiredService<ISettingProvider>();
+
+                var languages = await languageProvider.GetLanguagesAsync();
+                var defaultLanguage = await settingProvider.GetOrNullAsync(LocalizationSettingNames.DefaultLanguage);
+
+                var options = !languages.Any()
+                    ? new RequestLocalizationOptions()
+                    : new RequestLocalizationOptions
                     {
-                        using (var serviceScope = _serviceProviderFactory.CreateScope())
-                        {
-                            var languageProvider = serviceScope.ServiceProvider.GetRequiredService<ILanguageProvider>();
-                            var settingProvider = serviceScope.ServiceProvider.GetRequiredService<ISettingProvider>();
+                        DefaultRequestCulture = await GetDefaultRequestCultureAsync(defaultLanguage, languages),
 
-                            var languages = await languageProvider.GetLanguagesAsync();
-                            var defaultLanguage = await settingProvider.GetOrNullAsync(LocalizationSettingNames.DefaultLanguage);
+                        SupportedCultures = languages
+                            .Select(l => l.CultureName)
+                            .Distinct()
+                            .Select(c => new CultureInfo(c))
+                            .ToArray(),
 
-                            var options = !languages.Any()
-                                ? new RequestLocalizationOptions()
-                                : new RequestLocalizationOptions
-                                {
-                                    DefaultRequestCulture = DefaultGetRequestCulture(defaultLanguage, languages),
+                        SupportedUICultures = languages
+                            .Select(l => l.UiCultureName)
+                            .Distinct()
+                            .Select(c => new CultureInfo(c))
+                            .ToArray()
+                    };
 
-                                    SupportedCultures = languages
-                                        .Select(l => l.CultureName)
-                                        .Distinct()
-                                        .Select(c => new CultureInfo(c))
-                                        .ToArray(),
-
-                                    SupportedUICultures = languages
-                                        .Select(l => l.UiCultureName)
-                                        .Distinct()
-                                        .Select(c => new CultureInfo(c))
-                                        .ToArray()
-                                };
-
-                            foreach (var configurator in serviceScope.ServiceProvider
-                                .GetRequiredService<IOptions<AbpRequestLocalizationOptions>>()
-                                .Value.RequestLocalizationOptionConfigurators)
-                            {
-                                await configurator(serviceScope.ServiceProvider, options);
-                            }
-
-                            _optionsAction?.Invoke(options);
-                            _requestLocalizationOptions = options;
-                        }
-                    }
+                foreach (var configurator in serviceScope.ServiceProvider
+                    .GetRequiredService<IOptions<AbpRequestLocalizationOptions>>()
+                    .Value.RequestLocalizationOptionConfigurators)
+                {
+                    await configurator(serviceScope.ServiceProvider, options);
                 }
-            }
 
-            return _requestLocalizationOptions;
+                return options;
+            }
         }
 
-        private static RequestCulture DefaultGetRequestCulture(string defaultLanguage, IReadOnlyList<LanguageInfo> languages)
+        protected virtual Task<RequestCulture> GetDefaultRequestCultureAsync(string defaultLanguage, IReadOnlyList<LanguageInfo> languages)
         {
             if (defaultLanguage == null)
             {
-                var firstLanguage = languages.First();
-                return new RequestCulture(firstLanguage.CultureName, firstLanguage.UiCultureName);
+                var firstLanguage = languages[0];
+                return Task.FromResult(new RequestCulture(firstLanguage.CultureName, firstLanguage.UiCultureName));
             }
 
             var (cultureName, uiCultureName) = LocalizationSettingHelper.ParseLanguageSetting(defaultLanguage);
-            return new RequestCulture(cultureName, uiCultureName);
+            return Task.FromResult(new RequestCulture(cultureName, uiCultureName));
         }
     }
 }

--- a/framework/src/Volo.Abp.AspNetCore/Microsoft/AspNetCore/RequestLocalization/IAbpRequestLocalizationOptionsProvider.cs
+++ b/framework/src/Volo.Abp.AspNetCore/Microsoft/AspNetCore/RequestLocalization/IAbpRequestLocalizationOptionsProvider.cs
@@ -1,13 +1,10 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 
 namespace Microsoft.AspNetCore.RequestLocalization
 {
     public interface IAbpRequestLocalizationOptionsProvider
     {
-        void InitLocalizationOptions(Action<RequestLocalizationOptions> optionsAction = null);
-
         Task<RequestLocalizationOptions> GetLocalizationOptionsAsync();
     }
 }


### PR DESCRIPTION
Resolve #9158

Because the method parameters are changed. Although there may not be too many developers using it,
**it is a minor breaking change.**

The method uses a cache internally.
```
await languageProvider.GetLanguagesAsync();
await settingProvider.GetOrNullAsync(LocalizationSettingNames.DefaultLanguage);
```