### PR TITLE
CMS Kit - Blog Features Seeding

### DIFF
--- a/modules/cms-kit/src/Volo.CmsKit.Domain/Volo/CmsKit/Blogs/BlogFeatureDataSeedContributor.cs
+++ b/modules/cms-kit/src/Volo.CmsKit.Domain/Volo/CmsKit/Blogs/BlogFeatureDataSeedContributor.cs
@@ -1,0 +1,29 @@
+﻿using System.Threading.Tasks;
+using Volo.Abp.Data;
+using Volo.Abp.DependencyInjection;
+
+namespace Volo.CmsKit.Blogs;
+
+public class BlogFeatureDataSeedContributor : IDataSeedContributor, ITransientDependency
+{
+    private readonly BlogFeatureManager _blogFeatureManager;
+    private readonly IBlogRepository _blogRepository;
+
+    public BlogFeatureDataSeedContributor(
+        BlogFeatureManager blogFeatureManager,
+        IBlogRepository blogRepository)
+    {
+        _blogFeatureManager = blogFeatureManager;
+        _blogRepository = blogRepository;
+    }
+
+    public async Task SeedAsync(DataSeedContext context)
+    {
+        var blogs = await _blogRepository.GetListAsync();
+
+        foreach (var blog in blogs)
+        {
+            await _blogFeatureManager.SetDefaultsIfNotSetAsync(blog.Id);
+        }
+    }
+}

--- a/modules/cms-kit/src/Volo.CmsKit.Domain/Volo/CmsKit/Blogs/BlogFeatureManager.cs
+++ b/modules/cms-kit/src/Volo.CmsKit.Domain/Volo/CmsKit/Blogs/BlogFeatureManager.cs
@@ -44,4 +44,24 @@ public class BlogFeatureManager : DomainService
             await SetAsync(blogId, feature.FeatureName, isEnabled: true);
         }
     }
+
+    public async Task SetIfNotSetAsync(Guid blogId, string featureName, bool isEnabled)
+    {
+        var blogFeature = await BlogFeatureRepository.FindAsync(blogId, featureName);
+        if (blogFeature == null)
+        {
+            var newBlogFeature = new BlogFeature(blogId, featureName, isEnabled);
+            await BlogFeatureRepository.InsertAsync(newBlogFeature);
+        }
+    }
+
+    public async Task SetDefaultsIfNotSetAsync(Guid blogId)
+    {
+        var defaultFeatures = await DefaultBlogFeatureProvider.GetDefaultFeaturesAsync(blogId);
+
+        foreach (var feature in defaultFeatures)
+        {
+            await SetIfNotSetAsync(blogId, feature.FeatureName, isEnabled: true);
+        }
+    }
 }


### PR DESCRIPTION
Closes https://github.com/abpframework/abp/issues/12134

---

By default, newly added blog features won't be visible in the context menu. So this data seeding makes blog featured as synced after running the dbmigrator