### PR TITLE
CmsKit - Fix broken tags design

### DIFF
--- a/modules/cms-kit/src/Volo.CmsKit.Public.Web/Pages/CmsKit/Shared/Components/Tags/Default.cshtml
+++ b/modules/cms-kit/src/Volo.CmsKit.Public.Web/Pages/CmsKit/Shared/Components/Tags/Default.cshtml
@@ -10,19 +10,14 @@
             {
                 if (Model.UrlFormat.IsNullOrWhiteSpace())
                 {
-
-                    <span class="badge bg-light px-3 py-2 cmskit-tag font-weight-normal">
+                    <span class="badge rounded-pill bg-light text-dark px-3 py-2 cmskit-tag font-weight-normal">
                         @tag.Name
                     </span>
                 }
                 else
                 {
                     var formattedUrl = Model.UrlFormat.Replace("{TagId}", tag.Id.ToString());
-                    <a href="@formattedUrl">
-                        <span class="badge bg-light px-3 py-2 cmskit-tag font-weight-normal">
-                            @tag.Name
-                        </span>
-                    </a>
+                    <a href="@formattedUrl"><span class="badge rounded-pill bg-light text-dark px-3 py-2 cmskit-tag font-weight-normal">@tag.Name</span></a>
                 }
             }
         }


### PR DESCRIPTION
- Closes #12822 

Now the texts are readable and unnecessary link underline removed:

| old | new |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/23705418/169062406-36ac23c4-f90b-4eb5-b1c6-4bc51a04971f.png) | ![image](https://user-images.githubusercontent.com/23705418/173365850-ccff7917-fee9-4994-8788-fa082aa818bd.png) |
