### PR TITLE
Remove openning menus on hover on Blazor

### DIFF
--- a/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.Web.BasicTheme/wwwroot/libs/abp/css/theme.css
+++ b/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.Web.BasicTheme/wwwroot/libs/abp/css/theme.css
@@ -41,15 +41,6 @@
     box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075) !important;
 }
 
-@media screen and (min-width: 768px) {
-    .navbar .dropdown:hover > .dropdown-menu {
-        display: block;
-    }
-
-    .navbar .dropdown-submenu:hover > .dropdown-menu {
-        display: block;
-    }
-}
 .input-validation-error {
     border-color: #dc3545;
 }


### PR DESCRIPTION
Closes https://github.com/volosoft/volo/issues/11730

Menu items were bootstrap dropdown **but** they weren't managed by bootstrap. Custom style opens menus on hover. Since blazor applications are **SPA** _(Single Page Application)_, menu items aren't rendered after page navigation and only page content is updated. So, removing the hover effect from CSS solves that problem entirely.

---

![basic-theme-clickable-menus](https://user-images.githubusercontent.com/23705418/199681458-ce182838-594d-4d85-a211-a36d86729202.gif)
