### PR TITLE
Cms Kit: Use the first available style for reCaptcha

### DIFF
--- a/modules/cms-kit/host/Volo.CmsKit.Web.Unified/Migrations/20221223083811_Added_EntityVersion.Designer.cs
+++ b/modules/cms-kit/host/Volo.CmsKit.Web.Unified/Migrations/20221223083811_Added_EntityVersion.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Volo.Abp.EntityFrameworkCore;
 using Volo.CmsKit.EntityFrameworkCore;
@@ -12,9 +13,11 @@ using Volo.CmsKit.EntityFrameworkCore;
 namespace Volo.CmsKit.Migrations
 {
     [DbContext(typeof(UnifiedDbContext))]
-    partial class UnifiedDbContextModelSnapshot : ModelSnapshot
+    [Migration("20221223083811_Added_EntityVersion")]
+    partial class AddedEntityVersion
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/modules/cms-kit/host/Volo.CmsKit.Web.Unified/Migrations/20221223083811_Added_EntityVersion.cs
+++ b/modules/cms-kit/host/Volo.CmsKit.Web.Unified/Migrations/20221223083811_Added_EntityVersion.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Volo.CmsKit.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddedEntityVersion : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "EntityVersion",
+                table: "AbpUsers",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "EntityVersion",
+                table: "AbpTenants",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "EntityVersion",
+                table: "AbpRoles",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "EntityVersion",
+                table: "AbpOrganizationUnits",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "EntityVersion",
+                table: "AbpUsers");
+
+            migrationBuilder.DropColumn(
+                name: "EntityVersion",
+                table: "AbpTenants");
+
+            migrationBuilder.DropColumn(
+                name: "EntityVersion",
+                table: "AbpRoles");
+
+            migrationBuilder.DropColumn(
+                name: "EntityVersion",
+                table: "AbpOrganizationUnits");
+        }
+    }
+}

--- a/modules/cms-kit/src/Volo.CmsKit.Public.Web/Security/Captcha/CaptchaOptions.cs
+++ b/modules/cms-kit/src/Volo.CmsKit.Public.Web/Security/Captcha/CaptchaOptions.cs
@@ -6,11 +6,6 @@ namespace Volo.CmsKit.Public.Web.Security.Captcha;
 
 public class CaptchaOptions
 {
-    /// <summary>
-    /// Default fonts are  "Arial", "Verdana", "Times New Roman" in Windows. These fonts must exist in the target OS.
-    /// </summary>
-    public string[] FontFamilies { get; set; } = new string[] { "Arial", "Verdana", "Times New Roman" };
-
     public Color[] TextColor { get; set; } = new Color[]
     {
         Color.Blue, Color.Black, Color.Black, Color.Brown, Color.Gray, Color.Green

--- a/modules/cms-kit/src/Volo.CmsKit.Public.Web/Security/Captcha/SimpleMathsCaptchaGenerator.cs
+++ b/modules/cms-kit/src/Volo.CmsKit.Public.Web/Security/Captcha/SimpleMathsCaptchaGenerator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Numerics;
 using System.Threading.Tasks;
 using SixLabors.Fonts;
@@ -99,9 +100,9 @@ public class SimpleMathsCaptchaGenerator : ISingletonDependency
             var random = new Random();
             var startWith = (byte)random.Next(5, 10);
             image.Mutate(ctx => ctx.BackgroundColor(Color.Transparent));
-            var fontName = options.FontFamilies[random.Next(0, options.FontFamilies.Length)];
-            var font = SystemFonts.CreateFont(fontName, options.FontSize, options.FontStyle);
-
+            var fontFamily = SystemFonts.Families.FirstOrDefault(x => x.IsStyleAvailable(options.FontStyle))?.Name ?? SystemFonts.Families.First().Name;
+            var font = SystemFonts.CreateFont(fontFamily, options.FontSize, options.FontStyle);
+            
             foreach (var character in stringText)
             {
                 var text = character.ToString();


### PR DESCRIPTION
Some pre-defined font-families were not used in Linux, such as "Times New Roman" and I think we should not make it configurable. With this PR, now we'll check the available fonts by the current system and use the first one. 