### PR TITLE
Update Oracle package to v5.21.3

### DIFF
--- a/framework/src/Volo.Abp.EntityFrameworkCore.Oracle/Volo.Abp.EntityFrameworkCore.Oracle.csproj
+++ b/framework/src/Volo.Abp.EntityFrameworkCore.Oracle/Volo.Abp.EntityFrameworkCore.Oracle.csproj
@@ -18,8 +18,8 @@
         <ProjectReference Include="..\Volo.Abp.EntityFrameworkCore\Volo.Abp.EntityFrameworkCore.csproj" />
     </ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Oracle.EntityFrameworkCore" Version="5.21.1" />
+    <ItemGroup>        
+        <PackageReference Include="Oracle.EntityFrameworkCore" Version="5.21.3" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Related to https://github.com/abpframework/abp/issues/8210
We cannot update it on `dev `branch because it doesn't work with .NET6.

https://www.nuget.org/packages/Oracle.EntityFrameworkCore/