### PR TITLE
Remove unnecessary input name calculation from dom-event-handlers.js

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/wwwroot/libs/abp/aspnetcore-mvc-ui-theme-shared/bootstrap/dom-event-handlers.js
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/wwwroot/libs/abp/aspnetcore-mvc-ui-theme-shared/bootstrap/dom-event-handlers.js
@@ -86,7 +86,7 @@
                     parentSelector = ".modal.fade";
                 }
                 var name = $(this).attr("name");
-                var selectedTextInputName = name.substring(0, name.length - 1) + "_Text]";
+                var selectedTextInputName = name + "_Text";
                 var selectedTextInput = $('<input>', {
                     type: 'hidden',
                     id: selectedTextInputName,


### PR DESCRIPTION
Closes https://github.com/abpframework/abp/issues/14098
Now it's working well.
![image](https://user-images.githubusercontent.com/23705418/197981034-a6080bdd-e6e7-4bf6-87fa-d06ee5a3c176.png)
![image](https://user-images.githubusercontent.com/23705418/197981200-4ef3ce6b-d974-4bf1-9f0c-6bd76e55348e.png)
![image](https://user-images.githubusercontent.com/23705418/197981561-25759bf9-087c-4baa-865a-80e1a673282c.png)

Works as expected as documentation:
https://docs.abp.io/en/abp/latest/UI/AspNetCore/AutoComplete-Select