### PR TITLE
Ignore SaveChangesAsync if the uow has been rolled back.

### DIFF
--- a/framework/src/Volo.Abp.Uow/Volo/Abp/Uow/UnitOfWork.cs
+++ b/framework/src/Volo.Abp.Uow/Volo/Abp/Uow/UnitOfWork.cs
@@ -89,6 +89,11 @@ namespace Volo.Abp.Uow
 
         public virtual async Task SaveChangesAsync(CancellationToken cancellationToken = default)
         {
+            if (_isRolledback)
+            {
+                return;
+            }
+
             foreach (var databaseApi in GetAllActiveDatabaseApis())
             {
                 if (databaseApi is ISupportsSavingChanges)

--- a/framework/test/Volo.Abp.EntityFrameworkCore.Tests/Volo/Abp/EntityFrameworkCore/Transactions/Transaction_Tests.cs
+++ b/framework/test/Volo.Abp.EntityFrameworkCore.Tests/Volo/Abp/EntityFrameworkCore/Transactions/Transaction_Tests.cs
@@ -59,6 +59,9 @@ namespace Volo.Abp.EntityFrameworkCore.Transactions
                 await _personRepository.InsertAsync(new Person(personId, "Adam", 42));
 
                 await _unitOfWorkManager.Current.RollbackAsync();
+
+                //Will ignore this call.
+                await _unitOfWorkManager.Current.SaveChangesAsync();
             });
 
             var person = await _personRepository.FindAsync(personId);


### PR DESCRIPTION
Resolve #9263

Related: #8740
If `SaveChange` is called after the transaction is rolled back, EF Core still commits the changes.