### PR TITLE
Allow RabbitMq Exchange type to be specified

### DIFF
--- a/framework/src/Volo.Abp.EventBus.RabbitMQ/Volo/Abp/EventBus/RabbitMq/AbpRabbitMqEventBusOptions.cs
+++ b/framework/src/Volo.Abp.EventBus.RabbitMQ/Volo/Abp/EventBus/RabbitMq/AbpRabbitMqEventBusOptions.cs
@@ -14,11 +14,6 @@ public class AbpRabbitMqEventBusOptions
 
     public string ExchangeType { get; set; }
 
-    public AbpRabbitMqEventBusOptions()
-    {
-        ExchangeType = "direct";
-    }
-
     public string GetExchangeTypeOrDefault()
     {
         return string.IsNullOrEmpty(ExchangeType)

--- a/framework/src/Volo.Abp.EventBus.RabbitMQ/Volo/Abp/EventBus/RabbitMq/AbpRabbitMqEventBusOptions.cs
+++ b/framework/src/Volo.Abp.EventBus.RabbitMQ/Volo/Abp/EventBus/RabbitMq/AbpRabbitMqEventBusOptions.cs
@@ -1,10 +1,28 @@
-﻿namespace Volo.Abp.EventBus.RabbitMq;
+﻿using Volo.Abp.RabbitMQ;
+
+namespace Volo.Abp.EventBus.RabbitMq;
 
 public class AbpRabbitMqEventBusOptions
 {
+    public const string DefaultExchangeType = RabbitMqConsts.ExchangeTypes.Direct;
+
     public string ConnectionName { get; set; }
 
     public string ClientName { get; set; }
 
     public string ExchangeName { get; set; }
+
+    public string ExchangeType { get; set; }
+
+    public AbpRabbitMqEventBusOptions()
+    {
+        ExchangeType = "direct";
+    }
+
+    public string GetExchangeTypeOrDefault()
+    {
+        return string.IsNullOrEmpty(ExchangeType)
+            ? DefaultExchangeType
+            : ExchangeType;
+    }
 }

--- a/framework/src/Volo.Abp.EventBus.RabbitMQ/Volo/Abp/EventBus/RabbitMq/RabbitMqDistributedEventBus.cs
+++ b/framework/src/Volo.Abp.EventBus.RabbitMQ/Volo/Abp/EventBus/RabbitMq/RabbitMqDistributedEventBus.cs
@@ -244,7 +244,7 @@ public class RabbitMqDistributedEventBus : DistributedEventBusBase, ISingletonDe
         {
             channel.ExchangeDeclare(
                 AbpRabbitMqEventBusOptions.ExchangeName,
-                "direct",
+                AbpRabbitMqEventBusOptions.ExchangeType,
                 durable: true
             );
 

--- a/framework/src/Volo.Abp.EventBus.RabbitMQ/Volo/Abp/EventBus/RabbitMq/RabbitMqDistributedEventBus.cs
+++ b/framework/src/Volo.Abp.EventBus.RabbitMQ/Volo/Abp/EventBus/RabbitMq/RabbitMqDistributedEventBus.cs
@@ -69,7 +69,7 @@ public class RabbitMqDistributedEventBus : DistributedEventBusBase, ISingletonDe
         Consumer = MessageConsumerFactory.Create(
             new ExchangeDeclareConfiguration(
                 AbpRabbitMqEventBusOptions.ExchangeName,
-                type: "direct",
+                type: AbpRabbitMqEventBusOptions.ExchangeType,
                 durable: true
             ),
             new QueueDeclareConfiguration(

--- a/framework/src/Volo.Abp.EventBus.RabbitMQ/Volo/Abp/EventBus/RabbitMq/RabbitMqDistributedEventBus.cs
+++ b/framework/src/Volo.Abp.EventBus.RabbitMQ/Volo/Abp/EventBus/RabbitMq/RabbitMqDistributedEventBus.cs
@@ -69,7 +69,7 @@ public class RabbitMqDistributedEventBus : DistributedEventBusBase, ISingletonDe
         Consumer = MessageConsumerFactory.Create(
             new ExchangeDeclareConfiguration(
                 AbpRabbitMqEventBusOptions.ExchangeName,
-                type: AbpRabbitMqEventBusOptions.ExchangeType,
+                type: AbpRabbitMqEventBusOptions.GetExchangeTypeOrDefault(),
                 durable: true
             ),
             new QueueDeclareConfiguration(
@@ -244,7 +244,7 @@ public class RabbitMqDistributedEventBus : DistributedEventBusBase, ISingletonDe
         {
             channel.ExchangeDeclare(
                 AbpRabbitMqEventBusOptions.ExchangeName,
-                AbpRabbitMqEventBusOptions.ExchangeType,
+                AbpRabbitMqEventBusOptions.GetExchangeTypeOrDefault(),
                 durable: true
             );
 

--- a/framework/src/Volo.Abp.RabbitMQ/Volo/Abp/RabbitMQ/RabbitMqConsts.cs
+++ b/framework/src/Volo.Abp.RabbitMQ/Volo/Abp/RabbitMQ/RabbitMqConsts.cs
@@ -8,4 +8,15 @@ public static class RabbitMqConsts
 
         public const int Persistent = 2;
     }
+
+    public static class ExchangeTypes
+    {
+        public const string Direct = "direct";
+
+        public const string Topic = "topic";
+
+        public const string Fanout = "fanout";
+
+        public const string Headers = "headers";
+    }
 }


### PR DESCRIPTION
Added a `ExchangeType` property to `AbpRabbitMqEventBusOptions` to make the declared exchange type configurable.

The default value `direct` will be used if the value isn't configured manually.

Fixes #1528
Fixes #11487