### PR TITLE
Error when install front libs,not found leptomX-rc

### DIFF
--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Web/package.json
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Web/package.json
@@ -3,6 +3,6 @@
   "name": "my-app",
   "private": true,
   "dependencies": {
-    "@abp/aspnetcore.mvc.ui.theme.leptonxlite": "^1.0.0-rc.1"
+    "@abp/aspnetcore.mvc.ui.theme.leptonxlite": "~1.0.0-rc.1"
   }
 }


### PR DESCRIPTION
when the packages are installed with yarn, it shows that the package does not exist and throws an error, in the version of the template without layers it is like this ""@abp/aspnetcore.mvc.ui.theme.leptonxlite": "~1.0.0-rc .1"" and everything works fine