### PR TITLE
Use `targetDbContextType` instead of `TMongoDbContext`.

### DIFF
--- a/framework/src/Volo.Abp.MongoDB/Volo/Abp/Uow/MongoDB/UnitOfWorkMongoDbContextProvider.cs
+++ b/framework/src/Volo.Abp.MongoDB/Volo/Abp/Uow/MongoDB/UnitOfWorkMongoDbContextProvider.cs
@@ -70,7 +70,7 @@ namespace Volo.Abp.Uow.MongoDB
             var databaseName = mongoUrl.DatabaseName;
             if (databaseName.IsNullOrWhiteSpace())
             {
-                databaseName = ConnectionStringNameAttribute.GetConnStringName<TMongoDbContext>();
+                databaseName = ConnectionStringNameAttribute.GetConnStringName(targetDbContextType);
             }
 
             //TODO: Create only single MongoDbClient per connection string in an application (extract MongoClientCache for example).
@@ -98,7 +98,7 @@ namespace Volo.Abp.Uow.MongoDB
             var databaseName = mongoUrl.DatabaseName;
             if (databaseName.IsNullOrWhiteSpace())
             {
-                databaseName = ConnectionStringNameAttribute.GetConnStringName<TMongoDbContext>();
+                databaseName = ConnectionStringNameAttribute.GetConnStringName(targetDbContextType);
             }
 
             //TODO: Create only single MongoDbClient per connection string in an application (extract MongoClientCache for example).


### PR DESCRIPTION
Resolve #10652


```cs
context.Services.AddMongoDbContext<IdentityServiceMongoDbContext>(options =>
{
    options.ReplaceDbContext<IAbpIdentityMongoDbContext>(); 
    options.ReplaceDbContext<IAbpIdentityServerMongoDbContext>();

    options.AddDefaultRepositories(includeAllEntities: true);
});

IdentityService
ConnectionStringNameAttribute.GetConnStringName<IdentityServiceMongoDbContext>()

AbpIdentity
ConnectionStringNameAttribute.GetConnStringName<IAbpIdentityMongoDbContext>() 

AbpIdentityServer
ConnectionStringNameAttribute.GetConnStringName<IAbpIdentityServerMongoDbContext>() 
```