### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - 'rel-*'
       - 'dev'
+permissions:
+  contents: read
+
 jobs:
   build-test-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -3,8 +3,14 @@ on:
   push:
     branches:
       - rel-5.3
+permissions:
+  contents: read
+
 jobs:
   merge-rel-5-3-with-rel-5-2:
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to create branch
+      pull-requests: write  # for peter-evans/create-pull-request to create a PR
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,6 +31,9 @@ on:
       - 'templates/**/*.cshtml'
       - 'templates/**/*.csproj'
       - 'templates/**/*.razor'
+permissions:
+  contents: read
+
 jobs:
   build-test:
     runs-on: windows-latest

--- a/.github/workflows/cancel-workflow.yml
+++ b/.github/workflows/cancel-workflow.yml
@@ -1,7 +1,12 @@
 name: cancel-workflow
 on: [push]
+permissions:
+  contents: read
+
 jobs:
   cancel:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
     name: 'Cancel Previous Runs'
     runs-on: ubuntu-latest
     timeout-minutes: 3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,8 +24,15 @@ on:
       - 'abp/**/*.csproj'
       - 'abp/**/*.razor'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
+    permissions:
+      actions: read  # for github/codeql-action/init to get workflow details
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/autobuild to send a status report
     name: Analyze
     runs-on: ubuntu-latest
 

--- a/framework/test/Volo.Abp.Core.Tests/Volo/Abp/AbpTestModule.cs
+++ b/framework/test/Volo.Abp.Core.Tests/Volo/Abp/AbpTestModule.cs
@@ -4,5 +4,4 @@ namespace Volo.Abp;
 
 public class AbpTestModule : AbpModule
 {
-
 }

--- a/framework/test/Volo.Abp.Core.Tests/Volo/Abp/AbpTestModule.cs
+++ b/framework/test/Volo.Abp.Core.Tests/Volo/Abp/AbpTestModule.cs
@@ -4,4 +4,5 @@ namespace Volo.Abp;
 
 public class AbpTestModule : AbpModule
 {
+
 }


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
