### PR TITLE
Improve IdentityServer module.

### DIFF
--- a/modules/identityserver/src/Volo.Abp.IdentityServer.Domain/Volo/Abp/IdentityServer/ApiResources/ApiResource.cs
+++ b/modules/identityserver/src/Volo.Abp.IdentityServer.Domain/Volo/Abp/IdentityServer/ApiResources/ApiResource.cs
@@ -35,11 +35,9 @@ namespace Volo.Abp.IdentityServer.ApiResources
 
         }
 
-        public ApiResource(Guid id, [NotNull] string name, string displayName = null, string description = null)
+        public ApiResource(Guid id, [NotNull] string name, string displayName = null, string description = null) : base(id)
         {
             Check.NotNull(name, nameof(name));
-
-            Id = id;
 
             Name = name;
 

--- a/modules/identityserver/src/Volo.Abp.IdentityServer.Domain/Volo/Abp/IdentityServer/ApiScopes/ApiScope.cs
+++ b/modules/identityserver/src/Volo.Abp.IdentityServer.Domain/Volo/Abp/IdentityServer/ApiScopes/ApiScope.cs
@@ -40,11 +40,11 @@ namespace Volo.Abp.IdentityServer.ApiScopes
             bool required = false,
             bool emphasize = false,
             bool showInDiscoveryDocument = true,
-            bool enabled = true)
+            bool enabled = true
+        ) : base(id)
         {
             Check.NotNull(name, nameof(name));
 
-            Id = id;
             Name = name;
             DisplayName = displayName ?? name;
             Description = description;

--- a/modules/identityserver/src/Volo.Abp.IdentityServer.Domain/Volo/Abp/IdentityServer/Clients/Client.cs
+++ b/modules/identityserver/src/Volo.Abp.IdentityServer.Domain/Volo/Abp/IdentityServer/Clients/Client.cs
@@ -274,17 +274,17 @@ namespace Volo.Abp.IdentityServer.Clients
             Properties.Clear();
         }
 
-        public virtual void RemoveProperty(string key, string value)
+        public virtual void RemoveProperty(string key)
         {
-            Properties.RemoveAll(c => c.Value == value && c.Key == key);
+            Properties.RemoveAll(c => c.Key == key);
         }
 
-        public virtual ClientProperty FindProperty(string key, string value)
+        public virtual ClientProperty FindProperty(string key)
         {
-            return Properties.FirstOrDefault(c => c.Key == key && c.Value == value);
+            return Properties.FirstOrDefault(c => c.Key == key);
         }
 
-        public virtual void AddClaim([NotNull] string value, string type)
+        public virtual void AddClaim([NotNull] string type, [NotNull] string value)
         {
             Claims.Add(new ClientClaim(Id, type, value));
         }
@@ -294,12 +294,22 @@ namespace Volo.Abp.IdentityServer.Clients
             Claims.Clear();
         }
 
-        public virtual void RemoveClaim(string value, string type)
+        public virtual void RemoveClaim(string type)
         {
-            Claims.RemoveAll(c => c.Value == value && c.Type == type);
+            Claims.RemoveAll(c => c.Type == type);
         }
 
-        public virtual ClientClaim FindClaim(string value, string type)
+        public virtual void RemoveClaim(string type, string value)
+        {
+            Claims.RemoveAll(c => c.Type == type && c.Value == value);
+        }
+
+        public virtual List<ClientClaim> FindClaims(string type)
+        {
+            return Claims.Where(c => c.Type == type).ToList();
+        }
+
+        public virtual ClientClaim FindClaim(string type, string value)
         {
             return Claims.FirstOrDefault(c => c.Type == type && c.Value == value);
         }

--- a/modules/identityserver/src/Volo.Abp.IdentityServer.Domain/Volo/Abp/IdentityServer/Clients/ClientClaim.cs
+++ b/modules/identityserver/src/Volo.Abp.IdentityServer.Domain/Volo/Abp/IdentityServer/Clients/ClientClaim.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using JetBrains.Annotations;
 using Volo.Abp.Domain.Entities;
 
