### PR TITLE
fix http param creation

### DIFF
--- a/npm/ng-packs/packages/core/src/lib/services/rest.service.ts
+++ b/npm/ng-packs/packages/core/src/lib/services/rest.service.ts
@@ -51,14 +51,15 @@ export class RestService {
   }
 
   private getParams(params: Rest.Params, encoder?: HttpParameterCodec): HttpParams {
-    const httpParams = encoder ? new HttpParams({ encoder }) : new HttpParams();
-    return Object.keys(params).reduce((acc, key) => {
+    const filteredParams = Object.keys(params).reduce((acc, key) => {
       const value = params[key];
-
       if (isUndefinedOrEmptyString(value)) return acc;
       if (value === null && !this.options.sendNullsAsQueryParam) return acc;
-      acc = acc.set(key, value);
+      acc[key] = value;
       return acc;
-    }, httpParams);
+    }, {});
+    return encoder
+      ? new HttpParams({ encoder, fromObject: filteredParams })
+      : new HttpParams({ fromObject: filteredParams });
   }
 }


### PR DESCRIPTION
create an instance of http params with fromObject property instead of set key of http param after creating http param instance

same behavior if plain object given to http client's request method https://github.com/angular/angular/blob/master/packages/common/http/src/client.ts#L522

resolves #11524 