### PR TITLE
Get the `ApplicationConfigurationDto` again after the user state changes.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Components.Web/Volo/Abp/AspNetCore/Components/Web/Security/ApplicationConfigurationChangedService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Components.Web/Volo/Abp/AspNetCore/Components/Web/Security/ApplicationConfigurationChangedService.cs
@@ -1,0 +1,15 @@
+using Volo.Abp.DependencyInjection;
+
+namespace Volo.Abp.AspNetCore.Components.Web.Security;
+
+public delegate void ApplicationConfigurationChangedHandler();
+
+public class ApplicationConfigurationChangedService : IScopedDependency
+{
+    public event ApplicationConfigurationChangedHandler Changed;
+
+    public void NotifyChanged()
+    {
+        Changed?.Invoke();
+    }
+}

--- a/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.Web.BasicTheme/Themes/Basic/NavMenu.razor.cs
+++ b/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.Web.BasicTheme/Themes/Basic/NavMenu.razor.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
+using Volo.Abp.AspNetCore.Components.Web.Security;
 using Volo.Abp.UI.Navigation;
 
 namespace Volo.Abp.AspNetCore.Components.Web.BasicTheme.Themes.Basic;
@@ -12,24 +14,24 @@ public partial class NavMenu : IDisposable
     protected IMenuManager MenuManager { get; set; }
 
     [Inject]
-    protected AuthenticationStateProvider AuthenticationStateProvider { get; set; }
+    protected ApplicationConfigurationChangedService ApplicationConfigurationChangedService { get; set; }
 
     protected ApplicationMenu Menu { get; set; }
 
-    protected override async Task OnInitializedAsync()
+    protected async override Task OnInitializedAsync()
     {
         Menu = await MenuManager.GetMainMenuAsync();
-        AuthenticationStateProvider.AuthenticationStateChanged += AuthenticationStateProviderOnAuthenticationStateChanged;
+        ApplicationConfigurationChangedService.Changed += ApplicationConfigurationChanged;
+    }
+
+    private async void ApplicationConfigurationChanged()
+    {
+        Menu = await MenuManager.GetMainMenuAsync();
+        await InvokeAsync(StateHasChanged);
     }
 
     public void Dispose()
     {
-        AuthenticationStateProvider.AuthenticationStateChanged -= AuthenticationStateProviderOnAuthenticationStateChanged;
-    }
-
-    private async void AuthenticationStateProviderOnAuthenticationStateChanged(Task<AuthenticationState> task)
-    {
-        Menu = await MenuManager.GetMainMenuAsync();
-        await InvokeAsync(StateHasChanged);
+        ApplicationConfigurationChangedService.Changed -= ApplicationConfigurationChanged;
     }
 }

--- a/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.Web.BasicTheme/Themes/Basic/NavToolbar.razor.cs
+++ b/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.Web.BasicTheme/Themes/Basic/NavToolbar.razor.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
+using Volo.Abp.AspNetCore.Components.Web.Security;
 using Volo.Abp.AspNetCore.Components.Web.Theming.Toolbars;
 
 namespace Volo.Abp.AspNetCore.Components.Web.BasicTheme.Themes.Basic;
@@ -14,14 +15,14 @@ public partial class NavToolbar : IDisposable
     private IToolbarManager ToolbarManager { get; set; }
 
     [Inject]
-    private AuthenticationStateProvider AuthenticationStateProvider { get; set; }
+    protected ApplicationConfigurationChangedService ApplicationConfigurationChangedService { get; set; }
 
     private List<RenderFragment> ToolbarItemRenders { get; set; } = new List<RenderFragment>();
 
-    protected override async Task OnInitializedAsync()
+    protected async override Task OnInitializedAsync()
     {
         await GetToolbarItemRendersAsync();
-        AuthenticationStateProvider.AuthenticationStateChanged += AuthenticationStateProviderOnAuthenticationStateChanged;
+        ApplicationConfigurationChangedService.Changed += ApplicationConfigurationChanged;
     }
 
     private async Task GetToolbarItemRendersAsync()
@@ -41,7 +42,7 @@ public partial class NavToolbar : IDisposable
         }
     }
 
