### PR TITLE
UI Customization Guide - ABP Tag Helpers explained.

### DIFF
--- a/docs/en/UI/AspNetCore/Customization-User-Interface.md
+++ b/docs/en/UI/AspNetCore/Customization-User-Interface.md
@@ -63,7 +63,14 @@ The account module defines a `Login.cshtml` file under the `Pages/Account` folde
 
 You typically want to copy the original `.cshtml` file of the module, then make the necessary changes. You can find the original file [here](https://github.com/abpframework/abp/blob/dev/modules/account/src/Volo.Abp.Account.Web/Pages/Account/Login.cshtml). Do not copy the `Login.cshtml.cs` file which is the code behind file for the razor page and we don't want to override it yet (see the next section).
 
-If the page you want to override contains [ABP Tag Helpers](../Tag-Helpers/Index.md), don't forget to add ViewImports lines from [here](https://github.com/abpframework/abp/blob/dev/modules/account/src/Volo.Abp.Account.Web/Pages/Account/_ViewImports.cshtml) to your ViewImports.
+> Don't forget to add [_ViewImports.cshtml](https://learn.microsoft.com/en-us/aspnet/core/mvc/views/layout?view=aspnetcore-7.0#importing-shared-directives) if the page you want to override contains [ABP Tag Helpers](../Tag-Helpers/Index.md).
+
+````csharp
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@addTagHelper *, Volo.Abp.AspNetCore.Mvc.UI
+@addTagHelper *, Volo.Abp.AspNetCore.Mvc.UI.Bootstrap
+@addTagHelper *, Volo.Abp.AspNetCore.Mvc.UI.Bundling
+````
 
 That's all, you can change the file content however you like.
 

--- a/docs/en/UI/AspNetCore/Customization-User-Interface.md
+++ b/docs/en/UI/AspNetCore/Customization-User-Interface.md
@@ -63,6 +63,8 @@ The account module defines a `Login.cshtml` file under the `Pages/Account` folde
 
 You typically want to copy the original `.cshtml` file of the module, then make the necessary changes. You can find the original file [here](https://github.com/abpframework/abp/blob/dev/modules/account/src/Volo.Abp.Account.Web/Pages/Account/Login.cshtml). Do not copy the `Login.cshtml.cs` file which is the code behind file for the razor page and we don't want to override it yet (see the next section).
 
+If the page you want to override contains [ABP Tag Helpers](../Tag-Helpers/Index.md), don't forget to add ViewImports lines from [here](https://github.com/abpframework/abp/blob/dev/modules/account/src/Volo.Abp.Account.Web/Pages/Account/_ViewImports.cshtml) to your ViewImports.
+
 That's all, you can change the file content however you like.
 
 ### Completely Overriding a Razor Page


### PR DESCRIPTION
Explaining how to perform the necessary imports to use ABP Tag Helpers in UI Customization Guide.

For someone who is starting to use the ABP Framework. When trying to change the UI and taking the Views already made as a base, he will come across ABP Tag Helpers elements and without the necessary imports the screen will break, 
generating frustration.

This prevent it.