### PR TITLE
修复命名规则的错误表述。

### DIFF
--- a/docs/zh-Hans/Text-Templating.md
+++ b/docs/zh-Hans/Text-Templating.md
@@ -187,9 +187,9 @@ var result = await _templateRenderer.RenderAsync(
 
 示例中我们并没有创建模型类,但是创建了一个匿名对象模型.
 
-### 大驼峰 与 小驼峰
+### 大驼峰 与 蛇形命名（snake_case）
 
-PascalCase 属性名(如 `UserName`) 在模板中用做小驼峰(如 `userName`).
+PascalCase 属性名(如 `UserName`) 在模板中使用蛇形命名(如 `user_name`).
 
 ## 本地化
 


### PR DESCRIPTION
修复命名规则的错误表述。与英文版不同，并且经过验证，蛇形命名才是正确的。