### PR TITLE
Add console logging to app templates for every environment

### DIFF
--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.Server.Tiered/Program.cs
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.Server.Tiered/Program.cs
@@ -22,9 +22,7 @@ public class Program
             .MinimumLevel.Override("Microsoft.EntityFrameworkCore", LogEventLevel.Warning)
             .Enrich.FromLogContext()
             .WriteTo.Async(c => c.File("Logs/logs.txt"))
-#if DEBUG
             .WriteTo.Async(c => c.Console())
-#endif
             .CreateLogger();
 
         try

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.Server/Program.cs
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.Server/Program.cs
@@ -22,9 +22,7 @@ public class Program
             .MinimumLevel.Override("Microsoft.EntityFrameworkCore", LogEventLevel.Warning)
             .Enrich.FromLogContext()
             .WriteTo.Async(c => c.File("Logs/logs.txt"))
-#if DEBUG
             .WriteTo.Async(c => c.Console())
-#endif
             .CreateLogger();
 
         try

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.HttpApi.Host/Program.cs
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.HttpApi.Host/Program.cs
@@ -22,9 +22,7 @@ public class Program
             .MinimumLevel.Override("Microsoft.EntityFrameworkCore", LogEventLevel.Warning)
             .Enrich.FromLogContext()
             .WriteTo.Async(c => c.File("Logs/logs.txt"))
-#if DEBUG
             .WriteTo.Async(c => c.Console())
-#endif
             .CreateLogger();
 
         try

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.HttpApi.HostWithIds/Program.cs
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.HttpApi.HostWithIds/Program.cs
@@ -22,9 +22,7 @@ public class Program
             .MinimumLevel.Override("Microsoft.EntityFrameworkCore", LogEventLevel.Warning)
             .Enrich.FromLogContext()
             .WriteTo.Async(c => c.File("Logs/logs.txt"))
-#if DEBUG
             .WriteTo.Async(c => c.Console())
-#endif
             .CreateLogger();
 
         try

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.IdentityServer/Program.cs
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.IdentityServer/Program.cs
@@ -22,9 +22,7 @@ public class Program
             .MinimumLevel.Override("Microsoft.EntityFrameworkCore", LogEventLevel.Warning)
             .Enrich.FromLogContext()
             .WriteTo.Async(c => c.File("Logs/logs.txt"))
-#if DEBUG
             .WriteTo.Async(c => c.Console())
-#endif
             .CreateLogger();
 
         try

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Web.Host/Program.cs
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Web.Host/Program.cs
@@ -22,9 +22,7 @@ public class Program
             .MinimumLevel.Override("Microsoft.EntityFrameworkCore", LogEventLevel.Warning)
             .Enrich.FromLogContext()
             .WriteTo.Async(c => c.File("Logs/logs.txt"))
-#if DEBUG
             .WriteTo.Async(c => c.Console())
-#endif
             .CreateLogger();
 
         try

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Web/Program.cs
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Web/Program.cs
@@ -22,9 +22,7 @@ public class Program
             .MinimumLevel.Override("Microsoft.EntityFrameworkCore", LogEventLevel.Warning)
             .Enrich.FromLogContext()
             .WriteTo.Async(c => c.File("Logs/logs.txt"))
-#if DEBUG
             .WriteTo.Async(c => c.Console())
-#endif
             .CreateLogger();
 
         try

--- a/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.Blazor.Server.Host/Program.cs
+++ b/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.Blazor.Server.Host/Program.cs
@@ -22,9 +22,7 @@ public class Program
             .MinimumLevel.Override("Microsoft.EntityFrameworkCore", LogEventLevel.Warning)
             .Enrich.FromLogContext()
             .WriteTo.Async(c => c.File("Logs/logs.txt"))
-#if DEBUG
             .WriteTo.Async(c => c.Console())
-#endif
             .CreateLogger();
 
         try

--- a/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.HttpApi.Host/Program.cs
+++ b/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.HttpApi.Host/Program.cs
@@ -22,9 +22,7 @@ public class Program
             .MinimumLevel.Override("Microsoft.EntityFrameworkCore", LogEventLevel.Warning)
             .Enrich.FromLogContext()
             .WriteTo.Async(c => c.File("Logs/logs.txt"))
-#if DEBUG
             .WriteTo.Async(c => c.Console())
-#endif
             .CreateLogger();
 
         try

--- a/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.IdentityServer/Program.cs
+++ b/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.IdentityServer/Program.cs
@@ -22,9 +22,7 @@ public class Program
             .MinimumLevel.Override("Microsoft.EntityFrameworkCore", LogEventLevel.Warning)
             .Enrich.FromLogContext()
             .WriteTo.Async(c => c.File("Logs/logs.txt"))
-#if DEBUG
             .WriteTo.Async(c => c.Console())
-#endif
             .CreateLogger();
 
         try

--- a/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.Web.Host/Program.cs
+++ b/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.Web.Host/Program.cs
@@ -25,9 +25,7 @@ public class Program
             .MinimumLevel.Override("Microsoft.EntityFrameworkCore", LogEventLevel.Warning)
             .Enrich.FromLogContext()
             .WriteTo.Async(c => c.File("Logs/logs.txt"))
-#if DEBUG
             .WriteTo.Async(c => c.Console())
-#endif
             .CreateLogger();
 
         try

--- a/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.Web.Unified/Program.cs
+++ b/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.Web.Unified/Program.cs
@@ -25,9 +25,7 @@ public class Program
             .MinimumLevel.Override("Microsoft.EntityFrameworkCore", LogEventLevel.Warning)
             .Enrich.FromLogContext()
             .WriteTo.Async(c => c.File("Logs/logs.txt"))
-#if DEBUG
             .WriteTo.Async(c => c.Console())
-#endif
             .CreateLogger();
 
         try


### PR DESCRIPTION
It is currently available for only debugging. Docker and Kubernetes use stdout for logging. We should enable it for all environments.