### PR TITLE
Rename InitializeAsync to InitializeApplicationAsync

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Components.WebAssembly/Microsoft/AspNetCore/Components/WebAssembly/Hosting/AbpWebAssemblyHostBuilderExtensions.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Components.WebAssembly/Microsoft/AspNetCore/Components/WebAssembly/Hosting/AbpWebAssemblyHostBuilderExtensions.cs
@@ -65,7 +65,7 @@ public static class AbpWebAssemblyHostBuilderExtensions
         return application;
     }
 
-    public async static Task InitializeAsync(
+    public async static Task InitializeApplicationAsync(
         [NotNull] this IAbpApplicationWithExternalServiceProvider application,
         [NotNull] IServiceProvider serviceProvider)
     {

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor/Program.cs
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor/Program.cs
@@ -16,7 +16,7 @@ public class Program
 
         var host = builder.Build();
 
-        await application.InitializeAsync(host.Services);
+        await application.InitializeApplicationAsync(host.Services);
 
         await host.RunAsync();
     }

--- a/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.Blazor.Host/Program.cs
+++ b/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.Blazor.Host/Program.cs
@@ -16,7 +16,7 @@ public class Program
 
         var host = builder.Build();
 
-        await application.InitializeAsync(host.Services);
+        await application.InitializeApplicationAsync(host.Services);
 
         await host.RunAsync();
     }


### PR DESCRIPTION
We expect to call extended methods, but there are methods with the same name

![1fcb02d3e189fa9a8c5fb00b68dfb44](https://user-images.githubusercontent.com/16813853/147550947-8164ddce-9676-423c-8ac6-1b50d2ec1e03.png)
