### PR TITLE
Add AreaAttribute to ClientProxy controller

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AspNetCoreApiDescriptionModelProvider.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AspNetCoreApiDescriptionModelProvider.cs
@@ -80,7 +80,7 @@ namespace Volo.Abp.AspNetCore.Mvc
             var setting = FindSetting(controllerType);
 
             var moduleModel = applicationModel.GetOrAddModule(
-                GetRootPath(controllerType, setting),
+                GetRootPath(controllerType, apiDescription.ActionDescriptor, setting),
                 GetRemoteServiceName(controllerType, setting)
             );
 
@@ -327,7 +327,9 @@ namespace Volo.Abp.AspNetCore.Mvc
             return modelNameProvider.Name ?? parameterInfo.Name;
         }
 
-        private static string GetRootPath([NotNull] Type controllerType,
+        private static string GetRootPath(
+            [NotNull] Type controllerType,
+            [NotNull] ActionDescriptor actionDescriptor,
             [CanBeNull] ConventionalControllerSetting setting)
         {
             if (setting != null)
@@ -336,6 +338,12 @@ namespace Volo.Abp.AspNetCore.Mvc
             }
 
             var areaAttr = controllerType.GetCustomAttributes().OfType<AreaAttribute>().FirstOrDefault();
+            if (areaAttr != null)
+            {
+                return areaAttr.RouteValue;
+            }
+
+            areaAttr = actionDescriptor.EndpointMetadata.OfType<AreaAttribute>().FirstOrDefault();
             if (areaAttr != null)
             {
                 return areaAttr.RouteValue;

--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AspNetCoreApiDescriptionModelProvider.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AspNetCoreApiDescriptionModelProvider.cs
@@ -337,13 +337,7 @@ namespace Volo.Abp.AspNetCore.Mvc
                 return setting.RootPath;
             }
 
-            var areaAttr = controllerType.GetCustomAttributes().OfType<AreaAttribute>().FirstOrDefault();
-            if (areaAttr != null)
-            {
-                return areaAttr.RouteValue;
-            }
-
-            areaAttr = actionDescriptor.EndpointMetadata.OfType<AreaAttribute>().FirstOrDefault();
+            var areaAttr = controllerType.GetCustomAttributes().OfType<AreaAttribute>().FirstOrDefault() ?? actionDescriptor.EndpointMetadata.OfType<AreaAttribute>().FirstOrDefault();
             if (areaAttr != null)
             {
                 return areaAttr.RouteValue;

--- a/framework/src/Volo.Abp.Http.Client.Web/Volo/Abp/Http/Client/Web/Conventions/AbpHttpClientProxyServiceConvention.cs
+++ b/framework/src/Volo.Abp.Http.Client.Web/Volo/Abp/Http/Client/Web/Conventions/AbpHttpClientProxyServiceConvention.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using Microsoft.AspNetCore.Mvc;
@@ -49,6 +50,15 @@ namespace Volo.Abp.Http.Client.Web.Conventions
             foreach (var controller in GetClientProxyControllers(application))
             {
                 controller.ControllerName = controller.ControllerName.RemovePostFix("ClientProxy");
+
+                var moduleApiDescription = FindModuleApiDescriptionModel(controller);
+
+                if (moduleApiDescription != null && !moduleApiDescription.RootPath.IsNullOrWhiteSpace())
+                {
+                    var selector = controller.Selectors.FirstOrDefault();
+                    selector?.EndpointMetadata.Add(new AreaAttribute(moduleApiDescription.RootPath));
+                    controller.RouteValues.Add(new KeyValuePair<string, string>("area", moduleApiDescription.RootPath));
+                }
 
                 var controllerApiDescription = FindControllerApiDescriptionModel(controller);
                 if (controllerApiDescription != null &&


### PR DESCRIPTION
It breaks the dynamic JS proxy generation, because all module names are app

![image](https://user-images.githubusercontent.com/16813853/147639136-1b389a4a-91b8-45dc-ac8d-ad7d2c4ce918.png)
