### PR TITLE
change flag-icon-css to flag-icons

### DIFF
--- a/docs/en/UI/Blazor/Overall.md
+++ b/docs/en/UI/Blazor/Overall.md
@@ -88,7 +88,7 @@ There are a set of standard libraries that comes pre-installed and supported by 
 * [Twitter Bootstrap](https://getbootstrap.com/) as the fundamental HTML/CSS framework.
 * [Blazorise](https://github.com/stsrki/Blazorise) as a component library that supports the Bootstrap and adds extra components like Data Grid and Tree.
 * [FontAwesome](https://fontawesome.com/) as the fundamental CSS font library.
-* [Flag Icon](https://github.com/lipis/flag-icon-css) as a library to show flags of countries.
+* [Flag Icon](https://github.com/lipis/flag-icons) as a library to show flags of countries.
 
 These libraries are selected as the base libraries and available to the applications and modules.
 

--- a/docs/en/UI/Blazor/Theming.md
+++ b/docs/en/UI/Blazor/Theming.md
@@ -48,7 +48,7 @@ All the themes must depend on the [Volo.Abp.AspNetCore.Components.Server.Theming
 * [Twitter Bootstrap](https://getbootstrap.com/) as the fundamental HTML/CSS framework.
 * [Blazorise](https://github.com/stsrki/Blazorise) as a component library that supports the Bootstrap and adds extra components like Data Grid and Tree.
 * [FontAwesome](https://fontawesome.com/) as the fundamental CSS font library.
-* [Flag Icon](https://github.com/lipis/flag-icon-css) as a library to show flags of countries.
+* [Flag Icon](https://github.com/lipis/flag-icons) as a library to show flags of countries.
 
 These libraries are selected as the base libraries and available to the applications and modules.
 

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Packages/Volo/Abp/AspNetCore/Mvc/UI/Packages/FlagIconCss/FlagIconCssStyleContributor.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Packages/Volo/Abp/AspNetCore/Mvc/UI/Packages/FlagIconCss/FlagIconCssStyleContributor.cs
@@ -7,6 +7,6 @@ public class FlagIconCssStyleContributor : BundleContributor
 {
     public override void ConfigureBundle(BundleConfigurationContext context)
     {
-        context.Files.AddIfNotContains("/libs/flag-icon-css/css/flag-icons.min.css");
+        context.Files.AddIfNotContains("/libs/flag-icons/css/flag-icons.min.css");
     }
 }

--- a/npm/packs/flag-icon-css/abp.resourcemapping.js
+++ b/npm/packs/flag-icon-css/abp.resourcemapping.js
@@ -1,6 +1,0 @@
-module.exports = {
-    mappings: {
-        "@node_modules/flag-icon-css/css/*": "@libs/flag-icon-css/css",
-        "@node_modules/flag-icon-css/flags/1x1/*": "@libs/flag-icon-css/flags/1x1"
-    }
-}

--- a/npm/packs/flag-icons/abp.resourcemapping.js
+++ b/npm/packs/flag-icons/abp.resourcemapping.js
@@ -1,0 +1,6 @@
+module.exports = {
+    mappings: {
+        "@node_modules/flag-icons/css/*": "@libs/flag-icons/css",
+        "@node_modules/flag-icons/flags/1x1/*": "@libs/flag-icons/flags/1x1"
+    }
+}

--- a/npm/packs/flag-icons/package.json
+++ b/npm/packs/flag-icons/package.json
@@ -1,0 +1,11 @@
+{
+  "version": "7.0.1",
+  "name": "@abp/flag-icons",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "flag-icons": "6.6.6"
+  },
+  "gitHead": "bb4ea17d5996f01889134c138d00b6c8f858a431"
+}


### PR DESCRIPTION
### Description

Resolves volosoft/lepton#754

flag-icon-css package renamed to flag-icons
all its class names and package names are updated in all files