### PR TITLE
Fix MockRestService

### DIFF
--- a/npm/ng-packs/packages/core/testing/src/lib/services/mock-rest.service.ts
+++ b/npm/ng-packs/packages/core/testing/src/lib/services/mock-rest.service.ts
@@ -2,6 +2,7 @@ import {
   ABP,
   CORE_OPTIONS,
   EnvironmentService,
+  ExternalHttpClient,
   HttpErrorReporterService,
   RestService,
 } from '@abp/ng.core';
@@ -16,9 +17,10 @@ export class MockRestService extends RestService {
   constructor(
     @Inject(CORE_OPTIONS) protected options: ABP.Root,
     protected http: HttpClient,
+    protected externalhttp: ExternalHttpClient,
     protected environment: EnvironmentService,
   ) {
-    super(options, http, environment, null as unknown as HttpErrorReporterService);
+    super(options, http,externalhttp, environment, null as unknown as HttpErrorReporterService);
   }
 
   handleError(err: any): Observable<any> {


### PR DESCRIPTION
When the implement external http request in rest service as option, MockRestService is broken. it fixed.