### PR TITLE
Fix DefaultDotNetProjectBuilder.cs for path with space

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Build/DefaultDotNetProjectBuilder.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Build/DefaultDotNetProjectBuilder.cs
@@ -76,7 +76,7 @@ public class DefaultDotNetProjectBuilder : IDotNetProjectBuilder, ITransientDepe
         Console.WriteLine("Executing...: dotnet build " + project.CsProjPath + " " + buildArguments);
 
         var output = CmdHelper.RunCmdAndGetOutput(
-            "dotnet build " + project.CsProjPath + " " + buildArguments,
+            "dotnet build \"" + project.CsProjPath + "\" " + buildArguments,
             out int buildStatus
         );
 


### PR DESCRIPTION
If there is a space in the path, it's understood as two different parameter by dotnet, this PR fixes this problem.

> I've checked do we run `dotnet build` command before running the bundle command or not and it seems we are already building the project before running the bundle command. (see https://github.com/abpframework/abp/blob/dev/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/ProjectCreationCommandBase.cs#L426) FYI @enisn 