### PR TITLE
move RightAligned parameter to BarDropdown

### DIFF
--- a/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.Server.BasicTheme/Themes/Basic/LanguageSwitch.razor
+++ b/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.Server.BasicTheme/Themes/Basic/LanguageSwitch.razor
@@ -7,11 +7,11 @@
 @inject IAbpRequestLocalizationOptionsProvider RequestLocalizationOptionsProvider
 @if (_otherLanguages != null && _otherLanguages.Any())
 {
-    <BarDropdown>
+    <BarDropdown RightAligned="true">
         <BarDropdownToggle>
             @_currentLanguage.DisplayName
         </BarDropdownToggle>
-        <BarDropdownMenu RightAligned="true">
+        <BarDropdownMenu>
             @foreach (var language in _otherLanguages)
             {
                 <BarDropdownItem Clicked="() => ChangeLanguage(language)">@language.DisplayName</BarDropdownItem>

--- a/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.WebAssembly.BasicTheme/Themes/Basic/LanguageSwitch.razor
+++ b/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.WebAssembly.BasicTheme/Themes/Basic/LanguageSwitch.razor
@@ -5,11 +5,11 @@
 @inject IJSRuntime JsRuntime
 @if (_otherLanguages != null && _otherLanguages.Any())
 {
-    <BarDropdown>
+    <BarDropdown RightAligned="true">
         <BarDropdownToggle>
             @_currentLanguage.DisplayName
         </BarDropdownToggle>
-        <BarDropdownMenu RightAligned="true">
+        <BarDropdownMenu>
             @foreach (var language in _otherLanguages)
             {
                 <BarDropdownItem Clicked="() => ChangeLanguageAsync(language)">@language.DisplayName</BarDropdownItem>


### PR DESCRIPTION
Blazorise 1.0 has moved `RightAligned` parameter from `<BarDropdownMenu>` to `<BarDropdown>` component.

additonal info: The `RightAligned` feature in blazorise 1.0 looks like not work well, see https://github.com/Megabit/Blazorise/issues/3682