### PR TITLE
Add Role to Project in Docs module

### DIFF
--- a/modules/docs/app/VoloDocs.EntityFrameworkCore/Migrations/20221008123010_ProjectRole.Designer.cs
+++ b/modules/docs/app/VoloDocs.EntityFrameworkCore/Migrations/20221008123010_ProjectRole.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Volo.Abp.EntityFrameworkCore;
 using VoloDocs.EntityFrameworkCore;
@@ -12,9 +13,10 @@ using VoloDocs.EntityFrameworkCore;
 namespace Migrations
 {
     [DbContext(typeof(VoloDocsDbContext))]
-    partial class VoloDocsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20221008123010_ProjectRole")]
+    partial class ProjectRole
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/modules/docs/app/VoloDocs.EntityFrameworkCore/Migrations/20221008123010_ProjectRole.cs
+++ b/modules/docs/app/VoloDocs.EntityFrameworkCore/Migrations/20221008123010_ProjectRole.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Migrations
+{
+    public partial class ProjectRole : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Role",
+                table: "DocsProjects",
+                type: "nvarchar(256)",
+                maxLength: 256,
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Role",
+                table: "DocsProjects");
+        }
+    }
+}

--- a/modules/docs/src/Volo.Docs.Admin.Application.Contracts/Volo/Docs/Admin/Localization/Resources/Docs/ApplicationContracts/en.json
+++ b/modules/docs/src/Volo.Docs.Admin.Application.Contracts/Volo/Docs/Admin/Localization/Resources/Docs/ApplicationContracts/en.json
@@ -36,6 +36,7 @@
     "DisplayName:All": "Pull all",
     "DisplayName:LanguageCode": "Language code",
     "DisplayName:Version": "Version",
+    "DisplayName:Role": "Role",
     "Documents": "Documents",
     "RemoveFromCache": "Remove from cache",
     "Reindex": "Reindex",

--- a/modules/docs/src/Volo.Docs.Admin.Application.Contracts/Volo/Docs/Admin/Projects/CreateProjectDto.cs
+++ b/modules/docs/src/Volo.Docs.Admin.Application.Contracts/Volo/Docs/Admin/Projects/CreateProjectDto.cs
@@ -25,6 +25,8 @@ namespace Volo.Docs.Admin.Projects
 
         public string DocumentStoreType { get; set; }
 
+        public string Role { get; set; }
+
         public Dictionary<string, object> ExtraProperties { get; set; }
     }
 }

--- a/modules/docs/src/Volo.Docs.Admin.Application.Contracts/Volo/Docs/Admin/Projects/ProjectDto.cs
+++ b/modules/docs/src/Volo.Docs.Admin.Application.Contracts/Volo/Docs/Admin/Projects/ProjectDto.cs
@@ -28,6 +28,8 @@ namespace Volo.Docs.Admin.Projects
 
         public string DocumentStoreType { get; set; }
 
+        public string Role { get; set; }
+
         public Dictionary<string, object> ExtraProperties { get; set; }
 
         public string ConcurrencyStamp { get; set; }

--- a/modules/docs/src/Volo.Docs.Admin.Application.Contracts/Volo/Docs/Admin/Projects/UpdateProjectDto.cs
+++ b/modules/docs/src/Volo.Docs.Admin.Application.Contracts/Volo/Docs/Admin/Projects/UpdateProjectDto.cs
@@ -21,6 +21,8 @@ namespace Volo.Docs.Admin.Projects
 
         public string LatestVersionBranchName { get; set; }
 
+        public string Role { get; set; }
+
         public Dictionary<string, object> ExtraProperties { get; set; }
 
         public string ConcurrencyStamp { get; set; }

--- a/modules/docs/src/Volo.Docs.Admin.Application/Volo/Docs/Admin/Projects/ProjectAdminAppService.cs
+++ b/modules/docs/src/Volo.Docs.Admin.Application/Volo/Docs/Admin/Projects/ProjectAdminAppService.cs
@@ -76,7 +76,8 @@ namespace Volo.Docs.Admin.Projects
             {
                 MinimumVersion = input.MinimumVersion,
                 MainWebsiteUrl = input.MainWebsiteUrl,
-                LatestVersionBranchName = input.LatestVersionBranchName
+                LatestVersionBranchName = input.LatestVersionBranchName,
+                Role = input.Role
             };
 
             foreach (var extraProperty in input.ExtraProperties)
@@ -103,6 +104,7 @@ namespace Volo.Docs.Admin.Projects
             project.MinimumVersion = input.MinimumVersion;
             project.MainWebsiteUrl = input.MainWebsiteUrl;
             project.LatestVersionBranchName = input.LatestVersionBranchName;
