### PR TITLE
Remove `ConcurrencyStamp` parent div

### DIFF
--- a/modules/account/src/Volo.Abp.Account.Web/Pages/Account/Components/ProfileManagementGroup/PersonalInfo/Default.cshtml
+++ b/modules/account/src/Volo.Abp.Account.Web/Pages/Account/Components/ProfileManagementGroup/PersonalInfo/Default.cshtml
@@ -20,7 +20,7 @@
 <h4>@L["PersonalSettings"]</h4><hr/>
 <form method="post" id="PersonalSettingsForm">
     
-    <abp-input asp-for="ConcurrencyStamp" />
+    <input asp-for="ConcurrencyStamp" />
 
     <abp-input asp-for="UserName" readonly="!isUserNameUpdateEnabled"/>
 


### PR DESCRIPTION
`ConcurrencyStamp` is a hidden input, should not have ‘mb-3’ class.

Before:

<img width="523" alt="image" src="https://user-images.githubusercontent.com/12685126/170815857-6bd6dc67-f4a4-4f49-8936-6b7395d57c7f.png">

After:
 
<img width="581" alt="image" src="https://user-images.githubusercontent.com/12685126/170815888-847161ad-1a2e-4d2d-8025-11ba845e8316.png">
