### PR TITLE
Update Blazor LeptonXLite documentation

### DIFF
--- a/docs/en/Themes/LeptonXLite/blazor.md
+++ b/docs/en/Themes/LeptonXLite/blazor.md
@@ -18,9 +18,10 @@ LeptonX Lite has implementation for the ABP Framework Blazor WebAssembly & Blazo
 {{if UI == "Blazor"}}
 - Complete the [MVC Razor Pages Installation](mvc.md#installation) for the **HttpApi.Host** application first. _If the solution is tiered/micro-service, complete the MVC steps for all MVC applications such as **HttpApi.Host** and if identity server is separated, install to the **IdentityServer**_.
 
-- Add **Volo.Abp.AspNetCore.Components.WebAssembly.LeptonXLiteTheme** package to your **Blazor WebAssembly** application.
+- Add **Volo.Abp.AspNetCore.Components.WebAssembly.LeptonXLiteTheme** package to your **Blazor WebAssembly** application with the following command:
+
   ```bash
-  dotnet add package Volo.Abp.AspNetCore.Components.WebAssembly.LeptonXLiteTheme
+  dotnet add package Volo.Abp.AspNetCore.Components.WebAssembly.LeptonXLiteTheme --prerelease
   ```
 
 - Remove **Volo.Abp.AspNetCore.Components.WebAssembly.BasicTheme** reference from the project since it's not necessary after switching to LeptonX Lite.
@@ -53,9 +54,10 @@ builder.RootComponents.Add<App>("#ApplicationContainer");
 
 - Complete the [MVC Razor Pages Installation](mvc.md#installation) first. _If the solution is tiered/micro-service, complete the MVC steps for all MVC applications such as **HttpApi.Host** and **IdentityServer**_.
 
-- Add **Volo.Abp.AspNetCore.Components.Server.LeptonXLiteTheme** package to your **Blazor server** application.
+- Add **Volo.Abp.AspNetCore.Components.Server.LeptonXLiteTheme** package to your **Blazor server** application with the following command:
+
   ```bash
-  dotnet add package Volo.Abp.AspNetCore.Components.Server.LeptonXLiteTheme
+  dotnet add package Volo.Abp.AspNetCore.Components.Server.LeptonXLiteTheme --prerelease
   ```
 
 - Remove **Volo.Abp.AspNetCore.Components.Server.BasicTheme** reference from the project since it's not necessary after switching to LeptonX Lite.


### PR DESCRIPTION
> Without the `--prerelease` parameter, it tries to find the stable version.