### PR TITLE
Fix cross site scripting (reflected) vulnerability in docs-module

### DIFF
--- a/modules/docs/src/Volo.Docs.Web/HtmlConverting/HtmlNormalizer.cs
+++ b/modules/docs/src/Volo.Docs.Web/HtmlConverting/HtmlNormalizer.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Web;
 using Volo.Docs.Utils;
 
 namespace Volo.Docs.HtmlConverting
@@ -26,7 +27,7 @@ namespace Volo.Docs.HtmlConverting
                                          (localDirectory.IsNullOrEmpty() ? "" : localDirectory.TrimStart('/').EnsureEndsWith('/')) +
                                          match.Groups[2].Value.TrimStart('/');
 
-                    return match.Groups[1] + " src=\"" + newImageSource + "\" " + match.Groups[3];
+                    return match.Groups[1] + " src=\"" + HttpUtility.HtmlEncode(newImageSource) + "\" " + match.Groups[3];
 
                 }, RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Multiline);
 


### PR DESCRIPTION
Fixed a reflected cross site scripting vulnerability in docs-module.
One could possibly execute arbitrary javascript by changing the `version` URL parameter to `%22onmouseover%3D%22alert(document.domain)%22style%3D%22position%3Aabsolute%3Bwidth%3A100%25%3Bheight%3A100%25%3Btop%3A0%3Bleft%3A0%3B%22`. This PR aims to fix this issue.

Before:
![image](https://user-images.githubusercontent.com/55740298/178256589-01059695-7b41-4e04-bc61-e4f843942f78.png)

After:
![image](https://user-images.githubusercontent.com/55740298/178257872-fe34ace2-53a5-4760-adad-4b748bc58da1.png)