@@ -17,11 +17,6 @@ namespace Volo.Abp.IdentityServer.Clients
 
         }
 
-        public virtual bool Equals(Guid clientId, string value, string type)
-        {
-            return ClientId == clientId && Type == type && Value == value;
-        }
-
         protected internal ClientClaim(Guid clientId, [NotNull] string type, string value)
         {
             Check.NotNull(type, nameof(type));
@@ -29,6 +24,11 @@ namespace Volo.Abp.IdentityServer.Clients
             ClientId = clientId;
             Type = type;
             Value = value;
+        }
+
+        public virtual bool Equals(Guid clientId, string type, string value)
+        {
+            return ClientId == clientId && Type == type && Value == value;
         }
 
         public override object[] GetKeys()

--- a/modules/identityserver/src/Volo.Abp.IdentityServer.Domain/Volo/Abp/IdentityServer/Devices/DeviceFlowStore.cs
+++ b/modules/identityserver/src/Volo.Abp.IdentityServer.Domain/Volo/Abp/IdentityServer/Devices/DeviceFlowStore.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using IdentityModel;
 using IdentityServer4.Models;
@@ -38,7 +38,7 @@ namespace Volo.Abp.IdentityServer.Devices
                         DeviceCode = deviceCode,
                         UserCode = userCode,
                         ClientId = data.ClientId,
-                        SubjectId = data.Subject?.FindFirst(JwtClaimTypes.Subject).Value,
+                        SubjectId = data.Subject?.FindFirst(JwtClaimTypes.Subject)?.Value,
                         CreationTime = data.CreationTime,
                         Expiration = data.CreationTime.AddSeconds(data.Lifetime),
                         Data = Serialize(data)
@@ -93,7 +93,7 @@ namespace Volo.Abp.IdentityServer.Devices
                 throw new InvalidOperationException($"Could not update device code by the given userCode: {userCode}");
             }
 
-            deviceCodes.SubjectId = data.Subject?.FindFirst(JwtClaimTypes.Subject).Value;
+            deviceCodes.SubjectId = data.Subject?.FindFirst(JwtClaimTypes.Subject)?.Value;
             deviceCodes.Data = Serialize(data);
 
             await DeviceFlowCodesRepository

--- a/modules/identityserver/src/Volo.Abp.IdentityServer.Domain/Volo/Abp/IdentityServer/Grants/PersistedGrant.cs
+++ b/modules/identityserver/src/Volo.Abp.IdentityServer.Domain/Volo/Abp/IdentityServer/Grants/PersistedGrant.cs
@@ -5,6 +5,14 @@ namespace Volo.Abp.IdentityServer.Grants
 {
     public class PersistedGrant : AggregateRoot<Guid>
     {
+        protected PersistedGrant()
+        {
+        }
+
+        public PersistedGrant(Guid id) : base(id)
+        {
+        }
+
         public virtual string Key { get; set; }
 
         public virtual string Type { get; set; }
@@ -24,15 +32,5 @@ namespace Volo.Abp.IdentityServer.Grants
         public virtual DateTime? ConsumedTime { get; set; }
 
         public virtual string Data { get; set; }
-
-        protected PersistedGrant()
-        {
-
-        }
-
-        public PersistedGrant(Guid id)
-        {
-            Id = id;
-        }
     }
 }

--- a/modules/identityserver/src/Volo.Abp.IdentityServer.Domain/Volo/Abp/IdentityServer/IdentityResources/IdentityResource.cs
+++ b/modules/identityserver/src/Volo.Abp.IdentityServer.Domain/Volo/Abp/IdentityServer/IdentityResources/IdentityResource.cs
@@ -39,11 +39,11 @@ namespace Volo.Abp.IdentityServer.IdentityResources
             bool enabled = true,
             bool required = false,
             bool emphasize = false,
-            bool showInDiscoveryDocument = true)
+            bool showInDiscoveryDocument = true
+        ) : base(id)
         {
             Check.NotNull(name, nameof(name));
 
-            Id = id;
             Name = name;
             DisplayName = displayName;
             Description = description;
@@ -56,9 +56,8 @@ namespace Volo.Abp.IdentityServer.IdentityResources
             Properties = new List<IdentityResourceProperty>();
         }
 
