### PR TITLE
Add Password property on User Edit modal.

### DIFF
--- a/npm/ng-packs/packages/identity/src/lib/defaults/default-users-form-props.ts
+++ b/npm/ng-packs/packages/identity/src/lib/defaults/default-users-form-props.ts
@@ -63,6 +63,4 @@ export const DEFAULT_USERS_CREATE_FORM_PROPS = FormProp.createMany<IdentityUserD
   },
 ]);
 
-export const DEFAULT_USERS_EDIT_FORM_PROPS = DEFAULT_USERS_CREATE_FORM_PROPS.filter(
-  prop => prop.name !== 'password',
-);
+export const DEFAULT_USERS_EDIT_FORM_PROPS = DEFAULT_USERS_CREATE_FORM_PROPS


### PR DESCRIPTION
Resolves  #13532

I have implemented, but I think it shouldn't be like that. The User couldn't change another user's password without permission  but MVC works like that. 