### PR TITLE
Bug #15791 - Fix log out fails when EnableLocalLogin is false

### DIFF
--- a/modules/account/src/Volo.Abp.Account.Web/Pages/Account/Logout.cshtml.cs
+++ b/modules/account/src/Volo.Abp.Account.Web/Pages/Account/Logout.cshtml.cs
@@ -28,7 +28,13 @@ public class LogoutModel : AccountPageModel
             return RedirectSafely(ReturnUrl, ReturnUrlHash);
         }
 
-        return RedirectToPage("/Account/Login");
+        var enableLocalLogin = await SettingProvider.IsTrueAsync(AccountSettingNames.EnableLocalLogin);
+        if (enableLocalLogin)
+        {
+            return RedirectToPage("/Account/Login");
+        }
+
+        return RedirectToPage("/");
     }
 
     public virtual Task<IActionResult> OnPostAsync()

--- a/modules/account/src/Volo.Abp.Account.Web/Pages/Account/Logout.cshtml.cs
+++ b/modules/account/src/Volo.Abp.Account.Web/Pages/Account/Logout.cshtml.cs
@@ -1,6 +1,8 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
+using Volo.Abp.Account.Settings;
 using Volo.Abp.Identity;
+using Volo.Abp.Settings;
 
 namespace Volo.Abp.Account.Web.Pages.Account;
 
@@ -28,8 +30,7 @@ public class LogoutModel : AccountPageModel
             return RedirectSafely(ReturnUrl, ReturnUrlHash);
         }
 
-        var enableLocalLogin = await SettingProvider.IsTrueAsync(AccountSettingNames.EnableLocalLogin);
-        if (enableLocalLogin)
+        if (await SettingProvider.IsTrueAsync(AccountSettingNames.EnableLocalLogin))
         {
             return RedirectToPage("/Account/Login");
         }


### PR DESCRIPTION
### Description

Resolves #15791

Simply redirects to the home page rather than the login page if local login is disabled

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

1. In appsettings.json set EnableLocalLogin to false
2. Log in as external account (Azure AD)
3. Click the log out button

The app should now log out correctly.