### PR TITLE
Automatically set TenantId while creating a new entity object.

### DIFF
--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Entities/Entity.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Entities/Entity.cs
@@ -7,6 +7,11 @@ namespace Volo.Abp.Domain.Entities
     [Serializable]
     public abstract class Entity : IEntity
     {
+        protected Entity()
+        {
+            EntityHelper.TrySetTenantId(this);
+        }
+        
         /// <inheritdoc/>
         public override string ToString()
         {

--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Entities/EntityHelper.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Entities/EntityHelper.cs
@@ -265,5 +265,25 @@ namespace Volo.Abp.Domain.Entities
                     ? new Type[] { typeof(DisableIdGenerationAttribute) }
                     : new Type[] { });
         }
+
+        public static void TrySetTenantId(IEntity entity)
+        {
+            if (entity is not IMultiTenant multiTenantEntity)
+            {
+                return;
+            }
+
+            var tenantId = AsyncLocalCurrentTenantAccessor.Instance.Current?.TenantId;
+            if (tenantId == multiTenantEntity.TenantId)
+            {
+                return;
+            }
+
+            ObjectHelper.TrySetProperty(
+                multiTenantEntity,
+                x => x.TenantId,
+                () => tenantId
+            );
+        }
     }
 }

--- a/framework/src/Volo.Abp.MultiTenancy/Volo/Abp/MultiTenancy/AbpMultiTenancyModule.cs
+++ b/framework/src/Volo.Abp.MultiTenancy/Volo/Abp/MultiTenancy/AbpMultiTenancyModule.cs
@@ -18,6 +18,8 @@ namespace Volo.Abp.MultiTenancy
     {
         public override void ConfigureServices(ServiceConfigurationContext context)
         {
+            context.Services.AddSingleton<ICurrentTenantAccessor>(AsyncLocalCurrentTenantAccessor.Instance);
+            
             var configuration = context.Services.GetConfiguration();
             Configure<AbpDefaultTenantStoreOptions>(configuration);
         }

--- a/framework/src/Volo.Abp.MultiTenancy/Volo/Abp/MultiTenancy/AsyncLocalCurrentTenantAccessor.cs
+++ b/framework/src/Volo.Abp.MultiTenancy/Volo/Abp/MultiTenancy/AsyncLocalCurrentTenantAccessor.cs
@@ -3,8 +3,10 @@ using Volo.Abp.DependencyInjection;
 
 namespace Volo.Abp.MultiTenancy
 {
-    public class AsyncLocalCurrentTenantAccessor : ICurrentTenantAccessor, ISingletonDependency
+    public class AsyncLocalCurrentTenantAccessor : ICurrentTenantAccessor
     {
+        public static AsyncLocalCurrentTenantAccessor Instance { get; } = new();
+        
         public BasicTenantInfo Current
         {
             get => _currentScope.Value;
@@ -13,7 +15,7 @@ namespace Volo.Abp.MultiTenancy
 
         private readonly AsyncLocal<BasicTenantInfo> _currentScope;
 
-        public AsyncLocalCurrentTenantAccessor()
+        private AsyncLocalCurrentTenantAccessor()
         {
             _currentScope = new AsyncLocal<BasicTenantInfo>();
         }

--- a/framework/test/Volo.Abp.Ddd.Tests/Volo/Abp/Domain/Entities/Entity_Tests.cs
+++ b/framework/test/Volo.Abp.Ddd.Tests/Volo/Abp/Domain/Entities/Entity_Tests.cs
@@ -74,6 +74,23 @@ namespace Volo.Abp.Domain.Entities
             new Car(42, tenantId1).EntityEquals(new Car(42, tenantId1)).ShouldBeTrue();
         }
 
+        [Fact]
+        public void Should_Set_TenantId_On_Object_Creation()
+        {
+            var tenantId = Guid.NewGuid();
+            AsyncLocalCurrentTenantAccessor.Instance.Current = new BasicTenantInfo(tenantId);
+            new Car().TenantId.ShouldBe(tenantId);
+        }
+        
+        [Fact]
+        public void Should_Override_TenantId_Manually()
+        {
+            AsyncLocalCurrentTenantAccessor.Instance.Current = null;
+            
+            var tenantId = Guid.NewGuid();
+            new Car(0, tenantId).TenantId.ShouldBe(tenantId);
+        }
+
         public class Person : Entity<Guid>
         {
             public Person()
@@ -88,7 +105,7 @@ namespace Volo.Abp.Domain.Entities
 
         public class Car : Entity<int>, IMultiTenant
         {
-            public Guid? TenantId { get; }
+            public Guid? TenantId { get; private set; }
 
             public Car()
             {

--- a/framework/test/Volo.Abp.TestApp.Tests/Volo/Abp/TestApp/Application/PersonAppService_Tests.cs
+++ b/framework/test/Volo.Abp.TestApp.Tests/Volo/Abp/TestApp/Application/PersonAppService_Tests.cs
@@ -57,7 +57,7 @@ namespace Volo.Abp.TestApp.Application
             var uniquePersonName = Guid.NewGuid().ToString();
             var personDto = await _peopleAppService.CreateAsync(new PersonDto {Name = uniquePersonName});
 
-            var repository = ServiceProvider.GetService<IRepository<Person, Guid>>();
+            var repository = ServiceProvider.GetRequiredService<IRepository<Person, Guid>>();
             var person = await repository.FindAsync(personDto.Id);
 
             person.ShouldNotBeNull();


### PR DESCRIPTION
Previously ABP leaves it to the developer to set the right `TenantId` for a multi-tenant entity on object creation. With this change, it automatically sets the value from the current context.