### PR TITLE
Call `SetConcurrencyStampIfNotNull` before save changes.

### DIFF
--- a/modules/identity/src/Volo.Abp.Identity.Application/Volo/Abp/Identity/ProfileAppService.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Application/Volo/Abp/Identity/ProfileAppService.cs
@@ -39,6 +39,8 @@ namespace Volo.Abp.Identity
 
             var user = await UserManager.GetByIdAsync(CurrentUser.GetId());
 
+            user.SetConcurrencyStampIfNotNull(input.ConcurrencyStamp);
+
             if (!string.Equals(user.UserName, input.UserName, StringComparison.InvariantCultureIgnoreCase))
             {
                 if (await SettingProvider.IsTrueAsync(IdentitySettingNames.User.IsUserNameUpdateEnabled))
@@ -62,8 +64,6 @@ namespace Volo.Abp.Identity
 
             user.Name = input.Name;
             user.Surname = input.Surname;
-
-            user.SetConcurrencyStampIfNotNull(input.ConcurrencyStamp);
 
             input.MapExtraPropertiesTo(user);
 


### PR DESCRIPTION
`await UserManager.SetXXXAsync` will save changes. so the `ConcurrencyStamp` is changed.