-        public IdentityResource(Guid id, IdentityServer4.Models.IdentityResource resource)
+        public IdentityResource(Guid id, IdentityServer4.Models.IdentityResource resource) : base(id)
         {
-            Id = id;
             Name = resource.Name;
             DisplayName = resource.DisplayName;
             Description = resource.Description;

--- a/modules/identityserver/src/Volo.Abp.IdentityServer.EntityFrameworkCore/Volo/Abp/IdentityServer/ApiResources/ApiResourceRepository.cs
+++ b/modules/identityserver/src/Volo.Abp.IdentityServer.EntityFrameworkCore/Volo/Abp/IdentityServer/ApiResources/ApiResourceRepository.cs
@@ -20,23 +20,20 @@ namespace Volo.Abp.IdentityServer.ApiResources
 
         public async Task<ApiResource> FindByNameAsync(string apiResourceName, bool includeDetails = true, CancellationToken cancellationToken = default)
         {
-            var query = from apiResource in (await GetDbSetAsync()).IncludeDetails(includeDetails)
-                where apiResource.Name == apiResourceName
-                orderby apiResource.Id
-                select apiResource;
-
-            return await query.FirstOrDefaultAsync(GetCancellationToken(cancellationToken));
+            return await (await GetDbSetAsync())
+                .IncludeDetails(includeDetails)
+                .OrderBy(apiResource => apiResource.Id)
+                .FirstOrDefaultAsync(apiResource => apiResource.Name == apiResourceName, GetCancellationToken(cancellationToken));
         }
 
         public async Task<List<ApiResource>> FindByNameAsync(string[] apiResourceNames, bool includeDetails = true,
             CancellationToken cancellationToken = default)
         {
-            var query = from apiResource in (await GetDbSetAsync()).IncludeDetails(includeDetails)
-                where apiResourceNames.Contains(apiResource.Name)
-                orderby apiResource.Name
-                select apiResource;
-
-            return await query.ToListAsync(GetCancellationToken(cancellationToken));
+            return await (await GetDbSetAsync())
+                .IncludeDetails(includeDetails)
+                .Where(apiResource => apiResourceNames.Contains(apiResource.Name))
+                .OrderBy(apiResource => apiResource.Name)
+                .ToListAsync(GetCancellationToken(cancellationToken));
         }
 
         public virtual async Task<List<ApiResource>> GetListByScopesAsync(
@@ -44,11 +41,10 @@ namespace Volo.Abp.IdentityServer.ApiResources
             bool includeDetails = false,
             CancellationToken cancellationToken = default)
         {
-            var query = from api in (await GetDbSetAsync()).IncludeDetails(includeDetails)
-                        where api.Scopes.Any(x => scopeNames.Contains(x.Scope))
-                        select api;
-
-            return await query.ToListAsync(GetCancellationToken(cancellationToken));
+            return await (await GetDbSetAsync())
+                .IncludeDetails(includeDetails)
+                .Where(api => api.Scopes.Any(x => scopeNames.Contains(x.Scope)))
+                .ToListAsync(GetCancellationToken(cancellationToken));
         }
 
         public virtual async Task<List<ApiResource>> GetListAsync(

--- a/modules/identityserver/src/Volo.Abp.IdentityServer.EntityFrameworkCore/Volo/Abp/IdentityServer/ApiScopes/ApiScopeRepository.cs
+++ b/modules/identityserver/src/Volo.Abp.IdentityServer.EntityFrameworkCore/Volo/Abp/IdentityServer/ApiScopes/ApiScopeRepository.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Dynamic.Core;
@@ -21,6 +21,7 @@ namespace Volo.Abp.IdentityServer.ApiScopes
         public async Task<ApiScope> FindByNameAsync(string scopeName, bool includeDetails = true, CancellationToken cancellationToken = default)
         {
             return await (await GetDbSetAsync())
+                .IncludeDetails(includeDetails)
                 .OrderBy(x=>x.Id)
                 .FirstOrDefaultAsync(x => x.Name == scopeName, GetCancellationToken(cancellationToken));
         }

--- a/modules/identityserver/src/Volo.Abp.IdentityServer.EntityFrameworkCore/Volo/Abp/IdentityServer/ApiScopes/ApiScopeRepository.cs
+++ b/modules/identityserver/src/Volo.Abp.IdentityServer.EntityFrameworkCore/Volo/Abp/IdentityServer/ApiScopes/ApiScopeRepository.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Dynamic.Core;
@@ -29,12 +29,11 @@ namespace Volo.Abp.IdentityServer.ApiScopes
         public async Task<List<ApiScope>> GetListByNameAsync(string[] scopeNames, bool includeDetails = false,
             CancellationToken cancellationToken = default)
         {
-            var query = from scope in (await GetDbSetAsync()).IncludeDetails(includeDetails)
-                where scopeNames.Contains(scope.Name)
-                orderby scope.Id
-                select scope;
-
-            return await query.ToListAsync(GetCancellationToken(cancellationToken));
+            return await (await GetDbSetAsync())
+                .IncludeDetails(includeDetails)
+                .Where(scope => scopeNames.Contains(scope.Name))
+                .OrderBy(scope => scope.Id)
+                .ToListAsync(GetCancellationToken(cancellationToken));
         }
 
         public async Task<List<ApiScope>> GetListAsync(string sorting, int skipCount, int maxResultCount, string filter = null, bool includeDetails = false, CancellationToken cancellationToken = default)

--- a/modules/identityserver/src/Volo.Abp.IdentityServer.EntityFrameworkCore/Volo/Abp/IdentityServer/Clients/ClientRepository.cs
+++ b/modules/identityserver/src/Volo.Abp.IdentityServer.EntityFrameworkCore/Volo/Abp/IdentityServer/Clients/ClientRepository.cs
@@ -58,7 +58,7 @@ namespace Volo.Abp.IdentityServer.Clients
 
         public virtual async Task<bool> CheckClientIdExistAsync(string clientId, Guid? expectedId = null, CancellationToken cancellationToken = default)
         {
-            return await (await GetDbSetAsync()).AnyAsync(c => c.Id != expectedId && c.ClientId == clientId, cancellationToken: cancellationToken);
+            return await (await GetDbSetAsync()).AnyAsync(c => c.Id != expectedId && c.ClientId == clientId, GetCancellationToken(cancellationToken));
         }
 
         public async override Task DeleteAsync(Guid id, bool autoSave = false, CancellationToken cancellationToken = default)

--- a/modules/identityserver/src/Volo.Abp.IdentityServer.EntityFrameworkCore/Volo/Abp/IdentityServer/Devices/DeviceFlowCodesRepository.cs
+++ b/modules/identityserver/src/Volo.Abp.IdentityServer.EntityFrameworkCore/Volo/Abp/IdentityServer/Devices/DeviceFlowCodesRepository.cs
@@ -24,9 +24,8 @@ namespace Volo.Abp.IdentityServer.Devices
             CancellationToken cancellationToken = default)
         {
             return await (await GetDbSetAsync())
-                .Where(d => d.UserCode == userCode)
                 .OrderBy(d => d.Id)
-                .FirstOrDefaultAsync(GetCancellationToken(cancellationToken));
+                .FirstOrDefaultAsync(d => d.UserCode == userCode, GetCancellationToken(cancellationToken));
         }
 
         public virtual async Task<DeviceFlowCodes> FindByDeviceCodeAsync(
@@ -34,9 +33,8 @@ namespace Volo.Abp.IdentityServer.Devices
             CancellationToken cancellationToken = default)
         {
             return await (await GetDbSetAsync())
-                .Where(d => d.DeviceCode == deviceCode)
                 .OrderBy(d => d.Id)
-                .FirstOrDefaultAsync(GetCancellationToken(cancellationToken));
+                .FirstOrDefaultAsync(d => d.DeviceCode == deviceCode, GetCancellationToken(cancellationToken));
         }
 
         public virtual async Task<List<DeviceFlowCodes>> GetListByExpirationAsync(DateTime maxExpirationDate, int maxResultCount,

--- a/modules/identityserver/src/Volo.Abp.IdentityServer.EntityFrameworkCore/Volo/Abp/IdentityServer/Grants/PersistentGrantRepository.cs
+++ b/modules/identityserver/src/Volo.Abp.IdentityServer.EntityFrameworkCore/Volo/Abp/IdentityServer/Grants/PersistentGrantRepository.cs
@@ -30,9 +30,8 @@ namespace Volo.Abp.IdentityServer.Grants
             CancellationToken cancellationToken = default)
         {
             return await (await GetDbSetAsync())
-                .Where(x => x.Key == key)
                 .OrderBy(x => x.Id)
-                .FirstOrDefaultAsync(GetCancellationToken(cancellationToken));
+                .FirstOrDefaultAsync(x => x.Key == key, GetCancellationToken(cancellationToken));
         }
 
         public virtual async Task<List<PersistedGrant>> GetListBySubjectIdAsync(

--- a/modules/identityserver/src/Volo.Abp.IdentityServer.EntityFrameworkCore/Volo/Abp/IdentityServer/IdentityResources/IdentityResourceRepository.cs
+++ b/modules/identityserver/src/Volo.Abp.IdentityServer.EntityFrameworkCore/Volo/Abp/IdentityServer/IdentityResources/IdentityResourceRepository.cs
@@ -24,11 +24,10 @@ namespace Volo.Abp.IdentityServer.IdentityResources
             bool includeDetails = false,
             CancellationToken cancellationToken = default)
         {
-            var query = from identityResource in (await GetDbSetAsync()).IncludeDetails(includeDetails)
-                        where scopeNames.Contains(identityResource.Name)
-                        select identityResource;
-
-            return await query.ToListAsync(GetCancellationToken(cancellationToken));
+            return await (await GetDbSetAsync())
+                .IncludeDetails(includeDetails)
+                .Where(identityResource => scopeNames.Contains(identityResource.Name))
+                .ToListAsync(GetCancellationToken(cancellationToken));
         }
 
         [Obsolete("Use WithDetailsAsync method.")]
@@ -72,14 +71,13 @@ namespace Volo.Abp.IdentityServer.IdentityResources
         {
             return await (await GetDbSetAsync())
                 .IncludeDetails(includeDetails)
-                .Where(x => x.Name == name)
                 .OrderBy(x => x.Id)
-                .FirstOrDefaultAsync(GetCancellationToken(cancellationToken));
+                .FirstOrDefaultAsync(x => x.Name == name, GetCancellationToken(cancellationToken));
         }
 
         public virtual async Task<bool> CheckNameExistAsync(string name, Guid? expectedId = null, CancellationToken cancellationToken = default)
         {
-            return await (await GetDbSetAsync()).AnyAsync(ir => ir.Id != expectedId && ir.Name == name, cancellationToken: cancellationToken);
+            return await (await GetDbSetAsync()).AnyAsync(ir => ir.Id != expectedId && ir.Name == name, GetCancellationToken(cancellationToken));
         }
     }
 }

