### PR TITLE
Use `CancellationToken` if it exists in the parameter.

### DIFF
--- a/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/DynamicProxying/DynamicHttpProxyInterceptor.cs
+++ b/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/DynamicProxying/DynamicHttpProxyInterceptor.cs
@@ -174,7 +174,7 @@ namespace Volo.Abp.Http.Client.DynamicProxying
             var response = await client.SendAsync(
                 requestMessage,
                 HttpCompletionOption.ResponseHeadersRead /*this will buffer only the headers, the content will be used as a stream*/,
-                GetCancellationToken()
+                GetCancellationToken(invocation)
             );
 
             if (!response.IsSuccessStatusCode)
@@ -306,9 +306,10 @@ namespace Volo.Abp.Http.Client.DynamicProxying
             return input;
         }
 
-        protected virtual CancellationToken GetCancellationToken()
+        protected virtual CancellationToken GetCancellationToken(IAbpMethodInvocation invocation)
         {
-            return CancellationTokenProvider.Token;
+            var cancellationToken = invocation.Arguments.LastOrDefault(x => x is CancellationToken);
+            return (CancellationToken?)cancellationToken ?? CancellationTokenProvider.Token;
         }
     }
 }

--- a/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/DynamicProxying/DynamicHttpProxyInterceptor.cs
+++ b/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/DynamicProxying/DynamicHttpProxyInterceptor.cs
@@ -308,8 +308,17 @@ namespace Volo.Abp.Http.Client.DynamicProxying
 
         protected virtual CancellationToken GetCancellationToken(IAbpMethodInvocation invocation)
         {
-            var cancellationToken = invocation.Arguments.LastOrDefault(x => x is CancellationToken);
-            return (CancellationToken?)cancellationToken ?? CancellationTokenProvider.Token;
+            var cancellationTokenArg = invocation.Arguments.LastOrDefault(x => x is CancellationToken);
+            if (cancellationTokenArg != null)
+            {
+                var cancellationToken = (CancellationToken) cancellationTokenArg;
+                if (cancellationToken != default)
+                {
+                    return cancellationToken;
+                }
+            }
+
+            return CancellationTokenProvider.Token;
         }
     }
 }

--- a/framework/test/Volo.Abp.Http.Client.Tests/Volo/Abp/Http/DynamicProxying/IRegularTestController.cs
+++ b/framework/test/Volo.Abp.Http.Client.Tests/Volo/Abp/Http/DynamicProxying/IRegularTestController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Volo.Abp.Http.DynamicProxying
@@ -36,5 +37,7 @@ namespace Volo.Abp.Http.DynamicProxying
         Task<string> PatchValueWithHeaderAndQueryStringAsync(string headerValue, string qsValue);
 
         Task<int> DeleteByIdAsync(int id);
+
+        Task AbortRequestAsync(CancellationToken cancellationToken);
     }
 }

--- a/framework/test/Volo.Abp.Http.Client.Tests/Volo/Abp/Http/DynamicProxying/IRegularTestController.cs
+++ b/framework/test/Volo.Abp.Http.Client.Tests/Volo/Abp/Http/DynamicProxying/IRegularTestController.cs
@@ -38,6 +38,6 @@ namespace Volo.Abp.Http.DynamicProxying
 
         Task<int> DeleteByIdAsync(int id);
 
-        Task AbortRequestAsync(CancellationToken cancellationToken);
+        Task<string> AbortRequestAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/framework/test/Volo.Abp.Http.Client.Tests/Volo/Abp/Http/DynamicProxying/RegularTestController.cs
+++ b/framework/test/Volo.Abp.Http.Client.Tests/Volo/Abp/Http/DynamicProxying/RegularTestController.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using Volo.Abp.Application.Services;
 using Volo.Abp.AspNetCore.Mvc;
-using Volo.Abp.UI;
 
 namespace Volo.Abp.Http.DynamicProxying
 {
@@ -128,6 +127,13 @@ namespace Volo.Abp.Http.DynamicProxying
         public Task<int> DeleteByIdAsync(int id)
         {
             return Task.FromResult(id + 1);
+        }
+
+        [HttpGet]
+        [Route("abort-request")]
+        public async Task AbortRequestAsync(CancellationToken cancellationToken)
+        {
+            await Task.Delay(100, cancellationToken);
         }
     }
 

--- a/framework/test/Volo.Abp.Http.Client.Tests/Volo/Abp/Http/DynamicProxying/RegularTestController.cs
+++ b/framework/test/Volo.Abp.Http.Client.Tests/Volo/Abp/Http/DynamicProxying/RegularTestController.cs
@@ -131,9 +131,10 @@ namespace Volo.Abp.Http.DynamicProxying
 
         [HttpGet]
         [Route("abort-request")]
-        public async Task AbortRequestAsync(CancellationToken cancellationToken)
+        public async Task<string> AbortRequestAsync(CancellationToken cancellationToken = default)
         {
             await Task.Delay(100, cancellationToken);
+            return "AbortRequestAsync";
         }
     }
 

--- a/framework/test/Volo.Abp.Http.Client.Tests/Volo/Abp/Http/DynamicProxying/RegularTestControllerClientProxy_Tests.cs
+++ b/framework/test/Volo.Abp.Http.Client.Tests/Volo/Abp/Http/DynamicProxying/RegularTestControllerClientProxy_Tests.cs
@@ -1,10 +1,10 @@
 ﻿using System;
+using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Localization;
 using Shouldly;
 using Volo.Abp.Http.Client;
-using Volo.Abp.Http.Localization;
 using Volo.Abp.Localization;
 using Xunit;
 
@@ -159,5 +159,14 @@ namespace Volo.Abp.Http.DynamicProxying
             (await _controller.DeleteByIdAsync(42)).ShouldBe(43);
         }
 
+        [Fact]
+        public async Task AbortRequestAsync()
+        {
+            var cts = new CancellationTokenSource();
+            cts.CancelAfter(10);
+
+            var exception = await Assert.ThrowsAsync<HttpRequestException>(async () => await _controller.AbortRequestAsync(cts.Token));
+            exception.InnerException.InnerException.Message.ShouldBe("The client aborted the request.");
+        }
     }
 }

--- a/framework/test/Volo.Abp.Http.Client.Tests/Volo/Abp/Http/DynamicProxying/RegularTestControllerClientProxy_Tests.cs
+++ b/framework/test/Volo.Abp.Http.Client.Tests/Volo/Abp/Http/DynamicProxying/RegularTestControllerClientProxy_Tests.cs
@@ -165,6 +165,9 @@ namespace Volo.Abp.Http.DynamicProxying
             var cts = new CancellationTokenSource();
             cts.CancelAfter(10);
 
+            var result = await _controller.AbortRequestAsync(default);
+            result.ShouldBe("AbortRequestAsync");
+
             var exception = await Assert.ThrowsAsync<HttpRequestException>(async () => await _controller.AbortRequestAsync(cts.Token));
             exception.InnerException.InnerException.Message.ShouldBe("The client aborted the request.");
         }


### PR DESCRIPTION
When we call the API proxy in the Console or Blazor, we may manually provide the cancellation token.