### PR TITLE
add absolute project parameter to copy script

### DIFF
--- a/npm/ng-packs/package.json
+++ b/npm/ng-packs/package.json
@@ -38,7 +38,8 @@
     "debug:schematics-dist": "./node_modules/.bin/ng g ./dist/packages/schematics/collection.json:proxy-add --module __default --apiName __default --source __default --target __default --url http://localhost:4300 --service-type application",
     "ci": "yarn affected:lint && yarn affected:build && yarn affected:test",
     "lerna": "lerna",
-    "migrate-nx": "yarn nx migrate --run-migrations"
+    "migrate-nx": "yarn nx migrate --run-migrations",
+    "copy-to:app": "cd scripts && yarn && yarn copy-to-templates -t app"
   },
   "private": true,
   "devDependencies": {


### PR DESCRIPTION
### Description

add useExistingBuild option
add skipInstallOption

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [ ] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

yarn copy-to-template --skipInstall true --useExistingBuild true
