### PR TITLE
refactor component output names to follow angular style guide 

### DIFF
--- a/npm/ng-packs/packages/theme-shared/src/lib/components/checkbox/checkbox.component.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/components/checkbox/checkbox.component.ts
@@ -9,14 +9,16 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
       <input
         type="checkbox"
         [(ngModel)]="value"
-        [id]="checkboxId"  
+        [id]="checkboxId"
         [readonly]="checkboxReadonly"
-        [ngClass]="checkboxClass" 
-        [ngStyle]="checkboxStyle" 
-        (blur)="onBlur.next()"
-        (focus)="onFocus.next()" 
-      >    
-      <label *ngIf="label" [ngClass]="labelClass" [for]="checkboxId" > {{label | abpLocalization}} </label>
+        [ngClass]="checkboxClass"
+        [ngStyle]="checkboxStyle"
+        (blur)="checkboxBlur.next()"
+        (focus)="checkboxFocus.next()"
+      />
+      <label *ngIf="label" [ngClass]="labelClass" [for]="checkboxId">
+        {{ label | abpLocalization }}
+      </label>
     </div>
   `,
   providers: [
@@ -25,21 +27,19 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
       useExisting: forwardRef(() => FormCheckboxComponent),
       multi: true,
     },
-  ]
+  ],
 })
 export class FormCheckboxComponent extends AbstractNgModelComponent {
-
   @Input() label?: string;
   @Input() labelClass = 'form-check-label';
   @Input() checkboxId!: string;
   @Input() checkboxStyle = '';
   @Input() checkboxClass = 'form-check-input';
   @Input() checkboxReadonly = false;
-  @Output() onBlur = new EventEmitter<void>();
-  @Output() onFocus = new EventEmitter<void>();
+  @Output() checkboxBlur = new EventEmitter<void>();
+  @Output() checkboxFocus = new EventEmitter<void>();
 
   constructor(injector: Injector) {
     super(injector);
   }
-
 }

--- a/npm/ng-packs/packages/theme-shared/src/lib/components/form-input/form-input.component.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/components/form-input/form-input.component.ts
@@ -6,17 +6,20 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
   selector: 'abp-form-input',
   template: `
     <div class="mb-3">
-      <label class= *ngIf="label" [ngClass]="labelClass" [for]="inputId" > {{label | abpLocalization}} </label>
+      <label class="*ngIf" ="label" [ngClass]="labelClass" [for]="inputId">
+        {{ label | abpLocalization }}
+      </label>
       <input
         type="text"
-        [id]="inputId" 
-        [placeholder]="inputPlaceholder" 
+        [id]="inputId"
+        [placeholder]="inputPlaceholder"
         [readonly]="inputReadonly"
-        [ngClass]="inputClass" 
-        [ngStyle]="inputStyle" 
-        (blur)="onBlur.next()"
-        (focus)="onFocus.next()" 
-        [(ngModel)]="value">
+        [ngClass]="inputClass"
+        [ngStyle]="inputStyle"
+        (blur)="formBlur.next()"
+        (focus)="formFocus.next()"
+        [(ngModel)]="value"
+      />
     </div>
   `,
   providers: [
@@ -25,22 +28,21 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
       useExisting: forwardRef(() => FormInputComponent),
       multi: true,
     },
-  ]
+  ],
 })
 export class FormInputComponent extends AbstractNgModelComponent {
   @Input() inputId!: string;
-  @Input() inputReadonly: boolean = false;
-  @Input() label: string = '';
+  @Input() inputReadonly = false;
+  @Input() label = '';
   @Input() labelClass = 'form-label';
-  @Input() inputPlaceholder: string = '';
-  @Input() inputType: string = 'text';
-  @Input() inputStyle: string = '';
-  @Input() inputClass: string = 'form-control';
-  @Output() onBlur = new EventEmitter<void>();
-  @Output() onFocus = new EventEmitter<void>();
+  @Input() inputPlaceholder = '';
+  @Input() inputType = 'text';
+  @Input() inputStyle = '';
+  @Input() inputClass = 'form-control';
+  @Output() formBlur = new EventEmitter<void>();
+  @Output() formFocus = new EventEmitter<void>();
 
   constructor(injector: Injector) {
     super(injector);
   }
-
 }

--- a/npm/ng-packs/packages/theme-shared/src/lib/components/form-input/form-input.component.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/components/form-input/form-input.component.ts
@@ -6,7 +6,7 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
   selector: 'abp-form-input',
   template: `
     <div class="mb-3">
-      <label class="*ngIf" ="label" [ngClass]="labelClass" [for]="inputId">
+      <label *ngIf="label" [ngClass]="labelClass" [for]="inputId">
         {{ label | abpLocalization }}
       </label>
       <input


### PR DESCRIPTION
### Description

Resolves #15912 

TODO:  checkbox and form-input components output names changed to angular syle guide  

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)