### PR TITLE
remove themebasic testing module

### DIFF
--- a/templates/app-nolayers/angular/src/app/home/home.component.spec.ts
+++ b/templates/app-nolayers/angular/src/app/home/home.component.spec.ts
@@ -1,5 +1,4 @@
 import { CoreTestingModule } from '@abp/ng.core/testing';
-import { ThemeBasicTestingModule } from '@abp/ng.theme.basic/testing';
 import { ThemeSharedTestingModule } from '@abp/ng.theme.shared/testing';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { NgxValidateCoreModule } from '@ngx-validate/core';
@@ -17,7 +16,6 @@ describe('HomeComponent', () => {
       imports: [
         CoreTestingModule.withConfig(),
         ThemeSharedTestingModule.withConfig(),
-        ThemeBasicTestingModule.withConfig(),
         NgxValidateCoreModule,
       ],
       providers: [

--- a/templates/app/angular/src/app/home/home.component.spec.ts
+++ b/templates/app/angular/src/app/home/home.component.spec.ts
@@ -19,7 +19,6 @@ describe("HomeComponent", () => {
         imports: [
           CoreTestingModule.withConfig(),
           ThemeSharedTestingModule.withConfig(),
-          //ThemeLeptonXModule.withConfig(),
           NgxValidateCoreModule,
         ],
         providers: [

--- a/templates/app/angular/src/app/home/home.component.spec.ts
+++ b/templates/app/angular/src/app/home/home.component.spec.ts
@@ -1,11 +1,11 @@
 import { CoreTestingModule } from "@abp/ng.core/testing";
-import { ThemeBasicTestingModule } from "@abp/ng.theme.basic/testing";
 import { ThemeSharedTestingModule } from "@abp/ng.theme.shared/testing";
 import { ComponentFixture, TestBed, waitForAsync } from "@angular/core/testing";
 import { NgxValidateCoreModule } from "@ngx-validate/core";
 import { HomeComponent } from "./home.component";
 import { OAuthService } from 'angular-oauth2-oidc';
 import { AuthService } from '@abp/ng.core';
+
 
 
 describe("HomeComponent", () => {
@@ -19,7 +19,7 @@ describe("HomeComponent", () => {
         imports: [
           CoreTestingModule.withConfig(),
           ThemeSharedTestingModule.withConfig(),
-          ThemeBasicTestingModule.withConfig(),
+          //ThemeLeptonXModule.withConfig(),
           NgxValidateCoreModule,
         ],
         providers: [


### PR DESCRIPTION
### Description

Resolves #15983 

TODO: Theme basic was removed but forgotten to remove from testing. That was causing error when running tests so it has been removed in home.component.spect.ts files.

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)
