### PR TITLE
Cli: Check if file exists in NugetPackageToLocalReferenceConverter

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/NugetPackageToLocalReferenceConverter.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/NugetPackageToLocalReferenceConverter.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Xml;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Volo.Abp.Cli.Utils;
 using Volo.Abp.DependencyInjection;
 
@@ -12,6 +14,12 @@ namespace Volo.Abp.Cli.ProjectModification;
 
 public class NugetPackageToLocalReferenceConverter : ITransientDependency
 {
+    public ILogger<NugetPackageToLocalReferenceConverter> Logger { get; set; }
+
+    public NugetPackageToLocalReferenceConverter(){
+        Logger = NullLogger<NugetPackageToLocalReferenceConverter>.Instance;
+    }
+    
     public async Task Convert(ModuleWithMastersInfo module, string solutionFile, string modulePrefix = "Volo.")
     {
         var nugetPackageList = GetNugetPackages(module);
@@ -32,6 +40,7 @@ public class NugetPackageToLocalReferenceConverter : ITransientDependency
         {
             if (!File.Exists(projectFile))
             {
+                Logger.LogWarning($"{projectFile} could not be found, skipping...");
                 return;
             }
             

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/NugetPackageToLocalReferenceConverter.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/NugetPackageToLocalReferenceConverter.cs
@@ -30,6 +30,11 @@ public class NugetPackageToLocalReferenceConverter : ITransientDependency
 
         foreach (var projectFile in projectFiles)
         {
+            if (!File.Exists(projectFile))
+            {
+                return;
+            }
+            
             var content = File.ReadAllText(projectFile);
             using (var stream = StreamHelper.GenerateStreamFromString(content))
             {


### PR DESCRIPTION
Actually, it is guaranteed that the files exist. But for an unknown reason it throws DirectoryNotFoundException in some cases. See https://support.abp.io/QA/Questions/3114#answer-dbf14e3a-696d-2a17-7170-3a0411cbf1dd