### PR TITLE
Enhance the function of ignoring the CSRF for controllers.

### DIFF
--- a/docs/en/CSRF-Anti-Forgery.md
+++ b/docs/en/CSRF-Anti-Forgery.md
@@ -52,8 +52,18 @@ Configure<AbpAntiForgeryOptions>(options =>
 {
     options.TokenCookie.Expiration = TimeSpan.FromDays(365);
     options.AutoValidateIgnoredHttpMethods.Remove("GET");
-    options.AutoValidateFilter =
-        type => !type.Namespace.StartsWith("MyProject.MyIgnoredNamespace");
+    options.ShouldValidatePredicates.Add(filterContext =>
+    {
+        var controllerActionDescriptor = filterContext.ActionDescriptor.AsControllerActionDescriptor();
+
+        if (controllerActionDescriptor.ControllerTypeInfo.AsType() == typeof(IgnoreController) &&
+            controllerActionDescriptor.ActionName == nameof(IgnoreController.IgnoreMethod))
+        {
+            return Task.FromResult(false);
+        }
+
+        return Task.FromResult(true);
+    });
 });
 ```
 

--- a/docs/en/CSRF-Anti-Forgery.md
+++ b/docs/en/CSRF-Anti-Forgery.md
@@ -40,7 +40,7 @@ That's all. The systems works smoothly.
 * `TokenCookie`:  Can be used to configure the cookie details. This cookie is used to store the antiforgery token value in the client side, so clients can read it and sends the value as the HTTP header. Default cookie name is `XSRF-TOKEN`, expiration time is 10 years (yes, ten years! It should be a value longer than the authentication cookie max life time, for the security).
 * `AuthCookieSchemaName`: The name of the authentication cookie used by your application. Default value is `Identity.Application` (which becomes `AspNetCore.Identity.Application` on runtime). The default value properly works with the ABP startup templates. **If you change the authentication cookie name, you also must change this.**
 * `AutoValidate`: The single point to enable/disable the ABP automatic antiforgery validation system. Default value is `true`.
-* `AutoValidateFilter`: A predicate that gets a type and returns a boolean. ABP uses this predicate to check a controller type. If it returns false for a controller type, the controller is excluded from the automatic antiforgery token validation.
+* `ShouldValidatePredicates`: A list of predicates that gets `AuthorizationFilterContext` and returns a boolean. If any of these conditions return `false`, the request is excluded from the automatic antiforgery token validation.
 * `AutoValidateIgnoredHttpMethods`: A list of HTTP Methods to ignore on automatic antiforgery validation. Default value: "GET", "HEAD", "TRACE", "OPTIONS". These HTTP Methods are safe to skip antiforgery validation since they don't change the application state.
 
 If you need to change these options, do it in the `ConfigureServices` method of your [module](Module-Development-Basics.md).

--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AntiForgery/AbpAntiForgeryOptions.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AntiForgery/AbpAntiForgeryOptions.cs
@@ -41,9 +41,8 @@ namespace Volo.Abp.AspNetCore.Mvc.AntiForgery
         private Predicate<Type> _autoValidateFilter;
 
         /// <summary>
-        /// A predicate to filter types to auto-validate.
-        /// Return true to select the type to validate.
-        /// Default: returns true for all given types.
+        /// A list of predicates
+        /// Return true to validate the antiforgery of request.
         /// </summary>
         [NotNull]
         public List<Func<AuthorizationFilterContext, Task<bool>>> ShouldValidatePredicates

--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AntiForgery/AbpAntiForgeryOptions.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AntiForgery/AbpAntiForgeryOptions.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Filters;
 
 namespace Volo.Abp.AspNetCore.Mvc.AntiForgery
 {
@@ -30,12 +32,26 @@ namespace Volo.Abp.AspNetCore.Mvc.AntiForgery
         /// Default: returns true for all given types.
         /// </summary>
         [NotNull]
+        [Obsolete("Use ShouldValidatePredicates instead.")]
         public Predicate<Type> AutoValidateFilter
         {
             get => _autoValidateFilter;
             set => _autoValidateFilter = Check.NotNull(value, nameof(value));
         }
         private Predicate<Type> _autoValidateFilter;
+
+        /// <summary>
+        /// A predicate to filter types to auto-validate.
+        /// Return true to select the type to validate.
+        /// Default: returns true for all given types.
+        /// </summary>
+        [NotNull]
+        public List<Func<AuthorizationFilterContext, Task<bool>>> ShouldValidatePredicates
+        {
+            get => _shouldValidatePredicates;
+            set => _shouldValidatePredicates = Check.NotNull(value, nameof(value));
+        }
+        private List<Func<AuthorizationFilterContext, Task<bool>>> _shouldValidatePredicates;
 
         /// <summary>
         /// Default methods: "GET", "HEAD", "TRACE", "OPTIONS".
@@ -51,6 +67,7 @@ namespace Volo.Abp.AspNetCore.Mvc.AntiForgery
         public AbpAntiForgeryOptions()
         {
             AutoValidateFilter = type => true;
+            ShouldValidatePredicates = new List<Func<AuthorizationFilterContext, Task<bool>>>();
 
             TokenCookie = new CookieBuilder
             {

--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AntiForgery/AbpAntiForgeryOptions.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AntiForgery/AbpAntiForgeryOptions.cs
@@ -42,7 +42,7 @@ namespace Volo.Abp.AspNetCore.Mvc.AntiForgery
 
         /// <summary>
         /// A list of predicates
-        /// Return true to validate the antiforgery of request.
+        /// Return false to skip validate.
         /// </summary>
         [NotNull]
         public List<Func<AuthorizationFilterContext, Task<bool>>> ShouldValidatePredicates

--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AntiForgery/AbpAutoValidateAntiforgeryTokenAuthorizationFilter.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AntiForgery/AbpAutoValidateAntiforgeryTokenAuthorizationFilter.cs
@@ -45,13 +45,13 @@ namespace Volo.Abp.AspNetCore.Mvc.AntiForgery
                 {
                     return false;
                 }
-            }
 
-            foreach (var shouldValidatePredicate in _options.ShouldValidatePredicates)
-            {
-                if (!await shouldValidatePredicate(context))
+                foreach (var shouldValidatePredicate in _options.ShouldValidatePredicates)
                 {
-                    return false;
+                    if (!await shouldValidatePredicate(context))
+                    {
+                        return false;
+                    }
                 }
             }
 

--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AntiForgery/AbpAutoValidateAntiforgeryTokenAuthorizationFilter.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AntiForgery/AbpAutoValidateAntiforgeryTokenAuthorizationFilter.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Filters;
@@ -25,7 +27,7 @@ namespace Volo.Abp.AspNetCore.Mvc.AntiForgery
             _options = options.Value;
         }
 
-        protected override bool ShouldValidate(AuthorizationFilterContext context)
+        protected override async Task<bool> ShouldValidate(AuthorizationFilterContext context)
         {
             if (!_options.AutoValidate)
             {
@@ -45,12 +47,20 @@ namespace Volo.Abp.AspNetCore.Mvc.AntiForgery
                 }
             }
 
+            foreach (var shouldValidatePredicate in _options.ShouldValidatePredicates)
+            {
+                if (!await shouldValidatePredicate(context))
+                {
+                    return false;
+                }
+            }
+
             if (IsIgnoredHttpMethod(context))
             {
                 return false;
             }
 
-            return base.ShouldValidate(context);
+            return await base.ShouldValidate(context);
         }
 
         protected virtual bool IsIgnoredHttpMethod(AuthorizationFilterContext context)

--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AntiForgery/AbpValidateAntiforgeryTokenAuthorizationFilter.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AntiForgery/AbpValidateAntiforgeryTokenAuthorizationFilter.cs
@@ -38,7 +38,7 @@ namespace Volo.Abp.AspNetCore.Mvc.AntiForgery
                 return;
             }
 
-            if (ShouldValidate(context))
+            if (await ShouldValidate(context))
             {
                 try
                 {
@@ -52,7 +52,7 @@ namespace Volo.Abp.AspNetCore.Mvc.AntiForgery
             }
         }
 
-        protected virtual bool ShouldValidate(AuthorizationFilterContext context)
+        protected virtual Task<bool> ShouldValidate(AuthorizationFilterContext context)
         {
             var authCookieName = _antiForgeryCookieNameProvider.GetAuthCookieNameOrNull();
 
@@ -60,7 +60,7 @@ namespace Volo.Abp.AspNetCore.Mvc.AntiForgery
             if (authCookieName != null &&
                 context.HttpContext.Request.Cookies.ContainsKey(authCookieName))
             {
-                return true;
+                return Task.FromResult(true);
             }
 
             var antiForgeryCookieName = _antiForgeryCookieNameProvider.GetAntiForgeryCookieNameOrNull();
@@ -71,11 +71,11 @@ namespace Volo.Abp.AspNetCore.Mvc.AntiForgery
             if (antiForgeryCookieName != null &&
                 !context.HttpContext.Request.Cookies.ContainsKey(antiForgeryCookieName))
             {
-                return false;
+                return Task.FromResult(false);
             }
 
             // Anything else requires a token.
-            return true;
+            return Task.FromResult(true);
         }
     }
 }


### PR DESCRIPTION
```cs
Configure<AbpAntiForgeryOptions>(options =>
{
    options.ShouldValidatePredicates.Add(filterContext =>
    {
        var controllerActionDescriptor = filterContext.ActionDescriptor.AsControllerActionDescriptor();
        if (controllerActionDescriptor.ControllerTypeInfo.AsType() == typeof(IgnoreController) &&
            controllerActionDescriptor.ActionName == nameof(IgnoreController.IgnoreMethod))
        {
            return Task.FromResult(false);
        }
        return Task.FromResult(true);
    });
});
```