### PR TITLE
The `Configuration` of the `property` cannot be deleted

### DIFF
--- a/framework/src/Volo.Abp.ObjectExtending/Volo/Abp/ObjectExtending/Modularity/ModuleExtensionConfigurationHelper.cs
+++ b/framework/src/Volo.Abp.ObjectExtending/Volo/Abp/ObjectExtending/Modularity/ModuleExtensionConfigurationHelper.cs
@@ -174,7 +174,6 @@ public static class ModuleExtensionConfigurationHelper
                         property.DefaultValue = propertyConfig.DefaultValue;
                         property.DefaultValueFactory = propertyConfig.DefaultValueFactory;
                         property.Lookup = propertyConfig.UI.Lookup;
-                        property.Configuration.Clear();
                         foreach (var configuration in propertyConfig.Configuration)
                         {
                             property.Configuration[configuration.Key] = configuration.Value;


### PR DESCRIPTION
https://github.com/abpframework/abp/blob/e3e1779de6df5d26f01cdc8e99ac9cbcb3d24d3c/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/ObjectExtending/EfCoreObjectExtensionPropertyInfoExtensions.cs#L18

https://github.com/abpframework/abp/pull/14100