### PR TITLE
Add `AbpDesignTimeDbContextBase`.

### DIFF
--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/Design/AbpDesignTimeDbContextBase.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/Design/AbpDesignTimeDbContextBase.cs
@@ -1,0 +1,29 @@
+﻿using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Volo.Abp.Modularity;
+using Volo.Abp.Threading;
+
+namespace Volo.Abp.EntityFrameworkCore.Design;
+
+public abstract class AbpDesignTimeDbContextBase<TModule, TContext> : IDesignTimeDbContextFactory<TContext>
+    where TModule : AbpModule
+    where TContext : DbContext
+{
+    public virtual TContext CreateDbContext(string[] args)
+    {
+        return AsyncHelper.RunSync(() => CreateDbContextAsync(args));
+    }
+
+    protected virtual async Task<TContext> CreateDbContextAsync(string[] args)
+    {
+        var application = await AbpApplicationFactory.CreateAsync<TModule>();
+        application.Services.ReplaceConfiguration(BuildConfiguration());
+        await application.InitializeAsync();
+        return application.ServiceProvider.GetRequiredService<TContext>();
+    }
+
+    protected abstract IConfigurationRoot BuildConfiguration();
+}

--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/Design/AbpDesignTimeDbContextBase.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/Design/AbpDesignTimeDbContextBase.cs
@@ -19,10 +19,20 @@ public abstract class AbpDesignTimeDbContextBase<TModule, TContext> : IDesignTim
 
     protected virtual async Task<TContext> CreateDbContextAsync(string[] args)
     {
-        var application = await AbpApplicationFactory.CreateAsync<TModule>();
-        application.Services.ReplaceConfiguration(BuildConfiguration());
+        var application = await AbpApplicationFactory.CreateAsync<TModule>(options =>
+        {
+            options.Services.ReplaceConfiguration(BuildConfiguration());
+            ConfigureServices(options.Services);
+        });
+
         await application.InitializeAsync();
+
         return application.ServiceProvider.GetRequiredService<TContext>();
+    }
+
+    protected virtual void ConfigureServices(IServiceCollection services)
+    {
+
     }
 
     protected abstract IConfigurationRoot BuildConfiguration();


### PR DESCRIPTION
Support bootstrapping a module during `dotnet ef` command call.

```cs
public class MyProjectNameDbContextFactory : AbpDesignTimeDbContextBase<MyProjectNameEntityFrameworkCoreModule, MyProjectNameDbContext>
{
    protected override void ConfigureServices(IServiceCollection services)
    {
        services.AddAutofacServiceProviderFactory();
        services.Configure<AbpBackgroundJobOptions>(options =>
        {
            options.IsJobExecutionEnabled = false;
        });
    }

    protected override IConfigurationRoot BuildConfiguration()
    {
        var builder = new ConfigurationBuilder()
            .SetBasePath(Path.Combine(Directory.GetCurrentDirectory(), "../MyCompanyName.MyProjectName.DbMigrator/"))
            .AddJsonFile("appsettings.json", optional: false);
        return builder.Build();
    }
}

```
