### PR TITLE
Revert "Publish local events when uow completed."

### DIFF
--- a/framework/src/Volo.Abp.EventBus/Volo/Abp/EventBus/Distributed/LocalDistributedEventBus.cs
+++ b/framework/src/Volo.Abp.EventBus/Volo/Abp/EventBus/Distributed/LocalDistributedEventBus.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Options;
 using Volo.Abp.Collections;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.EventBus.Local;
-using Volo.Abp.Uow;
 
 namespace Volo.Abp.EventBus.Distributed
 {
@@ -16,19 +15,16 @@ namespace Volo.Abp.EventBus.Distributed
     {
         private readonly ILocalEventBus _localEventBus;
 
-        protected IUnitOfWorkManager UnitOfWorkManager { get; }
         protected IServiceScopeFactory ServiceScopeFactory { get; }
 
         protected AbpDistributedEventBusOptions AbpDistributedEventBusOptions { get; }
 
         public LocalDistributedEventBus(
             ILocalEventBus localEventBus,
-            IUnitOfWorkManager unitOfWorkManager,
             IServiceScopeFactory serviceScopeFactory,
             IOptions<AbpDistributedEventBusOptions> distributedEventBusOptions)
         {
             _localEventBus = localEventBus;
-            UnitOfWorkManager = unitOfWorkManager;
             ServiceScopeFactory = serviceScopeFactory;
             AbpDistributedEventBusOptions = distributedEventBusOptions.Value;
             Subscribe(distributedEventBusOptions.Value.Handlers);
@@ -126,57 +122,25 @@ namespace Volo.Abp.EventBus.Distributed
             _localEventBus.UnsubscribeAll(eventType);
         }
 
-        public async Task PublishAsync<TEvent>(TEvent eventData, bool onUnitOfWorkComplete = true)
+        public Task PublishAsync<TEvent>(TEvent eventData, bool onUnitOfWorkComplete = true)
             where TEvent : class
         {
-            await PublishAsync(typeof(TEvent), eventData, onUnitOfWorkComplete);
+            return _localEventBus.PublishAsync(eventData, onUnitOfWorkComplete);
         }
 
-        public async Task PublishAsync(Type eventType, object eventData, bool onUnitOfWorkComplete = true)
+        public Task PublishAsync(Type eventType, object eventData, bool onUnitOfWorkComplete = true)
         {
-            if (onUnitOfWorkComplete && UnitOfWorkManager.Current != null)
-            {
-                AddToUnitOfWork(
-                    UnitOfWorkManager.Current,
-                    new UnitOfWorkEventRecord(eventType, eventData, EventOrderGenerator.GetNext())
-                );
-                return;
-            }
-
-            await _localEventBus.PublishAsync(eventType, eventData, onUnitOfWorkComplete: false);
+            return _localEventBus.PublishAsync(eventType, eventData, onUnitOfWorkComplete);
+        }
+        
+        public Task PublishAsync<TEvent>(TEvent eventData, bool onUnitOfWorkComplete = true, bool useOutbox = true) where TEvent : class
+        {
+            return _localEventBus.PublishAsync(eventData, onUnitOfWorkComplete);
         }
 
-        public async Task PublishAsync<TEvent>(TEvent eventData, bool onUnitOfWorkComplete = true, bool useOutbox = true)
-            where TEvent : class
+        public Task PublishAsync(Type eventType, object eventData, bool onUnitOfWorkComplete = true, bool useOutbox = true)
         {
-            await PublishAsync(typeof(TEvent), eventData, onUnitOfWorkComplete, useOutbox);
-        }
-
-        public async Task PublishAsync(Type eventType, object eventData, bool onUnitOfWorkComplete = true, bool useOutbox = true)
-        {
-            if (onUnitOfWorkComplete && UnitOfWorkManager.Current != null)
-            {
-                AddToUnitOfWork(
-                    UnitOfWorkManager.Current,
-                    new UnitOfWorkEventRecord(eventType, eventData, EventOrderGenerator.GetNext(), useOutbox)
-                );
-                return;
-            }
-
-            if (useOutbox && UnitOfWorkManager.Current != null)
-            {
-                UnitOfWorkManager.Current.OnCompleted(async() => {
-                    await _localEventBus.PublishAsync(eventType, eventData, onUnitOfWorkComplete: false);
-                });
-                return;
-            }
-
-            await _localEventBus.PublishAsync(eventType, eventData, onUnitOfWorkComplete: false);
-        }
-
-        protected virtual void AddToUnitOfWork(IUnitOfWork unitOfWork, UnitOfWorkEventRecord eventRecord)
-        {
-            unitOfWork.AddOrReplaceDistributedEvent(eventRecord);
+            return _localEventBus.PublishAsync(eventType, eventData, onUnitOfWorkComplete);
         }
     }
 }

