### PR TITLE
Support 'Light Mode' for ABP CLI

### DIFF
--- a/framework/src/Volo.Abp.Cli/Volo.Abp.Cli.csproj
+++ b/framework/src/Volo.Abp.Cli/Volo.Abp.Cli.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.2-dev-00890" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(MicrosoftPackageVersion)" />
   </ItemGroup>

--- a/framework/src/Volo.Abp.Cli/Volo.Abp.Cli.csproj
+++ b/framework/src/Volo.Abp.Cli/Volo.Abp.Cli.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.2-dev-00890" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(MicrosoftPackageVersion)" />
   </ItemGroup>

--- a/framework/src/Volo.Abp.Cli/Volo/Abp/Cli/Program.cs
+++ b/framework/src/Volo.Abp.Cli/Volo/Abp/Cli/Program.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Serilog;
 using Serilog.Events;
+using Serilog.Sinks.SystemConsole.Themes;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -26,7 +27,7 @@ public class Program
 #endif
                 .Enrich.FromLogContext()
             .WriteTo.File(Path.Combine(CliPaths.Log, "abp-cli-logs.txt"))
-            .WriteTo.Console()
+            .WriteTo.Console(theme: AnsiConsoleTheme.Sixteen)
             .CreateLogger();
 
         using (var application = AbpApplicationFactory.Create<AbpCliModule>(


### PR DESCRIPTION
Resolves: https://github.com/abpframework/abp/issues/12256

Related with https://github.com/serilog/serilog-sinks-console/issues/123

- [x] need more test eg. macOS
- [x] waiting for the next release of `Serilog.Sinks.Console`

Before:
<img width="816" alt="dark-1" src="https://user-images.githubusercontent.com/12685126/170619547-065749b4-70af-4cf6-8278-14ec27ef1bfe.png">
<img width="816" alt="light-1" src="https://user-images.githubusercontent.com/12685126/170619550-cfb7b725-129f-42cc-94cd-bbd28ffb7855.png">

After:
<img width="816" alt="dark-2" src="https://user-images.githubusercontent.com/12685126/170619577-6b22a2b6-48a8-4768-b192-cab5b0a57a73.png">
<img width="816" alt="light-2" src="https://user-images.githubusercontent.com/12685126/170619585-f1037a0f-2e37-4841-b28d-85badb0377af.png">
