### PR TITLE
Fix PermissionManagementModal style

### DIFF
--- a/modules/permission-management/src/Volo.Abp.PermissionManagement.Web/Pages/AbpPermissionManagement/PermissionManagementModal.cshtml
+++ b/modules/permission-management/src/Volo.Abp.PermissionManagement.Web/Pages/AbpPermissionManagement/PermissionManagementModal.cshtml
@@ -25,7 +25,7 @@
                         <h4>@group.DisplayName</h4>
                         <hr class="mt-2 mb-3"/>
                         <div class="w-100" style="max-height: 640px;overflow-y: auto">
-                            <div class="pl-1 pt-1">
+                            <div class="ps-1 pt-1">
                                 <abp-input asp-for="@group.IsAllPermissionsGranted"
                                            check-box-hidden-input-render-mode="CheckBoxHiddenInputRenderMode.None"
                                            name="SelectAllInThisTab"


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/13699353/151099194-8de37288-3db6-4a84-9f7d-7d06268d6350.png)


https://getbootstrap.com/docs/5.1/utilities/spacing/#notation

Bootstrap5 does not have a class for `pl-*`, it should be `ps-*`.