### PR TITLE
Change `AllowChangingEmailSettings` localization resource value

### DIFF
--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/ar.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/ar.json
@@ -18,7 +18,7 @@
     "Feature:SettingManagementGroup": "إدارة الإعداد",
     "Feature:SettingManagementEnable": "تمكين إدارة الإعداد",
     "Feature:SettingManagementEnableDescription": "تفعيل إعداد نظام الإدارة في التطبيق.",
-    "Feature:AllowChangingEmailSettings": "السماح لتغيير إعدادات البريد الإلكتروني.",
+    "Feature:AllowChangingEmailSettings": "السماح لتغيير إعدادات البريد الإلكتروني",
     "Feature:AllowChangingEmailSettingsDescription": "السماح لتغيير إعدادات البريد الإلكتروني."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/cs.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/cs.json
@@ -18,7 +18,7 @@
     "Feature:SettingManagementGroup": "Správa nastavení",
     "Feature:SettingManagementEnable": "Povolit správu nastavení",
     "Feature:SettingManagementEnableDescription": "Povolit systém správy nastavení v aplikaci.",
-    "Feature:AllowChangingEmailSettings": "Povolit změnu nastavení e-mailu.",
+    "Feature:AllowChangingEmailSettings": "Povolit změnu nastavení e-mailu",
     "Feature:AllowChangingEmailSettingsDescription": "Povolit změnu nastavení e-mailu."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/de-DE.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/de-DE.json
@@ -18,7 +18,7 @@
     "Feature:SettingManagementGroup": "Einstellungsverwaltung",
     "Feature:SettingManagementEnable": "Einstellungsverwaltung aktivieren",
     "Feature:SettingManagementEnableDescription": "Aktivieren Sie das Einstellungsverwaltungssystem in der Anwendung.",
-    "Feature:AllowChangingEmailSettings": "Änderung der E-Mail-Einstellungen zulassen.",
+    "Feature:AllowChangingEmailSettings": "Änderung der E-Mail-Einstellungen zulassen",
     "Feature:AllowChangingEmailSettingsDescription": "Änderung der E-Mail-Einstellungen zulassen."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/el.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/el.json
@@ -28,7 +28,7 @@
     "Feature:SettingManagementGroup": "Διαχείριση ρυθμίσεων",
     "Feature:SettingManagementEnable": "Ενεργοποίηση διαχείρισης ρυθμίσεων",
     "Feature:SettingManagementEnableDescription": "Ενεργοποίηση συστήματος διαχείρισης ρυθμίσεων στην εφαρμογή.",
-    "Feature:AllowChangingEmailSettings": "Επιτρέψτε την αλλαγή των ρυθμίσεων email.",
+    "Feature:AllowChangingEmailSettings": "Επιτρέψτε την αλλαγή των ρυθμίσεων email",
     "Feature:AllowChangingEmailSettingsDescription": "Επιτρέψτε την αλλαγή των ρυθμίσεων email."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/en.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/en.json
@@ -28,7 +28,7 @@
     "Feature:SettingManagementGroup": "Setting Management",
     "Feature:SettingManagementEnable": "Enable setting management",
     "Feature:SettingManagementEnableDescription": "Enable setting management system in the application.",
-    "Feature:AllowChangingEmailSettings": "Allow changing email settings.",
+    "Feature:AllowChangingEmailSettings": "Allow changing email settings",
     "Feature:AllowChangingEmailSettingsDescription": "Allow changing email settings."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/es.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/es.json
@@ -18,7 +18,7 @@
     "Feature:SettingManagementGroup": "Gestión de la configuración",
     "Feature:SettingManagementEnable": "Habilitar la gestión de la configuración",
     "Feature:SettingManagementEnableDescription": "Habilite el sistema de gestión de la configuración en la aplicación.",
-    "Feature:AllowChangingEmailSettings": "Permitir cambiar la configuración de correo electrónico.",
+    "Feature:AllowChangingEmailSettings": "Permitir cambiar la configuración de correo electrónico",
     "Feature:AllowChangingEmailSettingsDescription": "Permitir cambiar la configuración de correo electrónico."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/fi.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/fi.json
@@ -18,7 +18,7 @@
     "Feature:SettingManagementGroup": "Asetusten hallinta",
     "Feature:SettingManagementEnable": "Ota asetusten hallinta käyttöön",
     "Feature:SettingManagementEnableDescription": "Ota asetustenhallintajärjestelmä käyttöön sovelluksessa.",
-    "Feature:AllowChangingEmailSettings": "Salli sähköpostiasetusten muuttaminen.",
+    "Feature:AllowChangingEmailSettings": "Salli sähköpostiasetusten muuttaminen",
     "Feature:AllowChangingEmailSettingsDescription": "Salli sähköpostiasetusten muuttaminen."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/fr.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/fr.json
