### PR TITLE
EF Mysql Changed ServerVersion.FromString to ServerVersion.Parse

### DIFF
--- a/docs/en/Entity-Framework-Core-MySQL.md
+++ b/docs/en/Entity-Framework-Core-MySQL.md
@@ -15,7 +15,7 @@ Find ***YourProjectName*EntityFrameworkCoreModule** class inside the `.EntityFra
 Find `UseSqlServer()` calls in your solution. Check the following files:
 
 * *YourProjectName*EntityFrameworkCoreModule.cs inside the `.EntityFrameworkCore` project. Replace `UseSqlServer()` with `UseMySQL()`.
-* *YourProjectName*DbContextFactory.cs inside the `.EntityFrameworkCore` project. Replace `UseSqlServer()` with `UseMySql()`. Then add a new parameter (`ServerVersion`) to `UseMySql()` method. Example: `.UseMySql(configuration.GetConnectionString("Default"), ServerVersion.FromString("8.0.21-mysql"))`. See [this issue](https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/pull/1233) for more information about `ServerVersion`)
+* *YourProjectName*DbContextFactory.cs inside the `.EntityFrameworkCore` project. Replace `UseSqlServer()` with `UseMySql()`. Then add a new parameter (`ServerVersion`) to `UseMySql()` method. Example: `.UseMySql(configuration.GetConnectionString("Default"), ServerVersion.Parse("8.0.21-mysql"))`. See [this issue](https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/pull/1233) for more information about `ServerVersion`)
 
 > Depending on your solution structure, you may find more code files need to be changed.
 


### PR DESCRIPTION
as [this change](https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/commit/6aac749dc0190cd16e3869f05dee4694eafdf75f?diff=split)

I don't know which version it changed ,but in abp v4.4.3,  it changed
ServerVersion.FromString to  ServerVersion.Parse