### PR TITLE
No longer use `AddRazorRuntimeCompilation`.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Microsoft/Extensions/DependencyInjection/AbpMvcBuilderExtensions.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Microsoft/Extensions/DependencyInjection/AbpMvcBuilderExtensions.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Extensions.DependencyInjection
             applicationParts.Add(new AssemblyPart(assembly));
         }
 
-        public static void AddAbpRazorRuntimeCompilation(this IMvcBuilder mvcCoreBuilder)
+        public static void AddAbpRazorRuntimeCompilation(this IMvcCoreBuilder mvcCoreBuilder)
         {
             mvcCoreBuilder.AddRazorRuntimeCompilation();
             mvcCoreBuilder.Services.Configure<MvcRazorRuntimeCompilationOptions>(options =>

--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Microsoft/Extensions/DependencyInjection/AbpMvcBuilderExtensions.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Microsoft/Extensions/DependencyInjection/AbpMvcBuilderExtensions.cs
@@ -1,7 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
+using Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation;
+using Volo.Abp.AspNetCore.VirtualFileSystem;
+using Volo.Abp.DependencyInjection;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -11,12 +15,12 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             mvcBuilder.PartManager.ApplicationParts.AddIfNotContains(assembly);
         }
-        
+
         public static void AddApplicationPartIfNotExists(this IMvcCoreBuilder mvcCoreBuilder, Assembly assembly)
         {
             mvcCoreBuilder.PartManager.ApplicationParts.AddIfNotContains(assembly);
         }
-        
+
         public static void AddIfNotContains(this IList<ApplicationPart> applicationParts, Assembly assembly)
         {
             if (applicationParts.Any(
@@ -26,6 +30,19 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             applicationParts.Add(new AssemblyPart(assembly));
+        }
+
+        public static void AddAbpRazorRuntimeCompilation(this IMvcBuilder mvcCoreBuilder)
+        {
+            mvcCoreBuilder.AddRazorRuntimeCompilation();
+            mvcCoreBuilder.Services.Configure<MvcRazorRuntimeCompilationOptions>(options =>
+            {
+                options.FileProviders.Add(
+                    new RazorViewEngineVirtualFileProvider(
+                        mvcCoreBuilder.Services.GetSingletonInstance<IObjectAccessor<IServiceProvider>>()
+                    )
+                );
+            });
         }
     }
 }

--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AbpAspNetCoreMvcModule.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AbpAspNetCoreMvcModule.cs
@@ -119,7 +119,6 @@ namespace Volo.Abp.AspNetCore.Mvc
                 );
 
             var mvcBuilder = context.Services.AddMvc()
-                .AddRazorRuntimeCompilation()
                 .AddDataAnnotationsLocalization(options =>
                 {
                     options.DataAnnotationLocalizerProvider = (type, factory) =>

--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AbpAspNetCoreMvcModule.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AbpAspNetCoreMvcModule.cs
@@ -138,6 +138,12 @@ namespace Volo.Abp.AspNetCore.Mvc
                 })
                 .AddViewLocalization(); //TODO: How to configure from the application? Also, consider to move to a UI module since APIs does not care about it.
 
+            if (context.Services.GetHostingEnvironment().IsDevelopment() &&
+                context.Services.ExecutePreConfiguredActions<AbpAspNetCoreMvcOptions>().EnableRazorRuntimeCompilationOnDevelopment)
+            {
+                mvcCoreBuilder.AddAbpRazorRuntimeCompilation();
+            }
+
             mvcCoreBuilder.AddAbpHybridJson();
 
             context.Services.ExecutePreConfiguredActions(mvcBuilder);

--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AbpAspNetCoreMvcModule.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AbpAspNetCoreMvcModule.cs
@@ -140,15 +140,6 @@ namespace Volo.Abp.AspNetCore.Mvc
 
             mvcCoreBuilder.AddAbpHybridJson();
 
-            Configure<MvcRazorRuntimeCompilationOptions>(options =>
-            {
-                options.FileProviders.Add(
-                    new RazorViewEngineVirtualFileProvider(
-                        context.Services.GetSingletonInstance<IObjectAccessor<IServiceProvider>>()
-                    )
-                );
-            });
-
             context.Services.ExecutePreConfiguredActions(mvcBuilder);
 
             //TODO: AddViewLocalization by default..?

--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AbpAspNetCoreMvcOptions.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AbpAspNetCoreMvcOptions.cs
@@ -14,11 +14,14 @@ namespace Volo.Abp.AspNetCore.Mvc
 
         public bool AutoModelValidation { get; set; }
 
+        public bool EnableRazorRuntimeCompilationOnDevelopment { get; set; }
+
         public AbpAspNetCoreMvcOptions()
         {
             ConventionalControllers = new AbpConventionalControllerOptions();
             IgnoredControllersOnModelExclusion = new HashSet<Type>();
             AutoModelValidation = true;
+            EnableRazorRuntimeCompilationOnDevelopment = true;
         }
     }
 }

--- a/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo.Abp.AspNetCore.Mvc.Tests.csproj
+++ b/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo.Abp.AspNetCore.Mvc.Tests.csproj
@@ -40,36 +40,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <ItemGroup>
-    <Content Update="Volo\Abp\AspNetCore\Mvc\Uow\UnitOfWorkTestPage.cshtml">
-      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </Content>
-    <Content Update="Volo\Abp\AspNetCore\Mvc\Auditing\AuditTestPage.cshtml">
-      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </Content>
-    <Content Update="Volo\Abp\AspNetCore\Mvc\Features\FeatureTestPage.cshtml">
-      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </Content>
-    <Content Update="Volo\Abp\AspNetCore\Mvc\ExceptionHandling\ExceptionTestPage.cshtml">
-      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </Content>
-    <Content Update="Volo\Abp\AspNetCore\Mvc\Authorization\AuthTestPage.cshtml">
-      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </Content>
-    <Content Update="Volo\Abp\AspNetCore\Mvc\GlobalFeature\DisabledGlobalFeatureTestPage.cshtml">
-      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </Content>
-    <Content Update="Volo\Abp\AspNetCore\Mvc\GlobalFeature\EnabledGlobalFeatureTestPage.cshtml">
-      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </Content>
-  </ItemGroup>
 
   <!-- https://github.com/NuGet/Home/issues/4412. -->
   <Target Name="CopyDepsFiles" AfterTargets="Build" Condition="'$(TargetFramework)'!=''">

--- a/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/AbpAspNetCoreMvcTestModule.cs
+++ b/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/AbpAspNetCoreMvcTestModule.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Security.Claims;
 using Localization.Resources.AbpUi;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.DependencyInjection;
 using Volo.Abp.AspNetCore.Mvc.Authorization;
@@ -113,6 +114,11 @@ namespace Volo.Abp.AspNetCore.Mvc
             Configure<RazorPagesOptions>(options =>
             {
                 options.RootDirectory = "/Volo/Abp/AspNetCore/Mvc";
+            });
+
+            Configure<RazorViewEngineOptions>(options =>
+            {
+                options.ViewLocationFormats.Add("/Volo/Abp/AspNetCore/App/Views/{1}/{0}.cshtml");
             });
 
             Configure<AbpClaimsMapOptions>(options =>


### PR DESCRIPTION
Related #10924 

https://github.com/dotnet/aspnetcore/issues/38566#issuecomment-981872198

**Since hot reload does not work well for `ProjectReference`, we add an option(`EnableRazorRuntimeCompilationOnDevelopment`) to enable it during development.**