### PR TITLE
Remove route constraints before determining which endpoints to hide

### DIFF
--- a/framework/src/Volo.Abp.Swashbuckle/Volo/Abp/Swashbuckle/AbpSwashbuckleDocumentFilter.cs
+++ b/framework/src/Volo.Abp.Swashbuckle/Volo/Abp/Swashbuckle/AbpSwashbuckleDocumentFilter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
@@ -10,6 +11,8 @@ namespace Volo.Abp.Swashbuckle;
 public class AbpSwashbuckleDocumentFilter : IDocumentFilter
 {
     protected virtual string[] ActionUrlPrefixes { get; set; } = new[] { "Volo." };
+
+    protected virtual string RegexConstraintPattern => @":regex\(([^()]*)\)";
     
     public virtual void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
     {
@@ -34,15 +37,22 @@ public class AbpSwashbuckleDocumentFilter : IDocumentFilter
         {
             return route;
         }
-        
-        var startIndex = route.IndexOf(":", StringComparison.Ordinal);
-        var endIndex = route.IndexOf("}", StringComparison.Ordinal);
-        
-        if (startIndex == -1 || endIndex == -1)
+
+        route = Regex.Replace(route, RegexConstraintPattern, "");
+
+        while (route.Contains(':'))
         {
-            return route;
+            var startIndex = route.IndexOf(":", StringComparison.Ordinal);
+            var endIndex = route.IndexOf("}", startIndex);
+
+            if (endIndex == -1)
+            {
+                break;
+            }
+            
+            route = route.Remove(startIndex, (endIndex - startIndex));
         }
 
-        return route.Remove(startIndex, (endIndex - startIndex));
+        return route;
     }
 }


### PR DESCRIPTION
### Description

Resolves https://github.com/abpframework/abp/issues/15712

As mentioned in [this issue](https://github.com/abpframework/abp/issues/15712), when there is a route constraint in the route, it would be hidden because we didn't handle the route constraints. We need to remove the constraint part from the route and then check if's ABP's endpoint and hide according to that. 

### Checklist

- [X] I fully tested it as developer / designer and created unit / integration tests
- [X] I documented it (or no need to document or I will create a separate documentation issue) - **No need to document**.

### How to test it?

You can create a controller and change its routes as `{id:minlength(1)}` (or any other built-in constraint) and also follow [this documentation](https://docs.abp.io/en/abp/latest/API/Swagger-Integration#hide-abp-endpoints-on-swagger-ui) to enable hiding abp related endpoints. Then, when you open the swagger, you should be able to see your custom route in the open api documentation.
