### PR TITLE
fixed CultureHelper.GetBaseCultureName

### DIFF
--- a/framework/src/Volo.Abp.Core/Volo/Abp/Localization/CultureHelper.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/Localization/CultureHelper.cs
@@ -57,8 +57,6 @@ public static class CultureHelper
 
     public static string GetBaseCultureName(string cultureName)
     {
-        return cultureName.Contains("-")
-            ? cultureName.Left(cultureName.IndexOf("-", StringComparison.Ordinal))
-            : cultureName;
+        return new CultureInfo(cultureName).Parent.Name;
     }
 }

--- a/framework/test/Volo.Abp.Localization.Tests/Volo/Abp/Localization/AbpLocalization_Tests.cs
+++ b/framework/test/Volo.Abp.Localization.Tests/Volo/Abp/Localization/AbpLocalization_Tests.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using System.Linq;
 using Microsoft.Extensions.Localization;
 using Shouldly;
@@ -182,6 +182,60 @@ public class AbpLocalization_Tests : AbpIntegratedTest<AbpLocalization_Tests.Tes
         using (CultureHelper.Use(CultureInfo.GetCultureInfo("es")))
         {
             _localizer["CarPlural"].Value.ShouldBe("Autos");
+        }
+
+        using (CultureHelper.Use(CultureInfo.GetCultureInfo("zh-Hans")))
+        {
+            _localizer["Car"].Value.ShouldBe("汽车");
+        }
+        using (CultureHelper.Use(CultureInfo.GetCultureInfo("zh-Hans")))
+        {
+            _localizer["CarPlural"].Value.ShouldBe("汽车");
+        }
+
+        using (CultureHelper.Use(CultureInfo.GetCultureInfo("zh-CN")))
+        {
+            _localizer["Car"].Value.ShouldBe("汽车");
+        }
+        using (CultureHelper.Use(CultureInfo.GetCultureInfo("zh-CN")))
+        {
+            _localizer["CarPlural"].Value.ShouldBe("汽车");
+        }
+        
+        using (CultureHelper.Use(CultureInfo.GetCultureInfo("zh-Hans-CN")))
+        {
+            _localizer["Car"].Value.ShouldBe("汽车");
+        }
+        using (CultureHelper.Use(CultureInfo.GetCultureInfo("zh-Hans-CN")))
+        {
+            _localizer["CarPlural"].Value.ShouldBe("汽车");
+        }
+
+        using (CultureHelper.Use(CultureInfo.GetCultureInfo("zh-Hant")))
+        {
+            _localizer["Car"].Value.ShouldBe("汽車");
+        }
+        using (CultureHelper.Use(CultureInfo.GetCultureInfo("zh-Hant")))
+        {
+            _localizer["CarPlural"].Value.ShouldBe("汽車");
+        }
+        
+        using (CultureHelper.Use(CultureInfo.GetCultureInfo("zh-TW")))
+        {
+            _localizer["Car"].Value.ShouldBe("汽車");
+        }
+        using (CultureHelper.Use(CultureInfo.GetCultureInfo("zh-TW")))
+        {
+            _localizer["CarPlural"].Value.ShouldBe("汽車");
+        }
+        
+        using (CultureHelper.Use(CultureInfo.GetCultureInfo("zh-Hant-TW")))
+        {
+            _localizer["Car"].Value.ShouldBe("汽車");
+        }
+        using (CultureHelper.Use(CultureInfo.GetCultureInfo("zh-Hant-TW")))
+        {
+            _localizer["CarPlural"].Value.ShouldBe("汽車");
         }
     }
 


### PR DESCRIPTION
ConsoleApp Test Code: 
```
using System.Globalization;

Console.WriteLine(CultureInfo.CurrentCulture.Name);
Console.WriteLine(CultureInfo.CurrentUICulture.Name);

Console.WriteLine(new CultureInfo("tr-TR").Parent.Name);
Console.WriteLine(new CultureInfo("zh-CN").Parent.Name);
Console.WriteLine(new CultureInfo("zh-TW").Parent.Name);
Console.WriteLine(new CultureInfo("zh-Hans-CN").Parent.Name);
Console.WriteLine(new CultureInfo("zh-Hant-TW").Parent.Name);

 //     zh-CN
 //     zh-CN

 //     tr
 //     zh-Hans
 //     zh-Hant
 //     zh-Hans
 //     zh-Hant
```

About CultureInfo.Parent: [dotnet/runtime/.../CultureInfo.cs#L477](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs#L477)
```
// We need to keep the parent chain for the zh cultures as follows to preserve the resource lookup compatability
 //      zh-CN -> zh-Hans -> zh -> Invariant
 //      zh-HK -> zh-Hant -> zh -> Invariant
 //      zh-MO -> zh-Hant -> zh -> Invariant
 //      zh-SG -> zh-Hans -> zh -> Invariant
 //      zh-TW -> zh-Hant -> zh -> Invariant
```