### PR TITLE
cms-kit: Fix global resource feature checking

### DIFF
--- a/modules/cms-kit/src/Volo.CmsKit.Public.Web/Pages/CmsKit/Shared/Components/GlobalResources/Script/Default.cshtml
+++ b/modules/cms-kit/src/Volo.CmsKit.Public.Web/Pages/CmsKit/Shared/Components/GlobalResources/Script/Default.cshtml
@@ -1,1 +1,1 @@
-﻿<script src="/cms-kit/global-resources/script"></script>
+﻿<script src="~/cms-kit/global-resources/script"></script>

--- a/modules/cms-kit/src/Volo.CmsKit.Public.Web/Pages/CmsKit/Shared/Components/GlobalResources/Script/GlobalScriptViewComponent.cs
+++ b/modules/cms-kit/src/Volo.CmsKit.Public.Web/Pages/CmsKit/Shared/Components/GlobalResources/Script/GlobalScriptViewComponent.cs
@@ -1,13 +1,27 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Volo.Abp.AspNetCore.Mvc;
+using Volo.Abp.Features;
+using Volo.CmsKit.Features;
 
 namespace Volo.CmsKit.Public.Web.Pages.CmsKit.Shared.Components.GlobalResources.Script;
 
 public class GlobalScriptViewComponent : AbpViewComponent
 {
+    protected IFeatureChecker FeatureChecker { get; }
+
+    public GlobalScriptViewComponent(IFeatureChecker featureChecker)
+    {
+        FeatureChecker = featureChecker;
+    }
+
     public async Task<IViewComponentResult> InvokeAsync()
     {
+        if (!await FeatureChecker.IsEnabledAsync(CmsKitFeatures.GlobalResourceEnable))
+        {
+            return Content(string.Empty);
+        }
+
         return View("~/Pages/CmsKit/Shared/Components/GlobalResources/Script/Default.cshtml");
     }
 }

--- a/modules/cms-kit/src/Volo.CmsKit.Public.Web/Pages/CmsKit/Shared/Components/GlobalResources/Style/Default.cshtml
+++ b/modules/cms-kit/src/Volo.CmsKit.Public.Web/Pages/CmsKit/Shared/Components/GlobalResources/Style/Default.cshtml
@@ -1,3 +1,1 @@
-﻿@model Volo.CmsKit.Public.Web.Pages.CmsKit.Shared.Components.GlobalResources.Style.GlobalStyleModel
-
-<link rel="stylesheet" href="@("/cms-kit/global-resources/style?v=" + Model.LastModificationTimeTimestamp)"/>
+﻿<link rel="stylesheet" href="~/cms-kit/global-resources/style" />

--- a/modules/cms-kit/src/Volo.CmsKit.Public.Web/Pages/CmsKit/Shared/Components/GlobalResources/Style/GlobalStyleModel.cs
+++ b/modules/cms-kit/src/Volo.CmsKit.Public.Web/Pages/CmsKit/Shared/Components/GlobalResources/Style/GlobalStyleModel.cs
@@ -1,6 +1,0 @@
-﻿namespace Volo.CmsKit.Public.Web.Pages.CmsKit.Shared.Components.GlobalResources.Style;
-
-public class GlobalStyleModel
-{
-    public long LastModificationTimeTimestamp { get; set; }
-}

--- a/modules/cms-kit/src/Volo.CmsKit.Public.Web/Pages/CmsKit/Shared/Components/GlobalResources/Style/GlobalStyleViewComponent.cs
+++ b/modules/cms-kit/src/Volo.CmsKit.Public.Web/Pages/CmsKit/Shared/Components/GlobalResources/Style/GlobalStyleViewComponent.cs
@@ -1,33 +1,27 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Volo.Abp.AspNetCore.Mvc;
-using Volo.CmsKit.Public.GlobalResources;
+using Volo.Abp.Features;
+using Volo.CmsKit.Features;
 
 namespace Volo.CmsKit.Public.Web.Pages.CmsKit.Shared.Components.GlobalResources.Style;
 
 public class GlobalStyleViewComponent : AbpViewComponent
 {
-    protected IGlobalResourcePublicAppService GlobalResourcePublicAppService { get; }
+    protected IFeatureChecker FeatureChecker { get; }
 
-    public GlobalStyleViewComponent(IGlobalResourcePublicAppService globalResourcePublicAppService)
+    public GlobalStyleViewComponent(IFeatureChecker featureChecker)
     {
-        GlobalResourcePublicAppService = globalResourcePublicAppService;
+        FeatureChecker = featureChecker;
     }
-
-    [BindProperty(SupportsGet = true)]
-    public DateTime? LastModificationTime { get; set; }
 
     public async Task<IViewComponentResult> InvokeAsync()
     {
-        var lastModificationTime = (await GlobalResourcePublicAppService.GetGlobalStyleAsync())?.LastModificationTime;
-        var lastModificationTimeTimestamp = (long)(lastModificationTime.HasValue ? lastModificationTime.Value.Subtract(DateTime.UnixEpoch).TotalSeconds : 0);
+        if (!await FeatureChecker.IsEnabledAsync(CmsKitFeatures.GlobalResourceEnable))
+        {
+            return Content(string.Empty);
+        }
 
-        return View("~/Pages/CmsKit/Shared/Components/GlobalResources/Style/Default.cshtml",
-            new GlobalStyleModel()
-            {
-                LastModificationTimeTimestamp = lastModificationTimeTimestamp
-            });
+        return View("~/Pages/CmsKit/Shared/Components/GlobalResources/Style/Default.cshtml");
     }
-
 }


### PR DESCRIPTION
### Description

- When disabled Host/Tenant global resources feature, the pages will be thrown an exception.
- `GlobalResourcePublicAppService.GetGlobalStyleAsync` renders the `/cms-kit/global-resources/style` controller cache useless and the controller does not return a response cache.

![screenshot1](https://user-images.githubusercontent.com/13699353/223025310-bd8cbef7-dff7-40d3-b7c9-57be6bf3ef6f.png)

### Changed
- If the global resources feature is disabled, the global resources hook will return blank content.
- Remove style timestamp.

