### PR TITLE
Refactor `IExceptionToErrorInfoConverter` namespace and namings

### DIFF
--- a/docs/en/Exception-Handling.md
+++ b/docs/en/Exception-Handling.md
@@ -328,13 +328,12 @@ You can also throw these type of exceptions in your code (although it's rarely n
 ````csharp
 Configure<AbpExceptionHandlingOptions>(options =>
 {
-    options.SendExceptionsDetailsToClients = true;
-    options.SendStackTraceToClients = false;
+    options.IncludeDetails = true;
+    options.IncludeStackTrace = false;
 });
 ````
 
 Here, a list of the options you can configure:
 
-* `SendExceptionsDetailsToClients` (default: `false`): You can enable or disable sending exception details to the client.
-* `SendStackTraceToClients` (default: `true`): You can enable or disable sending the stack trace of exception to the client. If you want to send the stack trace to the client, you must set both `SendStackTraceToClients` and `SendExceptionsDetailsToClients` options to `true` otherwise, the stack trace will not be sent to the client.
-
+* `IncludeDetails` (default: `false`): You can enable or disable sending exception details to the client.
+* `IncludeStackTrace` (default: `true`): You can enable or disable sending the stack trace of exception to the client. If you want to send the stack trace to the client, you must set both `IncludeStackTrace` and `IncludeDetails` options to `true` otherwise, the stack trace will not be sent to the client.

--- a/framework/src/Volo.Abp.AspNetCore.Components.Web/Volo/Abp/AspNetCore/Components/Web/ExceptionHandling/UserExceptionInformer.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Components.Web/Volo/Abp/AspNetCore/Components/Web/ExceptionHandling/UserExceptionInformer.cs
@@ -5,9 +5,8 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Volo.Abp.AspNetCore.Components.ExceptionHandling;
 using Microsoft.Extensions.Options;
 using Volo.Abp.AspNetCore.Components.Messages;
-using Volo.Abp.AspNetCore.ExceptionHandling;
 using Volo.Abp.DependencyInjection;
-using Volo.Abp.Http;
+using Volo.Abp.ExceptionHandling;
 
 namespace Volo.Abp.AspNetCore.Components.Web.ExceptionHandling;
 
@@ -61,12 +60,12 @@ public class UserExceptionInformer : IUserExceptionInformer, IScopedDependency
         }
     }
 
-    protected virtual RemoteServiceErrorInfo GetErrorInfo(UserExceptionInformerContext context)
+    protected virtual ErrorInfo GetErrorInfo(UserExceptionInformerContext context)
     {
         return ExceptionToErrorInfoConverter.Convert(context.Exception, options =>
         {
-            options.SendExceptionsDetailsToClients = Options.SendExceptionsDetailsToClients;
-            options.SendStackTraceToClients = Options.SendStackTraceToClients;
+            options.IncludeDetails = Options.IncludeDetails;
+            options.IncludeStackTrace = Options.IncludeStackTrace;
         });
     }
 }

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/Controllers/ErrorController.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/Controllers/ErrorController.cs
@@ -49,8 +49,8 @@ public class ErrorController : AbpController
 
         var errorInfo = _errorInfoConverter.Convert(exception, options =>
         {
-            options.SendExceptionsDetailsToClients = _exceptionHandlingOptions.SendExceptionsDetailsToClients;
-            options.SendStackTraceToClients = _exceptionHandlingOptions.SendStackTraceToClients;
+            options.IncludeDetails = _exceptionHandlingOptions.IncludeDetails;
+            options.IncludeStackTrace = _exceptionHandlingOptions.IncludeStackTrace;
         });
 
         if (httpStatusCode == 0)

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/Views/Error/AbpErrorViewModel.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/Views/Error/AbpErrorViewModel.cs
@@ -1,10 +1,10 @@
-﻿using Volo.Abp.Http;
+﻿using Volo.Abp.ExceptionHandling;
 
 namespace Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared.Views.Error;
 
 public class AbpErrorViewModel
 {
-    public RemoteServiceErrorInfo ErrorInfo { get; set; }
+    public ErrorInfo ErrorInfo { get; set; }
 
     public int HttpStatusCode { get; set; }
 }

