### PR TITLE
Add Support for Bulk Translations in IMultilingualObjectManager

### DIFF
--- a/framework/src/Volo.Abp.MultiLingualObjects/Volo.Abp.MultiLingualObjects.csproj
+++ b/framework/src/Volo.Abp.MultiLingualObjects/Volo.Abp.MultiLingualObjects.csproj
@@ -1,20 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <Import Project="..\..\..\configureawait.props" />
-    <Import Project="..\..\..\common.props" />
+	<Import Project="..\..\..\configureawait.props" />
+	<Import Project="..\..\..\common.props" />
 
-    <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
-        <PackageId>Volo.Abp.MultiLingualObject</PackageId>
-        <AssetTargetFallback>$(AssetTargetFallback);portable-net45+win8+wp8+wpa81;</AssetTargetFallback>
-        <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-        <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-        <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-        <RootNamespace />
-    </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<PackageId>Volo.Abp.MultiLingualObject</PackageId>
+		<AssetTargetFallback>$(AssetTargetFallback);portable-net45+win8+wp8+wpa81;</AssetTargetFallback>
+		<GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+		<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+		<GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+		<RootNamespace />
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\Volo.Abp.Localization\Volo.Abp.Localization.csproj" />
-    </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Volo.Abp.Localization\Volo.Abp.Localization.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/framework/src/Volo.Abp.MultiLingualObjects/Volo/Abp/MultiLingualObjects/IMultiLingualObjectManager.cs
+++ b/framework/src/Volo.Abp.MultiLingualObjects/Volo/Abp/MultiLingualObjects/IMultiLingualObjectManager.cs
@@ -5,16 +5,30 @@ namespace Volo.Abp.MultiLingualObjects;
 
 public interface IMultiLingualObjectManager
 {
-    Task<TTranslation> GetTranslationAsync<TMultiLingual, TTranslation>(
+    Task<TTranslation?> GetTranslationAsync<TMultiLingual, TTranslation>(
         TMultiLingual multiLingual,
-        string culture = null,
+        string? culture = null,
         bool fallbackToParentCultures = true)
         where TMultiLingual : IMultiLingualObject<TTranslation>
         where TTranslation : class, IObjectTranslation;
 
-    Task<TTranslation> GetTranslationAsync<TTranslation>(
-       ICollection<TTranslation> translations,
-       string culture = null,
+    Task<TTranslation?> GetTranslationAsync<TTranslation>(
+       IEnumerable<TTranslation> translations,
+       string? culture = null,
        bool fallbackToParentCultures = true)
+       where TTranslation : class, IObjectTranslation;
+
+
+    Task<List<TTranslation?>> GetBulkTranslationsAsync<TTranslation>(
+       IEnumerable<IEnumerable<TTranslation>> translationsCombined,
+       string? culture = null,
+       bool fallbackToParentCultures = true)
+       where TTranslation : class, IObjectTranslation;
+
+    Task<List<(TMultiLingual entity, TTranslation? translation)>> GetBulkTranslationsAsync<TMultiLingual, TTranslation>(
+       IEnumerable<TMultiLingual> multiLinguals,
+       string? culture = null,
+       bool fallbackToParentCultures = true)
+       where TMultiLingual : IMultiLingualObject<TTranslation>
        where TTranslation : class, IObjectTranslation;
 }

--- a/framework/src/Volo.Abp.MultiLingualObjects/Volo/Abp/MultiLingualObjects/MultiLingualObjectManager.cs
+++ b/framework/src/Volo.Abp.MultiLingualObjects/Volo/Abp/MultiLingualObjects/MultiLingualObjectManager.cs
@@ -19,16 +19,16 @@ public class MultiLingualObjectManager : IMultiLingualObjectManager, ITransientD
     {
         SettingProvider = settingProvider;
     }
-    public virtual async Task<TTranslation> GetTranslationAsync<TTranslation>(
-        ICollection<TTranslation> translations,
-        string culture,
+    public virtual async Task<TTranslation?> GetTranslationAsync<TTranslation>(
+        IEnumerable<TTranslation> translations,
+        string? culture,
         bool fallbackToParentCultures)
         where TTranslation : class, IObjectTranslation
 
     {
         culture ??= CultureInfo.CurrentUICulture.Name;
 
-        if (translations.IsNullOrEmpty())
+        if (translations == null || !translations.Any())
         {
             return null;
         }
@@ -65,9 +65,9 @@ public class MultiLingualObjectManager : IMultiLingualObjectManager, ITransientD
         return translation;
     }
 
-    public virtual Task<TTranslation> GetTranslationAsync<TMultiLingual, TTranslation>(
+    public virtual Task<TTranslation?> GetTranslationAsync<TMultiLingual, TTranslation>(
         TMultiLingual multiLingual,
-        string culture = null,
+        string? culture = null,
         bool fallbackToParentCultures = true)
         where TMultiLingual : IMultiLingualObject<TTranslation>
         where TTranslation : class, IObjectTranslation
@@ -75,13 +75,13 @@ public class MultiLingualObjectManager : IMultiLingualObjectManager, ITransientD
         return GetTranslationAsync(multiLingual.Translations, culture: culture, fallbackToParentCultures: fallbackToParentCultures);
     }
 
-    protected virtual TTranslation GetTranslationBasedOnCulturalRecursive<TTranslation>(
-        CultureInfo culture, ICollection<TTranslation> translations, int currentDepth)
+    protected virtual TTranslation? GetTranslationBasedOnCulturalRecursive<TTranslation>(
+        CultureInfo culture, IEnumerable<TTranslation> translations, int currentDepth)
         where TTranslation : class, IObjectTranslation
     {
         if (culture == null ||
             culture.Name.IsNullOrWhiteSpace() ||
-            translations.IsNullOrEmpty() ||
+            translations == null || !translations.Any() ||
             currentDepth > MaxCultureFallbackDepth)
         {
             return null;
@@ -89,5 +89,108 @@ public class MultiLingualObjectManager : IMultiLingualObjectManager, ITransientD
 
         var translation = translations.FirstOrDefault(pt => pt.Language.Equals(culture.Name, StringComparison.OrdinalIgnoreCase));
         return translation ?? GetTranslationBasedOnCulturalRecursive(culture.Parent, translations, currentDepth + 1);
+    }
+
+    public virtual async Task<List<TTranslation?>> GetBulkTranslationsAsync<TTranslation>(IEnumerable<IEnumerable<TTranslation>> translationsCombined, string? culture, bool fallbackToParentCultures)
+       where TTranslation : class, IObjectTranslation
+    {
+        culture ??= CultureInfo.CurrentUICulture.Name;
+
+        if (translationsCombined == null || !translationsCombined.Any())
+        {
+            return new();
+        }
+
+        var someHaveNoTranslations = false;
+        var res = new List<TTranslation?>();
+        foreach (var translations in translationsCombined)
+        {
+            if (!translations.Any())
+            {
+                //if the src has no translations, don't try to find a translation
+                res.Add(null);
+                continue;
+            }
+            var translation = translations.FirstOrDefault(pt => pt.Language == culture);
+            if (translation != null)
+            {
+                res.Add(translation);
+            }
+            else
+            {
+                if (fallbackToParentCultures)
+                {
+                    translation = GetTranslationBasedOnCulturalRecursive(
+                        CultureInfo.CurrentUICulture.Parent,
+                        translations,
+                        0
+                    );
+
+                    if (translation != null)
+                    {
+                        res.Add(translation);
+                    }
+                    else
+                    {
+                        res.Add(null);
+                        someHaveNoTranslations = true;
+                    }
+                }
+                else
+                {
+                    res.Add(null);
+                    someHaveNoTranslations = true;
+                }
+            }
+        }
+
+
+        if (someHaveNoTranslations)
+        {
+            var defaultLanguage = await SettingProvider.GetOrNullAsync(LocalizationSettingNames.DefaultLanguage);
+
+            var index = 0;
+            foreach (var translations in translationsCombined)
+            {
+                if (!translations.Any())
+                {
+                    //don't try to find a translation
+                }
+                else
+                {
+                    var translation = res[index];
+                    if (translation != null)
+                    {
+                        continue;
+                    }
+                    translation = translations.FirstOrDefault(pt => pt.Language == defaultLanguage);
+                    if (translation != null)
+                    {
+                        res[index] = translation;
+                    }
+                    else
+                    {
+                        res[index] = translations.FirstOrDefault();
+                    }
+                }
+                index++;
+            }
+        }
+        return res;
+    }
+
+    public virtual async Task<List<(TMultiLingual entity, TTranslation? translation)>> GetBulkTranslationsAsync<TMultiLingual, TTranslation>(IEnumerable<TMultiLingual> multiLinguals, string? culture, bool fallbackToParentCultures)
+       where TMultiLingual : IMultiLingualObject<TTranslation>
+       where TTranslation : class, IObjectTranslation
+    {
+        var resInitial = await GetBulkTranslationsAsync(multiLinguals.Select(x => x.Translations), culture, fallbackToParentCultures);
+        var index = 0;
+        var res = new List<(TMultiLingual entity, TTranslation? translation)>();
+        foreach (var item in multiLinguals)
+        {
+            var t = resInitial[index++];
+            res.Add((item, t));
+        }
+        return res;
     }
 }

--- a/framework/test/Volo.Abp.MultiLingualObjects.Tests/Volo.Abp.MultiLingualObjects.Tests.csproj
+++ b/framework/test/Volo.Abp.MultiLingualObjects.Tests/Volo.Abp.MultiLingualObjects.Tests.csproj
@@ -1,18 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <Import Project="..\..\..\common.test.props" />
+	<Import Project="..\..\..\common.test.props" />
 
-    <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
-        <RootNamespace />
-    </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net7.0</TargetFramework>
+		<RootNamespace />
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\..\src\Volo.Abp.Autofac\Volo.Abp.Autofac.csproj" />
-        <ProjectReference Include="..\..\src\Volo.Abp.MultiLingualObjects\Volo.Abp.MultiLingualObjects.csproj" />
-        <ProjectReference Include="..\..\src\Volo.Abp.ObjectMapping\Volo.Abp.ObjectMapping.csproj" />
-        <ProjectReference Include="..\AbpTestBase\AbpTestBase.csproj" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Volo.Abp.Autofac\Volo.Abp.Autofac.csproj" />
+		<ProjectReference Include="..\..\src\Volo.Abp.MultiLingualObjects\Volo.Abp.MultiLingualObjects.csproj" />
+		<ProjectReference Include="..\..\src\Volo.Abp.ObjectMapping\Volo.Abp.ObjectMapping.csproj" />
+		<ProjectReference Include="..\..\src\Volo.Abp.AutoMapper\Volo.Abp.AutoMapper.csproj" />
+
+		<ProjectReference Include="..\AbpTestBase\AbpTestBase.csproj" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
+	</ItemGroup>
 
 </Project>

--- a/framework/test/Volo.Abp.MultiLingualObjects.Tests/Volo/Abp/MultiLingualObjects/AbpMultiLingualObjectsTestModule.cs
+++ b/framework/test/Volo.Abp.MultiLingualObjects.Tests/Volo/Abp/MultiLingualObjects/AbpMultiLingualObjectsTestModule.cs
@@ -1,4 +1,6 @@
-﻿using Volo.Abp.Autofac;
+﻿using Microsoft.Extensions.DependencyInjection;
+using Volo.Abp.Autofac;
+using Volo.Abp.AutoMapper;
 using Volo.Abp.Localization;
 using Volo.Abp.Modularity;
 using Volo.Abp.ObjectMapping;
@@ -12,8 +14,21 @@ namespace Volo.Abp.MultiLingualObjects;
     typeof(AbpSettingsModule),
     typeof(AbpObjectMappingModule),
     typeof(AbpMultiLingualObjectsModule),
-    typeof(AbpTestBaseModule)
+    typeof(AbpTestBaseModule),
+    typeof(AbpAutoMapperModule)
 )]
 public class AbpMultiLingualObjectsTestModule : AbpModule
 {
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        Configure<AbpSettingOptions>(options =>
+        {   
+            options.DefinitionProviders.Add<LocalizationSettingProvider>();
+        });
+        context.Services.AddAutoMapperObjectMapper<AbpMultiLingualObjectsTestModule>();
+        Configure<AbpAutoMapperOptions>(options =>
+        {
+            options.AddMaps<AbpMultiLingualObjectsTestModule>(validate: true);
+        });
+    }
 }

