### PR TITLE
Cli: Enhancements related with starting ABP Suite

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/Services/SuiteAppSettingsService.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/Services/SuiteAppSettingsService.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using Volo.Abp.Cli.Utils;
+using Volo.Abp.DependencyInjection;
+
+namespace Volo.Abp.Cli.Commands.Services;
+
+public class SuiteAppSettingsService : ITransientDependency
+{
+    private const int DefaultPort = 3000;
+    
+    public CmdHelper CmdHelper { get; }
+
+    public SuiteAppSettingsService(CmdHelper cmdHelper)
+    {
+        CmdHelper = cmdHelper;
+    }
+    public async Task<int> GetSuitePortAsync(string version)
+    {
+        var filePath = GetFilePathOrNull(version);
+
+        if (filePath == null)
+        {
+            return DefaultPort;
+        }
+
+        var content = File.ReadAllText(filePath);
+
+        var contentAsJson = JObject.Parse(content);
+
+        var url = contentAsJson["AbpSuite"]?["ApplicationUrl"]?.ToString();
+
+        if (url == null)
+        {
+            return DefaultPort;
+        }
+        
+        return Convert.ToInt32(url.Split(":").Last());
+    }
+
+    private string GetFilePathOrNull(string version)
+    {
+        var suiteVersion = version;
+
+        if (suiteVersion == null)
+        {
+            return null;
+        }
+        
+        var path = Path.Combine(
+            "%USERPROFILE%",
+            ".dotnet",
+            "tools",
+            ".store",
+            "volo.abp.suite",
+            suiteVersion,
+            "volo.abp.suite",
+            suiteVersion,
+            "content",
+            "appsettings.json"
+            );
+
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        return path;
+    }
+}

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/Services/SuiteAppSettingsService.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/Services/SuiteAppSettingsService.cs
@@ -18,10 +18,12 @@ public class SuiteAppSettingsService : ITransientDependency
     {
         CmdHelper = cmdHelper;
     }
+    
     public async Task<int> GetSuitePortAsync()
     {
         return await GetSuitePortAsync(GetCurrentSuiteVersion());
     }
+    
     public async Task<int> GetSuitePortAsync(string version)
     {
         var filePath = GetFilePathOrNull(version);

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/Services/SuiteAppSettingsService.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/Services/SuiteAppSettingsService.cs
@@ -51,7 +51,7 @@ public class SuiteAppSettingsService : ITransientDependency
         }
         
         var path = Path.Combine(
-            "%USERPROFILE%",
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
             ".dotnet",
             "tools",
             ".store",
@@ -59,7 +59,9 @@ public class SuiteAppSettingsService : ITransientDependency
             suiteVersion,
             "volo.abp.suite",
             suiteVersion,
-            "content",
+            "tools",
+            "net7.0",
+            "any",
             "appsettings.json"
             );
 

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/Services/SuiteAppSettingsService.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/Services/SuiteAppSettingsService.cs
@@ -18,6 +18,10 @@ public class SuiteAppSettingsService : ITransientDependency
     {
         CmdHelper = cmdHelper;
     }
+    public async Task<int> GetSuitePortAsync()
+    {
+        return await GetSuitePortAsync(GetCurrentSuiteVersion());
+    }
     public async Task<int> GetSuitePortAsync(string version)
     {
         var filePath = GetFilePathOrNull(version);
@@ -71,5 +75,20 @@ public class SuiteAppSettingsService : ITransientDependency
         }
 
         return path;
+    }
+
+    private string GetCurrentSuiteVersion()
+    {
+        var dotnetToolList = CmdHelper.RunCmdAndGetOutput("dotnet tool list -g", out int exitCode);
+
+        var suiteLine = dotnetToolList.Split(Environment.NewLine)
+            .FirstOrDefault(l => l.ToLower().StartsWith("volo.abp.suite "));
+
+        if (string.IsNullOrEmpty(suiteLine))
+        {
+            return null;
+        }
+
+        return suiteLine.Split(" ", StringSplitOptions.RemoveEmptyEntries)[1];
     }
 }

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/Services/SuiteAppSettingsService.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/Services/SuiteAppSettingsService.cs
@@ -49,9 +49,7 @@ public class SuiteAppSettingsService : ITransientDependency
 
     private string GetFilePathOrNull(string version)
     {
-        var suiteVersion = version;
-
-        if (suiteVersion == null)
+        if (version == null)
         {
             return null;
         }
@@ -62,9 +60,9 @@ public class SuiteAppSettingsService : ITransientDependency
             "tools",
             ".store",
             "volo.abp.suite",
-            suiteVersion,
+            version,
             "volo.abp.suite",
-            suiteVersion,
+            version,
             "tools",
             "net7.0",
             "any",


### PR DESCRIPTION
Resolves https://github.com/volosoft/volo/issues/13480

- Suite won't try to start if it is already running and Cli will open Suite in the browser directly.
- Suite won't start if the Port is in usage by another process and show an error text.

@gizemmutukurt 
- You will test the scenarios above. 
- You will use local cli build in the related branch. 
- You don't need to test Suite's functionality.
