### PR TITLE
Add custom menu component support to Basic Theme

### DIFF
--- a/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.Web.BasicTheme/Navigation/BasicThemeNavigationExtensions.cs
+++ b/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.Web.BasicTheme/Navigation/BasicThemeNavigationExtensions.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using JetBrains.Annotations;
+using Volo.Abp.UI.Navigation;
+
+namespace Volo.Abp.AspNetCore.Components.Web.BasicTheme.Navigation;
+
+public static class BasicThemeNavigationExtensions
+{
+    public const string CustomDataComponentKey = "BasicTheme.CustomComponent";
+
+    public static ApplicationMenuItem UseComponent(this ApplicationMenuItem applicationMenuItem, Type componentType)
+    {
+        return applicationMenuItem.WithCustomData(CustomDataComponentKey, componentType);
+    }
+
+    [CanBeNull]
+    public static Type GetComponentTypeOrDefault(this ApplicationMenuItem applicationMenuItem)
+    {
+        if (applicationMenuItem.CustomData.TryGetValue(CustomDataComponentKey, out object componentType))
+        {
+            return componentType as Type;
+        }
+
+        return default;
+    }
+}

--- a/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.Web.BasicTheme/Themes/Basic/FirstLevelNavMenuItem.razor
+++ b/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.Web.BasicTheme/Themes/Basic/FirstLevelNavMenuItem.razor
@@ -1,13 +1,19 @@
-﻿@using Volo.Abp.UI.Navigation
+﻿@using Volo.Abp.AspNetCore.Components.Web.BasicTheme.Navigation;
+@using Volo.Abp.UI.Navigation
 @{
     var elementId = MenuItem.ElementId ?? "MenuItem_" + MenuItem.Name.Replace(".", "_");
     var cssClass = string.IsNullOrEmpty(MenuItem.CssClass) ? string.Empty : MenuItem.CssClass;
     var disabled = MenuItem.IsDisabled ? "disabled" : string.Empty;
     var url = MenuItem.Url == null ? "#" : MenuItem.Url.TrimStart('/', '~');
+    var customComponentType = MenuItem.GetComponentTypeOrDefault();
 }
 @if (MenuItem.IsLeaf)
 {
-    if (MenuItem.Url != null)
+    if (customComponentType != null)
+    {
+        <DynamicComponent Type="@customComponentType" />
+    }
+    else if (url != null)
     {
         <li class="nav-item @cssClass @disabled" id="@elementId">
             <a class="nav-link" href="@url" target="@MenuItem.Target">
@@ -27,20 +33,28 @@ else
 {
     <li class="nav-item">
         <div class="dropdown">
-            <a class="nav-link dropdown-toggle" @onclick="ToggleSubMenu" id="Menu_@(MenuItem.Name)" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                @if (MenuItem.Icon != null)
-                {
-                    if (MenuItem.Icon.StartsWith("fa"))
+            @if (customComponentType != null)
+            {
+                <DynamicComponent Type="@customComponentType" />
+            }
+            else
+            {
+                <a class="nav-link dropdown-toggle" @onclick="ToggleSubMenu" id="Menu_@(MenuItem.Name)" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    @if (MenuItem.Icon != null)
                     {
-                        <i class="@MenuItem.Icon me-1"></i>
+                        if (MenuItem.Icon.StartsWith("fa"))
+                        {
+                            <i class="@MenuItem.Icon me-1"></i>
+                        }
                     }
-                }
-                @MenuItem.DisplayName
-            </a>
+                    @MenuItem.DisplayName
+                </a>
+            }
+
             <div class="dropdown-menu border-0 shadow-sm @(IsSubMenuOpen ? "show" : "")" aria-labelledby="Menu_@(MenuItem.Name)">
                 @foreach (var childMenuItem in MenuItem.Items)
                 {
-                    <SecondLevelNavMenuItem MenuItem="childMenuItem"/>
+                    <SecondLevelNavMenuItem MenuItem="childMenuItem" />
                 }
             </div>
         </div>

--- a/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.Web.BasicTheme/Themes/Basic/SecondLevelNavMenuItem.razor
+++ b/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.Web.BasicTheme/Themes/Basic/SecondLevelNavMenuItem.razor
@@ -1,13 +1,19 @@
-﻿@using Volo.Abp.UI.Navigation
+﻿@using Volo.Abp.AspNetCore.Components.Web.BasicTheme.Navigation;
+@using Volo.Abp.UI.Navigation
 @{
     var elementId = MenuItem.ElementId ?? "MenuItem_" + MenuItem.Name.Replace(".", "_");
     var cssClass = string.IsNullOrEmpty(MenuItem.CssClass) ? string.Empty : MenuItem.CssClass;
     var disabled = MenuItem.IsDisabled ? "disabled" : string.Empty;
     var url = MenuItem.Url == null ? "#" : MenuItem.Url.TrimStart('/', '~');
+    var customComponentType = MenuItem.GetComponentTypeOrDefault();
 }
 @if (MenuItem.IsLeaf)
 {
-    if (MenuItem.Url != null)
+    if (customComponentType != null)
+    {
+        <DynamicComponent Type="@customComponentType" />
+    }
+    else if (MenuItem.Url != null)
     {
         <a class="dropdown-item @cssClass @disabled" href="@url" target="@MenuItem.Target" id="@elementId">
             @if (MenuItem.Icon != null)
@@ -23,16 +29,23 @@
 else
 {
     <div class="dropdown-submenu">
-        <a role="button" @onclick="ToggleSubMenu" class="btn dropdown-toggle" data-toggle="dropdown"
-                aria-haspopup="true" aria-expanded="false">
-            @if (MenuItem.Icon != null)
-            {
-                <i class="@MenuItem.Icon me-1"></i>
-            }
-            <span>
-                @MenuItem.DisplayName
-            </span>
-        </a>
+        @if (customComponentType != null)
+        {
+            <DynamicComponent Type="@customComponentType" />
+        }
+        else
+        {
+            <a role="button" @onclick="ToggleSubMenu" class="btn dropdown-toggle" data-toggle="dropdown"
+                    aria-haspopup="true" aria-expanded="false">
+                @if (MenuItem.Icon != null)
+                {
+                    <i class="@MenuItem.Icon me-1"></i>
+                }
+                <span>
+                    @MenuItem.DisplayName
+                </span>
+            </a>
+        }
         <div class="dropdown-menu border-0 shadow-sm @(IsSubMenuOpen ? "show" : "")">
             @foreach (var childMenuItem in MenuItem.Items)
             {
@@ -40,6 +53,4 @@ else
             }
         </div>
     </div>
-}
-@code {
 }


### PR DESCRIPTION
### Description

Resolves part of https://github.com/abpframework/abp/issues/12118 (write the related issue number if available)

Since defining a custom component is related to a theme, this operation can't be planned without a theme dependency. So, the component code will be different according to different themes. Each theme should implement this logic itself if possible.

![custom-component-basic-theme](https://user-images.githubusercontent.com/23705418/216966893-51840053-736d-4a70-95df-2a7ec314bf6a.gif)


### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue) _Will be done after all themes implemented_

### How to test it?

UseComponent() method can be used in MenuContributor in a project that uses the basic theme.

```csharp
context.Menu.Items.Add(
  new ApplicationMenuItem("Custom.1", "My Custom Menu", "#")
    .UseComponent(typeof(MyMenuComponent)));
```
