### PR TITLE
Icon customization properties added to confirmation popup. Issue #11511

### DIFF
--- a/docs/en/UI/Angular/Confirmation-Service.md
+++ b/docs/en/UI/Angular/Confirmation-Service.md
@@ -131,6 +131,25 @@ The open confirmation popup can be removed manually via the `clear` method:
 this.confirmation.clear();
 ```
 
+### How to Change Icons of The Confirmation Popup
+
+You can change icons with the token of "confirmationIcons" in ThemeSharedModule in the app.module.ts. The changes will affect  all confirmation popup in the project.
+
+```js
+...
+ThemeSharedModule.forRoot({
+  confirmationIcons: {
+    info: 'fa fa-info-circle',
+    success: 'fa fa-check-circle',
+    warning: 'fa fa-exclamation-triangle',
+    error: 'fa fa-times-circle',
+    default: 'fa fa-question-circle',
+  },
+}),
+...
+```
+
+
 ## API
 
 ### success

--- a/docs/en/UI/Angular/Confirmation-Service.md
+++ b/docs/en/UI/Angular/Confirmation-Service.md
@@ -75,7 +75,9 @@ const options: Partial<Confirmation.Options> = {
   yesText: 'Confirm',
   messageLocalizationParams: ['Demo'],
   titleLocalizationParams: [],
-};
+  icon: 'fa fa-info-circle',
+  iconTemplate : '<img src="custom-image-path.jpg" alt=""/>'
+} 
 
 this.confirmation.warn(
   'AbpIdentity::RoleDeletionConfirmationMessage',
@@ -91,6 +93,8 @@ this.confirmation.warn(
 - `yesText` is the text of the confirmation button. A localization key or localization object can be passed. Default value is `AbpUi::Yes`.
 - `messageLocalizationParams` is the interpolation parameters for the localization of the message.
 - `titleLocalizationParams` is the interpolation parameters for the localization of the title.
+- `icon` is the custom class of the icon. Default value is `undefined`.
+- `iconTemplate` is the template for icon. Default value is `undefined`.
 
 With the options above, the confirmation popup looks like this:
 

--- a/docs/en/UI/Angular/Confirmation-Service.md
+++ b/docs/en/UI/Angular/Confirmation-Service.md
@@ -75,8 +75,9 @@ const options: Partial<Confirmation.Options> = {
   yesText: 'Confirm',
   messageLocalizationParams: ['Demo'],
   titleLocalizationParams: [],
-  icon: 'fa fa-info-circle',
-  iconTemplate : '<img src="custom-image-path.jpg" alt=""/>'
+  // You can customize icon 
+  // icon: 'fa fa-exclamation-triangle', // or
+  // iconTemplate : '<img src="custom-image-path.jpg" alt=""/>'
 } 
 
 this.confirmation.warn(

--- a/npm/ng-packs/packages/theme-shared/src/lib/components/confirmation/confirmation.component.html
+++ b/npm/ng-packs/packages/theme-shared/src/lib/components/confirmation/confirmation.component.html
@@ -4,8 +4,11 @@
     (click)="data.options?.dismissible ? close(dismiss) : null"
   ></div>
   <div class="confirmation-dialog">
-    <div class="icon-container" [ngClass]="data.severity" *ngIf="data.severity">
-      <i class="fa icon" [ngClass]="getIconClass(data)"></i>
+    <div class="icon-container" [ngClass]="data.severity" *ngIf="data.severity || isCustomIconExists(data)">
+      <div  [outerHTML]="data.options.iconTemplate" *ngIf="isIconTemplateExits(data); else iconHolder" ></div>
+       <ng-template #iconHolder>
+         <i class="icon" [ngClass]="getIconClass(data)"></i>
+       </ng-template>
     </div>
     <div class="content">
       <h1

--- a/npm/ng-packs/packages/theme-shared/src/lib/components/confirmation/confirmation.component.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/components/confirmation/confirmation.component.ts
@@ -1,6 +1,6 @@
-import { Component } from '@angular/core';
-import { ReplaySubject } from 'rxjs';
-import { Confirmation } from '../../models/confirmation';
+import {Component} from '@angular/core';
+import {ReplaySubject} from 'rxjs';
+import {Confirmation} from '../../models/confirmation';
 
 @Component({
   selector: 'abp-confirmation',
@@ -20,18 +20,30 @@ export class ConfirmationComponent {
     this.clear(status);
   }
 
-  getIconClass({ severity }: Confirmation.DialogData): string {
+  getIconClass({severity, options}: Confirmation.DialogData): string {
+    if (options && options.icon) {
+      return options.icon
+    }
     switch (severity) {
       case 'info':
-        return 'fa-info-circle';
+        return 'fa fa-info-circle';
       case 'success':
-        return 'fa-check-circle';
+        return 'fa fa-check-circle';
       case 'warning':
-        return 'fa-exclamation-triangle';
+        return 'fa fa-exclamation-triangle';
       case 'error':
-        return 'fa-times-circle';
+        return 'fa fa-times-circle';
       default:
-        return 'fa-question-circle';
+        return 'fa fa-question-circle';
     }
   }
+
+  isCustomIconExists({options}: Confirmation.DialogData): boolean {
+    return !!(options && (options.iconTemplate || options.icon))
+  }
+
+  isIconTemplateExits({options}: Confirmation.DialogData): boolean {
+    return !!(options && options.iconTemplate)
+  }
+
 }

--- a/npm/ng-packs/packages/theme-shared/src/lib/components/confirmation/confirmation.component.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/components/confirmation/confirmation.component.ts
@@ -1,7 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, Inject } from '@angular/core';
 import { ReplaySubject } from 'rxjs';
 import { Confirmation } from '../../models/confirmation';
-import { ConfirmationIcons } from '../../tokens/confirmation-icons.token';
+import { CONFIRMATION_ICONS, ConfirmationIcons } from '../../tokens/confirmation-icons.token';
 
 @Component({
   selector: 'abp-confirmation',
@@ -9,12 +9,13 @@ import { ConfirmationIcons } from '../../tokens/confirmation-icons.token';
   styleUrls: ['./confirmation.component.scss'],
 })
 export class ConfirmationComponent {
+  constructor(@Inject(CONFIRMATION_ICONS) private icons: ConfirmationIcons) {}
+
   confirm = Confirmation.Status.confirm;
   reject = Confirmation.Status.reject;
   dismiss = Confirmation.Status.dismiss;
 
   confirmation$!: ReplaySubject<Confirmation.DialogData>;
-  icons: ConfirmationIcons;
 
   clear!: (status: Confirmation.Status) => void;
 

--- a/npm/ng-packs/packages/theme-shared/src/lib/components/confirmation/confirmation.component.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/components/confirmation/confirmation.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { ReplaySubject } from 'rxjs';
 import { Confirmation } from '../../models/confirmation';
+import { ConfirmationIcons } from '../../tokens/confirmation-icons.token';
 
 @Component({
   selector: 'abp-confirmation',
@@ -13,6 +14,7 @@ export class ConfirmationComponent {
   dismiss = Confirmation.Status.dismiss;
 
   confirmation$!: ReplaySubject<Confirmation.DialogData>;
+  icons: ConfirmationIcons;
 
   clear!: (status: Confirmation.Status) => void;
 
@@ -24,18 +26,10 @@ export class ConfirmationComponent {
     if (options && options.icon) {
       return options.icon;
     }
-    switch (severity) {
-      case 'info':
-        return 'fa fa-info-circle';
-      case 'success':
-        return 'fa fa-check-circle';
-      case 'warning':
-        return 'fa fa-exclamation-triangle';
-      case 'error':
-        return 'fa fa-times-circle';
-      default:
-        return 'fa fa-question-circle';
+    if (!this.icons) {
+      return '';
     }
+    return this.icons[severity] || this.icons.default;
   }
 
   isCustomIconExists({ options }: Confirmation.DialogData): boolean {

--- a/npm/ng-packs/packages/theme-shared/src/lib/components/confirmation/confirmation.component.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/components/confirmation/confirmation.component.ts
@@ -1,7 +1,7 @@
-import {Component} from '@angular/core';
-import {ReplaySubject} from 'rxjs';
-import {Confirmation} from '../../models/confirmation';
-
+import { Component } from '@angular/core';
+import { ReplaySubject } from 'rxjs';
+import { Confirmation } from '../../models/confirmation';
+//
 @Component({
   selector: 'abp-confirmation',
   templateUrl: './confirmation.component.html',
@@ -20,9 +20,9 @@ export class ConfirmationComponent {
     this.clear(status);
   }
 
-  getIconClass({severity, options}: Confirmation.DialogData): string {
+  getIconClass({ severity, options }: Confirmation.DialogData): string {
     if (options && options.icon) {
-      return options.icon
+      return options.icon;
     }
     switch (severity) {
       case 'info':
@@ -38,12 +38,11 @@ export class ConfirmationComponent {
     }
   }
 
-  isCustomIconExists({options}: Confirmation.DialogData): boolean {
-    return !!(options && (options.iconTemplate || options.icon))
+  isCustomIconExists({ options }: Confirmation.DialogData): boolean {
+    return !!(options && (options.iconTemplate || options.icon));
   }
 
-  isIconTemplateExits({options}: Confirmation.DialogData): boolean {
-    return !!(options && options.iconTemplate)
+  isIconTemplateExits({ options }: Confirmation.DialogData): boolean {
+    return !!(options && options.iconTemplate);
   }
-
 }

--- a/npm/ng-packs/packages/theme-shared/src/lib/components/confirmation/confirmation.component.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/components/confirmation/confirmation.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { ReplaySubject } from 'rxjs';
 import { Confirmation } from '../../models/confirmation';
-//
+
 @Component({
   selector: 'abp-confirmation',
   templateUrl: './confirmation.component.html',

--- a/npm/ng-packs/packages/theme-shared/src/lib/models/common.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/models/common.ts
@@ -5,7 +5,7 @@ import { Observable } from 'rxjs';
 import { ConfirmationIcons } from '../tokens/confirmation-icons.token';
 
 export interface RootParams {
-  httpErrorConfig: HttpErrorConfig;
+  httpErrorConfig?: HttpErrorConfig;
   validation?: Partial<Validation.Config>;
   confirmationIcons?: Partial<ConfirmationIcons>;
 }

--- a/npm/ng-packs/packages/theme-shared/src/lib/models/common.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/models/common.ts
@@ -2,10 +2,12 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { Injector, Type } from '@angular/core';
 import { Validation } from '@ngx-validate/core';
 import { Observable } from 'rxjs';
+import { ConfirmationIcons } from '../tokens/confirmation-icons.token';
 
 export interface RootParams {
   httpErrorConfig: HttpErrorConfig;
   validation?: Partial<Validation.Config>;
+  confirmationIcons?: Partial<ConfirmationIcons>;
 }
 
 export type ErrorScreenErrorCodes = 401 | 403 | 404 | 500;

--- a/npm/ng-packs/packages/theme-shared/src/lib/models/confirmation.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/models/confirmation.ts
@@ -12,7 +12,7 @@ export namespace Confirmation {
     cancelText?: LocalizationParam;
     yesText?: LocalizationParam;
     icon?: string;
-    iconTemplate?:string | TemplateRef<any>
+    iconTemplate?:string
   }
 
   export interface DialogData {

--- a/npm/ng-packs/packages/theme-shared/src/lib/models/confirmation.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/models/confirmation.ts
@@ -1,4 +1,5 @@
 import { LocalizationParam } from '@abp/ng.core';
+import {TemplateRef} from "@angular/core";
 
 export namespace Confirmation {
   export interface Options {
@@ -10,6 +11,8 @@ export namespace Confirmation {
     hideYesBtn?: boolean;
     cancelText?: LocalizationParam;
     yesText?: LocalizationParam;
+    icon?: string;
+    iconTemplate?:string | TemplateRef<any>
   }
 
   export interface DialogData {

--- a/npm/ng-packs/packages/theme-shared/src/lib/models/confirmation.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/models/confirmation.ts
@@ -1,5 +1,4 @@
 import { LocalizationParam } from '@abp/ng.core';
-import {TemplateRef} from "@angular/core";
 
 export namespace Confirmation {
   export interface Options {

--- a/npm/ng-packs/packages/theme-shared/src/lib/services/confirmation.service.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/services/confirmation.service.ts
@@ -2,8 +2,8 @@ import { ContentProjectionService, LocalizationParam, PROJECTION_STRATEGY } from
 import { ComponentRef, Injectable } from '@angular/core';
 import { fromEvent, Observable, ReplaySubject, Subject } from 'rxjs';
 import { debounceTime, filter, takeUntil } from 'rxjs/operators';
-import { ConfirmationComponent } from '../components/confirmation/confirmation.component';
-import { Confirmation } from '../models/confirmation';
+import { ConfirmationComponent } from '../components';
+import { Confirmation } from '../models';
 
 @Injectable({ providedIn: 'root' })
 export class ConfirmationService {
@@ -93,7 +93,7 @@ export class ConfirmationService {
         debounceTime(150),
         filter((key: KeyboardEvent) => key && key.key === 'Escape'),
       )
-      .subscribe(_ => {
+      .subscribe(() => {
         this.clear();
       });
   }

--- a/npm/ng-packs/packages/theme-shared/src/lib/services/confirmation.service.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/services/confirmation.service.ts
@@ -2,8 +2,8 @@ import { ContentProjectionService, LocalizationParam, PROJECTION_STRATEGY } from
 import { ComponentRef, Injectable } from '@angular/core';
 import { fromEvent, Observable, ReplaySubject, Subject } from 'rxjs';
 import { debounceTime, filter, takeUntil } from 'rxjs/operators';
-import { ConfirmationComponent } from '../components';
-import { Confirmation } from '../models';
+import { ConfirmationComponent } from '../components/confirmation/confirmation.component';
+import { Confirmation } from '../models/confirmation';
 
 @Injectable({ providedIn: 'root' })
 export class ConfirmationService {

--- a/npm/ng-packs/packages/theme-shared/src/lib/services/confirmation.service.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/services/confirmation.service.ts
@@ -1,10 +1,9 @@
 import { ContentProjectionService, LocalizationParam, PROJECTION_STRATEGY } from '@abp/ng.core';
-import { ComponentRef, Inject, Injectable } from '@angular/core';
+import { ComponentRef, Injectable } from '@angular/core';
 import { fromEvent, Observable, ReplaySubject, Subject } from 'rxjs';
 import { debounceTime, filter, takeUntil } from 'rxjs/operators';
 import { ConfirmationComponent } from '../components/confirmation/confirmation.component';
 import { Confirmation } from '../models/confirmation';
-import { CONFIRMATION_ICONS, ConfirmationIcons } from '../tokens/confirmation-icons.token';
 
 @Injectable({ providedIn: 'root' })
 export class ConfirmationService {
@@ -18,17 +17,13 @@ export class ConfirmationService {
     this.status$.next(status);
   };
 
-  constructor(
-    private contentProjectionService: ContentProjectionService,
-    @Inject(CONFIRMATION_ICONS) private confirmationIcons: ConfirmationIcons,
-  ) {}
+  constructor(private contentProjectionService: ContentProjectionService) {}
 
   private setContainer() {
     this.containerComponentRef = this.contentProjectionService.projectContent(
       PROJECTION_STRATEGY.AppendComponentToBody(ConfirmationComponent, {
         confirmation$: this.confirmation$,
         clear: this.clear,
-        icons: this.confirmationIcons,
       }),
     );
 

--- a/npm/ng-packs/packages/theme-shared/src/lib/services/confirmation.service.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/services/confirmation.service.ts
@@ -1,9 +1,10 @@
 import { ContentProjectionService, LocalizationParam, PROJECTION_STRATEGY } from '@abp/ng.core';
-import { ComponentRef, Injectable } from '@angular/core';
+import { ComponentRef, Inject, Injectable } from '@angular/core';
 import { fromEvent, Observable, ReplaySubject, Subject } from 'rxjs';
 import { debounceTime, filter, takeUntil } from 'rxjs/operators';
 import { ConfirmationComponent } from '../components/confirmation/confirmation.component';
 import { Confirmation } from '../models/confirmation';
+import { CONFIRMATION_ICONS, ConfirmationIcons } from '../tokens/confirmation-icons.token';
 
 @Injectable({ providedIn: 'root' })
 export class ConfirmationService {
@@ -17,13 +18,17 @@ export class ConfirmationService {
     this.status$.next(status);
   };
 
-  constructor(private contentProjectionService: ContentProjectionService) {}
+  constructor(
+    private contentProjectionService: ContentProjectionService,
+    @Inject(CONFIRMATION_ICONS) private confirmationIcons: ConfirmationIcons,
+  ) {}
 
   private setContainer() {
     this.containerComponentRef = this.contentProjectionService.projectContent(
       PROJECTION_STRATEGY.AppendComponentToBody(ConfirmationComponent, {
         confirmation$: this.confirmation$,
         clear: this.clear,
+        icons: this.confirmationIcons,
       }),
     );
 

--- a/npm/ng-packs/packages/theme-shared/src/lib/tests/confirmation.service.spec.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/tests/confirmation.service.spec.ts
@@ -13,6 +13,7 @@ import { CONFIRMATION_ICONS, DEFAULT_CONFIRMATION_ICONS } from '../tokens/confir
   entryComponents: [ConfirmationComponent],
   declarations: [ConfirmationComponent],
   imports: [CoreTestingModule.withConfig()],
+  providers: [{ provide: CONFIRMATION_ICONS, useValue: DEFAULT_CONFIRMATION_ICONS }],
 })
 export class MockModule {}
 
@@ -22,7 +23,6 @@ describe('ConfirmationService', () => {
   const createService = createServiceFactory({
     service: ConfirmationService,
     imports: [CoreTestingModule.withConfig(), MockModule],
-    providers: [{ provide: CONFIRMATION_ICONS, useValue: DEFAULT_CONFIRMATION_ICONS }],
   });
 
   beforeEach(() => {

--- a/npm/ng-packs/packages/theme-shared/src/lib/tests/confirmation.service.spec.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/tests/confirmation.service.spec.ts
@@ -6,6 +6,7 @@ import { timer } from 'rxjs';
 import { ConfirmationComponent } from '../components';
 import { Confirmation } from '../models';
 import { ConfirmationService } from '../services';
+import { CONFIRMATION_ICONS, DEFAULT_CONFIRMATION_ICONS } from '../tokens/confirmation-icons.token';
 
 @NgModule({
   exports: [ConfirmationComponent],
@@ -21,6 +22,7 @@ describe('ConfirmationService', () => {
   const createService = createServiceFactory({
     service: ConfirmationService,
     imports: [CoreTestingModule.withConfig(), MockModule],
+    providers: [{ provide: CONFIRMATION_ICONS, useValue: DEFAULT_CONFIRMATION_ICONS }],
   });
 
   beforeEach(() => {
@@ -61,27 +63,27 @@ describe('ConfirmationService', () => {
   }));
 
   test('should display custom FA icon', fakeAsync(() => {
-    service.show('MESSAGE', 'TITLE',undefined,{
-      icon:'fa fa-info'
+    service.show('MESSAGE', 'TITLE', undefined, {
+      icon: 'fa fa-info',
     });
 
     tick();
-    expect(selectConfirmationElement(".icon").className).toBe('icon fa fa-info')
+    expect(selectConfirmationElement('.icon').className).toBe('icon fa fa-info');
   }));
 
   test('should display custom icon as html element', fakeAsync(() => {
-    const className = 'custom-icon'
-    const selector = '.'+className;
+    const className = 'custom-icon';
+    const selector = '.' + className;
 
-    service.show('MESSAGE', 'TITLE',undefined,{
-      iconTemplate: `<span class="${className}">I am icon</span>`
+    service.show('MESSAGE', 'TITLE', undefined, {
+      iconTemplate: `<span class="${className}">I am icon</span>`,
     });
 
     tick();
 
-    const element = selectConfirmationElement(selector)
-    expect(element).toBeTruthy()
-    expect(element.innerHTML).toBe("I am icon")
+    const element = selectConfirmationElement(selector);
+    expect(element).toBeTruthy();
+    expect(element.innerHTML).toBe('I am icon');
   }));
   test.each`
     type         | selector      | icon

