### PR TITLE
fix select2 if modal doesn't exist

### DIFF
--- a/npm/packs/select2/src/select2-bootstrap-modal-patch.js
+++ b/npm/packs/select2/src/select2-bootstrap-modal-patch.js
@@ -1,4 +1,6 @@
 /*
     https://select2.org/troubleshooting/common-problems
 */
-$.fn.modal.Constructor.prototype._enforceFocus = function () { };
+if ($.fn.modal) {
+    $.fn.modal.Constructor.prototype._enforceFocus = function () { };
+}


### PR DESCRIPTION
When I try to use Select2ScriptContributor without bootstrap-modal I get Cannot read properties of undefined (reading 'Constructor') error.