### PR TITLE
fix `User.IsActive` and `IsLockedOut` is invalid when authorization

### DIFF
--- a/modules/openiddict/src/Volo.Abp.OpenIddict.AspNetCore/Volo/Abp/OpenIddict/Controllers/AbpOpenIdDictControllerBase.cs
+++ b/modules/openiddict/src/Volo.Abp.OpenIddict.AspNetCore/Volo/Abp/OpenIddict/Controllers/AbpOpenIdDictControllerBase.cs
@@ -73,4 +73,24 @@ public abstract class AbpOpenIdDictControllerBase : AbpController
 
         return false;
     }
+
+    protected virtual async Task<bool> PreSignInCheckAsync(IdentityUser user)
+    {
+        if (!user.IsActive)
+        {
+            return false;
+        }
+
+        if (!await SignInManager.CanSignInAsync(user))
+        {
+            return false;
+        }
+
+        if (await UserManager.IsLockedOutAsync(user))
+        {
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/modules/openiddict/src/Volo.Abp.OpenIddict.AspNetCore/Volo/Abp/OpenIddict/Controllers/TokenController.AuthorizationCode.cs
+++ b/modules/openiddict/src/Volo.Abp.OpenIddict.AspNetCore/Volo/Abp/OpenIddict/Controllers/TokenController.AuthorizationCode.cs
@@ -33,7 +33,7 @@ public partial class TokenController
             }
 
             // Ensure the user is still allowed to sign in.
-            if (!await SignInManager.CanSignInAsync(user))
+            if (!await PreSignInCheckAsync(user))
             {
                 return Forbid(
                     authenticationSchemes: OpenIddictServerAspNetCoreDefaults.AuthenticationScheme,

--- a/modules/openiddict/src/Volo.Abp.OpenIddict.AspNetCore/Volo/Abp/OpenIddict/Controllers/TokenController.DeviceCode.cs
+++ b/modules/openiddict/src/Volo.Abp.OpenIddict.AspNetCore/Volo/Abp/OpenIddict/Controllers/TokenController.DeviceCode.cs
@@ -33,7 +33,7 @@ public partial class TokenController
             }
 
             // Ensure the user is still allowed to sign in.
-            if (!await SignInManager.CanSignInAsync(user))
+            if (!await PreSignInCheckAsync(user))
             {
                 return Forbid(
                     authenticationSchemes: OpenIddictServerAspNetCoreDefaults.AuthenticationScheme,

--- a/modules/openiddict/src/Volo.Abp.OpenIddict.AspNetCore/Volo/Abp/OpenIddict/Controllers/TokenController.RefreshToken.cs
+++ b/modules/openiddict/src/Volo.Abp.OpenIddict.AspNetCore/Volo/Abp/OpenIddict/Controllers/TokenController.RefreshToken.cs
@@ -33,7 +33,7 @@ public partial class TokenController
             }
 
             // Ensure the user is still allowed to sign in.
-            if (!await SignInManager.CanSignInAsync(user))
+            if (!await PreSignInCheckAsync(user))
             {
                 return Forbid(
                     authenticationSchemes: OpenIddictServerAspNetCoreDefaults.AuthenticationScheme,


### PR DESCRIPTION
Reference link:

[AbpSignInManager.cs#L80](https://github.com/abpframework/abp/blob/dev/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpSignInManager.cs#L80)

[aspnetcore/Identity/SignInManager.cs#L379](https://github.com/dotnet/aspnetcore/blob/main/src/Identity/Core/src/SignInManager.cs#L379)