### PR TITLE
wrap defaultValue with quotes when type is string

### DIFF
--- a/npm/ng-packs/packages/schematics/src/models/model.ts
+++ b/npm/ng-packs/packages/schematics/src/models/model.ts
@@ -45,9 +45,13 @@ abstract class TypeRef {
   get default() {
     return this._default;
   }
-  set default(value: string) {
+  set default(value: any) {
     if (!value) return;
-    this._default = ` = ${value}`;
+    if (typeof value === 'string') {
+      this._default = ` = "${value}"`;
+    } else {
+      this._default = ` = ${value}`;
+    }
   }
 
   constructor(options: TypeRefOptions) {


### PR DESCRIPTION
### Description

Resolves #15605 

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [ ] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?
- run yarn dev:schematics and yarn build:schematics
- copy dist/schematics content to project's @abp/ng.schematics folder

Backend side

-Define the following method to backend controller
```csharp
        [HttpGet]
        [Route("my-endpoint")]
        public virtual async Task<Boolean> GetAnother4Async(Guid id, string sorting = "my val")
        {   
            return true;
        }
```

run abp generate-proxt -t ng 