### PR TITLE
Update Setting-Management.md

### DIFF
--- a/docs/en/Modules/Setting-Management.md
+++ b/docs/en/Modules/Setting-Management.md
@@ -88,7 +88,7 @@ Setting Management module is extensible, just like the [setting system](../Setti
 If you want to create your own provider, implement the `ISettingManagementProvider` interface or inherit from the `SettingManagementProvider` base class:
 
 ````csharp
-public class CustomSettingProvider : SettingManagementProvider
+public class CustomSettingProvider : SettingManagementProvider, ITransientDependency
 {
     public override string Name => "Custom";
 


### PR DESCRIPTION
Added 'ITransientDependency' interface to CustomSettingProvider class, so the following exception will not be thrown:
ComponentNotRegisteredException: The requested service 'CustomSettingProvider' has not been registered.