### PR TITLE
Add TwoLetterISOLanguageName LanguageInfo

### DIFF
--- a/framework/src/Volo.Abp.Localization/Volo/Abp/Localization/LanguageInfo.cs
+++ b/framework/src/Volo.Abp.Localization/Volo/Abp/Localization/LanguageInfo.cs
@@ -17,7 +17,7 @@ public class LanguageInfo : ILanguageInfo
     public virtual string DisplayName { get; protected set; }
 
     [NotNull]
-    public virtual string ShortDisplayName { get; protected set; }
+    public virtual string TwoLetterISOLanguageName { get; protected set; }
 
     [CanBeNull]
     public virtual string FlagIcon { get; set; }
@@ -55,7 +55,7 @@ public class LanguageInfo : ILanguageInfo
             ? displayName
             : cultureName;
         
-        ShortDisplayName = new CultureInfo(cultureName)
+        TwoLetterISOLanguageName = new CultureInfo(cultureName)
             .TwoLetterISOLanguageName;
     }
 }

--- a/framework/src/Volo.Abp.Localization/Volo/Abp/Localization/LanguageInfo.cs
+++ b/framework/src/Volo.Abp.Localization/Volo/Abp/Localization/LanguageInfo.cs
@@ -15,9 +15,13 @@ public class LanguageInfo : ILanguageInfo
     [NotNull]
     public virtual string DisplayName { get; protected set; }
 
+    [NotNull]
+    public virtual string ShortDisplayName { get; protected set; }
+
     [CanBeNull]
     public virtual string FlagIcon { get; set; }
 
+    
     protected LanguageInfo()
     {
 
@@ -49,5 +53,9 @@ public class LanguageInfo : ILanguageInfo
         DisplayName = !displayName.IsNullOrWhiteSpace()
             ? displayName
             : cultureName;
+
+        var culture = new System.Globalization.CultureInfo(cultureName);
+        
+        ShortDisplayName = culture.TwoLetterISOLanguageName;
     }
 }

--- a/framework/src/Volo.Abp.Localization/Volo/Abp/Localization/LanguageInfo.cs
+++ b/framework/src/Volo.Abp.Localization/Volo/Abp/Localization/LanguageInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using JetBrains.Annotations;
 
 namespace Volo.Abp.Localization;
@@ -53,9 +54,8 @@ public class LanguageInfo : ILanguageInfo
         DisplayName = !displayName.IsNullOrWhiteSpace()
             ? displayName
             : cultureName;
-
-        var culture = new System.Globalization.CultureInfo(cultureName);
         
-        ShortDisplayName = culture.TwoLetterISOLanguageName;
+        ShortDisplayName = new CultureInfo(cultureName)
+            .TwoLetterISOLanguageName;
     }
 }


### PR DESCRIPTION
Related to https://github.com/abpframework/abp/issues/15381

The purpose of this change is to provide TwoLetterISOLanguageName to non-CSharp clients.

![image](https://user-images.githubusercontent.com/23705418/212866323-33767277-54a2-4352-8723-70c4de02d204.png)