--- a/framework/test/Volo.Abp.MultiLingualObjects.Tests/Volo/Abp/MultiLingualObjects/MultiLingualObjectTestProfile.cs
+++ b/framework/test/Volo.Abp.MultiLingualObjects.Tests/Volo/Abp/MultiLingualObjects/MultiLingualObjectTestProfile.cs
@@ -1,0 +1,23 @@
+﻿namespace Volo.Abp.MultiLingualObjects;
+
+using System;
+using System.Collections.Generic;
+using global::AutoMapper;
+using Volo.Abp.MultiLingualObjects.TestObjects;
+
+public class MultiLingualObjectTestProfile : Profile
+{
+    public MultiLingualObjectTestProfile()
+    {
+        CreateMap<MultiLingualBook, MultiLingualBookDto>()
+            .ForMember(x => x.Name,
+            x => x.MapFrom((src, target, member, context) =>
+            {
+                if (context.Items.TryGetValue(nameof(MultiLingualBookTranslation), out var translationsRaw) && translationsRaw is IReadOnlyDictionary<Guid, MultiLingualBookTranslation> translations)
+                {
+                    return translations.GetValueOrDefault(src.Id)?.Name;
+                }
+                return null;
+            }));
+    }
+}

--- a/framework/test/Volo.Abp.MultiLingualObjects.Tests/Volo/Abp/MultiLingualObjects/TestObjects/MultiLingualBook.cs
+++ b/framework/test/Volo.Abp.MultiLingualObjects.Tests/Volo/Abp/MultiLingualObjects/TestObjects/MultiLingualBook.cs
@@ -15,5 +15,5 @@ public class MultiLingualBook : IMultiLingualObject<MultiLingualBookTranslation>
 
     public decimal Price { get; set; }
 
