### PR TITLE
disable tree style loading with token

### DIFF
--- a/npm/ng-packs/angular.json
+++ b/npm/ng-packs/angular.json
@@ -277,6 +277,11 @@
                 "inject": true,
                 "bundleName": "ngx-datatable-material"
               },
+              {
+                "input": "node_modules/ng-zorro-antd/tree/style/index.min.css",
+                "inject": false,
+                "bundleName": "ng-zorro-antd-tree"
+              },
               "apps/dev-app/src/styles.scss"
             ],
             "scripts": []

--- a/npm/ng-packs/packages/components/tree/src/lib/components/tree.component.ts
+++ b/npm/ng-packs/packages/components/tree/src/lib/components/tree.component.ts
@@ -2,7 +2,9 @@ import {
   Component,
   ContentChild,
   EventEmitter,
+  Inject,
   Input,
+  Optional,
   Output,
   TemplateRef,
   ViewEncapsulation,
@@ -13,6 +15,7 @@ import { TreeNodeTemplateDirective } from '../templates/tree-node-template.direc
 import { ExpandedIconTemplateDirective } from '../templates/expanded-icon-template.directive';
 import { NgbDropdown } from '@ng-bootstrap/ng-bootstrap';
 import { LazyLoadService, LOADING_STRATEGY, SubscriptionService } from '@abp/ng.core';
+import { DISABLE_TREE_STYLE_LADING_TOKEN } from '../disable-tree-style-loading.token';
 
 export type DropEvent = NzFormatEmitEvent & { pos: number };
 
@@ -27,7 +30,17 @@ export class TreeComponent {
   dropPosition: number;
 
   dropdowns = {} as { [key: string]: NgbDropdown };
-  constructor(private lazyLoadService: LazyLoadService, subscriptionService: SubscriptionService) {
+
+  constructor(
+    private lazyLoadService: LazyLoadService,
+    subscriptionService: SubscriptionService,
+    @Optional()
+    @Inject(DISABLE_TREE_STYLE_LADING_TOKEN)
+    disableTreeStyleLoading: boolean | undefined,
+  ) {
+    if (disableTreeStyleLoading) {
+      return;
+    }
     const loaded$ = this.lazyLoadService.load(
       LOADING_STRATEGY.AppendAnonymousStyleToHead('ng-zorro-antd-tree.css'),
     );

--- a/npm/ng-packs/packages/components/tree/src/lib/components/tree.component.ts
+++ b/npm/ng-packs/packages/components/tree/src/lib/components/tree.component.ts
@@ -15,7 +15,7 @@ import { TreeNodeTemplateDirective } from '../templates/tree-node-template.direc
 import { ExpandedIconTemplateDirective } from '../templates/expanded-icon-template.directive';
 import { NgbDropdown } from '@ng-bootstrap/ng-bootstrap';
 import { LazyLoadService, LOADING_STRATEGY, SubscriptionService } from '@abp/ng.core';
-import { DISABLE_TREE_STYLE_LADING_TOKEN } from '../disable-tree-style-loading.token';
+import { DISABLE_TREE_STYLE_LOADING_TOKEN } from '../disable-tree-style-loading.token';
 
 export type DropEvent = NzFormatEmitEvent & { pos: number };
 
@@ -35,7 +35,7 @@ export class TreeComponent {
     private lazyLoadService: LazyLoadService,
     subscriptionService: SubscriptionService,
     @Optional()
-    @Inject(DISABLE_TREE_STYLE_LADING_TOKEN)
+    @Inject(DISABLE_TREE_STYLE_LOADING_TOKEN)
     disableTreeStyleLoading: boolean | undefined,
   ) {
     if (disableTreeStyleLoading) {

--- a/npm/ng-packs/packages/components/tree/src/lib/components/tree.component.ts
+++ b/npm/ng-packs/packages/components/tree/src/lib/components/tree.component.ts
@@ -8,6 +8,7 @@ import {
   Output,
   TemplateRef,
   ViewEncapsulation,
+  OnInit
 } from '@angular/core';
 import { NzFormatBeforeDropEvent, NzFormatEmitEvent } from 'ng-zorro-antd/tree';
 import { of } from 'rxjs';
@@ -26,7 +27,7 @@ export type DropEvent = NzFormatEmitEvent & { pos: number };
   encapsulation: ViewEncapsulation.None,
   providers: [SubscriptionService],
 })
-export class TreeComponent {
+export class TreeComponent implements OnInit {
   dropPosition: number;
 
   dropdowns = {} as { [key: string]: NgbDropdown };
@@ -36,16 +37,8 @@ export class TreeComponent {
     subscriptionService: SubscriptionService,
     @Optional()
     @Inject(DISABLE_TREE_STYLE_LOADING_TOKEN)
-    disableTreeStyleLoading: boolean | undefined,
-  ) {
-    if (disableTreeStyleLoading) {
-      return;
-    }
-    const loaded$ = this.lazyLoadService.load(
-      LOADING_STRATEGY.AppendAnonymousStyleToHead('ng-zorro-antd-tree.css'),
-    );
-    subscriptionService.addOne(loaded$);
-  }
+    private disableTreeStyleLoading: boolean | undefined,
+  ) { }
 
   @ContentChild('menu') menu: TemplateRef<any>;
   @ContentChild(TreeNodeTemplateDirective) customNodeTemplate: TreeNodeTemplateDirective;
@@ -70,6 +63,20 @@ export class TreeComponent {
     return of(false);
   };
 
+  ngOnInit() {
+    this.loadStyle()
+  }
+
+  private loadStyle() {
+    if (disableTreeStyleLoading) {
+      return;
+    }
+    const loaded$ = this.lazyLoadService.load(
+      LOADING_STRATEGY.AppendAnonymousStyleToHead('ng-zorro-antd-tree.css'),
+    );
+    subscriptionService.addOne(loaded$);
+  }
+  
   onSelectedNodeChange(node) {
     this.selectedNode = node.origin.entity;
     if (this.changeCheckboxWithNode) {

--- a/npm/ng-packs/packages/components/tree/src/lib/disable-tree-style-loading.token.ts
+++ b/npm/ng-packs/packages/components/tree/src/lib/disable-tree-style-loading.token.ts
@@ -1,0 +1,5 @@
+import { InjectionToken } from '@angular/core';
+
+export const DISABLE_TREE_STYLE_LADING_TOKEN = new InjectionToken<boolean>(
+  'DISABLE_TREE_STYLE__LADING_TOKEN',
+);

--- a/npm/ng-packs/packages/components/tree/src/lib/disable-tree-style-loading.token.ts
+++ b/npm/ng-packs/packages/components/tree/src/lib/disable-tree-style-loading.token.ts
@@ -1,5 +1,5 @@
 import { InjectionToken } from '@angular/core';
 
-export const DISABLE_TREE_STYLE_LADING_TOKEN = new InjectionToken<boolean>(
-  'DISABLE_TREE_STYLE__LADING_TOKEN',
+export const DISABLE_TREE_STYLE_LOADING_TOKEN = new InjectionToken<boolean>(
+  'DISABLE_TREE_STYLE_LOADING_TOKEN',
 );

--- a/npm/ng-packs/packages/components/tree/src/public-api.ts
+++ b/npm/ng-packs/packages/components/tree/src/public-api.ts
@@ -3,3 +3,4 @@ export * from './lib/components/tree.component';
 export * from './lib/utils/nz-tree-adapter';
 export * from './lib/templates/tree-node-template.directive';
 export * from './lib/templates/expanded-icon-template.directive';
+export * from './lib/disable-tree-style-loading.token';


### PR DESCRIPTION
We are moved style to lazyLoadservice. If the user want to stop inject styling, it can do that with a token.