### PR TITLE
Style fix for code block in `Dynamic-CSharp-API-Clients` document

### DIFF
--- a/docs/en/API/Dynamic-CSharp-API-Clients.md
+++ b/docs/en/API/Dynamic-CSharp-API-Clients.md
@@ -74,7 +74,7 @@ public class MyClientAppModule : AbpModule
 
 `RemoteServices` section in the `appsettings.json` file is used to get remote service address by default. Simplest configuration is shown below:
 
-````
+```json
 {
   "RemoteServices": {
     "Default": {
@@ -82,7 +82,7 @@ public class MyClientAppModule : AbpModule
     } 
   } 
 }
-````
+```
 
 See the "AbpRemoteServiceOptions" section below for more detailed configuration.
 


### PR DESCRIPTION
**Screenshot of the problem:**

<img width="882" alt="Screen Shot 2021-12-08 at 11 07 57" src="https://user-images.githubusercontent.com/31216880/145171779-36dbe7f8-75df-4db4-80c9-4f1b7d9bd4bc.png">
