### PR TITLE
Add `AlwaysLogSelectors` to `AuditingOptions`

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.SignalR/Volo/Abp/AspNetCore/SignalR/Auditing/AbpAuditHubFilter.cs
+++ b/framework/src/Volo.Abp.AspNetCore.SignalR/Volo/Abp/AspNetCore/SignalR/Auditing/AbpAuditHubFilter.cs
@@ -50,7 +50,7 @@ public class AbpAuditHubFilter : IHubFilter
             }
             finally
             {
-                if (ShouldWriteAuditLog(invocationContext.ServiceProvider, hasError))
+                if (await ShouldWriteAuditLogAsync(auditingManager.Current.Log, invocationContext.ServiceProvider, hasError))
                 {
                     var unitOfWorkManager = invocationContext.ServiceProvider.GetRequiredService<IUnitOfWorkManager>();
                     if (unitOfWorkManager.Current != null)
@@ -76,12 +76,20 @@ public class AbpAuditHubFilter : IHubFilter
         }
     }
 
-    private bool ShouldWriteAuditLog(IServiceProvider serviceProvider, bool hasError)
+    private async Task<bool> ShouldWriteAuditLogAsync(AuditLogInfo auditLogInfo, IServiceProvider serviceProvider, bool hasError)
     {
         var options = serviceProvider.GetRequiredService<IOptions<AbpAuditingOptions>>().Value;
         if (options.AlwaysLogOnException && hasError)
         {
             return true;
+        }
+
+        foreach (var selector in options.AlwaysLogSelectors)
+        {
+            if (await selector(auditLogInfo))
+            {
+                return true;
+            }
         }
 
         if (!options.IsEnabledForAnonymousUsers && !serviceProvider.GetRequiredService<ICurrentUser>().IsAuthenticated)

--- a/framework/src/Volo.Abp.AspNetCore.SignalR/Volo/Abp/AspNetCore/SignalR/Auditing/AbpAuditHubFilter.cs
+++ b/framework/src/Volo.Abp.AspNetCore.SignalR/Volo/Abp/AspNetCore/SignalR/Auditing/AbpAuditHubFilter.cs
@@ -79,10 +79,6 @@ public class AbpAuditHubFilter : IHubFilter
     private async Task<bool> ShouldWriteAuditLogAsync(AuditLogInfo auditLogInfo, IServiceProvider serviceProvider, bool hasError)
     {
         var options = serviceProvider.GetRequiredService<IOptions<AbpAuditingOptions>>().Value;
-        if (options.AlwaysLogOnException && hasError)
-        {
-            return true;
-        }
 
         foreach (var selector in options.AlwaysLogSelectors)
         {
@@ -90,6 +86,11 @@ public class AbpAuditHubFilter : IHubFilter
             {
                 return true;
             }
+        }
+
+        if (options.AlwaysLogOnException && hasError)
+        {
+            return true;
         }
 
         if (!options.IsEnabledForAnonymousUsers && !serviceProvider.GetRequiredService<ICurrentUser>().IsAuthenticated)

--- a/framework/src/Volo.Abp.AspNetCore/Volo/Abp/AspNetCore/Auditing/AbpAuditingMiddleware.cs
+++ b/framework/src/Volo.Abp.AspNetCore/Volo/Abp/AspNetCore/Auditing/AbpAuditingMiddleware.cs
@@ -100,17 +100,17 @@ public class AbpAuditingMiddleware : IMiddleware, ITransientDependency
 
     private async Task<bool> ShouldWriteAuditLogAsync(AuditLogInfo auditLogInfo, HttpContext httpContext, bool hasError)
     {
-        if (AuditingOptions.AlwaysLogOnException && hasError)
-        {
-            return true;
-        }
-
         foreach (var selector in AuditingOptions.AlwaysLogSelectors)
         {
             if (await selector(auditLogInfo))
             {
                 return true;
             }
+        }
+
+        if (AuditingOptions.AlwaysLogOnException && hasError)
+        {
+            return true;
         }
 
         if (!AuditingOptions.IsEnabledForAnonymousUsers && !CurrentUser.IsAuthenticated)

--- a/framework/src/Volo.Abp.Auditing/Volo/Abp/Auditing/AbpAuditingOptions.cs
+++ b/framework/src/Volo.Abp.Auditing/Volo/Abp/Auditing/AbpAuditingOptions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq.Expressions;
+using System.Threading.Tasks;
 
 namespace Volo.Abp.Auditing;
 
@@ -37,6 +38,8 @@ public class AbpAuditingOptions
     /// </summary>
     public bool AlwaysLogOnException { get; set; }
 
+    public List<Func<AuditLogInfo, Task<bool>>> AlwaysLogSelectors { get; }
+
     public List<AuditLogContributor> Contributors { get; }
 
     public List<Type> IgnoredTypes { get; }
@@ -55,6 +58,7 @@ public class AbpAuditingOptions
         IsEnabledForAnonymousUsers = true;
         HideErrors = true;
         AlwaysLogOnException = true;
+        AlwaysLogSelectors = new List<Func<AuditLogInfo, Task<bool>>>();
 
         Contributors = new List<AuditLogContributor>();
 

--- a/framework/src/Volo.Abp.Auditing/Volo/Abp/Auditing/AuditingInterceptor.cs
+++ b/framework/src/Volo.Abp.Auditing/Volo/Abp/Auditing/AuditingInterceptor.cs
@@ -160,17 +160,17 @@ public class AuditingInterceptor : AbpInterceptor, ITransientDependency
         ICurrentUser currentUser,
         bool hasError)
     {
-        if (options.AlwaysLogOnException && hasError)
-        {
-            return true;
-        }
-
         foreach (var selector in options.AlwaysLogSelectors)
         {
             if (await selector(auditLogInfo))
             {
                 return true;
             }
+        }
+
+        if (options.AlwaysLogOnException && hasError)
+        {
+            return true;
         }
 
         if (!options.IsEnabledForAnonymousUsers && !currentUser.IsAuthenticated)

--- a/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/Auditing/AuditTestController_Tests.cs
+++ b/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/Auditing/AuditTestController_Tests.cs
@@ -49,6 +49,16 @@ public class AuditTestController_Tests : AspNetCoreMvcTestBase
         await _auditingStore.Received().SaveAsync(Arg.Any<AuditLogInfo>());
     }
 
+
+    [Fact]
+    public async Task Should_Trigger_Middleware_And_AuditLog_Success_For_Specified_Requests()
+    {
+        _options.AlwaysLogOnException = false;
+        _options.AlwaysLogSelectors.Add(info => Task.FromResult(info.Url.Contains("api/audit-test/audit-success")));
+        await GetResponseAsync("api/audit-test/audit-success");
+        await _auditingStore.Received().SaveAsync(Arg.Any<AuditLogInfo>());
+    }
+
     [Fact]
     public async Task Should_Trigger_Middleware_And_AuditLog_Exception_Always()
     {

--- a/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/Auditing/AuditTestPage_Tests.cs
+++ b/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/Auditing/AuditTestPage_Tests.cs
@@ -49,6 +49,15 @@ public class AuditTestPage_Tests : AspNetCoreMvcTestBase
     }
 
     [Fact]
+    public async Task Should_Trigger_Middleware_And_AuditLog_Success_For_Specified_Requests()
+    {
+        _options.AlwaysLogOnException = false;
+        _options.AlwaysLogSelectors.Add(info => Task.FromResult(info.Url.Contains("api/audit-test/audit-success")));
+        await GetResponseAsync("api/audit-test/audit-success");
+        await _auditingStore.Received().SaveAsync(Arg.Any<AuditLogInfo>());
+    }
+
+    [Fact]
     public async Task Should_Trigger_Middleware_And_AuditLog_Exception_Always()
     {
         _options.IsEnabled = true;


### PR DESCRIPTION
Resolve #11794

```cs
Configure<AbpAuditingOptions>(options =>
{
    options.AlwaysLogSelectors.Add(info => Task.FromResult(info.Url.Contains("api/my-get-request")));
});
```