### PR TITLE
when provider is not used Throw exception Value cannot be null. Arg_ParamName_Name

### DIFF
--- a/framework/src/Volo.Abp.BlobStoring/Volo/Abp/BlobStoring/DefaultBlobProviderSelector.cs
+++ b/framework/src/Volo.Abp.BlobStoring/Volo/Abp/BlobStoring/DefaultBlobProviderSelector.cs
@@ -35,6 +35,10 @@ public class DefaultBlobProviderSelector : IBlobProviderSelector, ITransientDepe
 
         foreach (var provider in BlobProviders)
         {
+            if (configuration.ProviderType == null)
+            {
+                throw new AbpException("BLOB Container provider is not used. Example: Configure to use the File System storage provider by default");
+            }
             if (ProxyHelper.GetUnProxiedType(provider).IsAssignableTo(configuration.ProviderType))
             {
                 return provider;


### PR DESCRIPTION
#11111 
AbpBlobStoring
when provider is not used Throw exception System.ArgumentNullException:“Value cannot be null. Arg_ParamName_Name”
More explicit exception information
"BLOB Container provider is not used. Example: Configure to use the File System storage provider by default"