### PR TITLE
Cli: Renamed ICmdHelper.OpenWebPage to ICmdHelper.Open

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/ProjectCreationCommandBase.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/ProjectCreationCommandBase.cs
@@ -333,14 +333,14 @@ public abstract class ProjectCreationCommandBase
         var tieredYesNo = tiered ? "yes" : "no";
         var url = $"https://{urlPrefix}.abp.io/project-created-success?ui={uiFramework:g}&db={databaseProvider:g}&tiered={tieredYesNo}";
 
-        CmdHelper.OpenWebPage(url);
+        CmdHelper.Open(url);
     }
 
     protected void OpenMicroserviceDocumentPage()
     {
         var url = "https://docs.abp.io/en/commercial/latest/startup-templates/microservice/index";
 
-        CmdHelper.OpenWebPage(url);
+        CmdHelper.Open(url);
     }
 
     protected bool GetCreateSolutionFolderPreference(CommandLineArgs commandLineArgs)

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/SolutionModuleAdder.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/SolutionModuleAdder.cs
@@ -153,7 +153,7 @@ public class SolutionModuleAdder : ITransientDependency
         var documentationLink = module.GetFirstDocumentationLinkOrNull();
         if (documentationLink != null)
         {
-            CmdHelper.OpenWebPage(documentationLink);
+            CmdHelper.Open(documentationLink);
         }
 
         return module;

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Utils/CmdHelper.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Utils/CmdHelper.cs
@@ -18,20 +18,20 @@ public class CmdHelper : ICmdHelper, ITransientDependency
         CliOptions = cliOptions.Value;
     }
     
-    public void OpenWebPage(string url)
+    public void Open(string pathOrUrl)
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            url = url.Replace("&", "^&");
-            Process.Start(new ProcessStartInfo("cmd", $"/c start {url}") { CreateNoWindow = true });
+            pathOrUrl = pathOrUrl.Replace("&", "^&");
+            Process.Start(new ProcessStartInfo("cmd", $"/c start {pathOrUrl}") { CreateNoWindow = true });
         }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
-            Process.Start("xdg-open", url);
+            Process.Start("xdg-open", pathOrUrl);
         }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
-            Process.Start("open", url);
+            Process.Start("open", pathOrUrl);
         }
     }
 

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Utils/ICmdHelper.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Utils/ICmdHelper.cs
@@ -4,7 +4,7 @@ namespace Volo.Abp.Cli.Utils;
 
 public interface ICmdHelper
 {
-    void OpenWebPage(string url);
+    void Open(string pathOrUrl);
 
     void Run(string file, string arguments);
 


### PR DESCRIPTION
This method can open files with default programs, folders in file explorer, and url's in web browser. We use this to open web pages but it is better to rename it to simply `Open`.