### PR TITLE
Fix attributes on PermissionDefinitionContext

### DIFF
--- a/framework/src/Volo.Abp.Authorization.Abstractions/Volo/Abp/Authorization/Permissions/IPermissionDefinitionContext.cs
+++ b/framework/src/Volo.Abp.Authorization.Abstractions/Volo/Abp/Authorization/Permissions/IPermissionDefinitionContext.cs
@@ -17,6 +17,7 @@ namespace Volo.Abp.Authorization.Permissions
         /// </summary>
         /// <param name="name">Name of the group</param>
         /// <returns></returns>
+		[NotNull]
         PermissionGroupDefinition GetGroup([NotNull] string name);
 
         /// <summary>
@@ -25,14 +26,14 @@ namespace Volo.Abp.Authorization.Permissions
         /// </summary>
         /// <param name="name">Name of the group</param>
         /// <returns></returns>
-        [NotNull]
-        PermissionGroupDefinition GetGroupOrNull(string name);
+		[CanBeNull]
+		PermissionGroupDefinition GetGroupOrNull([NotNull] string name);
 
-        [CanBeNull]
-        PermissionGroupDefinition AddGroup(
-            [NotNull] string name, 
-            ILocalizableString displayName = null,
-            MultiTenancySides multiTenancySide = MultiTenancySides.Both);
+		[NotNull]
+		PermissionGroupDefinition AddGroup(
+			[NotNull] string name, 
+			ILocalizableString displayName = null,
+			MultiTenancySides multiTenancySide = MultiTenancySides.Both);
 
         void RemoveGroup(string name);
 

--- a/framework/src/Volo.Abp.Authorization.Abstractions/Volo/Abp/Authorization/Permissions/PermissionDefinitionContext.cs
+++ b/framework/src/Volo.Abp.Authorization.Abstractions/Volo/Abp/Authorization/Permissions/PermissionDefinitionContext.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using JetBrains.Annotations;
 using Volo.Abp.Localization;
 using Volo.Abp.MultiTenancy;
 
@@ -33,8 +32,7 @@ namespace Volo.Abp.Authorization.Permissions
             return Groups[name] = new PermissionGroupDefinition(name, displayName, multiTenancySide);
         }
 
-        [NotNull]
-        public virtual PermissionGroupDefinition GetGroup([NotNull] string name)
+        public virtual PermissionGroupDefinition GetGroup(string name)
         {
             var group = GetGroupOrNull(name);
 
@@ -46,7 +44,7 @@ namespace Volo.Abp.Authorization.Permissions
             return group;
         }
 
-        public virtual PermissionGroupDefinition GetGroupOrNull([NotNull] string name)
+        public virtual PermissionGroupDefinition GetGroupOrNull(string name)
         {
             Check.NotNull(name, nameof(name));
 
@@ -70,7 +68,7 @@ namespace Volo.Abp.Authorization.Permissions
             Groups.Remove(name);
         }
 
-        public virtual PermissionDefinition GetPermissionOrNull([NotNull] string name)
+        public virtual PermissionDefinition GetPermissionOrNull(string name)
         {
             Check.NotNull(name, nameof(name));
 


### PR DESCRIPTION
Correct the [NotNull] and [CanBeNull] attributes for IPermissionDefinitionContext and remove these attributes from the implementation