--- a/modules/identityserver/src/Volo.Abp.IdentityServer.MongoDB/Volo/Abp/IdentityServer/MongoDB/MongoApiResourceRepository.cs
+++ b/modules/identityserver/src/Volo.Abp.IdentityServer.MongoDB/Volo/Abp/IdentityServer/MongoDB/MongoApiResourceRepository.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -21,9 +21,8 @@ namespace Volo.Abp.IdentityServer.MongoDB
         public async Task<ApiResource> FindByNameAsync(string apiResourceName, bool includeDetails = true, CancellationToken cancellationToken = default)
         {
             return await (await GetMongoQueryableAsync(cancellationToken))
-                .Where(ar => ar.Name == apiResourceName)
                 .OrderBy(ar => ar.Id)
-                .FirstOrDefaultAsync(GetCancellationToken(cancellationToken));
+                .FirstOrDefaultAsync(ar => ar.Name == apiResourceName, GetCancellationToken(cancellationToken));
         }
 
         public async Task<List<ApiResource>> FindByNameAsync(string[] apiResourceNames, bool includeDetails = true,

--- a/modules/identityserver/src/Volo.Abp.IdentityServer.MongoDB/Volo/Abp/IdentityServer/MongoDB/MongoApiScopeRepository.cs
+++ b/modules/identityserver/src/Volo.Abp.IdentityServer.MongoDB/Volo/Abp/IdentityServer/MongoDB/MongoApiScopeRepository.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -23,20 +23,17 @@ namespace Volo.Abp.IdentityServer.MongoDB
         public async Task<ApiScope> FindByNameAsync(string scopeName, bool includeDetails = true, CancellationToken cancellationToken = default)
         {
             return await (await GetMongoQueryableAsync(cancellationToken))
-                .Where(x => x.Name == scopeName)
                 .OrderBy(x => x.Id)
-                .FirstOrDefaultAsync(GetCancellationToken(cancellationToken));
+                .FirstOrDefaultAsync(x => x.Name == scopeName, GetCancellationToken(cancellationToken));
         }
 
         public async Task<List<ApiScope>> GetListByNameAsync(string[] scopeNames, bool includeDetails = false,
             CancellationToken cancellationToken = default)
         {
-            var query = from scope in (await GetMongoQueryableAsync(cancellationToken))
-                where scopeNames.Contains(scope.Name)
-                orderby scope.Id
-                select scope;
-
-            return await query.ToListAsync(GetCancellationToken(cancellationToken));
+            return await (await GetMongoQueryableAsync(cancellationToken))
+                .Where(scope => scopeNames.Contains(scope.Name))
+                .OrderBy(scope => scope.Id)
+                .ToListAsync(GetCancellationToken(cancellationToken));
         }
 
         public async Task<List<ApiScope>> GetListAsync(string sorting, int skipCount, int maxResultCount, string filter = null, bool includeDetails = false,

--- a/modules/identityserver/src/Volo.Abp.IdentityServer.MongoDB/Volo/Abp/IdentityServer/MongoDB/MongoClientRepository.cs
+++ b/modules/identityserver/src/Volo.Abp.IdentityServer.MongoDB/Volo/Abp/IdentityServer/MongoDB/MongoClientRepository.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -27,9 +27,8 @@ namespace Volo.Abp.IdentityServer.MongoDB
             CancellationToken cancellationToken = default)
         {
             return await (await GetMongoQueryableAsync(cancellationToken))
-                .Where(x => x.ClientId == clientId)
                 .OrderBy(x => x.Id)
-                .FirstOrDefaultAsync(GetCancellationToken(cancellationToken));
+                .FirstOrDefaultAsync(x => x.ClientId == clientId, GetCancellationToken(cancellationToken));
         }
 
         public virtual async Task<List<Client>> GetListAsync(
@@ -69,7 +68,7 @@ namespace Volo.Abp.IdentityServer.MongoDB
         public virtual async Task<bool> CheckClientIdExistAsync(string clientId, Guid? expectedId = null, CancellationToken cancellationToken = default)
         {
             return await (await GetMongoQueryableAsync(cancellationToken))
-                .AnyAsync(c => c.Id != expectedId && c.ClientId == clientId, cancellationToken: cancellationToken);
+                .AnyAsync(c => c.Id != expectedId && c.ClientId == clientId, GetCancellationToken(cancellationToken));
         }
     }
 }

