### PR TITLE
Convert CustomData to dictionary

### DIFF
--- a/docs/en/UI/AspNetCore/Navigation-Menu.md
+++ b/docs/en/UI/AspNetCore/Navigation-Menu.md
@@ -100,7 +100,7 @@ There are more options of a menu item (the constructor of the `ApplicationMenuIt
 * `url` (`string`): The URL of the menu item.
 * `icon` (`string`): An icon name. Free [Font Awesome](https://fontawesome.com/) icon classes are supported out of the box. Example: `fa fa-book`. You can use any CSS font icon class as long as you include the necessary CSS files to your application.
 * `order` (`int`): The order of the menu item. Default value is `1000`. Items are sorted by the adding order unless you specify an order value.
-* `customData` (`object`): A custom object that you can associate to the menu item and use it while rendering the menu item.
+* `customData` (`object`): A dictonary that allows storing custom objects that you can associate to the menu item and use it while rendering the menu item.
 * `target` (`string`): Target of the menu item. Can be `null` (default), "\_*blank*", "\_*self*", "\_*parent*", "\_*top*" or a frame name for web applications.
 * `elementId` (`string`): Can be used to render the element with a specific HTML `id` attribute.
 * `cssClass` (`string`): Additional string classes for the menu item.

--- a/docs/en/UI/AspNetCore/Navigation-Menu.md
+++ b/docs/en/UI/AspNetCore/Navigation-Menu.md
@@ -100,7 +100,7 @@ There are more options of a menu item (the constructor of the `ApplicationMenuIt
 * `url` (`string`): The URL of the menu item.
 * `icon` (`string`): An icon name. Free [Font Awesome](https://fontawesome.com/) icon classes are supported out of the box. Example: `fa fa-book`. You can use any CSS font icon class as long as you include the necessary CSS files to your application.
 * `order` (`int`): The order of the menu item. Default value is `1000`. Items are sorted by the adding order unless you specify an order value.
-* `customData` (`Dictionary<object, string>`): A dictionary that allows storing custom objects that you can associate with the menu item and use it while rendering the menu item.
+* `customData` (`Dictionary<string, object>`): A dictionary that allows storing custom objects that you can associate with the menu item and use it while rendering the menu item.
 * `target` (`string`): Target of the menu item. Can be `null` (default), "\_*blank*", "\_*self*", "\_*parent*", "\_*top*" or a frame name for web applications.
 * `elementId` (`string`): Can be used to render the element with a specific HTML `id` attribute.
 * `cssClass` (`string`): Additional string classes for the menu item.

--- a/docs/en/UI/AspNetCore/Navigation-Menu.md
+++ b/docs/en/UI/AspNetCore/Navigation-Menu.md
@@ -100,7 +100,7 @@ There are more options of a menu item (the constructor of the `ApplicationMenuIt
 * `url` (`string`): The URL of the menu item.
 * `icon` (`string`): An icon name. Free [Font Awesome](https://fontawesome.com/) icon classes are supported out of the box. Example: `fa fa-book`. You can use any CSS font icon class as long as you include the necessary CSS files to your application.
 * `order` (`int`): The order of the menu item. Default value is `1000`. Items are sorted by the adding order unless you specify an order value.
-* `customData` (`object`): A dictionary that allows storing custom objects that you can associate with the menu item and use it while rendering the menu item.
+* `customData` (`Dictionary<object, string>`): A dictionary that allows storing custom objects that you can associate with the menu item and use it while rendering the menu item.
 * `target` (`string`): Target of the menu item. Can be `null` (default), "\_*blank*", "\_*self*", "\_*parent*", "\_*top*" or a frame name for web applications.
 * `elementId` (`string`): Can be used to render the element with a specific HTML `id` attribute.
 * `cssClass` (`string`): Additional string classes for the menu item.

--- a/docs/en/UI/AspNetCore/Navigation-Menu.md
+++ b/docs/en/UI/AspNetCore/Navigation-Menu.md
@@ -100,7 +100,7 @@ There are more options of a menu item (the constructor of the `ApplicationMenuIt
 * `url` (`string`): The URL of the menu item.
 * `icon` (`string`): An icon name. Free [Font Awesome](https://fontawesome.com/) icon classes are supported out of the box. Example: `fa fa-book`. You can use any CSS font icon class as long as you include the necessary CSS files to your application.
 * `order` (`int`): The order of the menu item. Default value is `1000`. Items are sorted by the adding order unless you specify an order value.
-* `customData` (`object`): A dictonary that allows storing custom objects that you can associate to the menu item and use it while rendering the menu item.
+* `customData` (`object`): A dictionary that allows storing custom objects that you can associate with the menu item and use it while rendering the menu item.
 * `target` (`string`): Target of the menu item. Can be `null` (default), "\_*blank*", "\_*self*", "\_*parent*", "\_*top*" or a frame name for web applications.
 * `elementId` (`string`): Can be used to render the element with a specific HTML `id` attribute.
 * `cssClass` (`string`): Additional string classes for the menu item.

--- a/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/ApplicationMenu.cs
+++ b/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/ApplicationMenu.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using JetBrains.Annotations;
+using Volo.Abp.Data;
 using Volo.Abp.UI.Navigation;
 
 namespace Volo.Abp.UI.Navigation;
@@ -31,10 +33,9 @@ public class ApplicationMenu : IHasMenuItems
 
     /// <summary>
     /// Can be used to store a custom object related to this menu.
-    /// TODO: Convert to dictionary!
     /// </summary>
-    [CanBeNull]
-    public object CustomData { get; set; }
+    [NotNull]
+    public Dictionary<string, object> CustomData { get; } = new();
 
     public ApplicationMenu(
         [NotNull] string name,
@@ -56,6 +57,16 @@ public class ApplicationMenu : IHasMenuItems
     public ApplicationMenu AddItem([NotNull] ApplicationMenuItem menuItem)
     {
         Items.Add(menuItem);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a custom data item to <see cref="CustomData"/> with given key &amp; value.
+    /// </summary>
+    /// <returns>This <see cref="ApplicationMenu"/> itself.</returns>
+    public ApplicationMenu WithCustomData(string key, object value)
+    {
+        CustomData[key] = value;
         return this;
     }
 

--- a/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/ApplicationMenuItem.cs
+++ b/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/ApplicationMenuItem.cs
@@ -79,7 +79,8 @@ public class ApplicationMenuItem : IHasMenuItems, IHasSimpleStateCheckers<Applic
     /// <summary>
     /// Can be used to store a custom object related to this menu item. Optional.
     /// </summary>
-    public object CustomData { get; set; }
+    [NotNull]
+    public Dictionary<string, object> CustomData { get; } = new();
 
     /// <summary>
     /// Can be used to render the element with a specific Id for DOM selections.
@@ -97,7 +98,6 @@ public class ApplicationMenuItem : IHasMenuItems, IHasSimpleStateCheckers<Applic
         string url = null,
         string icon = null,
         int order = DefaultOrder,
-        object customData = null,
         string target = null,
         string elementId = null,
         string cssClass = null,
@@ -111,7 +111,6 @@ public class ApplicationMenuItem : IHasMenuItems, IHasSimpleStateCheckers<Applic
         Url = url;
         Icon = icon;
         Order = order;
-        CustomData = customData;
         Target = target;
         ElementId = elementId ?? GetDefaultElementId();
         CssClass = cssClass;
@@ -128,6 +127,16 @@ public class ApplicationMenuItem : IHasMenuItems, IHasSimpleStateCheckers<Applic
     public ApplicationMenuItem AddItem([NotNull] ApplicationMenuItem menuItem)
     {
         Items.Add(menuItem);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a custom data item to <see cref="CustomData"/> with given key &amp; value.
+    /// </summary>
+    /// <returns>This <see cref="ApplicationMenuItem"/> itself.</returns>
+    public ApplicationMenuItem WithCustomData(string key, object value)
+    {
+        CustomData[key] = value;
         return this;
     }
 

--- a/modules/cms-kit/src/Volo.CmsKit.Public.Web/Menus/CmsKitPublicMenuContributor.cs
+++ b/modules/cms-kit/src/Volo.CmsKit.Public.Web/Menus/CmsKitPublicMenuContributor.cs
@@ -58,7 +58,6 @@ public class CmsKitPublicMenuContributor : IMenuContributor
             menuItem.Url,
             menuItem.Icon,
             menuItem.Order,
-            customData: null,
             menuItem.Target,
             menuItem.ElementId,
             menuItem.CssClass

--- a/modules/feature-management/src/Volo.Abp.FeatureManagement.Domain/Volo/Abp/FeatureManagement/AbpFeatureManagementDomainModule.cs
+++ b/modules/feature-management/src/Volo.Abp.FeatureManagement.Domain/Volo/Abp/FeatureManagement/AbpFeatureManagementDomainModule.cs
@@ -52,6 +52,7 @@ public class AbpFeatureManagementDomainModule : AbpModule
     }
 
     private readonly CancellationTokenSource _cancellationTokenSource = new();
+    private Task _initializeDynamicFeaturesTask;
 
     public override void OnApplicationInitialization(ApplicationInitializationContext context)
     {
@@ -70,6 +71,11 @@ public class AbpFeatureManagementDomainModule : AbpModule
         return Task.CompletedTask;
     }
 
+    public Task GetInitializeDynamicFeaturesTask()
+    {
+        return _initializeDynamicFeaturesTask ?? Task.CompletedTask;
+    }
+
     private void InitializeDynamicFeatures(ApplicationInitializationContext context)
     {
         var options = context
@@ -84,7 +90,7 @@ public class AbpFeatureManagementDomainModule : AbpModule
 
         var rootServiceProvider = context.ServiceProvider.GetRequiredService<IRootServiceProvider>();
 
-        Task.Run(async () =>
+        _initializeDynamicFeaturesTask = Task.Run(async () =>
         {
             using var scope = rootServiceProvider.CreateScope();
             var applicationLifetime = scope.ServiceProvider.GetService<IHostApplicationLifetime>();

--- a/modules/feature-management/test/Volo.Abp.FeatureManagement.EntityFrameworkCore.Tests/Volo/Abp/FeatureManagement/EntityFrameworkCore/AbpFeatureManagementEntityFrameworkCoreTestModule.cs
+++ b/modules/feature-management/test/Volo.Abp.FeatureManagement.EntityFrameworkCore.Tests/Volo/Abp/FeatureManagement/EntityFrameworkCore/AbpFeatureManagementEntityFrameworkCoreTestModule.cs
@@ -1,10 +1,13 @@
-﻿using Microsoft.Data.Sqlite;
+﻿using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
 using Volo.Abp.EntityFrameworkCore;
 using Volo.Abp.EntityFrameworkCore.Sqlite;
 using Volo.Abp.Modularity;
+using Volo.Abp.Threading;
 using Volo.Abp.Uow;
 
 namespace Volo.Abp.FeatureManagement.EntityFrameworkCore;
@@ -41,5 +44,19 @@ public class AbpFeatureManagementEntityFrameworkCoreTestModule : AbpModule
         ).GetService<IRelationalDatabaseCreator>().CreateTables();
 
         return connection;
+    }
+
+    public override void OnApplicationInitialization(ApplicationInitializationContext context)
+    {
+        var task = context.ServiceProvider.GetRequiredService<AbpFeatureManagementDomainModule>().GetInitializeDynamicFeaturesTask();
+        if (!task.IsCompleted)
+        {
+            AsyncHelper.RunSync(() => Awaited(task));
+        }
+    }
+
+    private async static Task Awaited(Task task)
+    {
+        await task;
     }
 }

--- a/modules/permission-management/src/Volo.Abp.PermissionManagement.Domain/Volo/Abp/PermissionManagement/AbpPermissionManagementDomainModule.cs
+++ b/modules/permission-management/src/Volo.Abp.PermissionManagement.Domain/Volo/Abp/PermissionManagement/AbpPermissionManagementDomainModule.cs
@@ -26,7 +26,7 @@ namespace Volo.Abp.PermissionManagement;
 public class AbpPermissionManagementDomainModule : AbpModule
 {
     private readonly CancellationTokenSource _cancellationTokenSource = new();
-
+    private Task _initializeDynamicPermissionsTask;
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
         if (context.Services.IsDataMigrationEnvironment())
@@ -56,6 +56,11 @@ public class AbpPermissionManagementDomainModule : AbpModule
         return Task.CompletedTask;
     }
 
+    public Task GetInitializeDynamicPermissionsTask()
+    {
+        return _initializeDynamicPermissionsTask ?? Task.CompletedTask;
+    }
+
     private void InitializeDynamicPermissions(ApplicationInitializationContext context)
     {
         var options = context
@@ -70,7 +75,7 @@ public class AbpPermissionManagementDomainModule : AbpModule
 
         var rootServiceProvider = context.ServiceProvider.GetRequiredService<IRootServiceProvider>();
 
-        Task.Run(async () =>
+        _initializeDynamicPermissionsTask = Task.Run(async () =>
         {
             using var scope = rootServiceProvider.CreateScope();
             var applicationLifetime = scope.ServiceProvider.GetService<IHostApplicationLifetime>();

--- a/modules/permission-management/test/Volo.Abp.PermissionManagement.Domain.Tests/Volo/Abp/PermissionManagement/PermissionDefinitionRecordRepository_Tests.cs
+++ b/modules/permission-management/test/Volo.Abp.PermissionManagement.Domain.Tests/Volo/Abp/PermissionManagement/PermissionDefinitionRecordRepository_Tests.cs
@@ -1,10 +1,12 @@
 ﻿using System.Threading.Tasks;
 using Shouldly;
+using Volo.Abp.Modularity;
 using Xunit;
 
 namespace Volo.Abp.PermissionManagement;
 
-public abstract class PermissionDefinitionRecordRepository_Tests : PermissionTestBase
+public abstract class PermissionDefinitionRecordRepository_Tests<TStartupModule> : PermissionManagementTestBase<TStartupModule>
+    where TStartupModule : IAbpModule
 {
     protected IPermissionDefinitionRecordRepository PermissionDefinitionRecordRepository { get; set; }
 

--- a/modules/permission-management/test/Volo.Abp.PermissionManagement.EntityFrameworkCore.Tests/Volo/Abp/PermissionManagement/EntityFrameworkCore/AbpPermissionManagementEntityFrameworkCoreTestModule.cs
+++ b/modules/permission-management/test/Volo.Abp.PermissionManagement.EntityFrameworkCore.Tests/Volo/Abp/PermissionManagement/EntityFrameworkCore/AbpPermissionManagementEntityFrameworkCoreTestModule.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Volo.Abp.EntityFrameworkCore;
 using Volo.Abp.Modularity;
+using Volo.Abp.Threading;
 using Volo.Abp.Uow;
 
 namespace Volo.Abp.PermissionManagement.EntityFrameworkCore;
@@ -27,5 +29,19 @@ public class AbpPermissionManagementEntityFrameworkCoreTestModule : AbpModule
         });
 
         context.Services.AddAlwaysDisableUnitOfWorkTransaction();
+    }
+
+    public override void OnApplicationInitialization(ApplicationInitializationContext context)
+    {
+        var task = context.ServiceProvider.GetRequiredService<AbpPermissionManagementDomainModule>().GetInitializeDynamicPermissionsTask();
+        if (!task.IsCompleted)
+        {
+            AsyncHelper.RunSync(() => Awaited(task));
+        }
+    }
+
+    private async static Task Awaited(Task task)
+    {
+        await task;
     }
 }

--- a/modules/permission-management/test/Volo.Abp.PermissionManagement.EntityFrameworkCore.Tests/Volo/Abp/PermissionManagement/EntityFrameworkCore/EFCorePermissionDefinitionRecordRepository_Tests.cs
+++ b/modules/permission-management/test/Volo.Abp.PermissionManagement.EntityFrameworkCore.Tests/Volo/Abp/PermissionManagement/EntityFrameworkCore/EFCorePermissionDefinitionRecordRepository_Tests.cs
@@ -1,6 +1,6 @@
 ﻿namespace Volo.Abp.PermissionManagement.EntityFrameworkCore;
 
-public class EFCorePermissionDefinitionRecordRepository_Tests : PermissionDefinitionRecordRepository_Tests
+public class EFCorePermissionDefinitionRecordRepository_Tests : PermissionDefinitionRecordRepository_Tests<AbpPermissionManagementEntityFrameworkCoreTestModule>
 {
 
 }


### PR DESCRIPTION
### Description

Does not resolves but related to https://github.com/abpframework/abp/issues/12118 

This PR changes CustomData of ApplicationMenu & Item property to a dictionary.
There was already a **TODO** for that: 
https://github.com/abpframework/abp/blob/d682cc0f290961a6ef332e0f88a04ed370f326f8/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/ApplicationMenu.cs#L34-L37



### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

This is an API change.

### Breaking Change

This is a breaking change for **ApplicationMenu** & **ApplicationMenuItem**.

- `CustomData` property of both is changed to `Dictionary<string, object>` from `object`.
- Required action:
  - If it's used like this:
    ```csharp
    // Old Definition
    var menu = new ApplicationMenu("Home", L["Home"], "/", customData: new MyObject()); 

    // Old Access
    var myObject = menu.CustomData as MyObject;
    ```
  - It should be replaced with the following:
    ```csharp
    // New Definition
    var menu = new ApplicationMenu("Home", L["Home"], "/").WithCustomData("SomeKey", new MyObject()); 

    // New Access
    var myObject = menu.CustomData["SomeKey"] as MyObject;
    ```