-    private async void AuthenticationStateProviderOnAuthenticationStateChanged(Task<AuthenticationState> task)
+    private async void ApplicationConfigurationChanged()
     {
         await GetToolbarItemRendersAsync();
         await InvokeAsync(StateHasChanged);
@@ -49,6 +50,6 @@ public partial class NavToolbar : IDisposable
 
     public void Dispose()
     {
-        AuthenticationStateProvider.AuthenticationStateChanged -= AuthenticationStateProviderOnAuthenticationStateChanged;
+        ApplicationConfigurationChangedService.Changed -= ApplicationConfigurationChanged;
     }
 }

--- a/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.WebAssembly.BasicTheme/Pages/Authentication.razor
+++ b/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.WebAssembly.BasicTheme/Pages/Authentication.razor
@@ -1,7 +1,18 @@
 ﻿@page "/authentication/{action}"
 @using Microsoft.AspNetCore.Components.WebAssembly.Authentication
-<RemoteAuthenticatorView Action="@Action" />
-
+@using Volo.Abp.AspNetCore.Components.Web.Security
+<RemoteAuthenticatorView Action="@Action" OnLogInSucceeded="OnLogInSucceeded" OnLogOutSucceeded="OnLogOutSucceeded" />
+@inject WebAssemblyCachedApplicationConfigurationClient WebAssemblyCachedApplicationConfigurationClient
 @code{
     [Parameter] public string Action { get; set; }
+
+    private async Task OnLogInSucceeded(RemoteAuthenticationState state)
+    {
+        await WebAssemblyCachedApplicationConfigurationClient.InitializeAsync();
+    }
+
+    private async Task OnLogOutSucceeded(RemoteAuthenticationState state)
+    {
+        await WebAssemblyCachedApplicationConfigurationClient.InitializeAsync();
+    }
 }

--- a/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.WebAssembly.BasicTheme/Themes/Basic/LoginDisplay.razor.cs
+++ b/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.WebAssembly.BasicTheme/Themes/Basic/LoginDisplay.razor.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Routing;
 using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 using Microsoft.JSInterop;
+using Volo.Abp.AspNetCore.Components.Web.Security;
 using Volo.Abp.UI.Navigation;
 
 namespace Volo.Abp.AspNetCore.Components.WebAssembly.BasicTheme.Themes.Basic;
@@ -16,18 +17,17 @@ public partial class LoginDisplay : IDisposable
     protected IMenuManager MenuManager { get; set; }
 
     [Inject]
-    public AuthenticationStateProvider AuthenticationStateProvider { get; set; }
+    protected ApplicationConfigurationChangedService ApplicationConfigurationChangedService { get; set; }
 
     protected ApplicationMenu Menu { get; set; }
 
-    protected override async Task OnInitializedAsync()
+    protected async override Task OnInitializedAsync()
     {
         Menu = await MenuManager.GetAsync(StandardMenus.User);
 
         Navigation.LocationChanged += OnLocationChanged;
 
-        AuthenticationStateProvider.AuthenticationStateChanged +=
-            AuthenticationStateProviderOnAuthenticationStateChanged;
+        ApplicationConfigurationChangedService.Changed += ApplicationConfigurationChanged;
     }
 
     protected virtual void OnLocationChanged(object sender, LocationChangedEventArgs e)
@@ -35,7 +35,7 @@ public partial class LoginDisplay : IDisposable
         InvokeAsync(StateHasChanged);
     }
 
-    private async void AuthenticationStateProviderOnAuthenticationStateChanged(Task<AuthenticationState> task)
+    private async void ApplicationConfigurationChanged()
     {
         Menu = await MenuManager.GetAsync(StandardMenus.User);
         await InvokeAsync(StateHasChanged);
@@ -44,8 +44,7 @@ public partial class LoginDisplay : IDisposable
     public void Dispose()
     {
         Navigation.LocationChanged -= OnLocationChanged;
-        AuthenticationStateProvider.AuthenticationStateChanged -=
-            AuthenticationStateProviderOnAuthenticationStateChanged;
+        ApplicationConfigurationChangedService.Changed -= ApplicationConfigurationChanged;
     }
 
     private async Task NavigateToAsync(string uri, string target = null)


### PR DESCRIPTION
### Description

Blazor **Silent sign-in** will not refresh the page, and not get the latest `ApplicationConfigurationDto`, which will cause authorization failure.

The `ApplicationConfigurationChangedService` service will get the `ApplicationConfigurationDto` again after the user state changes.

### Checklist

- [x] I fully tested it as developer 
- [ ] I documented it


![image](https://user-images.githubusercontent.com/6908465/217703914-3f9404bd-6f06-44c8-b5ef-1c88e4303dcd.png)