--- a/npm/ng-packs/packages/theme-shared/src/lib/tests/confirmation.service.spec.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/tests/confirmation.service.spec.ts
@@ -60,6 +60,29 @@ describe('ConfirmationService', () => {
     expect(selectConfirmationContent('.custom-yes')).toBe('YES');
   }));
 
+  test('should display custom FA icon', fakeAsync(() => {
+    service.show('MESSAGE', 'TITLE',undefined,{
+      icon:'fa fa-info'
+    });
+
+    tick();
+    expect(selectConfirmationElement(".icon").className).toBe('icon fa fa-info')
+  }));
+
+  test('should display custom icon as html element', fakeAsync(() => {
+    const className = 'custom-icon'
+    const selector = '.'+className;
+
+    service.show('MESSAGE', 'TITLE',undefined,{
+      iconTemplate: `<span class="${className}">I am icon</span>`
+    });
+
+    tick();
+
+    const element = selectConfirmationElement(selector)
+    expect(element).toBeTruthy()
+    expect(element.innerHTML).toBe("I am icon")
+  }));
   test.each`
     type         | selector      | icon
     ${'info'}    | ${'.info'}    | ${'.fa-info-circle'}

--- a/npm/ng-packs/packages/theme-shared/src/lib/theme-shared.module.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/theme-shared.module.ts
@@ -34,6 +34,7 @@ import { THEME_SHARED_ROUTE_PROVIDERS } from './providers/route.provider';
 import { THEME_SHARED_APPEND_CONTENT } from './tokens/append-content.token';
 import { httpErrorConfigFactory, HTTP_ERROR_CONFIG } from './tokens/http-error.token';
 import { DateParserFormatter } from './utils/date-parser-formatter';
+import { CONFIRMATION_ICONS, DEFAULT_CONFIRMATION_ICONS } from './tokens/confirmation-icons.token';
 
 const declarationsWithExports = [
   BreadcrumbComponent,
@@ -52,16 +53,16 @@ const declarationsWithExports = [
 ];
 
 @NgModule({
-    imports: [
-        CoreModule,
-        NgxDatatableModule,
-        NgxValidateCoreModule,
-        NgbPaginationModule,
-        EllipsisModule,
-    ],
-    declarations: [...declarationsWithExports, HttpErrorWrapperComponent],
-    exports: [NgxDatatableModule, EllipsisModule, ...declarationsWithExports],
-    providers: [DatePipe]
+  imports: [
+    CoreModule,
+    NgxDatatableModule,
+    NgxValidateCoreModule,
+    NgbPaginationModule,
+    EllipsisModule,
+  ],
+  declarations: [...declarationsWithExports, HttpErrorWrapperComponent],
+  exports: [NgxDatatableModule, EllipsisModule, ...declarationsWithExports],
+  providers: [DatePipe],
 })
 export class BaseThemeSharedModule {}
 
@@ -71,7 +72,7 @@ export class BaseThemeSharedModule {}
 })
 export class ThemeSharedModule {
   static forRoot(
-    { httpErrorConfig, validation = {} } = {} as RootParams,
+    { httpErrorConfig, validation = {}, confirmationIcons = {} } = {} as RootParams,
   ): ModuleWithProviders<ThemeSharedModule> {
     return {
       ngModule: ThemeSharedModule,
@@ -118,6 +119,13 @@ export class ThemeSharedModule {
           useFactory: noop,
           multi: true,
           deps: [DocumentDirHandlerService],
+        },
+        {
+          provide: CONFIRMATION_ICONS,
+          useValue: {
+            ...DEFAULT_CONFIRMATION_ICONS,
+            ...(confirmationIcons || {}),
+          },
         },
       ],
     };

--- a/npm/ng-packs/packages/theme-shared/src/lib/tokens/confirmation-icons.token.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/tokens/confirmation-icons.token.ts
@@ -1,0 +1,21 @@
+import { InjectionToken } from '@angular/core';
+
+export interface ConfirmationIcons {
+  info: string;
+  success: string;
+  warning: string;
+  error: string;
+  default: string;
+}
+
+export const CONFIRMATION_ICONS = new InjectionToken<Partial<ConfirmationIcons>>(
+  'CONFIRMATION_ICONS',
+);
+
+export const DEFAULT_CONFIRMATION_ICONS: ConfirmationIcons = {
+  info: 'fa fa-info-circle',
+  success: 'fa fa-check-circle',
+  warning: 'fa fa-exclamation-triangle',
+  error: 'fa fa-times-circle',
+  default: 'fa fa-question-circle',
+};


### PR DESCRIPTION
Icon customization properties added to confirmation service options. Now you can set custom icon or class to icon.

Resolves  #11511 