### PR TITLE
CLI: Make related configurations for theme selection (Angular UI)

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Args/AngularThemeConfigurationArgs.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Args/AngularThemeConfigurationArgs.cs
@@ -1,0 +1,19 @@
+﻿using Volo.Abp.Cli.ProjectBuilding.Building;
+
+namespace Volo.Abp.Cli.Args;
+
+public class AngularThemeConfigurationArgs 
+{
+    public Theme Theme { get; }
+
+    public string ProjectName { get; }
+
+    public string AngularFolderPath { get; }
+
+    public AngularThemeConfigurationArgs(Theme theme, string projectName, string angularFolderPath)
+    {
+        Theme = theme;
+        ProjectName = projectName;
+        AngularFolderPath = angularFolderPath;
+    }
+}

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/NewCommand.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/NewCommand.cs
@@ -40,7 +40,8 @@ public class NewCommand : ProjectCreationCommandBase, IConsoleCommand, ITransien
         ILocalEventBus eventBus, 
         IBundlingService bundlingService,
         ITemplateInfoProvider templateInfoProvider, 
-        TemplateProjectBuilder templateProjectBuilder) :
+        TemplateProjectBuilder templateProjectBuilder,
+        AngularThemeConfigurer angularThemeConfigurer) :
         base(connectionStringProvider,
             solutionPackageVersionFinder, 
             cmdHelper, 
@@ -50,7 +51,8 @@ public class NewCommand : ProjectCreationCommandBase, IConsoleCommand, ITransien
             initialMigrationCreator,
             themePackageAdder, 
             eventBus, 
-            bundlingService)
+            bundlingService,
+            angularThemeConfigurer)
     {
         TemplateInfoProvider = templateInfoProvider;
         TemplateProjectBuilder = templateProjectBuilder;
@@ -95,6 +97,7 @@ public class NewCommand : ProjectCreationCommandBase, IConsoleCommand, ITransien
 
         Logger.LogInformation($"'{projectName}' has been successfully created to '{projectArgs.OutputFolder}'");
 
+        ConfigureAngularJsonForThemeSelection(projectArgs);
         ConfigureNpmPackagesForTheme(projectArgs);
         await RunGraphBuildForMicroserviceServiceTemplate(projectArgs);
         await CreateInitialMigrationsAsync(projectArgs);

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/ProjectCreationCommandBase.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/ProjectCreationCommandBase.cs
@@ -674,9 +674,8 @@ public abstract class ProjectCreationCommandBase
 
     protected void ConfigureAngularJsonForThemeSelection(ProjectBuildArgs projectArgs)
     {
-        var isProTemplate = !projectArgs.TemplateName.IsNullOrEmpty() && projectArgs.TemplateName.EndsWith("-pro", StringComparison.OrdinalIgnoreCase);
         var theme = projectArgs.Theme;
-        
+        var isProTemplate = !projectArgs.TemplateName.IsNullOrEmpty() && projectArgs.TemplateName.EndsWith("-pro", StringComparison.OrdinalIgnoreCase);
         var isDefaultTheme = (isProTemplate && theme == AppProTemplate.DefaultTheme) ||
                              (!isProTemplate && theme == AppTemplate.DefaultTheme);
 
@@ -687,10 +686,15 @@ public abstract class ProjectCreationCommandBase
         
         if (theme.HasValue && projectArgs.UiFramework == UiFramework.Angular)
         {
+            var angularFolderPath = projectArgs.TemplateName == MicroserviceProTemplate.TemplateName
+                ? projectArgs.OutputFolder.EnsureEndsWith(Path.DirectorySeparatorChar) + "apps" + Path.DirectorySeparatorChar + "angular"
+                : projectArgs.OutputFolder.EnsureEndsWith(Path.DirectorySeparatorChar) + "angular";
+
             AngularThemeConfigurer.Configure(new AngularThemeConfigurationArgs(
                 theme: theme.Value,
-                projectName: projectArgs.SolutionName.FullName, 
-                angularFolderPath: projectArgs.OutputFolder + Path.DirectorySeparatorChar + "angular"));
+                projectName: projectArgs.SolutionName.FullName,
+                angularFolderPath: angularFolderPath
+            ));
         }
     }
 

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/ProjectCreationCommandBase.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/ProjectCreationCommandBase.cs
@@ -38,6 +38,8 @@ public abstract class ProjectCreationCommandBase
     public ILogger<NewCommand> Logger { get; set; }
 
     public ThemePackageAdder ThemePackageAdder { get; }
