### PR TITLE
`abp add-module` command doesn't work for `blazor-server` project

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Bundling/BundlingService.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Bundling/BundlingService.cs
@@ -284,7 +284,6 @@ namespace Volo.Abp.Cli.Bundling
         {
             var document = new XmlDocument();
             document.Load(projectFilePath);
-            CheckProjectIsSupportedType(document);
 
             return document.SelectSingleNode("//TargetFramework").InnerText;
         }
@@ -293,11 +292,7 @@ namespace Volo.Abp.Cli.Bundling
         {
             var document = new XmlDocument();
             document.Load(projectFilePath);
-            CheckProjectIsSupportedType(document);
-        }
-
-        private void CheckProjectIsSupportedType(XmlDocument document)
-        {
+            
             var sdk = document.DocumentElement.GetAttribute("Sdk");
             if (sdk != BundlingConsts.SupportedWebAssemblyProjectType)
             {

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Bundling/BundlingService.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Bundling/BundlingService.cs
@@ -39,6 +39,8 @@ namespace Volo.Abp.Cli.Bundling
             }
 
             var projectFilePath = projectFiles[0];
+            
+            CheckProjectIsSupportedType(projectFilePath);
 
             var config = ConfigReader.Read(PathHelper.GetWwwRootPath(directory));
             var bundleConfig = config.Bundle;
@@ -282,14 +284,26 @@ namespace Volo.Abp.Cli.Bundling
         {
             var document = new XmlDocument();
             document.Load(projectFilePath);
+            CheckProjectIsSupportedType(document);
+
+            return document.SelectSingleNode("//TargetFramework").InnerText;
+        }
+
+        private void CheckProjectIsSupportedType(string projectFilePath)
+        {
+            var document = new XmlDocument();
+            document.Load(projectFilePath);
+            CheckProjectIsSupportedType(document);
+        }
+
+        private void CheckProjectIsSupportedType(XmlDocument document)
+        {
             var sdk = document.DocumentElement.GetAttribute("Sdk");
             if (sdk != BundlingConsts.SupportedWebAssemblyProjectType)
             {
                 throw new BundlingException(
                     $"Unsupported project type. Project type must be {BundlingConsts.SupportedWebAssemblyProjectType}.");
             }
-
-            return document.SelectSingleNode("//TargetFramework").InnerText;
         }
     }
 }

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/SolutionModuleAdder.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/SolutionModuleAdder.cs
@@ -7,8 +7,10 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using System.Xml;
 using NuGet.Versioning;
 using Volo.Abp.Cli.Args;
+using Volo.Abp.Cli.Bundling;
 using Volo.Abp.Cli.Commands;
 using Volo.Abp.Cli.Commands.Services;
 using Volo.Abp.Cli.Http;
@@ -181,6 +183,14 @@ namespace Volo.Abp.Cli.ProjectModification
             var blazorProject = projectFiles.FirstOrDefault(f => f.EndsWith(".Blazor.csproj"));
 
             if (blazorProject == null || !module.NugetPackages.Any(np => np.Target == NuGetPackageTarget.Blazor))
+            {
+                return;
+            }
+            // return if project is blazor-server
+            var document = new XmlDocument();
+            document.Load(blazorProject);
+            var sdk = document.DocumentElement.GetAttribute("Sdk");
+            if (sdk != BundlingConsts.SupportedWebAssemblyProjectType)
             {
                 return;
             }


### PR DESCRIPTION
In the `Blazor-Server` project, `abp bundle` command is run, but this command only supports `Blazor-Wasm` projects, so `abp add-module` command will not work in `Blazor-Server` project. Also, when the `abp-bundle` command is project `Blazor-Server`, it throws an error like the picture below, but this error is not descriptive. 

<img width="826" alt="Screen Shot 2021-11-09 at 10 46 38" src="https://user-images.githubusercontent.com/31216880/140883627-b31b09dc-11ab-4cc1-9350-df345dc94280.png">

That's why I made also changes on the `abp bundle` command.