### PR TITLE
Set table mode to StartTagAndEndTag.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Table/AbpTableTagHelperService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Table/AbpTableTagHelperService.cs
@@ -9,6 +9,7 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Table
         {
             output.TagName = "table";
             output.Attributes.AddClass("table");
+            output.TagMode = TagMode.StartTagAndEndTag;
 
             SetResponsiveness(context, output);
             SetTheme(context, output);


### PR DESCRIPTION
Resolve #9206

The `table`  element must have a start tag and an end tag.