--- a/framework/test/Volo.Abp.EventBus.Tests/Volo/Abp/EventBus/Distributed/LocalDistributedEventBus_Test.cs
+++ b/framework/test/Volo.Abp.EventBus.Tests/Volo/Abp/EventBus/Distributed/LocalDistributedEventBus_Test.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Threading.Tasks;
-using Shouldly;
 using Volo.Abp.Domain.Entities.Events.Distributed;
 using Volo.Abp.MultiTenancy;
-using Volo.Abp.Uow;
 using Xunit;
 
 namespace Volo.Abp.EventBus.Distributed
@@ -46,12 +44,12 @@ namespace Volo.Abp.EventBus.Distributed
 
             Assert.Equal(tenantId, MySimpleDistributedSingleInstanceEventHandler.TenantId);
         }
-
+        
         [Fact]
         public async Task Should_Get_TenantId_From_EventEto_Extra_Property()
         {
             var tenantId = Guid.NewGuid();
-
+            
             DistributedEventBus.Subscribe<MySimpleEto>(GetRequiredService<MySimpleDistributedSingleInstanceEventHandler>());
 
             await DistributedEventBus.PublishAsync(new MySimpleEto
@@ -61,72 +59,8 @@ namespace Volo.Abp.EventBus.Distributed
                     {"TenantId", tenantId.ToString()}
                 }
             });
-
+            
             Assert.Equal(tenantId, MySimpleDistributedSingleInstanceEventHandler.TenantId);
-        }
-
-        [Fact]
-        public async Task Event_Should_Published_On_UnitOfWorkComplete()
-        {
-            var id = 0;
-            DistributedEventBus.Subscribe<MySimpleEventData>(data =>
-            {
-                id = data.Value;
-                return Task.CompletedTask;
-            });
-
-            var unitOfWorkManager = GetRequiredService<IUnitOfWorkManager>();
-            using (var uow = unitOfWorkManager.Begin())
-            {
-                await DistributedEventBus.PublishAsync(new MySimpleEventData(3), onUnitOfWorkComplete: true, useOutbox: false);
-            }
-            id.ShouldBe(0);
-
-            using (var uow = unitOfWorkManager.Begin())
-            {
-                await DistributedEventBus.PublishAsync(new MySimpleEventData(3), onUnitOfWorkComplete: true, useOutbox: false);
-                await uow.CompleteAsync();
-            }
-            id.ShouldBe(3);
-
-            id = 0;
-            using (var uow = unitOfWorkManager.Begin())
-            {
-                await DistributedEventBus.PublishAsync(new MySimpleEventData(3), onUnitOfWorkComplete: false, useOutbox: false);
-            }
-            id.ShouldBe(3);
-        }
-
-        [Fact]
-        public async Task Event_Should_Published_On_UnitOfWorkComplete_UseOutbox()
-        {
-            var id = 0;
-            DistributedEventBus.Subscribe<MySimpleEventData>(data =>
-            {
-                id = data.Value;
-                return Task.CompletedTask;
-            });
-
-            var unitOfWorkManager = GetRequiredService<IUnitOfWorkManager>();
-            using (var uow = unitOfWorkManager.Begin())
-            {
-                await DistributedEventBus.PublishAsync(new MySimpleEventData(3), onUnitOfWorkComplete: false, useOutbox: true);
-            }
-            id.ShouldBe(0);
-
-            using (var uow = unitOfWorkManager.Begin())
-            {
-                await DistributedEventBus.PublishAsync(new MySimpleEventData(3), onUnitOfWorkComplete: false, useOutbox: true);
-                await uow.CompleteAsync();
-            }
-            id.ShouldBe(3);
-
-            id = 0;
-            using (var uow = unitOfWorkManager.Begin())
-            {
-                await DistributedEventBus.PublishAsync(new MySimpleEventData(3), onUnitOfWorkComplete: false, useOutbox: false);
-            }
-            id.ShouldBe(3);
         }
     }
 }


### PR DESCRIPTION
Reverts abpframework/abp#11125

#11125 was a mistake and it breaks how we designed it with ABP 5.0 and declared in the [blog post](https://blog.abp.io/abp/ABP-IO-Platform-5.0-RC-1-Has-Been-Released):

![image](https://user-images.githubusercontent.com/1210527/165534146-95aa6947-23e9-493b-936c-9f184875b923.png)

Distributed event handlers must be executed in the same unit of work where we publish the events.