--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/ExceptionHandling/AbpExceptionPageFilter.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/ExceptionHandling/AbpExceptionPageFilter.cs
@@ -71,20 +71,20 @@ public class AbpExceptionPageFilter : IAsyncPageFilter, ITransientDependency
 
         var exceptionHandlingOptions = context.GetRequiredService<IOptions<AbpExceptionHandlingOptions>>().Value;
         var exceptionToErrorInfoConverter = context.GetRequiredService<IExceptionToErrorInfoConverter>();
-        var remoteServiceErrorInfo = exceptionToErrorInfoConverter.Convert(context.Exception, options =>
+        var errorInfo = exceptionToErrorInfoConverter.Convert(context.Exception, options =>
        {
-           options.SendExceptionsDetailsToClients = exceptionHandlingOptions.SendExceptionsDetailsToClients;
-           options.SendStackTraceToClients = exceptionHandlingOptions.SendStackTraceToClients;
+           options.IncludeDetails = exceptionHandlingOptions.IncludeDetails;
+           options.IncludeStackTrace = exceptionHandlingOptions.IncludeStackTrace;
        });
 
         var logLevel = context.Exception.GetLogLevel();
 
-        var remoteServiceErrorInfoBuilder = new StringBuilder();
-        remoteServiceErrorInfoBuilder.AppendLine($"---------- {nameof(RemoteServiceErrorInfo)} ----------");
-        remoteServiceErrorInfoBuilder.AppendLine(context.GetRequiredService<IJsonSerializer>().Serialize(remoteServiceErrorInfo, indented: true));
+        var errorInfoBuilder = new StringBuilder();
+        errorInfoBuilder.AppendLine($"---------- {nameof(ErrorInfo)} ----------");
+        errorInfoBuilder.AppendLine(context.GetRequiredService<IJsonSerializer>().Serialize(errorInfo, indented: true));
 
         var logger = context.GetService<ILogger<AbpExceptionFilter>>(NullLogger<AbpExceptionFilter>.Instance);
-        logger.LogWithLevel(logLevel, remoteServiceErrorInfoBuilder.ToString());
+        logger.LogWithLevel(logLevel, errorInfoBuilder.ToString());
 
         logger.LogException(context.Exception, logLevel);
 
@@ -102,7 +102,7 @@ public class AbpExceptionPageFilter : IAsyncPageFilter, ITransientDependency
                 .GetRequiredService<IHttpExceptionStatusCodeFinder>()
                 .GetStatusCode(context.HttpContext, context.Exception);
 
-            context.Result = new ObjectResult(new RemoteServiceErrorResponse(remoteServiceErrorInfo));
+            context.Result = new ObjectResult(new RemoteServiceErrorResponse(errorInfo));
         }
 
         context.Exception = null; //Handled!

--- a/framework/src/Volo.Abp.AspNetCore/Volo/Abp/AspNetCore/ExceptionHandling/AbpExceptionHandlingMiddleware.cs
+++ b/framework/src/Volo.Abp.AspNetCore/Volo/Abp/AspNetCore/ExceptionHandling/AbpExceptionHandlingMiddleware.cs
@@ -89,8 +89,8 @@ public class AbpExceptionHandlingMiddleware : IMiddleware, ITransientDependency
                     new RemoteServiceErrorResponse(
                         errorInfoConverter.Convert(exception, options =>
                         {
-                            options.SendExceptionsDetailsToClients = exceptionHandlingOptions.SendExceptionsDetailsToClients;
-                            options.SendStackTraceToClients = exceptionHandlingOptions.SendStackTraceToClients;
+                            options.IncludeDetails = exceptionHandlingOptions.IncludeDetails;
+                            options.IncludeStackTrace = exceptionHandlingOptions.IncludeStackTrace;
                         })
                     )
                 )

