### PR TITLE
remove duplicate ICurrentTenant injection in blazor template

### DIFF
--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.Server.Tiered/Pages/Index.razor
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.Server.Tiered/Pages/Index.razor
@@ -1,7 +1,6 @@
 ﻿@page "/"
 @using Volo.Abp.MultiTenancy
 @inherits MyProjectNameComponentBase
-@inject ICurrentTenant CurrentTenant
 @inject AuthenticationStateProvider AuthenticationStateProvider
 <div class="container">
     <div class="p-5 text-center">

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.Server/Pages/Index.razor
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.Server/Pages/Index.razor
@@ -1,7 +1,6 @@
 ﻿@page "/"
 @using Volo.Abp.MultiTenancy
 @inherits MyProjectNameComponentBase
-@inject ICurrentTenant CurrentTenant
 @inject AuthenticationStateProvider AuthenticationStateProvider
 <div class="container">
     <div class="p-5 text-center">

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor/Pages/Index.razor
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor/Pages/Index.razor
@@ -1,7 +1,6 @@
 ﻿@page "/"
 @using Volo.Abp.MultiTenancy
 @inherits MyProjectNameComponentBase
-@inject ICurrentTenant CurrentTenant
 @inject AuthenticationStateProvider AuthenticationStateProvider
 <div class="container">
     <div class="p-5 text-center">


### PR DESCRIPTION
`CurrentTenant` has been injected from base component
https://github.com/abpframework/abp/blob/e7505fae9bf5a2cea8c5a5263fb2793e62508f8e/framework/src/Volo.Abp.AspNetCore.Components/Volo/Abp/AspNetCore/Components/AbpComponentBase.cs#L59