### PR TITLE
make ui message alert extendable in blazor

### DIFF
--- a/framework/src/Volo.Abp.BlazoriseUI/Components/UiMessageAlert.razor.cs
+++ b/framework/src/Volo.Abp.BlazoriseUI/Components/UiMessageAlert.razor.cs
@@ -94,7 +94,12 @@ public partial class UiMessageAlert : ComponentBase, IDisposable
         Options = e.Options;
         Callback = e.Callback;
 
-        await InvokeAsync(ModalRef.Show);
+        await ShowMessageAlert();
+    }
+
+    protected virtual Task ShowMessageAlert()
+    {
+        return InvokeAsync(ModalRef.Show);
     }
 
     public void Dispose()

--- a/framework/src/Volo.Abp.BlazoriseUI/Components/UiMessageAlert.razor.cs
+++ b/framework/src/Volo.Abp.BlazoriseUI/Components/UiMessageAlert.razor.cs
@@ -97,9 +97,9 @@ public partial class UiMessageAlert : ComponentBase, IDisposable
         await ShowMessageAlert();
     }
 
-    protected virtual Task ShowMessageAlert()
+    protected virtual async Task ShowMessageAlert()
     {
-        return InvokeAsync(ModalRef.Show);
+        await InvokeAsync(ModalRef.Show);
     }
 
     public void Dispose()


### PR DESCRIPTION
resolve #12151

after this PR, we can simple replace default message alert to SweetAlert in blazor, here we use [CurrieTechnologies.Razor.SweetAlert2](https://github.com/Basaingeal/Razor.SweetAlert2) package:
```cs
[Dependency(ReplaceServices = true)]
[ExposeServices(typeof(UiMessageAlert))]
public class SweetAlertUiMessage : UiMessageAlert
{
    [Inject] private SweetAlertService SweetAlertService { get; set; }

    protected override void BuildRenderTree(RenderTreeBuilder builder)
    {
    }

    protected override async Task ShowMessageAlert()
    {
        var sweetAlertOptions = new SweetAlertOptions
        {
            Title = Title,
            Html = Message,
            Icon = MessageType switch
            {
                UiMessageType.Info => SweetAlertIcon.Info,
                UiMessageType.Success => SweetAlertIcon.Success,
                UiMessageType.Warning => SweetAlertIcon.Warning,
                UiMessageType.Error => SweetAlertIcon.Error,
                UiMessageType.Confirmation => SweetAlertIcon.Question,
                _ => null
            },
            ShowCancelButton = MessageType == UiMessageType.Confirmation,
            ConfirmButtonText = MessageType == UiMessageType.Confirmation
                ? Options.ConfirmButtonText
                : Options.OkButtonText,
            CancelButtonText = Options.CancelButtonText
        };

        await InvokeAsync(async () =>
        {
            var result = await SweetAlertService.FireAsync(sweetAlertOptions);
            if (MessageType == UiMessageType.Confirmation)
            {
                Callback?.SetResult(result.IsConfirmed);
            }
        });
    }
}
```