### PR TITLE
refactor OnAfterRenderAsync of AbpCrudPageBase

### DIFF
--- a/framework/src/Volo.Abp.BlazoriseUI/AbpCrudPageBase.cs
+++ b/framework/src/Volo.Abp.BlazoriseUI/AbpCrudPageBase.cs
@@ -224,10 +224,10 @@ public abstract class AbpCrudPageBase<
     {
         if (firstRender)
         {
-            await base.OnAfterRenderAsync(firstRender);
             await SetToolbarItemsAsync();
             await SetBreadcrumbItemsAsync();
         }
+        await base.OnAfterRenderAsync(firstRender);
     }
 
 


### PR DESCRIPTION
In the previous code, the OnAfterRenderAsync method of the base class is called only when firstRender is true, it should be changed to OnAfterRenderAsync method of the base class needs to be called at any time