--- a/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/AspNetCore/ExceptionHandling/AbpExceptionHandlingOptions.cs
+++ b/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/AspNetCore/ExceptionHandling/AbpExceptionHandlingOptions.cs
@@ -1,8 +1,0 @@
-﻿namespace Volo.Abp.AspNetCore.ExceptionHandling;
-
-public class AbpExceptionHandlingOptions
-{
-    public bool SendExceptionsDetailsToClients { get; set; } = false;
-
-    public bool SendStackTraceToClients { get; set; } = true;
-}

--- a/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/ExceptionHandling/AbpExceptionHandlingOptions.cs
+++ b/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/ExceptionHandling/AbpExceptionHandlingOptions.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace Volo.Abp.ExceptionHandling;
+
+public class AbpExceptionHandlingOptions
+{
+    public bool IncludeDetails { get; set; } = false;
+
+    public bool IncludeStackTrace { get; set; } = true;
+
+    /// <summary>
+    /// Alias to keep Compatibility to previous versions
+    /// </summary>
+    [Browsable(false)]
+    [Obsolete($"Please use '{nameof(IncludeDetails)}' instead.")]
+    public bool SendExceptionsDetailsToClients {
+        get => IncludeDetails;
+        set => IncludeDetails = value;
+    }
+
+    /// <summary>
+    /// Alias to keep Compatibility to previous versions
+    /// </summary>
+    [Browsable(false)]
+    [Obsolete($"Please use '{nameof(IncludeStackTrace)}' instead.")]
+    public bool SendStackTraceToClients {
+        get => IncludeStackTrace;
+        set => IncludeStackTrace = value;
+    }
+}

--- a/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/ExceptionHandling/ErrorInfo.cs
+++ b/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/ExceptionHandling/ErrorInfo.cs
@@ -1,13 +1,14 @@
 ﻿using System;
 using System.Collections;
+using Volo.Abp.Http;
 
-namespace Volo.Abp.Http;
+namespace Volo.Abp.ExceptionHandling;
 
 /// <summary>
 /// Used to store information about an error.
 /// </summary>
 [Serializable]
