### PR TITLE
Angular/FeatureManagement: Export `/models/index.ts` from `public-api.ts`

### DIFF
--- a/npm/ng-packs/packages/feature-management/src/public-api.ts
+++ b/npm/ng-packs/packages/feature-management/src/public-api.ts
@@ -2,3 +2,4 @@ export * from './lib/components';
 export * from './lib/directives';
 export * from './lib/enums/components';
 export * from './lib/feature-management.module';
+export * from './lib/models';


### PR DESCRIPTION
Exported the `FeatureManagement`-namespace to be able to use `FeatureManagementComponentInputs` + `FeatureManagementComponentOutputs` interfaces.