@@ -18,7 +18,7 @@
     "Feature:SettingManagementGroup": "Gestion des paramètres",
     "Feature:SettingManagementEnable": "Activer la gestion des paramètres",
     "Feature:SettingManagementEnableDescription": "Activer le système de gestion des paramètres dans l'application.",
-    "Feature:AllowChangingEmailSettings": "Autoriser la modification des paramètres de messagerie.",
+    "Feature:AllowChangingEmailSettings": "Autoriser la modification des paramètres de messagerie",
     "Feature:AllowChangingEmailSettingsDescription": "Autoriser la modification des paramètres de messagerie."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/hu.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/hu.json
@@ -18,7 +18,7 @@
     "Feature:SettingManagementGroup": "Beállításkezelés",
     "Feature:SettingManagementEnable": "Beállításkezelés engedélyezése",
     "Feature:SettingManagementEnableDescription": "A beállításkezelő rendszer engedélyezése az alkalmazásban.",
-    "Feature:AllowChangingEmailSettings": "Az e-mail beállítások módosításának engedélyezése.",
+    "Feature:AllowChangingEmailSettings": "Az e-mail beállítások módosításának engedélyezése",
     "Feature:AllowChangingEmailSettingsDescription": "Az e-mail beállítások módosításának engedélyezése."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/is.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/is.json
@@ -18,7 +18,7 @@
     "Feature:SettingManagementGroup": "Stillingar",
     "Feature:SettingManagementEnable": "Virkja stillingar",
     "Feature:SettingManagementEnableDescription": "Virkja stillingar í forritinu.",
-    "Feature:AllowChangingEmailSettings": "Leyfa að breyta stillingum tölvupósts.",
+    "Feature:AllowChangingEmailSettings": "Leyfa að breyta stillingum tölvupósts",
     "Feature:AllowChangingEmailSettingsDescription": "Leyfa að breyta stillingum tölvupósts."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/it.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/it.json
@@ -18,7 +18,7 @@
     "Feature:SettingManagementGroup": "Gestione Impostazioni",
     "Feature:SettingManagementEnable": "Abilita gestione impostazioni",
     "Feature:SettingManagementEnableDescription": "Abilita sistema gestione impostazioni nell'applicazione",
-    "Feature:AllowChangingEmailSettings": "Consenti di modificare le loro impostazioni e-mail.",
+    "Feature:AllowChangingEmailSettings": "Consenti di modificare le loro impostazioni e-mail",
     "Feature:AllowChangingEmailSettingsDescription": "Consenti di modificare le loro impostazioni e-mail."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/nl.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/nl.json
@@ -18,7 +18,7 @@
     "Feature:SettingManagementGroup": "Instellingsbeheer",
     "Feature:SettingManagementEnable": "Instellingenbeheer inschakelen",
     "Feature:SettingManagementEnableDescription": "Schakel het instellingsbeheersysteem in de toepassing in.",
-    "Feature:AllowChangingEmailSettings": "Toestaan om e-mailinstellingen te wijzigen.",
+    "Feature:AllowChangingEmailSettings": "Toestaan om e-mailinstellingen te wijzigen",
     "Feature:AllowChangingEmailSettingsDescription": "Toestaan om e-mailinstellingen te wijzigen."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/pl-PL.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/pl-PL.json
@@ -18,7 +18,7 @@
     "Feature:SettingManagementGroup": "Zarządzanie ustawieniami",
     "Feature:SettingManagementEnable": "Włącz zarządzanie ustawieniami",
     "Feature:SettingManagementEnableDescription": "Włącz system zarządzania ustawieniami w aplikacji.",
-    "Feature:AllowChangingEmailSettings": "Zezwól na zmianę ustawień poczty e-mail.",
+    "Feature:AllowChangingEmailSettings": "Zezwól na zmianę ustawień poczty e-mail",
     "Feature:AllowChangingEmailSettingsDescription": "Zezwól na zmianę ustawień poczty e-mail."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/pt-BR.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/pt-BR.json
@@ -28,7 +28,7 @@
     "Feature:SettingManagementGroup": "Gestão de Cenários",
     "Feature:SettingManagementEnable": "Habilitar gerenciamento de configuração",
     "Feature:SettingManagementEnableDescription": "Habilite o sistema de gerenciamento de configuração no aplicativo.",
-    "Feature:AllowChangingEmailSettings": "Permitir alterar as configurações de e-mail.",
+    "Feature:AllowChangingEmailSettings": "Permitir alterar as configurações de e-mail",
     "Feature:AllowChangingEmailSettingsDescription": "Permitir alterar as configurações de e-mail."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/ro-RO.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/ro-RO.json
@@ -18,7 +18,7 @@
     "Feature:SettingManagementGroup": "Administrarea setărilor",
     "Feature:SettingManagementEnable": "Activează administrarea setărilor",
     "Feature:SettingManagementEnableDescription": "Activează sistemul de administrare a setărilor în aplicaţie.",
