### PR TITLE
Update AbpApplicationConfigurationController.cs

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/ApplicationConfigurations/AbpApplicationConfigurationController.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/ApplicationConfigurations/AbpApplicationConfigurationController.cs
@@ -21,7 +21,7 @@ public class AbpApplicationConfigurationController : AbpControllerBase, IAbpAppl
     }
 
     [HttpGet]
-    public async Task<ApplicationConfigurationDto> GetAsync()
+    public virtual async Task<ApplicationConfigurationDto> GetAsync()
     {
         _antiForgeryManager.SetCookie();
         return await _applicationConfigurationAppService.GetAsync();


### PR DESCRIPTION
In some projects, we may need to Customize AbpApplicationConfigurationController controllers. So it has to be virtual.