### PR TITLE
MVC Datatable Sort by name property if its provided.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/wwwroot/libs/abp/aspnetcore-mvc-ui-theme-shared/datatables/datatables-extensions.js
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/wwwroot/libs/abp/aspnetcore-mvc-ui-theme-shared/datatables/datatables-extensions.js
@@ -354,7 +354,14 @@ var abp = abp || {};
                     for (var i = 0; i < requestData.order.length; i++) {
                         var orderingField = requestData.order[i];
 
-                        if (requestData.columns[orderingField.column].data) {
+                        if (requestData.columns[orderingField.column].name) {
+                            input.sorting += requestData.columns[orderingField.column].name + " " + orderingField.dir;
+
+                            if (i < requestData.order.length - 1) {
+                                input.sorting += ",";
+                            }
+                        }
+                        else if (requestData.columns[orderingField.column].data) {
                             input.sorting += requestData.columns[orderingField.column].data + " " + orderingField.dir;
 
                             if (i < requestData.order.length - 1) {


### PR DESCRIPTION
Sometimes we need different property name for sorting especially while using joined tables on server side query. I override the sorting part on my app and it works.