### PR TITLE
Cli: Class parsing should support File-Scoped Namespaces

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo.Abp.Cli.Core.csproj
+++ b/framework/src/Volo.Abp.Cli.Core/Volo.Abp.Cli.Core.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="NuGet.Versioning" Version="5.11.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="$(MicrosoftPackageVersion)" />
     <PackageReference Include="System.Security.Permissions" Version="$(MicrosoftPackageVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" />
     <PackageReference Include="Polly" Version="7.2.2" />
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
     <PackageReference Include="LibGit2Sharp" Version="0.26.2" />

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/DerivedClassFinder.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/DerivedClassFinder.cs
@@ -54,8 +54,14 @@ public class DerivedClassFinder : ITransientDependency
     protected bool IsDerived(string csFile, string baseClass)
     {
         var root = CSharpSyntaxTree.ParseText(File.ReadAllText(csFile)).GetRoot();
-        var namespaceSyntax = root.DescendantNodes().OfType<NamespaceDeclarationSyntax>().First();
-        var classDeclaration = (namespaceSyntax.DescendantNodes().OfType<ClassDeclarationSyntax>()).First();
+        var namespaceSyntax = root.DescendantNodes().OfType<NamespaceDeclarationSyntax>().FirstOrDefault();
+        var classDeclaration = (namespaceSyntax?.DescendantNodes().OfType<ClassDeclarationSyntax>())?.FirstOrDefault();
+
+        if (classDeclaration == null)
+        {
+            classDeclaration = root.DescendantNodes().OfType<ClassDeclarationSyntax>().First();
+        }
+
         var baseTypeList = classDeclaration.BaseList?.Types.Select(t => t.ToString()).ToList();
 
         if (baseTypeList == null)

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/SolutionModuleAdder.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/SolutionModuleAdder.cs
@@ -704,13 +704,13 @@ public class SolutionModuleAdder : ITransientDependency
             new NugetPackageInfo
             {
                 Name = $"{module.Name}.Blazor.WebAssembly",
-                ModuleClass = $"{module.Name}.Blazor.{moduleProjectName}BlazorWebAssemblyModule",
+                ModuleClass = $"{module.Name}.Blazor.WebAssembly.{moduleProjectName}BlazorWebAssemblyModule",
                 Target = NuGetPackageTarget.BlazorWebAssembly
             },
             new NugetPackageInfo
             {
                 Name = $"{module.Name}.Blazor.Server",
-                ModuleClass = $"{module.Name}.Blazor.{moduleProjectName}BlazorServerModule",
+                ModuleClass = $"{module.Name}.Blazor.Server.{moduleProjectName}BlazorServerModule",
                 Target = NuGetPackageTarget.BlazorServer
             },
             new NugetPackageInfo


### PR DESCRIPTION
Also fix blazor namespaces for cli.

resolves https://github.com/abpframework/abp/issues/11312