-    "Feature:AllowChangingEmailSettings": "Permiteți modificarea setărilor de e-mail.",
+    "Feature:AllowChangingEmailSettings": "Permiteți modificarea setărilor de e-mail",
     "Feature:AllowChangingEmailSettingsDescription": "Permiteți modificarea setărilor de e-mail."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/ru.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/ru.json
@@ -18,7 +18,7 @@
     "Feature:SettingManagementGroup": "Управление настройками",
     "Feature:SettingManagementEnable": "Включить управление настройками",
     "Feature:SettingManagementEnableDescription": "Включите систему управления настройками в приложении.",
-    "Feature:AllowChangingEmailSettings": "Разрешить изменение настроек электронной почты.",
+    "Feature:AllowChangingEmailSettings": "Разрешить изменение настроек электронной почты",
     "Feature:AllowChangingEmailSettingsDescription": "Разрешить изменение настроек электронной почты."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/sk.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/sk.json
@@ -18,7 +18,7 @@
     "Feature:SettingManagementGroup": "Správa nastavení",
     "Feature:SettingManagementEnable": "Povoliť správu nastavení",
     "Feature:SettingManagementEnableDescription": "Povoliť systém správy nastavení v aplikácii.",
-    "Feature:AllowChangingEmailSettings": "Povoliť zmenu nastavení e-mailu.",
+    "Feature:AllowChangingEmailSettings": "Povoliť zmenu nastavení e-mailu",
     "Feature:AllowChangingEmailSettingsDescription": "Povoliť zmenu nastavení e-mailu."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/sl.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/sl.json
@@ -18,7 +18,7 @@
     "Feature:SettingManagementGroup": "Upravljanje nastavitev",
     "Feature:SettingManagementEnable": "Omogoči upravljanje nastavitev",
     "Feature:SettingManagementEnableDescription": "Omogočite nastavitev sistema upravljanja v aplikaciji.",
-    "Feature:AllowChangingEmailSettings": "Dovoli spreminjanje e-poštnih nastavitev.",
+    "Feature:AllowChangingEmailSettings": "Dovoli spreminjanje e-poštnih nastavitev",
     "Feature:AllowChangingEmailSettingsDescription": "Dovoli spreminjanje e-poštnih nastavitev."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/tr.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/tr.json
@@ -28,7 +28,7 @@
     "Feature:SettingManagementGroup": "Ayar yönetimi",
     "Feature:SettingManagementEnable": "Ayar yönetimini etkinleştir",
     "Feature:SettingManagementEnableDescription": "Uygulamada ayar yönetim sistemini etkinleştirin.",
-    "Feature:AllowChangingEmailSettings": "E-posta ayarlarını değiştirmeye izin verin.",
+    "Feature:AllowChangingEmailSettings": "E-posta ayarlarını değiştirmeye izin verin",
     "Feature:AllowChangingEmailSettingsDescription": "E-posta ayarlarını değiştirmeye izin verin."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/vi.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/vi.json
@@ -18,7 +18,7 @@
     "Feature:SettingManagementGroup": "Cài đặt quản lý",
     "Feature:SettingManagementEnable": "Bật quản lý cài đặt",
     "Feature:SettingManagementEnableDescription": "Bật cài đặt hệ thống quản lý trong ứng dụng.",
-    "Feature:AllowChangingEmailSettings": "Cho phép thay đổi cài đặt email.",
+    "Feature:AllowChangingEmailSettings": "Cho phép thay đổi cài đặt email",
     "Feature:AllowChangingEmailSettingsDescription": "Cho phép thay đổi cài đặt email."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/zh-Hans.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/zh-Hans.json
@@ -28,7 +28,7 @@
     "Feature:SettingManagementGroup": "设置管理",
     "Feature:SettingManagementEnable": "启用设置管理",
     "Feature:SettingManagementEnableDescription": "在应用程序中启用设置管理系统.",
-    "Feature:AllowChangingEmailSettings": "允许更改邮件设置.",
+    "Feature:AllowChangingEmailSettings": "允许更改邮件设置",
     "Feature:AllowChangingEmailSettingsDescription": "允许更改邮件设置."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/zh-Hant.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/zh-Hant.json
@@ -28,7 +28,7 @@
     "Feature:SettingManagementGroup": "設定管理",
     "Feature:SettingManagementEnable": "啟用設定管理",
     "Feature:SettingManagementEnableDescription": "在應用程序中啟用設定管理系統.",
-    "Feature:AllowChangingEmailSettings": "允許更改電子郵件設置。",
+    "Feature:AllowChangingEmailSettings": "允許更改電子郵件設置",
     "Feature:AllowChangingEmailSettingsDescription": "允許更改電子郵件設置。"
   }
 }


### PR DESCRIPTION
Removed unnecessary periods.

For consistency with other settings option titles, `AllowChangingEmailSettings` should not end in punctuation.

![image](https://user-images.githubusercontent.com/13272730/184302371-bf274988-e666-4d66-8306-d841288c74db.png)
