### PR TITLE
docs: offline support

### DIFF
--- a/modules/docs/src/Volo.Docs.Domain/Volo/Docs/DocsDomainModule.cs
+++ b/modules/docs/src/Volo.Docs.Domain/Volo/Docs/DocsDomainModule.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -13,6 +14,7 @@ using Volo.Abp.VirtualFileSystem;
 using Volo.Docs.Documents;
 using Volo.Docs.Documents.FullSearch.Elastic;
 using Volo.Docs.FileSystem.Documents;
+using Volo.Docs.GitHub;
 using Volo.Docs.GitHub.Documents;
 using Volo.Docs.Localization;
 using Volo.Docs.Projects;
@@ -58,6 +60,16 @@ namespace Volo.Docs
             {
                 options.Sources[GithubDocumentSource.Type] = typeof(GithubDocumentSource);
                 options.Sources[FileSystemDocumentSource.Type] = typeof(FileSystemDocumentSource);
+            });
+            
+            Configure<DocsGithubLanguageOptions>(options =>
+            {
+                options.DefaultLanguage = new LanguageConfigElement 
+                {
+                    Code = "en", 
+                    DisplayName = "English", 
+                    IsDefault = true
+                };
             });
 
             context.Services.AddHttpClient(GithubRepositoryManager.HttpClientName, client =>

--- a/modules/docs/src/Volo.Docs.Domain/Volo/Docs/Documents/IDocumentSource.cs
+++ b/modules/docs/src/Volo.Docs.Domain/Volo/Docs/Documents/IDocumentSource.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Volo.Abp.Domain.Services;
-using Volo.Docs.GitHub.Documents;
 using Volo.Docs.Projects;
 
 namespace Volo.Docs.Documents

--- a/modules/docs/src/Volo.Docs.Domain/Volo/Docs/GitHub/DocsGithubLanguageOptions.cs
+++ b/modules/docs/src/Volo.Docs.Domain/Volo/Docs/GitHub/DocsGithubLanguageOptions.cs
@@ -1,0 +1,8 @@
+﻿using Volo.Docs.Documents;
+
+namespace Volo.Docs.GitHub;
+
+public class DocsGithubLanguageOptions
+{
+    public LanguageConfigElement DefaultLanguage { get; set; }
+}


### PR DESCRIPTION
Resolves https://github.com/abpframework/abp/issues/15130

---

In the current architecture, we are not saving language information to the database. We retrieve it from Github, then cache it and get the cached result in the subsequent calls. When github.com went offline, we can't get language information. I introduced the `DocsGithubLanguageOptions` options class and get the default language value from it in case of github.com is offline.

https://github.com/abpframework/abp/blob/557c50265a45db401fae26d3efd760fabb5d429f/modules/docs/src/Volo.Docs.Domain/Volo/Docs/DocsDomainModule.cs#L67-L72

---

For testing the PR, you can follow the following steps (@gizemmutukurt):
1. Mock your system to make it inaccessible to github.com and raw.githubusercontent.com for an offline scenario. See my comment to see how to do it: https://github.com/abpframework/abp/issues/12801#issuecomment-1352988544
2. Check whether the document is retrieved from the database or not.
3. Check the default language is shown on the language list and also please ensure the document shows for other languages.
