### PR TITLE
Allow using master and dev branch names as version names

### DIFF
--- a/modules/docs/src/Volo.Docs.Domain.Shared/Volo/Docs/Documents/Version/SemanticVersionHelper.cs
+++ b/modules/docs/src/Volo.Docs.Domain.Shared/Volo/Docs/Documents/Version/SemanticVersionHelper.cs
@@ -26,6 +26,11 @@ namespace Volo.Docs.GitHub.Documents.Version
 
         private static string NormalizeVersion(string version)
         {
+            if (version == "master" || version == "dev")
+            {
+                return version;
+            }
+            
             version = version.RemovePreFix("v");
 
             var normalizedVersion = "";


### PR DESCRIPTION
This will keep backward compatibility for docs.aspnetzero.com