-public class RemoteServiceErrorInfo
+public class ErrorInfo
 {
     /// <summary>
     /// Error code.
@@ -32,24 +33,24 @@ public class RemoteServiceErrorInfo
     /// <summary>
     /// Validation errors if exists.
     /// </summary>
-    public RemoteServiceValidationErrorInfo[] ValidationErrors { get; set; }
+    public ValidationErrorInfo[] ValidationErrors { get; set; }
 
     /// <summary>
-    /// Creates a new instance of <see cref="RemoteServiceErrorInfo"/>.
+    /// Creates a new instance of <see cref="ErrorInfo"/>.
     /// </summary>
-    public RemoteServiceErrorInfo()
+    public ErrorInfo()
     {
 
     }
 
     /// <summary>
-    /// Creates a new instance of <see cref="RemoteServiceErrorInfo"/>.
+    /// Creates a new instance of <see cref="ErrorInfo"/>.
     /// </summary>
     /// <param name="code">Error code</param>
     /// <param name="details">Error details</param>
     /// <param name="message">Error message</param>
     /// <param name="data">Error data</param>
-    public RemoteServiceErrorInfo(string message, string details = null, string code = null, IDictionary data = null)
+    public ErrorInfo(string message, string details = null, string code = null, IDictionary data = null)
     {
         Message = message;
         Details = details;

--- a/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/ExceptionHandling/IExceptionToErrorInfoConverter.cs
+++ b/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/ExceptionHandling/IExceptionToErrorInfoConverter.cs
@@ -1,10 +1,9 @@
 ﻿using System;
-using Volo.Abp.Http;
 
-namespace Volo.Abp.AspNetCore.ExceptionHandling;
+namespace Volo.Abp.ExceptionHandling;
 
 /// <summary>
-/// This interface can be implemented to convert an <see cref="Exception"/> object to an <see cref="RemoteServiceErrorInfo"/> object.
+/// This interface can be implemented to convert an <see cref="Exception"/> object to an <see cref="ErrorInfo"/> object.
 /// Implements Chain Of Responsibility pattern.
 /// </summary>
 public interface IExceptionToErrorInfoConverter
@@ -16,7 +15,7 @@ public interface IExceptionToErrorInfoConverter
     /// <param name="includeSensitiveDetails">Should include sensitive details to the error info?</param>
     /// <returns>Error info or null</returns>
     [Obsolete("Use other Convert method.")]
-    RemoteServiceErrorInfo Convert(Exception exception, bool includeSensitiveDetails);
+    ErrorInfo Convert(Exception exception, bool includeSensitiveDetails);
 
     /// <summary>
     /// Converter method.
@@ -24,5 +23,5 @@ public interface IExceptionToErrorInfoConverter
     /// <param name="exception">The exception.</param>
     /// <param name="options">Additional options.</param>
     /// <returns>Error info or null</returns>
-    RemoteServiceErrorInfo Convert(Exception exception, Action<AbpExceptionHandlingOptions> options = null);
+    ErrorInfo Convert(Exception exception, Action<AbpExceptionHandlingOptions> options = null);
 }

--- a/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/ExceptionHandling/ValidationErrorInfo.cs
+++ b/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/ExceptionHandling/ValidationErrorInfo.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 
-namespace Volo.Abp.Http;
+namespace Volo.Abp.ExceptionHandling;
 
 /// <summary>
 /// Used to store information about a validation error.
 /// </summary>
 [Serializable]
-public class RemoteServiceValidationErrorInfo
+public class ValidationErrorInfo
 {
     /// <summary>
     /// Validation error message.
@@ -19,39 +19,39 @@ public class RemoteServiceValidationErrorInfo
     public string[] Members { get; set; }
 
     /// <summary>
-    /// Creates a new instance of <see cref="RemoteServiceValidationErrorInfo"/>.
+    /// Creates a new instance of <see cref="ValidationErrorInfo"/>.
     /// </summary>
-    public RemoteServiceValidationErrorInfo()
+    public ValidationErrorInfo()
     {
 
     }
 
     /// <summary>
-    /// Creates a new instance of <see cref="RemoteServiceValidationErrorInfo"/>.
+    /// Creates a new instance of <see cref="ValidationErrorInfo"/>.
     /// </summary>
     /// <param name="message">Validation error message</param>
-    public RemoteServiceValidationErrorInfo(string message)
+    public ValidationErrorInfo(string message)
     {
         Message = message;
     }
 
     /// <summary>
-    /// Creates a new instance of <see cref="RemoteServiceValidationErrorInfo"/>.
+    /// Creates a new instance of <see cref="ValidationErrorInfo"/>.
     /// </summary>
     /// <param name="message">Validation error message</param>
     /// <param name="members">Related invalid members</param>
-    public RemoteServiceValidationErrorInfo(string message, string[] members)
+    public ValidationErrorInfo(string message, string[] members)
         : this(message)
     {
         Members = members;
     }
 
     /// <summary>
-    /// Creates a new instance of <see cref="RemoteServiceValidationErrorInfo"/>.
+    /// Creates a new instance of <see cref="ValidationErrorInfo"/>.
     /// </summary>
     /// <param name="message">Validation error message</param>
     /// <param name="member">Related invalid member</param>
-    public RemoteServiceValidationErrorInfo(string message, string member)
+    public ValidationErrorInfo(string message, string member)
         : this(message, new[] { member })
     {
 

--- a/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/Http/Client/AbpRemoteCallException.cs
+++ b/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/Http/Client/AbpRemoteCallException.cs
@@ -13,7 +13,7 @@ public class AbpRemoteCallException : AbpException, IHasErrorCode, IHasErrorDeta
 
     public string Details => Error?.Details;
 
-    public RemoteServiceErrorInfo Error { get; set; }
+    public ErrorInfo Error { get; set; }
 
     public AbpRemoteCallException()
     {
@@ -32,7 +32,7 @@ public class AbpRemoteCallException : AbpException, IHasErrorCode, IHasErrorDeta
 
     }
 
-    public AbpRemoteCallException(RemoteServiceErrorInfo error, Exception innerException = null)
+    public AbpRemoteCallException(ErrorInfo error, Exception innerException = null)
         : base(error.Message, innerException)
     {
         Error = error;

--- a/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/Http/RemoteServiceErrorResponse.cs
+++ b/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/Http/RemoteServiceErrorResponse.cs
@@ -1,10 +1,12 @@
-﻿namespace Volo.Abp.Http;
+﻿using Volo.Abp.ExceptionHandling;
+
+namespace Volo.Abp.Http;
 
 public class RemoteServiceErrorResponse
 {
-    public RemoteServiceErrorInfo Error { get; set; }
+    public ErrorInfo Error { get; set; }
 
-    public RemoteServiceErrorResponse(RemoteServiceErrorInfo error)
+    public RemoteServiceErrorResponse(ErrorInfo error)
     {
         Error = error;
     }

--- a/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/ClientProxying/ClientProxyBase.cs
+++ b/framework/src/Volo.Abp.Http.Client/Volo/Abp/Http/Client/ClientProxying/ClientProxyBase.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Volo.Abp.Content;
 using Volo.Abp.DependencyInjection;
+using Volo.Abp.ExceptionHandling;
 using Volo.Abp.Http.Client.Authentication;
 using Volo.Abp.Http.Client.Proxying;
 using Volo.Abp.Http.Modeling;
@@ -228,7 +229,7 @@ public class ClientProxyBase<TService> : ITransientDependency
             catch (Exception ex)
             {
                 throw new AbpRemoteCallException(
-                    new RemoteServiceErrorInfo
+                    new ErrorInfo
                     {
                         Message = response.ReasonPhrase,
                         Code = response.StatusCode.ToString()
@@ -248,7 +249,7 @@ public class ClientProxyBase<TService> : ITransientDependency
         else
         {
             throw new AbpRemoteCallException(
-                new RemoteServiceErrorInfo
+                new ErrorInfo
                 {
                     Message = response.ReasonPhrase,
                     Code = response.StatusCode.ToString()

--- a/framework/test/Volo.Abp.Authorization.Tests/Microsoft/AspNetCore/Authorization/AbpAuthorizationServiceExtensions_Tests.cs
+++ b/framework/test/Volo.Abp.Authorization.Tests/Microsoft/AspNetCore/Authorization/AbpAuthorizationServiceExtensions_Tests.cs
@@ -1,6 +1,6 @@
 ﻿using Shouldly;
-using Volo.Abp.AspNetCore.ExceptionHandling;
 using Volo.Abp.Authorization;
+using Volo.Abp.ExceptionHandling;
 using Volo.Abp.Localization;
 using Xunit;
 

--- a/framework/test/Volo.Abp.Features.Tests/Volo/Abp/Features/FeatureCheckerExtensions_Tests.cs
+++ b/framework/test/Volo.Abp.Features.Tests/Volo/Abp/Features/FeatureCheckerExtensions_Tests.cs
@@ -1,6 +1,6 @@
 ﻿using Shouldly;
-using Volo.Abp.AspNetCore.ExceptionHandling;
 using Volo.Abp.Authorization;
+using Volo.Abp.ExceptionHandling;
 using Volo.Abp.Localization;
 using Xunit;
 

--- a/framework/test/Volo.Abp.GlobalFeatures.Tests/Volo/Abp/GlobalFeatures/AbpGlobalFeatureNotEnableException_Localization_Test.cs
+++ b/framework/test/Volo.Abp.GlobalFeatures.Tests/Volo/Abp/GlobalFeatures/AbpGlobalFeatureNotEnableException_Localization_Test.cs
@@ -1,5 +1,5 @@
 ﻿using Shouldly;
-using Volo.Abp.AspNetCore.ExceptionHandling;
+using Volo.Abp.ExceptionHandling;
 using Volo.Abp.Localization;
 using Xunit;
 

--- a/modules/account/src/Volo.Abp.Account.Web.IdentityServer/Areas/Account/Controllers/ErrorController.cs
+++ b/modules/account/src/Volo.Abp.Account.Web.IdentityServer/Areas/Account/Controllers/ErrorController.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Options;
 using Volo.Abp.AspNetCore.Mvc;
 using Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared;
 using Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared.Views.Error;
-using Volo.Abp.Http;
+using Volo.Abp.ExceptionHandling;
 
 namespace Volo.Abp.Account.Web.Areas.Account.Controllers;
 
@@ -48,7 +48,7 @@ public class ErrorController : AbpController
 
         return View(GetErrorPageUrl(statusCode), new AbpErrorViewModel
         {
-            ErrorInfo = new RemoteServiceErrorInfo(errorMessage.Error, errorMessage.ErrorDescription),
+            ErrorInfo = new ErrorInfo(errorMessage.Error, errorMessage.ErrorDescription),
             HttpStatusCode = statusCode
         });
     }

--- a/modules/audit-logging/src/Volo.Abp.AuditLogging.Domain/Volo/Abp/AuditLogging/AuditLogInfoToAuditLogConverter.cs
+++ b/modules/audit-logging/src/Volo.Abp.AuditLogging.Domain/Volo/Abp/AuditLogging/AuditLogInfoToAuditLogConverter.cs
@@ -3,12 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
-using Volo.Abp.AspNetCore.ExceptionHandling;
 using Volo.Abp.Auditing;
 using Volo.Abp.Data;
 using Volo.Abp.DependencyInjection;
+using Volo.Abp.ExceptionHandling;
 using Volo.Abp.Guids;
-using Volo.Abp.Http;
 using Volo.Abp.Json;
 
 namespace Volo.Abp.AuditLogging;
@@ -55,10 +54,10 @@ public class AuditLogInfoToAuditLogConverter : IAuditLogInfoToAuditLogConverter,
 
         var remoteServiceErrorInfos = auditLogInfo.Exceptions?.Select(exception => ExceptionToErrorInfoConverter.Convert(exception, options =>
                                           {
-                                              options.SendExceptionsDetailsToClients = ExceptionHandlingOptions.SendExceptionsDetailsToClients;
-                                              options.SendStackTraceToClients = ExceptionHandlingOptions.SendStackTraceToClients;
+                                              options.IncludeDetails = ExceptionHandlingOptions.IncludeDetails;
+                                              options.IncludeStackTrace = ExceptionHandlingOptions.IncludeStackTrace;
                                           }))
-                                      ?? new List<RemoteServiceErrorInfo>();
+                                      ?? new List<ErrorInfo>();
 
         var exceptions = remoteServiceErrorInfos.Any()
             ? JsonSerializer.Serialize(remoteServiceErrorInfos, indented: true)


### PR DESCRIPTION
Fixes #15557 

## Summary

Refactored `IExceptionToErrorInfoConverter` and related classes:
* Changed namespace from `Volo.Abp.AspNetCore.ExceptionHandling` to `Volo.Abp.ExceptionHandling`
* Renamed classes where appropriate
* Renamed option properties
  * kept compatibility for now by using aliases for previous option names; can remove compatibility layer if wanted

## Further considerations

We could inject `IOptions<AbpExceptionHandlingOptions>` into `DefaultExceptionToErrorInfoConverter` so the configured default values could be used. Currently every caller manually injects the options on the `Convert` method.

We could change the class like this:

```csharp
    protected AbpExceptionLocalizationOptions LocalizationOptions { get; }

    public DefaultExceptionToErrorInfoConverter(
        IOptions<AbpExceptionLocalizationOptions> localizationOptions,
        IOptions<AbpExceptionHandlingOptions> handlingOptions,
        /* omitted for readability */
    )

    protected virtual AbpExceptionHandlingOptions CreateDefaultOptions()
    {
        return new AbpExceptionHandlingOptions
        {
            IncludeDetails = HandlingOptions.IncludeDetails,
            IncludeStackTrace = HandlingOptions.IncludeStackTrace
        };
    }
```