### PR TITLE
Use providers instead of direct repository access for resetting features

### DIFF
--- a/modules/feature-management/src/Volo.Abp.FeatureManagement.Application/Volo/Abp/FeatureManagement/FeatureAppService.cs
+++ b/modules/feature-management/src/Volo.Abp.FeatureManagement.Application/Volo/Abp/FeatureManagement/FeatureAppService.cs
@@ -14,18 +14,15 @@ public class FeatureAppService : FeatureManagementAppServiceBase, IFeatureAppSer
 {
     protected FeatureManagementOptions Options { get; }
     protected IFeatureManager FeatureManager { get; }
-    protected IFeatureValueRepository FeatureValueRepository { get; }
     protected IFeatureDefinitionManager FeatureDefinitionManager { get; }
 
     public FeatureAppService(IFeatureManager featureManager,
         IFeatureDefinitionManager featureDefinitionManager,
-        IOptions<FeatureManagementOptions> options,
-        IFeatureValueRepository featureValueRepository)
+        IOptions<FeatureManagementOptions> options)
     {
         FeatureManager = featureManager;
         FeatureDefinitionManager = featureDefinitionManager;
         Options = options.Value;
-        FeatureValueRepository = featureValueRepository;
     }
 
     public virtual async Task<GetFeatureListResultDto> GetAsync([NotNull] string providerName, string providerKey)
@@ -140,6 +137,6 @@ public class FeatureAppService : FeatureManagementAppServiceBase, IFeatureAppSer
 
     public virtual async Task DeleteAsync([NotNull] string providerName, string providerKey)
     {
-        await FeatureValueRepository.DeleteAsync(providerName, providerKey);
+        await FeatureManager.DeleteAsync(providerName, providerKey);
     }
 }

--- a/modules/feature-management/src/Volo.Abp.FeatureManagement.Domain/Volo/Abp/FeatureManagement/FeatureManager.cs
+++ b/modules/feature-management/src/Volo.Abp.FeatureManagement.Domain/Volo/Abp/FeatureManagement/FeatureManager.cs
@@ -235,7 +235,6 @@ public class FeatureManager : IFeatureManager, ISingletonDependency
             .TakeWhile(p => p.Name == providerName)
             .ToList(); //Getting list for case of there are more than one provider with same providerName
 
-
         foreach (var featureNameValue in featureNameValues)
         {
             var feature = await FeatureDefinitionManager.GetAsync(featureNameValue.Name);

--- a/modules/feature-management/src/Volo.Abp.FeatureManagement.Domain/Volo/Abp/FeatureManagement/FeatureManager.cs
+++ b/modules/feature-management/src/Volo.Abp.FeatureManagement.Domain/Volo/Abp/FeatureManagement/FeatureManager.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Xml.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Options;

--- a/modules/feature-management/src/Volo.Abp.FeatureManagement.Domain/Volo/Abp/FeatureManagement/FeatureManager.cs
+++ b/modules/feature-management/src/Volo.Abp.FeatureManagement.Domain/Volo/Abp/FeatureManagement/FeatureManager.cs
@@ -216,7 +216,7 @@ public class FeatureManager : IFeatureManager, ISingletonDependency
         return featureNameValueWithGrantedProvider;
     }
 
-    public async Task DeleteAsync(string providerName, string providerKey)
+    public virtual async Task DeleteAsync(string providerName, string providerKey)
     {
         var featureNameValues = await GetAllAsync(providerName, providerKey);
 

--- a/modules/feature-management/src/Volo.Abp.FeatureManagement.Domain/Volo/Abp/FeatureManagement/IFeatureManager.cs
+++ b/modules/feature-management/src/Volo.Abp.FeatureManagement.Domain/Volo/Abp/FeatureManagement/IFeatureManager.cs
@@ -15,4 +15,5 @@ public interface IFeatureManager
     Task<List<FeatureNameValueWithGrantedProvider>> GetAllWithProviderAsync([NotNull] string providerName, [CanBeNull] string providerKey, bool fallback = true);
 
     Task SetAsync([NotNull] string name, [CanBeNull] string value, [NotNull] string providerName, [CanBeNull] string providerKey, bool forceToSet = false);
+    Task DeleteAsync(string providerName, string providerKey);
 }

--- a/modules/feature-management/src/Volo.Abp.FeatureManagement.Domain/Volo/Abp/FeatureManagement/IFeatureManager.cs
+++ b/modules/feature-management/src/Volo.Abp.FeatureManagement.Domain/Volo/Abp/FeatureManagement/IFeatureManager.cs
@@ -15,5 +15,6 @@ public interface IFeatureManager
     Task<List<FeatureNameValueWithGrantedProvider>> GetAllWithProviderAsync([NotNull] string providerName, [CanBeNull] string providerKey, bool fallback = true);
 
     Task SetAsync([NotNull] string name, [CanBeNull] string value, [NotNull] string providerName, [CanBeNull] string providerKey, bool forceToSet = false);
+
     Task DeleteAsync(string providerName, string providerKey);
 }

--- a/modules/feature-management/test/Volo.Abp.FeatureManagement.Domain.Tests/Volo/Abp/FeatureManagement/FeatureManager_Tests.cs
+++ b/modules/feature-management/test/Volo.Abp.FeatureManagement.Domain.Tests/Volo/Abp/FeatureManagement/FeatureManager_Tests.cs
@@ -195,4 +195,18 @@ public class FeatureManager_Tests : FeatureManagementDomainTestBase
         featureValue.ShouldNotBeNull();
         featureValue.Value.ShouldBe(true.ToString().ToLower());
     }
+
+    [Fact]
+    public async Task DeleteAsync()
+    {
+        //Default
+        (await _featureManager.GetOrNullAsync(TestFeatureDefinitionProvider.BackupCount, TenantFeatureValueProvider.ProviderName, TestEditionIds.TenantId.ToString())).ShouldBe("0");
+
+        await _featureManager.SetAsync(TestFeatureDefinitionProvider.BackupCount, "2", TenantFeatureValueProvider.ProviderName, TestEditionIds.TenantId.ToString());
+        (await _featureManager.GetOrNullAsync(TestFeatureDefinitionProvider.BackupCount, TenantFeatureValueProvider.ProviderName, TestEditionIds.TenantId.ToString())).ShouldBe("2");
+
+        await _featureManager.DeleteAsync(TenantFeatureValueProvider.ProviderName, TestEditionIds.TenantId.ToString());
+
+        (await _featureManager.GetOrNullAsync(TestFeatureDefinitionProvider.BackupCount, TenantFeatureValueProvider.ProviderName, TestEditionIds.TenantId.ToString())).ShouldBe("0");
+    }
 }


### PR DESCRIPTION
Deleting from the database is not an option for this feature. Also, data still remains in the cache when we remove it with Repository. So, this PR just uses Providers to reset features.

---

Firstly appeared in https://github.com/abpframework/abp/pull/14514

---

Closes https://github.com/volosoft/volo/issues/13278