### PR TITLE
cli: provide backward compatibility for identity server project

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectBuilding/Templates/App/AppTemplateSwitchEntityFrameworkCoreToMongoDbStep.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectBuilding/Templates/App/AppTemplateSwitchEntityFrameworkCoreToMongoDbStep.cs
@@ -45,16 +45,7 @@ public class AppTemplateSwitchEntityFrameworkCoreToMongoDbStep : ProjectBuildPip
             _hasDbMigrations ? "EntityFrameworkCore.DbMigrations" : "EntityFrameworkCore",
             "MongoDB"
         );
-
-        ChangeNamespaceAndKeyword(
-            context,
-            "/aspnet-core/src/MyCompanyName.MyProjectName.AuthServer/MyProjectNameIdentityServerModule.cs",
-            "MyCompanyName.MyProjectName.EntityFrameworkCore",
-            "MyCompanyName.MyProjectName.MongoDB",
-            _hasDbMigrations ? "MyProjectNameEntityFrameworkCoreDbMigrationsModule" : "MyProjectNameEntityFrameworkCoreModule",
-            "MyProjectNameMongoDbModule"
-        );
-
+        
         ChangeNamespaceAndKeyword(
             context,
             "/aspnet-core/src/MyCompanyName.MyProjectName.AuthServer/MyProjectNameAuthServerModule.cs",
@@ -210,6 +201,9 @@ public class AppTemplateSwitchEntityFrameworkCoreToMongoDbStep : ProjectBuildPip
             "MyProjectNameMongoDbCollectionFixtureBase"
         );
 
+        // TODO: remove this method after published 6.0.0
+        ProvideIdentityServerBackwardCompatibility(context);
+
         if (context.BuildArgs.PublicWebSite)
         {
             ChangeProjectReference(
@@ -323,5 +317,32 @@ public class AppTemplateSwitchEntityFrameworkCoreToMongoDbStep : ProjectBuildPip
         }
 
         throw new ApplicationException("Could not find the 'Default' connection string in appsettings.json file!");
+    }
+    
+    // TODO: remove this method after published 6.0.0
+    private void ProvideIdentityServerBackwardCompatibility(ProjectBuildContext context)
+    {
+        ChangeProjectReference(
+            context,
+            "/aspnet-core/src/MyCompanyName.MyProjectName.IdentityServer/MyCompanyName.MyProjectName.IdentityServer.csproj",
+            _hasDbMigrations ? "EntityFrameworkCore.DbMigrations" : "EntityFrameworkCore",
+            "MongoDB"
+        );
+
+        ChangeNamespaceAndKeyword(
+            context,
+            "/aspnet-core/src/MyCompanyName.MyProjectName.IdentityServer/MyProjectNameIdentityServerModule.cs",
+            "MyCompanyName.MyProjectName.EntityFrameworkCore",
+            "MyCompanyName.MyProjectName.MongoDB",
+            _hasDbMigrations
+                ? "MyProjectNameEntityFrameworkCoreDbMigrationsModule"
+                : "MyProjectNameEntityFrameworkCoreModule",
+            "MyProjectNameMongoDbModule"
+        );
+
+        ChangeConnectionStringToMongoDb(
+            context,
+            "/aspnet-core/src/MyCompanyName.MyProjectName.IdentityServer/appsettings.json"
+        );
     }
 }


### PR DESCRIPTION
This compatibility is required for our websites until a new stable version is released.

---
Since we no longer have a class called `MyProjectNameIdentityServerModule`, I deleted the lines below. And, the correct one already exists so I didn't add it.

https://github.com/abpframework/abp/blob/6df284811992ea279727281a1befe0975b0d12a0/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectBuilding/Templates/App/AppTemplateSwitchEntityFrameworkCoreToMongoDbStep.cs#L49-L56



