### PR TITLE
Implement layout hooks for blazor

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Components/LayoutHooks/LayoutHook.razor
+++ b/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Components/LayoutHooks/LayoutHook.razor
@@ -1,0 +1,7 @@
+﻿@if (LayoutHookViewModel.Hooks.Any())
+{
+    foreach (var hook in LayoutHookViewModel.Hooks)
+    {
+        <DynamicComponent Type="@hook.ComponentType" />
+    }
+}

--- a/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Components/LayoutHooks/LayoutHook.razor.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Components/LayoutHooks/LayoutHook.razor.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Options;
+using Volo.Abp.Ui.LayoutHooks;
+
+namespace Volo.Abp.AspNetCore.Components.Web.Theming.Components.LayoutHooks;
+
+public partial class LayoutHook : ComponentBase
+{
+    [Parameter]
+    public string Name { get; set; }
+    
+    [Parameter]
+    public string Layout { get; set; }
+
+    [Inject]
+    protected IOptions<AbpLayoutHookOptions> LayoutHookOptions { get; set; }
+
+    protected LayoutHookViewModel LayoutHookViewModel { get; private set; }
+
+    protected override Task OnInitializedAsync()
+    {
+        if (LayoutHookOptions.Value.Hooks.TryGetValue(Name, out var layoutHooks))
+        {
+            layoutHooks = layoutHooks
+                .WhereIf(string.IsNullOrWhiteSpace(Layout), x => x.Layout == Layout)
+                .ToList();
+        }
+
+        layoutHooks ??= new List<LayoutHookInfo>();
+        
+        LayoutHookViewModel = new LayoutHookViewModel(layoutHooks.ToArray(), Layout);
+        
+        return Task.CompletedTask;
+    }
+}

--- a/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Layout/StandardLayouts.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Layout/StandardLayouts.cs
@@ -2,7 +2,5 @@
 
 public static class StandardLayouts
 {
-    public const string Main = "Main";
-    public const string TopMenu = "TopMenu";
-    public const string SideMenu = "SideMenu";
+    public const string Application = "Application";
 }

