### PR TITLE
No longer include parent cultures in `ApplicationLocalizationConfigurationDto`.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/ApplicationConfigurations/AbpApplicationConfigurationAppService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/ApplicationConfigurations/AbpApplicationConfigurationAppService.cs
@@ -231,7 +231,7 @@ public class AbpApplicationConfigurationAppService : ApplicationService, IAbpApp
 
                 if (localizer != null)
                 {
-                    foreach (var localizedString in await localizer.GetAllStringsAsync())
+                    foreach (var localizedString in await localizer.GetAllStringsAsync(includeParentCultures: false))
                     {
                         dictionary[localizedString.Name] = localizedString.Value;
                     }


### PR DESCRIPTION
Resolve #14413