### PR TITLE
Upgrade Rebus.ServiceProvider to the latest

### DIFF
--- a/framework/src/Volo.Abp.EventBus.Rebus/Volo.Abp.EventBus.Rebus.csproj
+++ b/framework/src/Volo.Abp.EventBus.Rebus/Volo.Abp.EventBus.Rebus.csproj
@@ -20,7 +20,7 @@
 
     <ItemGroup>
       <PackageReference Include="Rebus" Version="6.5.5" />
-      <PackageReference Include="Rebus.ServiceProvider" Version="6.4.1" />
+      <PackageReference Include="Rebus.ServiceProvider" Version="7.0.0" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftPackageVersion)" />
     </ItemGroup>
     

--- a/framework/src/Volo.Abp.EventBus.Rebus/Volo/Abp/EventBus/Rebus/AbpEventBusRebusModule.cs
+++ b/framework/src/Volo.Abp.EventBus.Rebus/Volo/Abp/EventBus/Rebus/AbpEventBusRebusModule.cs
@@ -1,8 +1,8 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using Rebus.Config;
 using Rebus.Handlers;
 using Rebus.Pipeline;
 using Rebus.Pipeline.Receive;
-using Rebus.ServiceProvider;
 using Volo.Abp.Modularity;
 
 namespace Volo.Abp.EventBus.Rebus;


### PR DESCRIPTION
Fix:

`warning NU1608: Detected package version outside of dependency constraint: Rebus.ServiceProvider 6.4.1 requires Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.0.0 && < 6.0.0) but version Microsoft.Extensions.DependencyInjection.Abstractions 6.0.0 was resolved`