### PR TITLE
Fixed project file encoding to retain existing encoding.

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/SolutionFileModifier.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/SolutionFileModifier.cs
@@ -10,24 +10,28 @@ namespace Volo.Abp.Cli.ProjectModification;
 
 public class SolutionFileModifier : ITransientDependency
 {
+    public static Encoding DefaultEncoding = Encoding.UTF8;
+
     public async Task RemoveProjectFromSolutionFileAsync(string solutionFile, string projectName)
     {
-        using (var fs = File.Open(solutionFile, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
-        using (var sr = new StreamReader(fs, Encoding.Default, true))
+        using (var fileStream = File.Open(solutionFile, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
         {
-            var solutionFileContent = await sr.ReadToEndAsync();
-            solutionFileContent.NormalizeLineEndings();
-
-            var lines = solutionFileContent.Split(new[] { Environment.NewLine, "\n" }, StringSplitOptions.None);
-            var updatedContent = RemoveProject(lines.ToList(), projectName).JoinAsString(Environment.NewLine);
-
-            fs.Seek(0, SeekOrigin.Begin);
-            fs.SetLength(0);
-
-            using (var sw = new StreamWriter(fs, sr.CurrentEncoding))
+            using (var sr = new StreamReader(fileStream, Encoding.Default, true))
             {
-                sw.Write(updatedContent);
-                sw.Flush();
+                var solutionFileContent = await sr.ReadToEndAsync();
+                solutionFileContent.NormalizeLineEndings();
+
+                var lines = solutionFileContent.Split(new[] { Environment.NewLine, "\n" }, StringSplitOptions.None);
+                var updatedContent = RemoveProject(lines.ToList(), projectName).JoinAsString(Environment.NewLine);
+
+                fileStream.Seek(0, SeekOrigin.Begin);
+                fileStream.SetLength(0);
+
+                using (var sw = new StreamWriter(fileStream, DefaultEncoding))
+                {
+                    await sw.WriteAsync(updatedContent);
+                    await sw.FlushAsync();
+                }
             }
         }
     }
@@ -46,8 +50,8 @@ public class SolutionFileModifier : ITransientDependency
     {
         var srcFolderId = await AddNewFolderAndGetIdOrGetExistingIdAsync(solutionFile, "src");
 
-        var file = File.ReadAllText(solutionFile);
-        var lines = file.Split(Environment.NewLine).ToList();
+        var solutionFileContent = File.ReadAllText(solutionFile);
+        var lines = solutionFileContent.Split(Environment.NewLine).ToList();
 
         if (lines.Any(l => l.Contains($"\"{package.Name}\"")))
         {
@@ -77,7 +81,7 @@ public class SolutionFileModifier : ITransientDependency
 
         lines.InsertAfter(l => l.Contains("GlobalSection") && l.Contains("NestedProjects"), newPreSolutionLine);
 
-        File.WriteAllText(solutionFile, string.Join(Environment.NewLine, lines), Encoding.UTF8);
+        File.WriteAllText(solutionFile, string.Join(Environment.NewLine, lines), DefaultEncoding);
     }
 
     private List<string> RemoveProject(List<string> solutionFileLines, string projectName)
@@ -150,7 +154,7 @@ public class SolutionFileModifier : ITransientDependency
                 Path.Combine(Path.GetDirectoryName(solutionFile), "modules", module.Name, "test"),
                 "*.csproj",
                 SearchOption.AllDirectories).ToList();
-        } 
+        }
 
         foreach (var projectPath in projectsUnderModule)
         {

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/VoloNugetPackagesVersionUpdater.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/VoloNugetPackagesVersionUpdater.cs
@@ -18,6 +18,7 @@ public class VoloNugetPackagesVersionUpdater : ITransientDependency
     private readonly NuGetService _nuGetService;
     private readonly MyGetPackageListFinder _myGetPackageListFinder;
     public ILogger<VoloNugetPackagesVersionUpdater> Logger { get; set; }
+    public static Encoding DefaultEncoding = Encoding.UTF8;
 
     public VoloNugetPackagesVersionUpdater(NuGetService nuGetService, MyGetPackageListFinder myGetPackageListFinder)
     {
@@ -43,25 +44,27 @@ public class VoloNugetPackagesVersionUpdater : ITransientDependency
             async Task UpdateAsync(string filePath)
             {
                 using (var fs = File.Open(filePath, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
-                using (var sr = new StreamReader(fs, Encoding.Default, true))
                 {
-                    var fileContent = await sr.ReadToEndAsync();
-
-                    var updatedContent = await UpdateVoloPackagesAsync(fileContent,
-                        includePreviews,
-                        includeReleaseCandidates,
-                        switchToStable,
-                        latestVersionFromNuget,
-                        latestReleaseCandidateVersionFromNuget,
-                        latestVersionFromMyGet,
-                        version);
-
-                    fs.Seek(0, SeekOrigin.Begin);
-                    fs.SetLength(0);
-                    using (var sw = new StreamWriter(fs, sr.CurrentEncoding))
+                    using (var sr = new StreamReader(fs, Encoding.Default, true))
                     {
-                        sw.Write(updatedContent);
-                        sw.Flush();
+                        var fileContent = await sr.ReadToEndAsync();
+
+                        var updatedContent = await UpdateVoloPackagesAsync(fileContent,
+                            includePreviews,
+                            includeReleaseCandidates,
+                            switchToStable,
+                            latestVersionFromNuget,
+                            latestReleaseCandidateVersionFromNuget,
+                            latestVersionFromMyGet,
+                            version);
+
+                        fs.Seek(0, SeekOrigin.Begin);
+                        fs.SetLength(0);
+                        using (var sw = new StreamWriter(fs, DefaultEncoding))
+                        {
+                            await sw.WriteAsync(updatedContent);
+                            await sw.FlushAsync();
+                        }
                     }
                 }
             }
@@ -83,26 +86,28 @@ public class VoloNugetPackagesVersionUpdater : ITransientDependency
             var latestVersionFromMyGet = await GetLatestVersionFromMyGet("Volo.Abp.Core");
 
             using (var fs = File.Open(projectPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
-            using (var sr = new StreamReader(fs, Encoding.Default, true))
             {
-                var fileContent = await sr.ReadToEndAsync();
-
-                var updatedContent = await UpdateVoloPackagesAsync(fileContent,
-                    includeNightlyPreviews,
-                    includeReleaseCandidates,
-                    switchToStable,
-                    latestVersionFromNuget,
-                    latestReleaseCandidateVersionFromNuget,
-                    latestVersionFromMyGet,
-                    version);
-
-                fs.Seek(0, SeekOrigin.Begin);
-                fs.SetLength(0);
-
-                using (var sw = new StreamWriter(fs, sr.CurrentEncoding))
+                using (var sr = new StreamReader(fs, Encoding.Default, true))
                 {
-                    sw.Write(updatedContent);
-                    sw.Flush();
+                    var fileContent = await sr.ReadToEndAsync();
+
+                    var updatedContent = await UpdateVoloPackagesAsync(fileContent,
+                        includeNightlyPreviews,
+                        includeReleaseCandidates,
+                        switchToStable,
+                        latestVersionFromNuget,
+                        latestReleaseCandidateVersionFromNuget,
+                        latestVersionFromMyGet,
+                        version);
+
+                    fs.Seek(0, SeekOrigin.Begin);
+                    fs.SetLength(0);
+
+                    using (var sw = new StreamWriter(fs, sr.CurrentEncoding))
+                    {
+                        await sw.WriteAsync(updatedContent);
+                        await sw.FlushAsync();
+                    }
                 }
             }
         }
@@ -111,19 +116,21 @@ public class VoloNugetPackagesVersionUpdater : ITransientDependency
     protected virtual async Task UpdateInternalAsync(string projectPath, bool includeNightlyPreviews = false, bool includeReleaseCandidates = false, bool switchToStable = false)
     {
         using (var fs = File.Open(projectPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
-        using (var sr = new StreamReader(fs, Encoding.Default, true))
         {
-            var fileContent = await sr.ReadToEndAsync();
-
-            var updatedContent = await UpdateVoloPackagesAsync(fileContent, includeNightlyPreviews, includeReleaseCandidates, switchToStable);
-
-            fs.Seek(0, SeekOrigin.Begin);
-            fs.SetLength(0);
-
-            using (var sw = new StreamWriter(fs, sr.CurrentEncoding))
+            using (var sr = new StreamReader(fs, Encoding.Default, true))
             {
-                sw.Write(updatedContent);
-                sw.Flush();
+                var fileContent = await sr.ReadToEndAsync();
+
+                var updatedContent = await UpdateVoloPackagesAsync(fileContent, includeNightlyPreviews, includeReleaseCandidates, switchToStable);
+
+                fs.Seek(0, SeekOrigin.Begin);
+                fs.SetLength(0);
+
+                using (var sw = new StreamWriter(fs, sr.CurrentEncoding))
+                {
+                    await sw.WriteAsync(updatedContent);
+                    await sw.FlushAsync();
+                }
             }
         }
     }
@@ -245,7 +252,7 @@ public class VoloNugetPackagesVersionUpdater : ITransientDependency
         }
         catch (Exception ex)
         {
-            Logger.LogError("Cannot update Volo.* packages! An error occured while updating the package \"{0}\". Error: {1}", packageId, ex.Message);
+            Logger.LogError("Cannot update Volo.* packages! An error occurred while updating the package \"{0}\". Error: {1}", packageId, ex.Message);
             Logger.LogException(ex);
         }
 


### PR DESCRIPTION
When using the command `abp update` it was changing the current file encoding from UTF8 to Windows-1252. 
This patch maintains the existing file encoding or defaults to UTF8.