### PR TITLE
CLI - Change adding order of `blazor.webassembly.js`

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Bundling/BundlingService.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Bundling/BundlingService.cs
@@ -108,15 +108,15 @@ public class BundlingService : IBundlingService, ITransientDependency
             Parameters = parameters
         };
 
+        scriptContext.BundleDefinitions.AddIfNotContains(
+            x => x.Source == "_framework/blazor.webassembly.js", 
+            () => new BundleDefinition { Source = "_framework/blazor.webassembly.js" });
+
         foreach (var bundleDefinition in bundleDefinitions)
         {
             var contributor = CreateContributorInstance(bundleDefinition.BundleContributorType);
             contributor.AddScripts(scriptContext);
         }
-        
-        scriptContext.BundleDefinitions.AddIfNotContains(
-            x => x.Source == "_framework/blazor.webassembly.js", 
-            () => new BundleDefinition { Source = "_framework/blazor.webassembly.js" });
 
         return scriptContext;
     }


### PR DESCRIPTION
`blazor.webassembly.js` can't be removed because it was added after **execution of bundlecontributors**. 
This PR changes the order of adding `blazor.webassembly.js` and moves it before **execution of bundlecontributors**

---

According to https://github.com/abpframework/abp/issues/13684#issuecomment-1282400917