### PR TITLE
Fix EfCoreBlogPostRepository & EfCoreBlogRepository to use ICmsKitDbC…

### DIFF
--- a/modules/cms-kit/src/Volo.CmsKit.EntityFrameworkCore/Volo/CmsKit/Blogs/EfCoreBlogFeatureRepository.cs
+++ b/modules/cms-kit/src/Volo.CmsKit.EntityFrameworkCore/Volo/CmsKit/Blogs/EfCoreBlogFeatureRepository.cs
@@ -10,9 +10,9 @@ using Volo.CmsKit.EntityFrameworkCore;
 
 namespace Volo.CmsKit.Blogs;
 
-public class EfCoreBlogFeatureRepository : EfCoreRepository<CmsKitDbContext, BlogFeature, Guid>, IBlogFeatureRepository
+public class EfCoreBlogFeatureRepository : EfCoreRepository<ICmsKitDbContext, BlogFeature, Guid>, IBlogFeatureRepository
 {
-    public EfCoreBlogFeatureRepository(IDbContextProvider<CmsKitDbContext> dbContextProvider) : base(dbContextProvider)
+    public EfCoreBlogFeatureRepository(IDbContextProvider<ICmsKitDbContext> dbContextProvider) : base(dbContextProvider)
     {
     }
 

--- a/modules/cms-kit/src/Volo.CmsKit.EntityFrameworkCore/Volo/CmsKit/Blogs/EfCoreBlogPostRepository.cs
+++ b/modules/cms-kit/src/Volo.CmsKit.EntityFrameworkCore/Volo/CmsKit/Blogs/EfCoreBlogPostRepository.cs
@@ -16,12 +16,12 @@ using Volo.CmsKit.Users;
 
 namespace Volo.CmsKit.Blogs;
 
-public class EfCoreBlogPostRepository : EfCoreRepository<CmsKitDbContext, BlogPost, Guid>, IBlogPostRepository
+public class EfCoreBlogPostRepository : EfCoreRepository<ICmsKitDbContext, BlogPost, Guid>, IBlogPostRepository
 {
     private EntityTagManager _entityTagManager;
 
     public EfCoreBlogPostRepository(
-        IDbContextProvider<CmsKitDbContext> dbContextProvider,
+        IDbContextProvider<ICmsKitDbContext> dbContextProvider,
         EntityTagManager entityTagManager) : base(dbContextProvider)
     {
         _entityTagManager = entityTagManager;


### PR DESCRIPTION
Related to [ReplaceDbContext-causes-an-error](https://support.abp.io/QA/Questions/1290/microservice-service-template-ReplaceDbContext-causes-an-error).

I move this to repository to ICmsKitDbContext