### PR TITLE
fix(Cli): `add-module` command doesn't work with modules not contain test project

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/SolutionFileModifier.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/SolutionFileModifier.cs
@@ -130,10 +130,14 @@ namespace Volo.Abp.Cli.ProjectModification
                 "*.csproj",
                 SearchOption.AllDirectories);
 
-            var projectsUnderTest = Directory.GetFiles(
-                Path.Combine(Path.GetDirectoryName(solutionFile), "modules", module.Name, "test"),
-                "*.csproj",
-                SearchOption.AllDirectories);
+            var projectsUnderTest = new List<string>();
+            if (Directory.Exists(Path.Combine(Path.GetDirectoryName(solutionFile), "modules", module.Name, "test")))
+            {
+                projectsUnderTest = Directory.GetFiles(
+                    Path.Combine(Path.GetDirectoryName(solutionFile), "modules", module.Name, "test"),
+                    "*.csproj",
+                    SearchOption.AllDirectories).ToList();
+            }
 
             foreach (var projectPath in projectsUnderModule)
             {


### PR DESCRIPTION
Resolves #10310

You can test with bellow arguments:
`add-module Volo.Users --with-source-code --add-to-solution-file`

**Please wait for the following issues to close before testing.**

- https://github.com/abpframework/abp/issues/10843
- https://github.com/abpframework/abp/issues/10845