-    public ICollection<MultiLingualBookTranslation> Translations { get; set; }
+    public ICollection<MultiLingualBookTranslation> Translations { get; set; } = new List<MultiLingualBookTranslation>();
 }

--- a/framework/test/Volo.Abp.MultiLingualObjects.Tests/Volo/Abp/MultiLingualObjects/TestObjects/MultiLingualBookDto.cs
+++ b/framework/test/Volo.Abp.MultiLingualObjects.Tests/Volo/Abp/MultiLingualObjects/TestObjects/MultiLingualBookDto.cs
@@ -6,7 +6,7 @@ public class MultiLingualBookDto
 {
     public Guid Id { get; set; }
 
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
     public decimal Price { get; set; }
 }

--- a/framework/test/Volo.Abp.MultiLingualObjects.Tests/Volo/Abp/MultiLingualObjects/TestObjects/MultiLingualBookTranslation.cs
+++ b/framework/test/Volo.Abp.MultiLingualObjects.Tests/Volo/Abp/MultiLingualObjects/TestObjects/MultiLingualBookTranslation.cs
@@ -2,7 +2,7 @@
 
 public class MultiLingualBookTranslation : IObjectTranslation
 {
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
-    public string Language { get; set; }
+    public required string Language { get; set; }
 }


### PR DESCRIPTION
This PR adds support for Bulk translations in the `Volo.Abp.MultiLingualObjects` module, which prevents calling 
`await SettingProvider.GetOrNullAsync(LocalizationSettingNames.DefaultLanguage)` for each object, and only calls it once.

I also added some tests, and added an example for mapping using `AutoMapper`.

I also loosened the constraints of the manager methods to take `IEnumerable<TTranslation>` instead of `ICollection<TTranslation>`