--- a/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Layout/StandardLayouts.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Layout/StandardLayouts.cs
@@ -1,0 +1,8 @@
+﻿namespace Volo.Abp.AspNetCore.Components.Web.Theming.Layout;
+
+public static class StandardLayouts
+{
+    public const string Main = "Main";
+    public const string TopMenu = "TopMenu";
+    public const string SideMenu = "SideMenu";
+}

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI/Volo/Abp/AspNetCore/Mvc/UI/Components/LayoutHook/Default.cshtml
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI/Volo/Abp/AspNetCore/Mvc/UI/Components/LayoutHook/Default.cshtml
@@ -1,5 +1,4 @@
-﻿@using Volo.Abp.AspNetCore.Mvc.UI.Components.LayoutHook
-@model LayoutHookViewModel
+﻿@model Volo.Abp.Ui.LayoutHooks.LayoutHookViewModel
 @if (Model.Hooks.Any())
 {
     foreach (var hook in Model.Hooks)

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI/Volo/Abp/AspNetCore/Mvc/UI/Components/LayoutHook/LayoutHookViewComponent.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI/Volo/Abp/AspNetCore/Mvc/UI/Components/LayoutHook/LayoutHookViewComponent.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
+using Volo.Abp.Ui.LayoutHooks;
 
 namespace Volo.Abp.AspNetCore.Mvc.UI.Components.LayoutHook;
 

--- a/framework/src/Volo.Abp.UI/Volo/Abp/Ui/LayoutHooks/AbpLayoutHookOptions.cs
+++ b/framework/src/Volo.Abp.UI/Volo/Abp/Ui/LayoutHooks/AbpLayoutHookOptions.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace Volo.Abp.AspNetCore.Mvc.UI.Components.LayoutHook;
+namespace Volo.Abp.Ui.LayoutHooks;
 
 public class AbpLayoutHookOptions
 {

--- a/framework/src/Volo.Abp.UI/Volo/Abp/Ui/LayoutHooks/LayoutHookInfo.cs
+++ b/framework/src/Volo.Abp.UI/Volo/Abp/Ui/LayoutHooks/LayoutHookInfo.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 
-namespace Volo.Abp.AspNetCore.Mvc.UI.Components.LayoutHook;
+namespace Volo.Abp.Ui.LayoutHooks;
 
 public class LayoutHookInfo
 {
     /// <summary>
-    /// ViewComponent type.
+    /// Component type.
     /// </summary>
     public Type ComponentType { get; }
 

--- a/framework/src/Volo.Abp.UI/Volo/Abp/Ui/LayoutHooks/LayoutHookViewModel.cs
+++ b/framework/src/Volo.Abp.UI/Volo/Abp/Ui/LayoutHooks/LayoutHookViewModel.cs
@@ -1,4 +1,4 @@
-﻿namespace Volo.Abp.AspNetCore.Mvc.UI.Components.LayoutHook;
+﻿namespace Volo.Abp.Ui.LayoutHooks;
 
 public class LayoutHookViewModel
 {

--- a/framework/src/Volo.Abp.UI/Volo/Abp/Ui/LayoutHooks/LayoutHooks.cs
+++ b/framework/src/Volo.Abp.UI/Volo/Abp/Ui/LayoutHooks/LayoutHooks.cs
@@ -1,4 +1,4 @@
-﻿namespace Volo.Abp.AspNetCore.Mvc.UI.Components.LayoutHook;
+﻿namespace Volo.Abp.Ui.LayoutHooks;
 
 public static class LayoutHooks
 {

--- a/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.Web.BasicTheme/Themes/Basic/MainLayout.razor
+++ b/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.Web.BasicTheme/Themes/Basic/MainLayout.razor
@@ -1,4 +1,5 @@
-﻿@using Volo.Abp.AspNetCore.Components.Web.Theming.Components;
+﻿@using Volo.Abp.Ui.LayoutHooks
+@using Volo.Abp.AspNetCore.Components.Web.Theming.Layout
 @inherits LayoutComponentBase
 <nav class="navbar navbar-expand-md navbar-dark bg-dark shadow-sm flex-column flex-md-row mb-4" id="main-navbar" style="min-height: 4rem;">
     <div class="container">
@@ -18,7 +19,9 @@
 </nav>
 <div class="container">
     <PageAlert />
+    <LayoutHook Name="@LayoutHooks.Body.First" Layout="@StandardLayouts.Main" />
     @Body
+    <LayoutHook Name="@LayoutHooks.Body.Last" Layout="@StandardLayouts.Main"/>
     <DynamicLayoutComponent />
     <UiMessageAlert />
     <UiNotificationAlert />

--- a/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.Web.BasicTheme/Themes/Basic/MainLayout.razor
+++ b/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.Web.BasicTheme/Themes/Basic/MainLayout.razor
@@ -19,9 +19,9 @@
 </nav>
 <div class="container">
     <PageAlert />
-    <LayoutHook Name="@LayoutHooks.Body.First" Layout="@StandardLayouts.Main" />
+    <LayoutHook Name="@LayoutHooks.Body.First" Layout="@StandardLayouts.Application" />
     @Body
-    <LayoutHook Name="@LayoutHooks.Body.Last" Layout="@StandardLayouts.Main"/>
+    <LayoutHook Name="@LayoutHooks.Body.Last" Layout="@StandardLayouts.Application" />
     <DynamicLayoutComponent />
     <UiMessageAlert />
     <UiNotificationAlert />

--- a/modules/basic-theme/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic/Themes/Basic/Layouts/Account.cshtml
+++ b/modules/basic-theme/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic/Themes/Basic/Layouts/Account.cshtml
@@ -12,6 +12,7 @@
 @using Volo.Abp.MultiTenancy
 @using Volo.Abp.Localization
 @using Volo.Abp.Ui.Branding
+@using Volo.Abp.Ui.LayoutHooks
 @inject IBrandingProvider BrandingProvider
 @inject IOptions<AbpMultiTenancyOptions> MultiTenancyOptions
 @inject ICurrentTenant CurrentTenant

--- a/modules/basic-theme/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic/Themes/Basic/Layouts/Application.cshtml
+++ b/modules/basic-theme/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic/Themes/Basic/Layouts/Application.cshtml
@@ -8,6 +8,7 @@
 @using Volo.Abp.AspNetCore.Mvc.UI.Widgets.Components.WidgetStyles
 @using Volo.Abp.Localization
 @using Volo.Abp.Ui.Branding
+@using Volo.Abp.Ui.LayoutHooks
 @inject IBrandingProvider BrandingProvider
 @inject IPageLayout PageLayout
 @{

--- a/modules/basic-theme/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic/Themes/Basic/Layouts/Empty.cshtml
+++ b/modules/basic-theme/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic/Themes/Basic/Layouts/Empty.cshtml
@@ -7,6 +7,7 @@
 @using Volo.Abp.AspNetCore.Mvc.UI.Widgets.Components.WidgetStyles
 @using Volo.Abp.Localization
 @using Volo.Abp.Ui.Branding
+@using Volo.Abp.Ui.LayoutHooks
 @inject IBrandingProvider BrandingProvider
 @inject IPageLayout PageLayout
 @{

--- a/modules/cms-kit/src/Volo.CmsKit.Public.Web/CmsKitPublicWebModule.cs
+++ b/modules/cms-kit/src/Volo.CmsKit.Public.Web/CmsKitPublicWebModule.cs
@@ -2,7 +2,7 @@
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.DependencyInjection;
 using Volo.Abp.AspNetCore.Mvc.Localization;
-using Volo.Abp.AspNetCore.Mvc.UI.Components.LayoutHook;
+using Volo.Abp.Ui.LayoutHooks;
 using Volo.Abp.AutoMapper;
 using Volo.Abp.GlobalFeatures;
 using Volo.Abp.Http.ProxyScripting.Generators.JQuery;

--- a/modules/docs/src/Volo.Docs.Web/DocsWebModule.cs
+++ b/modules/docs/src/Volo.Docs.Web/DocsWebModule.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Options;
 using Volo.Abp.AspNetCore.Mvc.Localization;
 using Volo.Abp.AspNetCore.Mvc.UI.Bootstrap;
 using Volo.Abp.AspNetCore.Mvc.UI.Bundling;
-using Volo.Abp.AspNetCore.Mvc.UI.Components.LayoutHook;
+using Volo.Abp.Ui.LayoutHooks;
 using Volo.Abp.AspNetCore.Mvc.UI.Packages;
 using Volo.Abp.AspNetCore.Mvc.UI.Packages.Prismjs;
 using Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared;


### PR DESCRIPTION
Resolves #6261 

---

⚠️ *LayoutHookInfo.cs*, *LayoutHookViewModel.cs*, *LayoutHooks.cs*, *AbpLayoutHookOptions.cs* classes have been moved under the **Volo.Abp.Ui.LayoutHooks** namespace.