### PR TITLE
Enhance the error that occurs during the http request.

### DIFF
--- a/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/AspNetCore/ExceptionHandling/DefaultExceptionToErrorInfoConverter.cs
+++ b/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/AspNetCore/ExceptionHandling/DefaultExceptionToErrorInfoConverter.cs
@@ -42,7 +42,7 @@ namespace Volo.Abp.AspNetCore.ExceptionHandling
         {
             var errorInfo = CreateErrorInfoWithoutCode(exception, includeSensitiveDetails);
 
-            if (exception is IHasErrorCode hasErrorCodeException && hasErrorCodeException.Code.IsNullOrWhiteSpace())
+            if (exception is IHasErrorCode hasErrorCodeException)
             {
                 errorInfo.Code = hasErrorCodeException.Code;
             }

--- a/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/AspNetCore/ExceptionHandling/DefaultExceptionToErrorInfoConverter.cs
+++ b/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/AspNetCore/ExceptionHandling/DefaultExceptionToErrorInfoConverter.cs
@@ -42,7 +42,7 @@ namespace Volo.Abp.AspNetCore.ExceptionHandling
         {
             var errorInfo = CreateErrorInfoWithoutCode(exception, includeSensitiveDetails);
 
-            if (exception is IHasErrorCode hasErrorCodeException)
+            if (exception is IHasErrorCode hasErrorCodeException && hasErrorCodeException.Code.IsNullOrWhiteSpace())
             {
                 errorInfo.Code = hasErrorCodeException.Code;
             }
@@ -61,7 +61,7 @@ namespace Volo.Abp.AspNetCore.ExceptionHandling
 
             if (exception is AbpRemoteCallException remoteCallException)
             {
-                return remoteCallException.Error;
+                return remoteCallException.Error ?? new RemoteServiceErrorInfo(remoteCallException.Message);
             }
 
             if (exception is AbpDbConcurrencyException)
@@ -175,7 +175,7 @@ namespace Volo.Abp.AspNetCore.ExceptionHandling
 
             return new RemoteServiceErrorInfo(exception.Message);
         }
-        
+
         protected virtual Exception TryToGetActualException(Exception exception)
         {
             if (exception is AggregateException && exception.InnerException != null)

--- a/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/AspNetCore/ExceptionHandling/DefaultExceptionToErrorInfoConverter.cs
+++ b/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/AspNetCore/ExceptionHandling/DefaultExceptionToErrorInfoConverter.cs
@@ -59,9 +59,9 @@ namespace Volo.Abp.AspNetCore.ExceptionHandling
 
             exception = TryToGetActualException(exception);
 
-            if (exception is AbpRemoteCallException remoteCallException)
+            if (exception is AbpRemoteCallException remoteCallException && remoteCallException.Error != null)
             {
-                return remoteCallException.Error ?? new RemoteServiceErrorInfo(remoteCallException.Message);
+                return remoteCallException.Error;
             }
 
             if (exception is AbpDbConcurrencyException)
@@ -76,7 +76,7 @@ namespace Volo.Abp.AspNetCore.ExceptionHandling
 
             var errorInfo = new RemoteServiceErrorInfo();
 
-            if (exception is IUserFriendlyException)
+            if (exception is IUserFriendlyException || exception is AbpRemoteCallException)
             {
                 errorInfo.Message = exception.Message;
                 errorInfo.Details = (exception as IHasErrorDetails)?.Details;

--- a/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/Http/Client/AbpRemoteCallException.cs
+++ b/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/Http/Client/AbpRemoteCallException.cs
@@ -15,7 +15,14 @@ namespace Volo.Abp.Http.Client
 
         public RemoteServiceErrorInfo Error { get; set; }
 
-        public AbpRemoteCallException()
+        public AbpRemoteCallException(string message)
+            : base(message)
+        {
+
+        }
+
+        public AbpRemoteCallException(string message, Exception innerException)
+            : base(message, innerException)
         {
 
         }

--- a/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/Http/Client/AbpRemoteCallException.cs
+++ b/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/Http/Client/AbpRemoteCallException.cs
@@ -15,13 +15,7 @@ namespace Volo.Abp.Http.Client
 
         public RemoteServiceErrorInfo Error { get; set; }
 
-        public AbpRemoteCallException(string message)
-            : base(message)
-        {
-
-        }
-
-        public AbpRemoteCallException(string message, Exception innerException)
+        public AbpRemoteCallException(string message, Exception innerException = null)
             : base(message, innerException)
         {
 

--- a/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/Http/Client/AbpRemoteCallException.cs
+++ b/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/Http/Client/AbpRemoteCallException.cs
@@ -15,6 +15,11 @@ namespace Volo.Abp.Http.Client
 
         public RemoteServiceErrorInfo Error { get; set; }
 
+        public AbpRemoteCallException()
+        {
+
+        }
+
         public AbpRemoteCallException(string message, Exception innerException = null)
             : base(message, innerException)
         {

--- a/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/Http/Client/AbpRemoteCallException.cs
+++ b/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/Http/Client/AbpRemoteCallException.cs
@@ -33,8 +33,8 @@ namespace Volo.Abp.Http.Client
 
         }
 
-        public AbpRemoteCallException(RemoteServiceErrorInfo error)
-            : base(error.Message)
+        public AbpRemoteCallException(RemoteServiceErrorInfo error, Exception innerException = null)
+            : base(error.Message, innerException)
         {
             Error = error;
 

--- a/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/ClientProxying/ClientProxyBase.cs
+++ b/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/ClientProxying/ClientProxyBase.cs
@@ -6,8 +6,6 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Volo.Abp.Content;
@@ -28,7 +26,6 @@ namespace Volo.Abp.Http.Client.ClientProxying
     {
         public IAbpLazyServiceProvider LazyServiceProvider { get; set; }
 
-        protected ILogger<ClientProxyBase<TService>> Logger => LazyServiceProvider.LazyGetService<ILogger<ClientProxyBase<TService>>>(NullLogger<ClientProxyBase<TService>>.Instance);
         protected IClientProxyApiDescriptionFinder ClientProxyApiDescriptionFinder => LazyServiceProvider.LazyGetRequiredService<IClientProxyApiDescriptionFinder>();
         protected ICancellationTokenProvider CancellationTokenProvider => LazyServiceProvider.LazyGetRequiredService<ICancellationTokenProvider>();
         protected ICorrelationIdProvider CorrelationIdProvider => LazyServiceProvider.LazyGetRequiredService<ICorrelationIdProvider>();

--- a/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/ClientProxying/ClientProxyBase.cs
+++ b/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/ClientProxying/ClientProxyBase.cs
@@ -132,11 +132,20 @@ namespace Volo.Abp.Http.Client.ClientProxying
                 );
             }
 
-            var response = await client.SendAsync(
-                requestMessage,
-                HttpCompletionOption.ResponseHeadersRead /*this will buffer only the headers, the content will be used as a stream*/,
-                GetCancellationToken(requestContext.Arguments)
-            );
+            HttpResponseMessage response;
+            try
+            {
+                response = await client.SendAsync(
+                    requestMessage,
+                    HttpCompletionOption
+                        .ResponseHeadersRead /*this will buffer only the headers, the content will be used as a stream*/,
+                    GetCancellationToken(requestContext.Arguments)
+                );
+            }
+            catch (Exception ex)
+            {
+                throw new AbpRemoteCallException($"An error occurred during the ABP remote HTTP request. ({ex.Message}) See the inner exception for details.", ex);
+            }
 
             if (!response.IsSuccessStatusCode)
             {

--- a/framework/test/Volo.Abp.Http.Client.Tests/Volo/Abp/Http/DynamicProxying/RegularTestControllerClientProxy_AbpRemoteCallException_Tests.cs
+++ b/framework/test/Volo.Abp.Http.Client.Tests/Volo/Abp/Http/DynamicProxying/RegularTestControllerClientProxy_AbpRemoteCallException_Tests.cs
@@ -1,0 +1,61 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Volo.Abp.AspNetCore.TestBase;
+using Volo.Abp.Http.Client;
+using Volo.Abp.Http.Client.Proxying;
+using Xunit;
+
+namespace Volo.Abp.Http.DynamicProxying
+{
+    public class RegularTestControllerClientProxy_AbpRemoteCallException_Tests : AbpHttpClientTestBase
+    {
+        private readonly IRegularTestController _controller;
+
+        public RegularTestControllerClientProxy_AbpRemoteCallException_Tests()
+        {
+            _controller = ServiceProvider.GetRequiredService<IRegularTestController>();
+        }
+
+        protected override void ConfigureServices(HostBuilderContext context, IServiceCollection services)
+        {
+            services.Replace(ServiceDescriptor.Singleton<IProxyHttpClientFactory, TestProxyHttpClientFactory>());
+        }
+
+        [Fact]
+        public async Task AbpRemoteCallException_On_SendAsync_Test()
+        {
+            var exception = await Assert.ThrowsAsync<AbpRemoteCallException>(async () => await _controller.AbortRequestAsync(default));
+            exception.Message.ShouldContain("An error occurred during the ABP remote HTTP request.");
+        }
+
+        class TestProxyHttpClientFactory : IProxyHttpClientFactory
+        {
+            private readonly ITestServerAccessor _testServerAccessor;
+
+            private int _count;
+
+            public TestProxyHttpClientFactory(ITestServerAccessor testServerAccessor)
+            {
+                _testServerAccessor = testServerAccessor;
+            }
+
+            public HttpClient Create(string name) => Create();
+
+            public HttpClient Create()
+            {
+                if (_count++ > 0)
+                {
+                    //Will get an error on the SendAsync method.
+                    return new HttpClient();
+                }
+
+                // for DynamicHttpProxyInterceptor.GetActionApiDescriptionModel
+                return _testServerAccessor.Server.CreateClient();
+            }
+        }
+    }
+}

--- a/framework/test/Volo.Abp.Http.Client.Tests/Volo/Abp/Http/DynamicProxying/RegularTestControllerClientProxy_Tests.cs
+++ b/framework/test/Volo.Abp.Http.Client.Tests/Volo/Abp/Http/DynamicProxying/RegularTestControllerClientProxy_Tests.cs
@@ -168,8 +168,8 @@ namespace Volo.Abp.Http.DynamicProxying
             var result = await _controller.AbortRequestAsync(default);
             result.ShouldBe("AbortRequestAsync");
 
-            var exception = await Assert.ThrowsAsync<HttpRequestException>(async () => await _controller.AbortRequestAsync(cts.Token));
-            exception.InnerException.InnerException.Message.ShouldBe("The client aborted the request.");
+            var exception = await Assert.ThrowsAsync<AbpRemoteCallException>(async () => await _controller.AbortRequestAsync(cts.Token));
+            exception.InnerException.InnerException.InnerException.Message.ShouldBe("The client aborted the request.");
         }
     }
 }


### PR DESCRIPTION
```
[INF] Sending HTTP request GET https://localhost:44300/api/multi-tenancy/tenants
[ERR] ---------- RemoteServiceErrorInfo ----------
{
  "code": null,
  "message": "An error occurred during the ABP remote HTTP request. (No connection could be made because the target machine actively refused it. (localhost:44300)) See the inner exception for details.",
  "details": null,
  "data": {},
  "validationErrors": null
}

```