### PR TITLE
Cli: Make adding new empty module to solution faster

### DIFF
--- a/docs/en/CLI.md
+++ b/docs/en/CLI.md
@@ -133,6 +133,7 @@ For more samples, go to [ABP CLI Create Solution Samples](CLI-New-Command-Sample
   * `PostgreSQL`
 * `--local-framework-ref --abp-path`: Uses local projects references to the ABP framework instead of using the NuGet packages. This can be useful if you download the ABP Framework source code and have a local reference to the framework from your application.
 * `--no-random-port`: Uses template's default ports.
+* `--skip-installing-libs` or `-sib`: Skip installing client side packages.
 
 See some [examples for the new command](CLI-New-Command-Samples.md) here.
 

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/NewCommand.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/NewCommand.cs
@@ -79,9 +79,15 @@ public class NewCommand : ProjectCreationCommandBase, IConsoleCommand, ITransien
         Logger.LogInformation($"'{projectName}' has been successfully created to '{projectArgs.OutputFolder}'");
 
         RunGraphBuildForMicroserviceServiceTemplate(projectArgs);
-        await RunInstallLibsForWebTemplateAsync(projectArgs);
-        ConfigurePwaSupportForAngular(projectArgs);
 
+        var skipInstallLibs = commandLineArgs.Options.ContainsKey(Options.SkipInstallingLibs.Long) || commandLineArgs.Options.ContainsKey(Options.SkipInstallingLibs.Short);
+        if (!skipInstallLibs)
+        {
+            await RunInstallLibsForWebTemplateAsync(projectArgs);
+        }
+        
+        ConfigurePwaSupportForAngular(projectArgs);
+        
         OpenRelatedWebPage(projectArgs, template, isTiered, commandLineArgs);
     }
 
@@ -111,6 +117,7 @@ public class NewCommand : ProjectCreationCommandBase, IConsoleCommand, ITransien
         sb.AppendLine("--no-ui                                     (if supported by the template)");
         sb.AppendLine("--no-random-port                            (Use template's default ports)");
         sb.AppendLine("--separate-identity-server                  (if supported by the template)");
+        sb.AppendLine("-sib|--skip-installing-libs                 (skip installing client side packages)");
         sb.AppendLine("--local-framework-ref --abp-path <your-local-abp-repo-path>  (keeps local references to projects instead of replacing with NuGet package references)");
         sb.AppendLine("");
         sb.AppendLine("Examples:");

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/ProjectCreationCommandBase.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/ProjectCreationCommandBase.cs
@@ -518,6 +518,12 @@ public abstract class ProjectCreationCommandBase
             public const string Long = "create-solution-folder";
         }
 
+        public static class SkipInstallingLibs
+        {
+            public const string Short = "sib";
+            public const string Long = "skip-installing-libs";
+        }
+
         public static class Tiered
         {
             public const string Long = "tiered";

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/SolutionModuleAdder.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/SolutionModuleAdder.cs
@@ -489,6 +489,7 @@ public class SolutionModuleAdder : ITransientDependency
         args.Options.Add("t", newProTemplate ? ModuleProTemplate.TemplateName : ModuleTemplate.TemplateName);
         args.Options.Add("v", version);
         args.Options.Add("o", Path.Combine(modulesFolderInSolution, module.Name));
+        args.Options.Add("sib", true.ToString());
 
         await NewCommand.ExecuteAsync(args);
     }


### PR DESCRIPTION
Also, i've added a new option to `abp new` command:

`--skip-installing-libs`

This makes application/module creation done in a few seconds.