### PR TITLE
Fix ConcurrencyStamp consistency issue for IdentityRole and IdentityUser

### DIFF
--- a/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/IdentityRole.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/IdentityRole.cs
@@ -62,7 +62,7 @@ namespace Volo.Abp.Identity
             Name = name;
             TenantId = tenantId;
             NormalizedName = name.ToUpperInvariant();
-            ConcurrencyStamp = Guid.NewGuid().ToString();
+            ConcurrencyStamp = Guid.NewGuid().ToString("N");
 
             Claims = new Collection<IdentityRoleClaim>();
         }

--- a/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/IdentityUser.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/IdentityUser.cs
@@ -153,7 +153,7 @@ namespace Volo.Abp.Identity
             NormalizedUserName = userName.ToUpperInvariant();
             Email = email;
             NormalizedEmail = email.ToUpperInvariant();
-            ConcurrencyStamp = Guid.NewGuid().ToString();
+            ConcurrencyStamp = Guid.NewGuid().ToString("N");
             SecurityStamp = Guid.NewGuid().ToString();
 
             Roles = new Collection<IdentityUserRole>();

--- a/modules/identity/test/Volo.Abp.Identity.Domain.Tests/Volo/Abp/Identity/IdentityUserStore_Tests.cs
+++ b/modules/identity/test/Volo.Abp.Identity.Domain.Tests/Volo/Abp/Identity/IdentityUserStore_Tests.cs
@@ -112,7 +112,7 @@ namespace Volo.Abp.Identity
 
             (await _identityUserStore.UpdateAsync(user)).Succeeded.ShouldBeTrue();
 
-            user.ConcurrencyStamp = Guid.NewGuid().ToString();
+            user.ConcurrencyStamp = Guid.NewGuid().ToString("N");
             var identityResult = await _identityUserStore.UpdateAsync(user);
 
             identityResult.Succeeded.ShouldBeFalse();


### PR DESCRIPTION
Noticed that updated Roles have a different ConcurrencyStamp format.