### PR TITLE
Get application name's default value from the entrance assembly

### DIFF
--- a/framework/src/Volo.Abp.Core/Microsoft/Extensions/DependencyInjection/ServiceCollectionConfigurationExtensions.cs
+++ b/framework/src/Volo.Abp.Core/Microsoft/Extensions/DependencyInjection/ServiceCollectionConfigurationExtensions.cs
@@ -1,6 +1,8 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿using JetBrains.Annotations;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Volo.Abp;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -11,7 +13,15 @@ public static class ServiceCollectionConfigurationExtensions
         return services.Replace(ServiceDescriptor.Singleton<IConfiguration>(configuration));
     }
 
+    [NotNull]
     public static IConfiguration GetConfiguration(this IServiceCollection services)
+    {
+        return services.GetConfigurationOrNull() ?? 
+               throw new AbpException("Could not find an implementation of " + typeof(IConfiguration).AssemblyQualifiedName + " in the service collection.");
+    }
+    
+    [CanBeNull]
+    public static IConfiguration GetConfigurationOrNull(this IServiceCollection services)
     {
         var hostBuilderContext = services.GetSingletonInstanceOrNull<HostBuilderContext>();
         if (hostBuilderContext?.Configuration != null)
@@ -19,6 +29,6 @@ public static class ServiceCollectionConfigurationExtensions
             return hostBuilderContext.Configuration as IConfigurationRoot;
         }
 
-        return services.GetSingletonInstance<IConfiguration>();
+        return services.GetSingletonInstanceOrNull<IConfiguration>();
     }
 }

--- a/framework/src/Volo.Abp.Core/Volo/Abp/AbpApplicationBase.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/AbpApplicationBase.cs
@@ -44,7 +44,7 @@ public abstract class AbpApplicationBase : IAbpApplication
         var options = new AbpApplicationCreationOptions(services);
         optionsAction?.Invoke(options);
         
-        ApplicationName = options.ApplicationName;
+        ApplicationName = GetApplicationName(options);
 
         services.AddSingleton<IAbpApplication>(this);
         services.AddSingleton<IApplicationNameAccessor>(this);
@@ -311,5 +311,31 @@ public abstract class AbpApplicationBase : IAbpApplication
         }
 
         _configuredServices = true;
+    }
+    
+    private static string GetApplicationName(AbpApplicationCreationOptions options)
+    {
+        if (!string.IsNullOrWhiteSpace(options.ApplicationName))
+        {
+            return options.ApplicationName;
+        }
+
+        var configuration = options.Services.GetConfigurationOrNull();
+        if (configuration != null)
+        {
+            var appNameConfig = configuration["ApplicationName"];
+            if (string.IsNullOrWhiteSpace(appNameConfig))
+            {
+                return appNameConfig;
+            }
+        }
+        
+        var entryAssembly = Assembly.GetEntryAssembly();
+        if (entryAssembly != null)
+        {
+            return entryAssembly.GetName().Name;
+        }
+
+        return null;
     }
 }

--- a/framework/src/Volo.Abp.Core/Volo/Abp/AbpApplicationBase.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/AbpApplicationBase.cs
@@ -23,7 +23,7 @@ public abstract class AbpApplicationBase : IAbpApplication
     public IServiceCollection Services { get; }
 
     public IReadOnlyList<IAbpModuleDescriptor> Modules { get; }
-    
+
     public string ApplicationName { get; }
 
     private bool _configuredServices;
@@ -43,7 +43,7 @@ public abstract class AbpApplicationBase : IAbpApplication
 
         var options = new AbpApplicationCreationOptions(services);
         optionsAction?.Invoke(options);
-        
+
         ApplicationName = GetApplicationName(options);
 
         services.AddSingleton<IAbpApplication>(this);
@@ -147,7 +147,7 @@ public abstract class AbpApplicationBase : IAbpApplication
     public virtual async Task ConfigureServicesAsync()
     {
         CheckMultipleConfigureServices();
-        
+
         var context = new ServiceConfigurationContext(Services);
         Services.AddSingleton(context);
 
@@ -312,7 +312,7 @@ public abstract class AbpApplicationBase : IAbpApplication
 
         _configuredServices = true;
     }
