### PR TITLE
A space should be left between values that appear adjacent to the tab

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Tab/AbpTabsTagHelperService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Tab/AbpTabsTagHelperService.cs
@@ -84,7 +84,7 @@ public class AbpTabsTagHelperService : AbpTagHelperService<AbpTabsTagHelper>
         var id = TagHelper.Name + "Content";
 
         var wrapper = new TagBuilder("div");
-        wrapper.AddCssClass("tab-content");
+        wrapper.AddCssClass("tab-content pt-3");
         wrapper.Attributes.Add("id", id);
         wrapper.InnerHtml.AppendHtml(contents);
 


### PR DESCRIPTION
fixes https://github.com/volosoft/vs-internal/issues/1159
![image](https://user-images.githubusercontent.com/13196534/205333406-d89b6aff-5a1c-4795-9997-21de7295aa00.png)
