### PR TITLE
Remove `AsQueryable` method.

### DIFF
--- a/framework/src/Volo.Abp.Localization/Volo/Abp/Localization/LocalizationResourceContributorList.cs
+++ b/framework/src/Volo.Abp.Localization/Volo/Abp/Localization/LocalizationResourceContributorList.cs
@@ -8,8 +8,7 @@ public class LocalizationResourceContributorList : List<ILocalizationResourceCon
 {
     public LocalizedString GetOrNull(string cultureName, string name)
     {
-        this.Reverse();
-        foreach (var contributor in this)
+        foreach (var contributor in this.Select(x => x).Reverse())
         {
             var localString = contributor.GetOrNull(cultureName, name);
             if (localString != null)

--- a/framework/src/Volo.Abp.Localization/Volo/Abp/Localization/LocalizationResourceContributorList.cs
+++ b/framework/src/Volo.Abp.Localization/Volo/Abp/Localization/LocalizationResourceContributorList.cs
@@ -8,7 +8,8 @@ public class LocalizationResourceContributorList : List<ILocalizationResourceCon
 {
     public LocalizedString GetOrNull(string cultureName, string name)
     {
-        foreach (var contributor in this.AsQueryable().Reverse())
+        this.Reverse();
+        foreach (var contributor in this)
         {
             var localString = contributor.GetOrNull(cultureName, name);
             if (localString != null)


### PR DESCRIPTION
Resolve #11641
There is a performance issue with the `AsQueryable` method.


```cs
[Fact]
public void Test()
{
    var ls = new List<ILocalizationResourceContributor>()
    {
        new JsonVirtualFileLocalizationResourceContributor("")
    };

    var time = Stopwatch.StartNew();
    for (var i = 0; i < 100000; i++)
    {
        var lsQueryable = ls.AsQueryable().Reverse().ToList();
    }
    time.Stop();
    var t = time.ElapsedMilliseconds;
    _testOutputHelper.WriteLine(t.ToString());


    var time2 = Stopwatch.StartNew();
    for (var i = 0; i < 100000; i++)
    {
        ls.Reverse();
        var lsQueryable = ls.Select(x => x).Reverse();
    }
    time2.Stop();
    t = time2.ElapsedMilliseconds;
    _testOutputHelper.WriteLine(t.ToString());
}

Output:

15759
14
```