+            project.Role = input.Role;
 
             foreach (var extraProperty in input.ExtraProperties)
             {

--- a/modules/docs/src/Volo.Docs.Admin.Web/Pages/Docs/Admin/Projects/Create.cshtml.cs
+++ b/modules/docs/src/Volo.Docs.Admin.Web/Pages/Docs/Admin/Projects/Create.cshtml.cs
@@ -104,6 +104,9 @@ namespace Volo.Docs.Admin.Pages.Docs.Admin.Projects
 
             [HiddenInput]
             public string DocumentStoreType { get; set; } = "GitHub";
+
+            [DynamicStringLength(typeof(ProjectConsts), nameof(ProjectConsts.MaxRoleLength))]
+            public string Role { get; set; }
         }
 
         public class CreateGithubProjectViewModel : CreateProjectViewModelBase

--- a/modules/docs/src/Volo.Docs.Admin.Web/Pages/Docs/Admin/Projects/Edit.cshtml.cs
+++ b/modules/docs/src/Volo.Docs.Admin.Web/Pages/Docs/Admin/Projects/Edit.cshtml.cs
@@ -123,6 +123,9 @@ namespace Volo.Docs.Admin.Pages.Docs.Admin.Projects
 
             [HiddenInput]
             public string ConcurrencyStamp { get; set; }
+
+            [DynamicStringLength(typeof(ProjectConsts), nameof(ProjectConsts.MaxRoleLength))]
+            public string Role { get; set; }
         }
 
         public class EditGithubProjectViewModel : EditProjectViewModelBase

--- a/modules/docs/src/Volo.Docs.Application.Contracts/Volo/Docs/Projects/ProjectDto.cs
+++ b/modules/docs/src/Volo.Docs.Application.Contracts/Volo/Docs/Projects/ProjectDto.cs
@@ -25,6 +25,8 @@ namespace Volo.Docs.Projects
 
         public string DocumentStoreType { get; set; }
 
+        public string Role { get; set; }
+
         public Dictionary<string, object> ExtraProperties { get; set; }
     }
 }

--- a/modules/docs/src/Volo.Docs.Domain.Shared/Volo/Docs/Projects/ProjectConsts.cs
+++ b/modules/docs/src/Volo.Docs.Domain.Shared/Volo/Docs/Projects/ProjectConsts.cs
@@ -36,5 +36,11 @@
         /// Default value: 128
         /// </summary>
         public static int MaxVersionNameLength { get; set; } = 128;
+
+        /// <summary>
+        /// Default value: 256
+        /// </summary>
+        public static int MaxRoleLength { get; set; } = 256;
+
     }
 }

--- a/modules/docs/src/Volo.Docs.Domain.Shared/Volo/Docs/Projects/ProjectEto.cs
+++ b/modules/docs/src/Volo.Docs.Domain.Shared/Volo/Docs/Projects/ProjectEto.cs
@@ -26,5 +26,8 @@ namespace Volo.Docs.Projects
         public string MainWebsiteUrl { get; set; }
 
         public string LatestVersionBranchName { get; set; }
+
+        public string Role { get; set; }
+
     }
 }

--- a/modules/docs/src/Volo.Docs.Domain/Volo/Docs/Projects/Project.cs
+++ b/modules/docs/src/Volo.Docs.Domain/Volo/Docs/Projects/Project.cs
@@ -48,6 +48,8 @@ namespace Volo.Docs.Projects
 
         public virtual string LatestVersionBranchName { get; set; }
 
+        public virtual string Role { get; set; }
+
         protected Project()
         {
         }

--- a/modules/docs/src/Volo.Docs.EntityFrameworkCore/Volo/Docs/EntityFrameworkCore/DocsDbContextModelBuilderExtensions.cs
+++ b/modules/docs/src/Volo.Docs.EntityFrameworkCore/Volo/Docs/EntityFrameworkCore/DocsDbContextModelBuilderExtensions.cs
@@ -31,6 +31,7 @@ namespace Volo.Docs.EntityFrameworkCore
                 b.Property(x => x.NavigationDocumentName).IsRequired().HasMaxLength(ProjectConsts.MaxNavigationDocumentNameLength);
                 b.Property(x => x.ParametersDocumentName).IsRequired().HasMaxLength(ProjectConsts.MaxParametersDocumentNameLength);
                 b.Property(x => x.LatestVersionBranchName).HasMaxLength(ProjectConsts.MaxLatestVersionBranchNameLength);
+                b.Property(x => x.Role).HasMaxLength(ProjectConsts.MaxRoleLength);
 
                 b.ApplyObjectExtensionMappings();
             });


### PR DESCRIPTION
Modules: Docs

I added a Role field to the project. Only string type, the name of the Role must be entered.
If it is not filled in, the operation is unchanged.
If you fill it in, the project is not public, it is visible only after logging in and only to the user who is a member of the set Role.
I think this is a useful feature in applications where there is non-public documentation.