### PR TITLE
fix(CLI): Add missing namespace

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/NewCommand.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/NewCommand.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Volo.Abp.Cli.Args;
 using Volo.Abp.Cli.Commands.Services;
 using Volo.Abp.Cli.ProjectBuilding;
+using Volo.Abp.Cli.ProjectModification;
 using Volo.Abp.Cli.Utils;
 using Volo.Abp.DependencyInjection;
 


### PR DESCRIPTION
Related #10770

Error Message:
```text
/abp/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/NewCommand.cs(29,9): error CS0246: The type or namespace name 'SolutionPackageVersionFinder' could not be found (are you missing a using directive or an assembly reference?) [/abp/framework/src/Volo.Abp.Cli.Core/Volo.Abp.Cli.Core.csproj]
```