### PR TITLE
Fix object reference not set to an instance of an object for http proxy

### DIFF
--- a/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/DynamicProxying/UrlBuilder.cs
+++ b/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/DynamicProxying/UrlBuilder.cs
@@ -139,7 +139,7 @@ namespace Volo.Abp.Http.Client.DynamicProxying
                 return dateTimeValue.ToUniversalTime().ToString("O");
             }
 
-            return value.ToString();
+            return value?.ToString();
         }
     }
 }

--- a/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/DynamicProxying/UrlBuilder.cs
+++ b/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/DynamicProxying/UrlBuilder.cs
@@ -132,7 +132,7 @@ namespace Volo.Abp.Http.Client.DynamicProxying
             return true;
         }
 
-        private static string ConvertValueToString([NotNull] object value)
+        private static string ConvertValueToString([CanBeNull] object value)
         {
             if (value is DateTime dateTimeValue)
             {


### PR DESCRIPTION
The method ConvertValueToString reports Object reference not set to an instance of an object if there is an array or collection with null elements in the parameter.