### PR TITLE
Cli: Improve NpmHelper Npm & Yarn installation check

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Utils/NpmHelper.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Utils/NpmHelper.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System;
+using System.Linq;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NuGet.Versioning;
 using Volo.Abp.DependencyInjection;
@@ -19,15 +21,30 @@ public class NpmHelper : ITransientDependency
     public bool IsNpmInstalled()
     {
         var output = CmdHelper.RunCmdAndGetOutput("npm -v").Trim();
-        return SemanticVersion.TryParse(output, out _);
+        var outputLines = output.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+
+        return outputLines.Any(ol => SemanticVersion.TryParse(ol, out _));
     }
 
     public bool IsYarnAvailable()
     {
         var output = CmdHelper.RunCmdAndGetOutput("yarn -v").Trim();
-        if (!SemanticVersion.TryParse(output, out var version)){
+        var outputLines = output.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+        SemanticVersion version = null;
+
+        foreach (var outputLine in outputLines)
+        {
+            if (SemanticVersion.TryParse(outputLine, out version))
+            {
+                break;
+            }
+        }
+
+        if (version == null)
+        {
             return false;
         }
+        
         return version > SemanticVersion.Parse("1.20.0");
     }
 


### PR DESCRIPTION
resolves https://github.com/abpframework/abp/issues/13207

Sometimes `npm -v` command prints a warning before the version and this causes Cli to act like NPM is not installed. This PR will resolve this case.