### PR TITLE
Fix the typo in the summary of the EntityNotFoundException.cs

### DIFF
--- a/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/Domain/Entities/EntityNotFoundException.cs
+++ b/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/Domain/Entities/EntityNotFoundException.cs
@@ -3,7 +3,7 @@
 namespace Volo.Abp.Domain.Entities;
 
 /// <summary>
-/// This exception is thrown if an entity excepted to be found but not found.
+/// This exception is thrown if an entity is expected to be found but not found.
 /// </summary>
 public class EntityNotFoundException : AbpException
 {


### PR DESCRIPTION
### Description

There was a typo in the summary of the `EntityNotFoundException` class. I fixed it with this PR.

### Checklist

- [X] I fully tested it as developer/designer.
- [X] I documented it - no need to document.

