### PR TITLE
Document: sample project - Add-Migration

### DIFF
--- a/docs/en/Tutorials/Part-1.md
+++ b/docs/en/Tutorials/Part-1.md
@@ -187,6 +187,12 @@ Select the `Acme.BookStore.EntityFrameworkCore.DbMigrations` as the **default pr
 Add-Migration "Created_Book_Entity"
 ```
 
+If you get error something like this on the console:
+
+>"Your startup project 'Acme.BookStore.EntityFrameworkCore' doesn't reference Microsoft.EntityFrameworkCore.Design..."
+
+Then just install `Microsoft.EntityFrameworkCore.Design` into `Acme.BookStore.EntityFrameworkCore` project and try again
+
 ![bookstore-pmc-add-book-migration](./images/bookstore-pmc-add-book-migration-v2.png)
 
 This will create a new migration class inside the `Migrations` folder of the `Acme.BookStore.EntityFrameworkCore.DbMigrations` project.

--- a/docs/en/Tutorials/Part-1.md
+++ b/docs/en/Tutorials/Part-1.md
@@ -193,6 +193,8 @@ If you get error something like this on the console:
 
 Then just install `Microsoft.EntityFrameworkCore.Design` into `Acme.BookStore.EntityFrameworkCore` project and try again
 
+After trying, in case it says that it can not load `Acme.BookStore.EntityFrameworkCore.DbMigrations` project, just restart your visual studio
+
 ![bookstore-pmc-add-book-migration](./images/bookstore-pmc-add-book-migration-v2.png)
 
 This will create a new migration class inside the `Migrations` folder of the `Acme.BookStore.EntityFrameworkCore.DbMigrations` project.


### PR DESCRIPTION
When we run `Add-Migration "Created_Book_Entity"`, it will throw an error like this, update document to guide developer install necessary package

>Your startup project 'Acme.BookStore.EntityFrameworkCore' doesn't reference Microsoft.EntityFrameworkCore.Design. This package is required for the Entity Framework Core >Tools to work. Ensure your startup project is correct, install the package, and try again.