### PR TITLE
CLI: Use created project's angular cli instead of the global ng cli

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/NewCommand.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/NewCommand.cs
@@ -97,7 +97,6 @@ public class NewCommand : ProjectCreationCommandBase, IConsoleCommand, ITransien
 
         Logger.LogInformation($"'{projectName}' has been successfully created to '{projectArgs.OutputFolder}'");
 
-        ConfigureAngularJsonForThemeSelection(projectArgs);
         ConfigureNpmPackagesForTheme(projectArgs);
         await RunGraphBuildForMicroserviceServiceTemplate(projectArgs);
         await CreateInitialMigrationsAsync(projectArgs);
@@ -106,6 +105,7 @@ public class NewCommand : ProjectCreationCommandBase, IConsoleCommand, ITransien
         if (!skipInstallLibs)
         {
             await RunInstallLibsForWebTemplateAsync(projectArgs);
+            ConfigureAngularJsonForThemeSelection(projectArgs);
         }
         
         var skipBundling = commandLineArgs.Options.ContainsKey(Options.SkipBundling.Long) || commandLineArgs.Options.ContainsKey(Options.SkipBundling.Short);


### PR DESCRIPTION
Resolves #15247
