### PR TITLE
CmsKit - Try to use Public Layout if presented by Theme

### DIFF
--- a/modules/cms-kit/src/Volo.CmsKit.Public.Web/Pages/Public/CmsKit/_ViewStart.cshtml
+++ b/modules/cms-kit/src/Volo.CmsKit.Public.Web/Pages/Public/CmsKit/_ViewStart.cshtml
@@ -1,0 +1,5 @@
+﻿@using Volo.Abp.AspNetCore.Mvc.UI.Theming
+@inject IThemeManager ThemeManager
+@{
+    Layout = ThemeManager.CurrentTheme.GetPublicLayout();
+}


### PR DESCRIPTION
CmsKit Public pages should try to use Public layout if presented by theme.
Currently, developer must add **_ViewStart.cshtml** file into the end project