### PR TITLE
Cli: show the current cli version

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/CliService.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/CliService.cs
@@ -51,7 +51,7 @@ public class CliService : ITransientDependency
     public async Task RunAsync(string[] args)
     {
         var currentCliVersion = await GetCurrentCliVersionInternalAsync(typeof(CliService).Assembly);
-        Logger.LogInformation($"ABP CLI {currentCliVersion} (https://abp.io)");
+        Logger.LogInformation($"ABP CLI {currentCliVersion}");
 
         var commandLineArgs = CommandLineArgumentParser.Parse(args);
 

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/CliService.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/CliService.cs
@@ -50,14 +50,15 @@ public class CliService : ITransientDependency
 
     public async Task RunAsync(string[] args)
     {
-        Logger.LogInformation("ABP CLI (https://abp.io)");
+        var currentCliVersion = await GetCurrentCliVersionInternalAsync(typeof(CliService).Assembly);
+        Logger.LogInformation($"ABP CLI {currentCliVersion} (https://abp.io)");
 
         var commandLineArgs = CommandLineArgumentParser.Parse(args);
 
 #if !DEBUG
         if (!commandLineArgs.Options.ContainsKey("skip-cli-version-check"))
         {
-            await CheckCliVersionAsync();
+            await CheckCliVersionAsync(currentCliVersion);
         }
 #endif
         try
@@ -168,7 +169,7 @@ public class CliService : ITransientDependency
         }
     }
 
-    private async Task CheckCliVersionAsync()
+    private async Task CheckCliVersionAsync(SemanticVersion currentCliVersion)
     {
         if (!await IsLatestVersionCheckExpiredAsync())
         {
@@ -177,10 +178,7 @@ public class CliService : ITransientDependency
         
         var assembly = typeof(CliService).Assembly;
         var toolPath = GetToolPath(assembly);
-        var currentCliVersion = await GetCurrentCliVersionInternalAsync(assembly);
         var updateChannel = GetUpdateChannel(currentCliVersion);
-
-        Logger.LogInformation($"Version {currentCliVersion} ({updateChannel})");
 
         try
         {


### PR DESCRIPTION
resolves https://github.com/abpframework/abp/issues/15114

This way we can see the cli version when someone send us their CLI logs. And we don't send request to anywhere, so it doesn't slow CLI down much.

![image](https://user-images.githubusercontent.com/5793291/207846398-e58ef391-ba1a-4b63-901e-b5558e9a19c1.png)