--- a/modules/identityserver/src/Volo.Abp.IdentityServer.MongoDB/Volo/Abp/IdentityServer/MongoDB/MongoIdentityResourceRepository.cs
+++ b/modules/identityserver/src/Volo.Abp.IdentityServer.MongoDB/Volo/Abp/IdentityServer/MongoDB/MongoIdentityResourceRepository.cs
@@ -62,7 +62,7 @@ namespace Volo.Abp.IdentityServer.MongoDB
         public virtual async Task<bool> CheckNameExistAsync(string name, Guid? expectedId = null, CancellationToken cancellationToken = default)
         {
             return await (await GetMongoQueryableAsync(cancellationToken))
-                .AnyAsync(ir => ir.Id != expectedId && ir.Name == name, cancellationToken: cancellationToken);
+                .AnyAsync(ir => ir.Id != expectedId && ir.Name == name, GetCancellationToken(cancellationToken));
         }
     }
 }

--- a/modules/identityserver/test/Volo.Abp.IdentityServer.TestBase/Volo/Abp/IdentityServer/AbpIdentityServerTestDataBuilder.cs
+++ b/modules/identityserver/test/Volo.Abp.IdentityServer.TestBase/Volo/Abp/IdentityServer/AbpIdentityServerTestDataBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Guids;
@@ -149,7 +149,7 @@ namespace Volo.Abp.IdentityServer
 
             client.AddCorsOrigin("https://client1-origin.com");
             client.AddCorsOrigin("https://{0}.abp.io");