+    
+    public AngularThemeConfigurer AngularThemeConfigurer { get; }
 
     public ProjectCreationCommandBase(
         ConnectionStringProvider connectionStringProvider,
@@ -49,7 +51,8 @@ public abstract class ProjectCreationCommandBase
         InitialMigrationCreator initialMigrationCreator,
         ThemePackageAdder themePackageAdder,
         ILocalEventBus eventBus,
-        IBundlingService bundlingService)
+        IBundlingService bundlingService, 
+        AngularThemeConfigurer angularThemeConfigurer)
     {
         _bundlingService = bundlingService;
         ConnectionStringProvider = connectionStringProvider;
@@ -61,6 +64,7 @@ public abstract class ProjectCreationCommandBase
         InitialMigrationCreator = initialMigrationCreator;
         EventBus = eventBus;
         ThemePackageAdder = themePackageAdder;
+        AngularThemeConfigurer = angularThemeConfigurer;
 
         Logger = NullLogger<NewCommand>.Instance;
     }
@@ -664,6 +668,18 @@ public abstract class ProjectCreationCommandBase
         if (projectArgs.UiFramework is UiFramework.Angular)
         {
             ThemePackageAdder.AddAngularPackage(projectArgs.OutputFolder, "@volo/abp.ng.theme.lepton", projectArgs.Version);
+        }
+    }
+
+    protected void ConfigureAngularJsonForThemeSelection(ProjectBuildArgs projectArgs)
+    {
+        //TODO: do not run if the theme is default
+        if (projectArgs.Theme.HasValue && projectArgs.UiFramework == UiFramework.Angular)
+        {
+            AngularThemeConfigurer.Configure(new AngularThemeConfigurationArgs(
+                theme: projectArgs.Theme.Value,
+                projectName: projectArgs.SolutionName.FullName, 
+                angularFolderPath: projectArgs.OutputFolder + Path.DirectorySeparatorChar + "angular"));
         }
     }
 

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/ProjectCreationCommandBase.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/ProjectCreationCommandBase.cs
@@ -19,6 +19,7 @@ using Volo.Abp.Cli.ProjectBuilding.Events;
 using Volo.Abp.Cli.ProjectBuilding.Templates.App;
 using Volo.Abp.Cli.ProjectBuilding.Templates.Microservice;
 using Volo.Abp.Cli.ProjectBuilding.Templates.Module;
+using Volo.Abp.Cli.ProjectBuilding.Templates.MvcModule;
 using Volo.Abp.Cli.Utils;
 using Volo.Abp.EventBus.Local;
 
@@ -673,11 +674,21 @@ public abstract class ProjectCreationCommandBase
 
     protected void ConfigureAngularJsonForThemeSelection(ProjectBuildArgs projectArgs)
     {
-        //TODO: do not run if the theme is default
-        if (projectArgs.Theme.HasValue && projectArgs.UiFramework == UiFramework.Angular)
+        var isProTemplate = !projectArgs.TemplateName.IsNullOrEmpty() && projectArgs.TemplateName.EndsWith("-pro", StringComparison.OrdinalIgnoreCase);
+        var theme = projectArgs.Theme;
+        
+        var isDefaultTheme = (isProTemplate && theme == AppProTemplate.DefaultTheme) ||
+                             (!isProTemplate && theme == AppTemplate.DefaultTheme);
+
+        if (isDefaultTheme || projectArgs.TemplateName == ModuleTemplate.TemplateName)
+        {
+            return;
+        }
+        
+        if (theme.HasValue && projectArgs.UiFramework == UiFramework.Angular)
         {
             AngularThemeConfigurer.Configure(new AngularThemeConfigurationArgs(
-                theme: projectArgs.Theme.Value,
+                theme: theme.Value,
                 projectName: projectArgs.SolutionName.FullName, 
                 angularFolderPath: projectArgs.OutputFolder + Path.DirectorySeparatorChar + "angular"));
         }

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/AngularThemeConfigurer.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/AngularThemeConfigurer.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Volo.Abp.Cli.Args;
+using Volo.Abp.Cli.Utils;
+using Volo.Abp.DependencyInjection;
+
+namespace Volo.Abp.Cli.ProjectModification;
+
+public class AngularThemeConfigurer : ITransientDependency
+{
+    private readonly ICmdHelper _cmdHelper;
+
+    public AngularThemeConfigurer(ICmdHelper cmdHelper)
+    {
+        _cmdHelper = cmdHelper;
+    }
+
+    public void Configure(AngularThemeConfigurationArgs args)
+    {
+        if (args.ProjectName.IsNullOrEmpty() || args.AngularFolderPath.IsNullOrEmpty())
+        {
+            return;
+        }
+        
+        var command = "npx ng g @abp/ng.schematics:change-theme " +
+                      $"--name {(int)args.Theme} " +
+                      $"--target-project {args.ProjectName}";
+        
+        _cmdHelper.RunCmd(command, workingDirectory: args.AngularFolderPath);
+    }
+}


### PR DESCRIPTION
Resolves #14446

---

We were suggesting developers read the [Theme Configuration documentation](https://docs.abp.io/en/abp/latest/UI/Angular/Theme-Configurations) to make related configurations in the **angular.json** file for different theme selections (Angular UI). [A schematics command has been created](https://github.com/abpframework/abp/pull/14445) and with this PR now we run it on CLI.