### PR TITLE
Convert property to enum if necessary.

### DIFF
--- a/framework/src/Volo.Abp.BlazoriseUI/AbpCrudPageBase.cs
+++ b/framework/src/Volo.Abp.BlazoriseUI/AbpCrudPageBase.cs
@@ -494,17 +494,17 @@ namespace Volo.Abp.BlazoriseUI
                 await HandleErrorAsync(ex);
             }
         }
-            
+
         protected virtual Task OnDeletingEntityAsync()
         {
             return Task.CompletedTask;
         }
-            
+
         protected virtual async Task OnDeletedEntityAsync()
         {
             await GetEntitiesAsync();
             await InvokeAsync(StateHasChanged);
-        }     
+        }
 
         protected virtual string GetDeleteConfirmationMessage(TListViewModel entity)
         {
@@ -596,7 +596,7 @@ namespace Volo.Abp.BlazoriseUI
                         if (propertyInfo.Type.IsEnum)
                         {
                             column.ValueConverter = (val) =>
-                                EnumHelper.GetLocalizedMemberName(propertyInfo.Type, val, StringLocalizerFactory);
+                                EnumHelper.GetLocalizedMemberName(propertyInfo.Type, val.As<ExtensibleObject>().ExtraProperties[propertyInfo.Name], StringLocalizerFactory);
                         }
 
                         yield return column;

--- a/framework/src/Volo.Abp.ObjectExtending/Volo/Abp/Data/ExtraPropertyDictionaryExtensions.cs
+++ b/framework/src/Volo.Abp.ObjectExtending/Volo/Abp/Data/ExtraPropertyDictionaryExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace Volo.Abp.Data
+{
+    public static class ExtraPropertyDictionaryExtensions
+    {
+        public static T ToEnum<T>(this ExtraPropertyDictionary extraPropertyDictionary, string key)
+            where T : Enum
+        {
+            if (extraPropertyDictionary[key].GetType() == typeof(T))
+            {
+                return (T)extraPropertyDictionary[key];
+            }
+
+            extraPropertyDictionary[key] = Enum.Parse(typeof(T), extraPropertyDictionary[key].ToString(), ignoreCase: true);
+            return (T)extraPropertyDictionary[key];
+        }
+
+        public static object ToEnum(this ExtraPropertyDictionary extraPropertyDictionary, string key, Type enumType)
+        {
+            if (!enumType.IsEnum || extraPropertyDictionary[key].GetType() == enumType)
+            {
+                return extraPropertyDictionary[key];
+            }
+
+            extraPropertyDictionary[key] = Enum.Parse(enumType, extraPropertyDictionary[key].ToString(), ignoreCase: true);
+            return extraPropertyDictionary[key];
+        }
+    }
+}

--- a/modules/identity/src/Volo.Abp.Identity.Web/Pages/Identity/Roles/CreateModal.cshtml
+++ b/modules/identity/src/Volo.Abp.Identity.Web/Pages/Identity/Roles/CreateModal.cshtml
@@ -30,6 +30,10 @@
                 {
                     if (propertyInfo.Type.IsEnum || !propertyInfo.Lookup.Url.IsNullOrEmpty())
                     {
+                        if (propertyInfo.Type.IsEnum)
+                        {
+                            Model.Role.ExtraProperties.ToEnum(propertyInfo.Name, propertyInfo.Type);
+                        }
                         <abp-select asp-for="Role.ExtraProperties[propertyInfo.Name]"
                                     label="@propertyInfo.GetLocalizedDisplayName(StringLocalizerFactory)"
                                     autocomplete-api-url="@propertyInfo.Lookup.Url"

--- a/modules/identity/src/Volo.Abp.Identity.Web/Pages/Identity/Roles/EditModal.cshtml
+++ b/modules/identity/src/Volo.Abp.Identity.Web/Pages/Identity/Roles/EditModal.cshtml
@@ -40,6 +40,10 @@
                 {
                     if (propertyInfo.Type.IsEnum || !propertyInfo.Lookup.Url.IsNullOrEmpty())
                     {
+                        if (propertyInfo.Type.IsEnum)
+                        {
+                            Model.Role.ExtraProperties.ToEnum(propertyInfo.Name, propertyInfo.Type);
+                        }
                         <abp-select asp-for="Role.ExtraProperties[propertyInfo.Name]"
                                     label="@propertyInfo.GetLocalizedDisplayName(StringLocalizerFactory)"
                                     autocomplete-api-url="@propertyInfo.Lookup.Url"

--- a/modules/identity/src/Volo.Abp.Identity.Web/Pages/Identity/Users/CreateModal.cshtml
+++ b/modules/identity/src/Volo.Abp.Identity.Web/Pages/Identity/Users/CreateModal.cshtml
@@ -35,6 +35,10 @@
                         {
                             if (propertyInfo.Type.IsEnum || !propertyInfo.Lookup.Url.IsNullOrEmpty())
                             {
+                                if (propertyInfo.Type.IsEnum)
+                                {
+                                    Model.UserInfo.ExtraProperties.ToEnum(propertyInfo.Name, propertyInfo.Type);
+                                }
                                 <abp-select asp-for="UserInfo.ExtraProperties[propertyInfo.Name]"
                                             label="@propertyInfo.GetLocalizedDisplayName(StringLocalizerFactory)"
                                             autocomplete-api-url="@propertyInfo.Lookup.Url"

--- a/modules/identity/src/Volo.Abp.Identity.Web/Pages/Identity/Users/EditModal.cshtml
+++ b/modules/identity/src/Volo.Abp.Identity.Web/Pages/Identity/Users/EditModal.cshtml
@@ -35,6 +35,10 @@
                         {
                             if (propertyInfo.Type.IsEnum || !propertyInfo.Lookup.Url.IsNullOrEmpty())
                             {
+                                if (propertyInfo.Type.IsEnum)
+                                {
+                                    Model.UserInfo.ExtraProperties.ToEnum(propertyInfo.Name, propertyInfo.Type);
+                                }
                                 <abp-select asp-for="UserInfo.ExtraProperties[propertyInfo.Name]"
                                             label="@propertyInfo.GetLocalizedDisplayName(StringLocalizerFactory)"
                                             autocomplete-api-url="@propertyInfo.Lookup.Url"

--- a/modules/tenant-management/src/Volo.Abp.TenantManagement.Web/Pages/TenantManagement/Tenants/CreateModal.cshtml
+++ b/modules/tenant-management/src/Volo.Abp.TenantManagement.Web/Pages/TenantManagement/Tenants/CreateModal.cshtml
@@ -29,6 +29,10 @@
                 {
                     if (propertyInfo.Type.IsEnum || !propertyInfo.Lookup.Url.IsNullOrEmpty())
                     {
+                        if (propertyInfo.Type.IsEnum)
+                        {
+                            Model.Tenant.ExtraProperties.ToEnum(propertyInfo.Name, propertyInfo.Type);
+                        }
                         <abp-select asp-for="Tenant.ExtraProperties[propertyInfo.Name]"
                                     label="@propertyInfo.GetLocalizedDisplayName(StringLocalizerFactory)"
                                     autocomplete-api-url="@propertyInfo.Lookup.Url"

--- a/modules/tenant-management/src/Volo.Abp.TenantManagement.Web/Pages/TenantManagement/Tenants/EditModal.cshtml
+++ b/modules/tenant-management/src/Volo.Abp.TenantManagement.Web/Pages/TenantManagement/Tenants/EditModal.cshtml
@@ -25,6 +25,10 @@
                 {
                     if (propertyInfo.Type.IsEnum || !propertyInfo.Lookup.Url.IsNullOrEmpty())
                     {
+                        if (propertyInfo.Type.IsEnum)
+                        {
+                            Model.Tenant.ExtraProperties.ToEnum(propertyInfo.Name, propertyInfo.Type);
+                        }
                         <abp-select asp-for="Tenant.ExtraProperties[propertyInfo.Name]"
                                     label="@propertyInfo.GetLocalizedDisplayName(StringLocalizerFactory)"
                                     autocomplete-api-url="@propertyInfo.Lookup.Url"


### PR DESCRIPTION
Resolve #9447 

The `ExtraProperties` may be deserialized from JSON In the tiered project, it is no longer an `enum` type.