-            client.AddClaim(nameof(ClientClaim.Value), nameof(ClientClaim.Type));
+            client.AddClaim(nameof(ClientClaim.Type), nameof(ClientClaim.Value));
             client.AddGrantType(nameof(ClientGrantType.GrantType));
             client.AddIdentityProviderRestriction(nameof(ClientIdPRestriction.Provider));
             client.AddPostLogoutRedirectUri(nameof(ClientPostLogoutRedirectUri.PostLogoutRedirectUri));


### PR DESCRIPTION
There are 3 commits in this PR:

### [fix(identity-server): includeDetails of ApiScopeRepository.FindByNameAsync.](https://github.com/abpframework/abp/pull/10142/commits/52bc3bb57137934b3f1f4b4a64710a3e82c49e7e)
Fix the missing `includeDetails` in `ApiScopeRepository.FindByNameAsync` method.

### [chore(identity-server): some detailed improvements.](https://github.com/abpframework/abp/pull/10142/commits/3149f770eadb336fab2a6e31498300bb58249e51)
1. Use `base(id)` in constructor of entities if available.
2. Prevent some possible `NullReferenceException` in [`DeviceFlowStore`](https://github.com/abpframework/abp/pull/10142/commits/68a5bd64cd04f352b862ac4082bc32f3630c57b7#diff-e4ff39aa3f9a6a916bd0256b9eab7f798d6bb79ed69c7c6453c242694b619799).
3. Convert some LINQ from query syntax to method syntax.
4. Combine `.Where()` filter with `.FirstOrDefaultAsync()`.
5. Replace some `cancellationToken` with `GetCancellationToken(cancellationToken)`.

### [feat(identity-server): improve property and claim of Client.](https://github.com/abpframework/abp/pull/10142/commits/f6ef8e5ed221ccca2f3e6c53f44a316aeaa3fb3b)
1. Simply `ClientProperty` related methods in `Client` class.
The `Property` of other entities such as `ApiResourceProperty`, `ApiScopeProperty`, there are common domain methods such as `ApiScopeProperty FindProperty(string key)`, `void RemoveProperty(string key)`.
But in `Client` class, these methods need a extra argument `value`.
According to [this unit test of IdentityServer4](https://github.com/IdentityServer/IdentityServer4/blob/4.1.2/src/EntityFramework.Storage/test/UnitTests/Mappers/ClientMappersTests.cs#L67-L81), I got that the Client cannot have multiple properties with the same key.
So I think these methods should be unified, just drop the unnecessary `value` argument.

2. Sort the arguments of `ClientClaim`.
I change the arguments order from `value, type` to `type, value`. Because the `type` work like a `key`, it's different from `ApiResourceSecret.Type`.

3. Add some new API of `ClientClaim`.
- `void Client.RemoveClaim(string type)`
- `List<ClientClaim> Client.FindClaims(string type)`
It's different from `ClientProperty`. The `ClientClaim` can have multiple values with same type.

**Notice: This is a breaking change.**