### PR TITLE
Revert "Publish event when uow completed"

### DIFF
--- a/framework/test/Volo.Abp.EventBus.Tests/Volo/Abp/EventBus/Distributed/LocalDistributedEventBus_Test.cs
+++ b/framework/test/Volo.Abp.EventBus.Tests/Volo/Abp/EventBus/Distributed/LocalDistributedEventBus_Test.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Threading.Tasks;
-using Shouldly;
 using Volo.Abp.Domain.Entities.Events.Distributed;
 using Volo.Abp.MultiTenancy;
-using Volo.Abp.Uow;
 using Xunit;
 
 namespace Volo.Abp.EventBus.Distributed;
@@ -51,7 +49,7 @@ public class LocalDistributedEventBus_Test : LocalDistributedEventBusTestBase
     public async Task Should_Get_TenantId_From_EventEto_Extra_Property()
     {
         var tenantId = Guid.NewGuid();
-
+        
         DistributedEventBus.Subscribe<MySimpleEto>(GetRequiredService<MySimpleDistributedSingleInstanceEventHandler>());
 
         await DistributedEventBus.PublishAsync(new MySimpleEto
@@ -61,71 +59,7 @@ public class LocalDistributedEventBus_Test : LocalDistributedEventBusTestBase
                 {"TenantId", tenantId.ToString()}
             }
         });
-
+        
         Assert.Equal(tenantId, MySimpleDistributedSingleInstanceEventHandler.TenantId);
-    }
-
-    [Fact]
-    public async Task Event_Should_Published_On_UnitOfWorkComplete()
-    {
-        var id = 0;
-        DistributedEventBus.Subscribe<MySimpleEventData>(data =>
-        {
-            id = data.Value;
-            return Task.CompletedTask;
-        });
-
-        var unitOfWorkManager = GetRequiredService<IUnitOfWorkManager>();
-        using (var uow = unitOfWorkManager.Begin())
-        {
-            await DistributedEventBus.PublishAsync(new MySimpleEventData(3), onUnitOfWorkComplete: true, useOutbox: false);
-        }
-        id.ShouldBe(0);
-
-        using (var uow = unitOfWorkManager.Begin())
-        {
-            await DistributedEventBus.PublishAsync(new MySimpleEventData(3), onUnitOfWorkComplete: true, useOutbox: false);
-            await uow.CompleteAsync();
-        }
-        id.ShouldBe(3);
-
-        id = 0;
-        using (var uow = unitOfWorkManager.Begin())
-        {
-            await DistributedEventBus.PublishAsync(new MySimpleEventData(3), onUnitOfWorkComplete: false, useOutbox: false);
-        }
-        id.ShouldBe(3);
-    }
-
-    [Fact]
-    public async Task Event_Should_Published_On_UnitOfWorkComplete_UseOutbox()
-    {
-        var id = 0;
-        DistributedEventBus.Subscribe<MySimpleEventData>(data =>
-        {
-            id = data.Value;
-            return Task.CompletedTask;
-        });
-
-        var unitOfWorkManager = GetRequiredService<IUnitOfWorkManager>();
-        using (var uow = unitOfWorkManager.Begin())
-        {
-            await DistributedEventBus.PublishAsync(new MySimpleEventData(3), onUnitOfWorkComplete: false, useOutbox: true);
-        }
-        id.ShouldBe(0);
-
-        using (var uow = unitOfWorkManager.Begin())
-        {
-            await DistributedEventBus.PublishAsync(new MySimpleEventData(3), onUnitOfWorkComplete: false, useOutbox: true);
-            await uow.CompleteAsync();
-        }
-        id.ShouldBe(3);
-
-        id = 0;
-        using (var uow = unitOfWorkManager.Begin())
-        {
-            await DistributedEventBus.PublishAsync(new MySimpleEventData(3), onUnitOfWorkComplete: false, useOutbox: false);
-        }
-        id.ShouldBe(3);
     }
 }


### PR DESCRIPTION
Reverts abpframework/abp#11125

#11125 was a mistake and it breaks how we designed it with ABP 5.0 and declared in the [blog post](https://blog.abp.io/abp/ABP-IO-Platform-5.0-RC-1-Has-Been-Released):

![image](https://user-images.githubusercontent.com/1210527/165534146-95aa6947-23e9-493b-936c-9f184875b923.png)

Distributed event handlers must be executed in the same unit of work where we publish the events.
