### PR TITLE
cms-kit: Fix `TagHelper` name

### DIFF
--- a/modules/cms-kit/src/Volo.CmsKit.Public.Web/Pages/Public/CmsKit/Blogs/BlogPost.cshtml
+++ b/modules/cms-kit/src/Volo.CmsKit.Public.Web/Pages/Public/CmsKit/Blogs/BlogPost.cshtml
@@ -29,17 +29,17 @@
 @section styles{
     @if (isScrollIndexEnabled)
     {
-        <abp-abp-style-bundle>
+        <abp-style-bundle>
             <abp-style src="/Pages/Public/CmsKit/Blogs/bootstrap-toc.css" />
-        </abp-abp-style-bundle>
+        </abp-style-bundle>
     }
-    <abp-abp-style-bundle>
+    <abp-style-bundle>
         <abp-style src="/Pages/Public/CmsKit/Blogs/blogPost.css" />
         <abp-style type="typeof(HighlightJsStyleContributor)" />
-    </abp-abp-style-bundle>
+    </abp-style-bundle>
 }
 
-    @section scripts{
+@section scripts{
     @if (isScrollIndexEnabled)
     {
         <abp-script-bundle>


### PR DESCRIPTION
It should be `abp-style-bundle`