### PR TITLE
Encode URL before saving it into database

### DIFF
--- a/modules/blogging/src/Volo.Blogging.Web/Pages/Blogs/Posts/Edit.cshtml.cs
+++ b/modules/blogging/src/Volo.Blogging.Web/Pages/Blogs/Posts/Edit.cshtml.cs
@@ -50,6 +50,7 @@ namespace Volo.Blogging.Pages.Blog.Posts
             var postDto = await _postAppService.GetAsync(new Guid(PostId));
             Post = ObjectMapper.Map<PostWithDetailsDto, EditPostViewModel>(postDto);
             Post.Tags = String.Join(", ", postDto.Tags.Select(p => p.Name).ToArray());
+            Post.Url = WebUtility.UrlDecode(Post.Url);
 
             return Page();
         }
@@ -60,7 +61,7 @@ namespace Volo.Blogging.Pages.Blog.Posts
             {
                 BlogId = Post.BlogId,
                 Title = Post.Title,
-                Url = Post.Url,
+                Url = WebUtility.UrlEncode(Post.Url),
                 CoverImage = Post.CoverImage,
                 Content = Post.Content,
                 Tags = Post.Tags,

--- a/modules/blogging/src/Volo.Blogging.Web/Pages/Blogs/Posts/New.cshtml.cs
+++ b/modules/blogging/src/Volo.Blogging.Web/Pages/Blogs/Posts/New.cshtml.cs
@@ -66,7 +66,6 @@ namespace Volo.Blogging.Pages.Blog.Posts
                 Post.Description = Post.Content.Truncate(PostConsts.MaxSeoFriendlyDescriptionLength);
             }
 
-            // Url encode the url
             Post.Url = WebUtility.UrlEncode(Post.Url);
             
             var postWithDetailsDto = await _postAppService.CreateAsync(ObjectMapper.Map<CreatePostViewModel, CreatePostDto>(Post));

--- a/modules/blogging/src/Volo.Blogging.Web/Pages/Blogs/Posts/New.cshtml.cs
+++ b/modules/blogging/src/Volo.Blogging.Web/Pages/Blogs/Posts/New.cshtml.cs
@@ -66,6 +66,9 @@ namespace Volo.Blogging.Pages.Blog.Posts
                 Post.Description = Post.Content.Truncate(PostConsts.MaxSeoFriendlyDescriptionLength);
             }
 
+            // Url encode the url
+            Post.Url = WebUtility.UrlEncode(Post.Url);
+            
             var postWithDetailsDto = await _postAppService.CreateAsync(ObjectMapper.Map<CreatePostViewModel, CreatePostDto>(Post));
 
             //TODO: Try Url.Page(...)


### PR DESCRIPTION
### Description

Resolves #15694 

TODO: We need to encode the specified URL before saving the related blog post into the database. Otherwise, a URL mismatch occurs and the related blog post can not be retrieved from the database. To prevent this type of problem, we need to encode URLs.

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [ ] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

Please describe how this can be tested by the test engineers if it is not already explicit - or remove this section if no need to description.
