### PR TITLE
Fix uncaught type error in docs module

### DIFF
--- a/modules/docs/src/Volo.Docs.Web/Pages/Documents/Shared/Scripts/vs.js
+++ b/modules/docs/src/Volo.Docs.Web/Pages/Documents/Shared/Scripts/vs.js
@@ -60,7 +60,7 @@
 
             $targetElement = $targetElement.length
                 ? $targetElement
-                : $('[name=' + this.hash.slice(1) + ']');
+                : $('[name=' + hash.slice(1) + ']');
 
             if (!$targetElement.length) {
                 return;


### PR DESCRIPTION
Fixes an uncaught type error in docs module / `vs.js`. Fixes #14906.

Before:
![image](https://user-images.githubusercontent.com/55740298/201892684-d54c18eb-f310-490f-8ff0-ad8b7a805e0c.png)