### PR TITLE
Migrate @swimlane/ngx-datatable to 20.0.0 to match @angular v12

### DIFF
--- a/npm/ng-packs/packages/theme-shared/package.json
+++ b/npm/ng-packs/packages/theme-shared/package.json
@@ -12,7 +12,7 @@
     "@ng-bootstrap/ng-bootstrap": "~12.0.0-beta.4",
     "@ngx-validate/core": "^0.1.2",
     "@popperjs/core": "~2.11.2",
-    "@swimlane/ngx-datatable": "^19.0.0",
+    "@swimlane/ngx-datatable": "^20.0.0",
     "bootstrap": "^5.1.1",
     "tslib": "^2.0.0"
   },


### PR DESCRIPTION
- Migrate @swimlane/ngx-datatable to 20.0.0 for matching angular version with @abp/ng.theme.shared@5.3.0

Related #13025 Cannot start angular app `ng serve`