### PR TITLE
Update package.json to include the repository

### DIFF
--- a/npm/packs/aspnetcore.mvc.ui.theme.basic/package.json
+++ b/npm/packs/aspnetcore.mvc.ui.theme.basic/package.json
@@ -1,6 +1,11 @@
 {
   "version": "5.0.0-beta.1",
   "name": "@abp/aspnetcore.mvc.ui.theme.basic",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/abpframework/abp.git",
+    "directory": "npm/packs/aspnetcore.mvc.ui.theme.basic"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/npm/packs/aspnetcore.mvc.ui.theme.shared/package.json
+++ b/npm/packs/aspnetcore.mvc.ui.theme.shared/package.json
@@ -1,6 +1,11 @@
 {
   "version": "5.0.0-beta.1",
   "name": "@abp/aspnetcore.mvc.ui.theme.shared",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/abpframework/abp.git",
+    "directory": "npm/packs/aspnetcore.mvc.ui.theme.shared"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/npm/packs/aspnetcore.mvc.ui/package.json
+++ b/npm/packs/aspnetcore.mvc.ui/package.json
@@ -1,6 +1,11 @@
 {
   "version": "5.0.0-beta.1",
   "name": "@abp/aspnetcore.mvc.ui",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/abpframework/abp.git",
+    "directory": "npm/packs/aspnetcore.mvc.ui"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/npm/packs/bootstrap-datepicker/package.json
+++ b/npm/packs/bootstrap-datepicker/package.json
@@ -1,6 +1,11 @@
 {
   "version": "5.0.0-beta.1",
   "name": "@abp/bootstrap-datepicker",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/abpframework/abp.git",
+    "directory": "npm/packs/bootstrap-datepicker"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/npm/packs/bootstrap/package.json
+++ b/npm/packs/bootstrap/package.json
@@ -1,6 +1,11 @@
 {
   "version": "5.0.0-beta.1",
   "name": "@abp/bootstrap",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/abpframework/abp.git",
+    "directory": "npm/packs/bootstrap"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/npm/packs/core/package.json
+++ b/npm/packs/core/package.json
@@ -1,6 +1,11 @@
 {
   "version": "5.0.0-beta.1",
   "name": "@abp/core",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/abpframework/abp.git",
+    "directory": "npm/packs/core"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/npm/packs/datatables.net-bs4/package.json
+++ b/npm/packs/datatables.net-bs4/package.json
@@ -1,6 +1,11 @@
 {
   "version": "5.0.0-beta.1",
   "name": "@abp/datatables.net-bs4",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/abpframework/abp.git",
+    "directory": "npm/packs/datatables.net-bs4"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/npm/packs/datatables.net/package.json
+++ b/npm/packs/datatables.net/package.json
@@ -1,6 +1,11 @@
 {
   "version": "5.0.0-beta.1",
   "name": "@abp/datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/abpframework/abp.git",
+    "directory": "npm/packs/datatables.net"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/npm/packs/font-awesome/package.json
+++ b/npm/packs/font-awesome/package.json
@@ -1,6 +1,11 @@
 {
   "version": "5.0.0-beta.1",
   "name": "@abp/font-awesome",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/abpframework/abp.git",
+    "directory": "npm/packs/font-awesome"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/npm/packs/jquery-form/package.json
+++ b/npm/packs/jquery-form/package.json
@@ -1,6 +1,11 @@
 {
   "version": "5.0.0-beta.1",
   "name": "@abp/jquery-form",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/abpframework/abp.git",
+    "directory": "npm/packs/jquery-form"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/npm/packs/jquery-validation-unobtrusive/package.json
+++ b/npm/packs/jquery-validation-unobtrusive/package.json
@@ -1,6 +1,11 @@
 {
   "version": "5.0.0-beta.1",
   "name": "@abp/jquery-validation-unobtrusive",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/abpframework/abp.git",
+    "directory": "npm/packs/jquery-validation-unobtrusive"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/npm/packs/jquery-validation/package.json
+++ b/npm/packs/jquery-validation/package.json
@@ -1,6 +1,11 @@
 {
   "version": "5.0.0-beta.1",
   "name": "@abp/jquery-validation",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/abpframework/abp.git",
+    "directory": "npm/packs/jquery-validation"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/npm/packs/jquery/package.json
+++ b/npm/packs/jquery/package.json
@@ -1,6 +1,11 @@
 {
   "version": "5.0.0-beta.1",
   "name": "@abp/jquery",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/abpframework/abp.git",
+    "directory": "npm/packs/jquery"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/npm/packs/lodash/package.json
+++ b/npm/packs/lodash/package.json
@@ -1,6 +1,11 @@
 {
   "version": "5.0.0-beta.1",
   "name": "@abp/lodash",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/abpframework/abp.git",
+    "directory": "npm/packs/lodash"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/npm/packs/luxon/package.json
+++ b/npm/packs/luxon/package.json
@@ -1,6 +1,11 @@
 {
   "version": "5.0.0-beta.1",
   "name": "@abp/luxon",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/abpframework/abp.git",
+    "directory": "npm/packs/luxon"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/npm/packs/malihu-custom-scrollbar-plugin/package.json
+++ b/npm/packs/malihu-custom-scrollbar-plugin/package.json
@@ -1,6 +1,11 @@
 {
   "version": "5.0.0-beta.1",
   "name": "@abp/malihu-custom-scrollbar-plugin",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/abpframework/abp.git",
+    "directory": "npm/packs/malihu-custom-scrollbar-plugin"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/npm/packs/select2/package.json
+++ b/npm/packs/select2/package.json
@@ -1,6 +1,11 @@
 {
   "version": "5.0.0-beta.1",
   "name": "@abp/select2",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/abpframework/abp.git",
+    "directory": "npm/packs/select2"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/npm/packs/sweetalert2/package.json
+++ b/npm/packs/sweetalert2/package.json
@@ -4,6 +4,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/abpframework/abp.git",
+    "directory":"npm/packs/sweetalert2"
+  },
   "dependencies": {
     "@abp/core": "~5.0.0-beta.1",
     "sweetalert2": "^11.0.18"

--- a/npm/packs/timeago/package.json
+++ b/npm/packs/timeago/package.json
@@ -1,6 +1,11 @@
 {
   "version": "5.0.0-beta.1",
   "name": "@abp/timeago",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/abpframework/abp.git",
+    "directory": "npm/packs/timeago"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/npm/packs/toastr/package.json
+++ b/npm/packs/toastr/package.json
@@ -1,6 +1,11 @@
 {
   "version": "5.0.0-beta.1",
   "name": "@abp/toastr",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/abpframework/abp.git",
+    "directory": "npm/packs/toastr"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/npm/packs/utils/package.json
+++ b/npm/packs/utils/package.json
@@ -13,6 +13,11 @@
     "access": "public"
   },
   "main": "dist/bundles/abp-utils.umd.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/abpframework/abp.git",
+    "directory": "npm/packs/utils"
+  },
   "module": "dist/fesm2015/abp-utils.js",
   "es2015_ivy_ngcc": "__ivy_ngcc__/dist/fesm2015/abp-utils.js",
   "es2015": "dist/fesm2015/abp-utils.js",


### PR DESCRIPTION
Hi there!
This change adds the repository property to your package.json file(s). Having this available provides a number of benefits to security tooling. For example, it allows for greater trust by checking for signed commits, contributors to a release and validating history with the project. It also allows for comparison between the source code and the published artifact in order to detect attacks on authors during the publication process.
We validate that we're making a PR against the correct repository by comparing the metadata for the published artifact on [npmjs.com](www.npmjs.com) against the metadata in the package.json file in the repository.
This change is provided by a team at Microsoft -- we're happy to answer any questions you may have. (Members of this team include [@s-tuli](https://github.com/s-tuli), [@iarna](https://github.com/iarna), [@rancyr](https://github.com/v-rr), [@Jaydon Peng](https://github.com/v-jiepeng), [@Zhongpeng Zhou](https://github.com/v-zhzhou) and [@Jingying Gu](https://github.com/v-gjy)). If you would prefer that we not make these sorts of PRs to projects you maintain, please just say. If you'd like to learn more about what we're doing here, we've prepared a document talking about both this project and some of our other activities around supply chain security here: [microsoft/Secure-Supply-Chain](https://github.com/microsoft/Secure-Supply-Chain)
This PR provides repository metadata for the following packages:
* @abp/utils
* @abp/toastr
* @abp/timeago
* @abp/sweetalert
* @abp/select2
* @abp/malihu-custom-scrollbar-plugin
* @abp/luxon
* @abp/lodash
* @abp/jquery-validation-unobtrusive
* @abp/jquery-validation
* @abp/jquery-form
* @abp/jquery
* @abp/font-awesome
* @abp/datatables.net-bs4
* @abp/datatables.net
* @abp/core
* @abp/bootstrap-datepicker
* @abp/bootstrap
* @abp/aspnetcore.mvc.ui.theme.shared
* @abp/aspnetcore.mvc.ui.theme.basic
* @abp/aspnetcore.mvc.ui