-    
+
     private static string GetApplicationName(AbpApplicationCreationOptions options)
     {
         if (!string.IsNullOrWhiteSpace(options.ApplicationName))
@@ -324,12 +324,12 @@ public abstract class AbpApplicationBase : IAbpApplication
         if (configuration != null)
         {
             var appNameConfig = configuration["ApplicationName"];
-            if (string.IsNullOrWhiteSpace(appNameConfig))
+            if (!string.IsNullOrWhiteSpace(appNameConfig))
             {
                 return appNameConfig;
             }
         }
-        
+
         var entryAssembly = Assembly.GetEntryAssembly();
         if (entryAssembly != null)
         {

--- a/framework/src/Volo.Abp.Core/Volo/Abp/IApplicationNameAccessor.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/IApplicationNameAccessor.cs
@@ -1,3 +1,5 @@
+using JetBrains.Annotations;
+
 namespace Volo.Abp;
 
 public interface IApplicationNameAccessor
@@ -7,5 +9,6 @@ public interface IApplicationNameAccessor
     /// This is useful for systems with multiple applications, to distinguish
     /// resources of the applications located together.
     /// </summary>
+    [CanBeNull]
     string ApplicationName { get; }
 }

--- a/framework/test/Volo.Abp.Core.Tests/Volo/Abp/AbpApplication_Initialize_Tests.cs
+++ b/framework/test/Volo.Abp.Core.Tests/Volo/Abp/AbpApplication_Initialize_Tests.cs
@@ -1,10 +1,16 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
 using Shouldly;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Modularity;
 using Volo.Abp.Modularity.PlugIns;
 using Xunit;
+using IConfiguration = Castle.Core.Configuration.IConfiguration;
 
 namespace Volo.Abp;
 
@@ -147,8 +153,8 @@ public class AbpApplication_Initialize_Tests
     [Fact]
     public void Should_Set_And_Get_ApplicationName()
     {
-        const string applicationName = "MyApplication";
-        
+        var applicationName = "MyApplication";
+
         using (var application = AbpApplicationFactory.Create<IndependentEmptyModule>(options =>
                {
                    options.ApplicationName = applicationName;
@@ -156,16 +162,49 @@ public class AbpApplication_Initialize_Tests
         {
             application.ApplicationName.ShouldBe(applicationName);
             application.Services.GetApplicationName().ShouldBe(applicationName);
-            
+
             application.Initialize();
-            
+
+            application.ServiceProvider
+                .GetRequiredService<IApplicationNameAccessor>()
+                .ApplicationName
+                .ShouldBe(applicationName);
+        }
+
+        using (var application = AbpApplicationFactory.Create<IndependentEmptyModule>(options =>
+               {
+                   options.Services.ReplaceConfiguration(new ConfigurationBuilder()
+                       .AddInMemoryCollection(new Dictionary<string, string> {{"ApplicationName", applicationName}})
+                       .Build());
+               }))
+        {
+
+            application.ApplicationName.ShouldBe(applicationName);
+            application.Services.GetApplicationName().ShouldBe(applicationName);
+
+            application.Initialize();
+
+            application.ServiceProvider
+                .GetRequiredService<IApplicationNameAccessor>()
+                .ApplicationName
+                .ShouldBe(applicationName);
+        }
+
+        applicationName = Assembly.GetEntryAssembly()?.GetName().Name;
+        using (var application = AbpApplicationFactory.Create<IndependentEmptyModule>())
+        {
+            application.ApplicationName.ShouldBe(applicationName);
+            application.Services.GetApplicationName().ShouldBe(applicationName);
+
+            application.Initialize();
+
             application.ServiceProvider
                 .GetRequiredService<IApplicationNameAccessor>()
                 .ApplicationName
                 .ShouldBe(applicationName);
         }
     }
-    
+
     [Fact]
     public async Task Should_Resolve_Root_Service_Provider()
     {


### PR DESCRIPTION
With this PR, default value of the application name (that can be retrieved with `IApplicationNameAccessor.ApplicationName`) is calculated as:

* Try to get from `AbpApplicationCreationOptions.ApplicationName`.
* If not provided, try to get from `IConfiguration["ApplicationName"]`.
* If not provided, try to get from `Assembly.GetEntryAssembly().GetName().Name`
* If not found, use `null`.