### PR TITLE
Use Type instead of TypeAsString to compare.

### DIFF
--- a/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/DynamicProxying/ApiDescriptionFinder.cs
+++ b/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/DynamicProxying/ApiDescriptionFinder.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Options;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Http.Modeling;
 using Volo.Abp.MultiTenancy;
+using Volo.Abp.Reflection;
 using Volo.Abp.Threading;
 using Volo.Abp.Tracing;
 
@@ -142,17 +143,9 @@ namespace Volo.Abp.Http.Client.DynamicProxying
 
         protected virtual bool TypeMatches(MethodParameterApiDescriptionModel actionParameter, ParameterInfo methodParameter)
         {
-            return NormalizeTypeName(actionParameter.TypeAsString) ==
-                   NormalizeTypeName(methodParameter.ParameterType.GetFullNameWithAssemblyName());
+            // make it lower-coupled, see https://github.com/abpframework/abp/issues/9357
+            return actionParameter.Type == TypeHelper.GetFullNameHandlingNullableAndGenerics(methodParameter.ParameterType);
         }
 
-        protected virtual string NormalizeTypeName(string typeName)
-        {
-            const string placeholder = "%COREFX%";
-            const string netCoreLib = "System.Private.CoreLib";
-            const string netFxLib = "mscorlib";
-
-            return typeName.Replace(netCoreLib, placeholder).Replace(netFxLib, placeholder);
-        }
     }
 }

--- a/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/DynamicProxying/ApiDescriptionFinder.cs
+++ b/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/DynamicProxying/ApiDescriptionFinder.cs
@@ -143,8 +143,7 @@ namespace Volo.Abp.Http.Client.DynamicProxying
 
         protected virtual bool TypeMatches(MethodParameterApiDescriptionModel actionParameter, ParameterInfo methodParameter)
         {
-            // make it lower-coupled, see https://github.com/abpframework/abp/issues/9357
-            return actionParameter.Type == TypeHelper.GetFullNameHandlingNullableAndGenerics(methodParameter.ParameterType);
+            return actionParameter.Type.ToUpper() == TypeHelper.GetFullNameHandlingNullableAndGenerics(methodParameter.ParameterType).ToUpper();
         }
 
     }


### PR DESCRIPTION
Close #9357 

Compatible for different versions and assemblies.

Type: 
**System.Collections.Generic.IEnumerable<System.Guid>**

TypeAsString: 
**System.Collections.Generic.IEnumerable`1[[System.Guid, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Private.CoreLib**


