### PR TITLE
Cli: Make Cli compatible with LeptonX packages

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/SolutionPackageVersionFinder.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/SolutionPackageVersionFinder.cs
@@ -1,5 +1,6 @@
-﻿using System.IO;
-using System.Text.RegularExpressions;
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Xml;
 using NuGet.Versioning;
 using Volo.Abp.Cli.Utils;
@@ -9,13 +10,13 @@ namespace Volo.Abp.Cli.ProjectModification;
 
 public class SolutionPackageVersionFinder : ITransientDependency
 {
-    public string Find(string solutionFile, string packagePrefix = "Volo.Abp")
+    public string Find(string solutionFile, string packagePrefix = "Volo.Abp", string excludedKeywords = "LeptonX")
     {
         var projectFilesUnderSrc = GetProjectFilesOfSolution(solutionFile);
         foreach (var projectFile in projectFilesUnderSrc)
         {
             var content = File.ReadAllText(projectFile);
-            if (TryParseVersionFromCsprojViaXmlDocument(content, out var s, packagePrefix))
+            if (TryParseVersionFromCsprojViaXmlDocument(content, out var s, packagePrefix, excludedKeywords))
             {
                 return s;
             }
@@ -24,14 +25,35 @@ public class SolutionPackageVersionFinder : ITransientDependency
         return null;
     }
 
-    private static bool TryParseVersionFromCsprojViaXmlDocument(string content, out string version, string packagePrefix)
+    private static bool TryParseVersionFromCsprojViaXmlDocument(string content, out string version, string packagePrefix, string excludedKeywords)
     {
         var doc = new XmlDocument() { PreserveWhitespace = true };
         using (var stream = StreamHelper.GenerateStreamFromString(content))
         {
             doc.Load(stream);
             var nodes = doc.SelectNodes($"/Project/ItemGroup/PackageReference[starts-with(@Include, '{packagePrefix}')]");
-            var value = nodes?[0]?.Attributes?["Version"]?.Value;
+
+            var targetNodes = new List<XmlNode>();
+
+            foreach (XmlNode node in nodes!)
+            {
+                var packageId = node!.Attributes["Include"]?.Value;
+
+                if (excludedKeywords.Split(',').Any(ek => packageId!.Contains(ek)))
+                {
+                    continue;
+                }
+
+                targetNodes.Add(node);
+            }
+
+            if (!targetNodes.Any())
+            {
+                version = null;
+                return false;
+            }
+            
+            var value = targetNodes.First().Attributes?["Version"]?.Value;
             if (value == null)
             {
                 version = null;
@@ -43,40 +65,17 @@ public class SolutionPackageVersionFinder : ITransientDependency
         }
     }
 
-    public static bool TryParseVersionFromCsprojFile(string csprojContent, out string version, string packagePrefix = "Volo.Abp")
+    public static bool TryParseVersionFromCsprojFile(string csprojContent, out string version, string packagePrefix = "Volo.Abp", string excludedKeywords = "LeptonX")
     {
-        try
-        {
-            var matches = Regex.Matches(csprojContent,
-                  @"PackageReference\s*Include\s*=\s*\""" + packagePrefix + @"(.*?)\""\s*Version\s*=\s*\""(.*?)\""",
-                  RegexOptions.IgnoreCase |
-                  RegexOptions.IgnorePatternWhitespace |
-                  RegexOptions.Singleline | RegexOptions.Multiline);
-
-            foreach (Match match in matches)
-            {
-                if (match.Groups.Count > 2)
-                {
-                    version = match.Groups[2].Value;
-                    return true;
-                }
-            }
-        }
-        catch
-        {
-            //ignored
-        }
-
-        version = null;
-        return false;
+        return TryParseVersionFromCsprojViaXmlDocument(csprojContent, out version, packagePrefix, excludedKeywords);
     }
 
 
-    public static bool TryParseSemanticVersionFromCsprojFile(string csprojContent, out SemanticVersion version, string packagePrefix = "Volo.Abp")
+    public static bool TryParseSemanticVersionFromCsprojFile(string csprojContent, out SemanticVersion version, string packagePrefix = "Volo.Abp", string excludedKeywords = "LeptonX")
     {
         try
         {
-            if (TryParseVersionFromCsprojFile(csprojContent, out var versionText, packagePrefix))
+            if (TryParseVersionFromCsprojViaXmlDocument(csprojContent, out var versionText, packagePrefix, excludedKeywords))
             {
                 return SemanticVersion.TryParse(versionText, out version);
             }
@@ -89,51 +88,6 @@ public class SolutionPackageVersionFinder : ITransientDependency
         version = null;
         return false;
     }
-
-    public static bool TryFind(string solutionFile, out string version, string packagePrefix = "Volo.Abp")
-    {
-        var projectFiles = GetProjectFilesOfSolution(solutionFile);
-        foreach (var projectFile in projectFiles)
-        {
-            var csprojContent = File.ReadAllText(projectFile);
-            if (TryParseVersionFromCsprojFile(csprojContent, out var parsedVersion, packagePrefix))
-            {
-                version = parsedVersion;
-                return true;
-            }
-        }
-
-        version = null;
-        return false;
-    }
-
-    public static bool TryFindSemanticVersion(string solutionFile, out SemanticVersion version, string packagePrefix = "Volo.Abp")
-    {
-        var projectFiles = GetProjectFilesOfSolution(solutionFile);
-        foreach (var projectFile in projectFiles)
-        {
-            var csprojContent = File.ReadAllText(projectFile);
-            if (TryParseSemanticVersionFromCsprojFile(csprojContent, out var parsedVersion, packagePrefix))
-            {
-                version = parsedVersion;
-                return true;
-            }
-        }
-
-        version = null;
-        return false;
-    }
-
-    //public static bool TryFindSemanticVersion(string solutionFile, out SemanticVersion version)
-    //{
-    //    if (TryFind(solutionFile, out var versionText))
-    //    {
-    //        return SemanticVersion.TryParse(versionText, out version);
-    //    }
-
-    //    version = null;
-    //    return false;
-    //}
 
     private static string[] GetProjectFilesOfSolution(string solutionFile)
     {

--- a/framework/test/Volo.Abp.Cli.Core.Tests/Volo/Abp/Cli/ProjectVersionParse_Tests.cs
+++ b/framework/test/Volo.Abp.Cli.Core.Tests/Volo/Abp/Cli/ProjectVersionParse_Tests.cs
@@ -19,8 +19,8 @@ public class ProjectVersionParse_Tests
                                      "<ProjectReference Include=\"..\\Blazoor.EfCore07062034.Domain.Shared\\Blazoor.EfCore07062034.Domain.Shared.csproj\" />" +
                                      "</ItemGroup>" +
                                      "<ItemGroup>" +
-                                     "< PackageReference    Include  =  \"Volo.Abp.Emailing\"   Version  =  \"4.4.0-rc.1\"  />" +
-                                     "<PackageReference  Include= \"Volo.Abp.PermissionManagement.Domain.Identity\"   Version= \"4.4.0-rc.1\" />" +
+                                     "<PackageReference    Include=\"Volo.Abp.Emailing\"   Version=\"4.4.0-rc.1\"  />" +
+                                     "<PackageReference  Include=\"Volo.Abp.PermissionManagement.Domain.Identity\"   Version=\"4.4.0-rc.1\" />" +
                                      "<PackageReference Include=\"Volo.Abp.IdentityServer.Domain\" Version=\"4.4.0-rc.1\" />" +
                                      "<PackageReference Include=\"Volo.Abp.PermissionManagement.Domain.IdentityServer\" Version=\"4.4.0-rc.1\" />" +
                                      "<PackageReference Include=\"Volo.Abp.BackgroundJobs.Domain\" Version=\"4.4.0-rc.1\" />" +
@@ -54,7 +54,7 @@ public class ProjectVersionParse_Tests
                                      "<ProjectReference Include=\"..\\Blazoor.EfCore07062034.Domain.Shared\\Blazoor.EfCore07062034.Domain.Shared.csproj\" />" +
                                      "</ItemGroup>" +
                                      "<ItemGroup>" +
-                                     "< PackageReference  Include =  \"Volo.Abp.Emailing\"   Version=  \"12.8.3-beta.1\"  />" +
+                                     "<PackageReference Include=\"Volo.Abp.Emailing\" Version=\"12.8.3-beta.1\"  />" +
                                      "</ItemGroup>" +
                                      "</Project>";
 


### PR DESCRIPTION
- Ignore LeptonX packages when detecting solution's ABP version.
- Don't use ABP framework version when updating LeptonX packages

resolves https://github.com/abpframework/abp/issues/13495