### PR TITLE
change GetAsync to FindAsync for organization unit GetCodeOrDefaultAsync method

### DIFF
--- a/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/OrganizationUnitManager.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/OrganizationUnitManager.cs
@@ -122,7 +122,7 @@ public class OrganizationUnitManager : DomainService
 
     public virtual async Task<string> GetCodeOrDefaultAsync(Guid id)
     {
-        var ou = await OrganizationUnitRepository.GetAsync(id);
+        var ou = await OrganizationUnitRepository.FindAsync(id);
         return ou?.Code;
     }
 


### PR DESCRIPTION
### Description

Maybe we shoudle use FindAsync instead of GetAsync because if we can't find the organization unit object based on the Id, an EntityNotFound exception message will be thrown. And there is obviously no need to throw an exception here.

### Checklist

- [ ] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)
