### PR TITLE
Create abp.resourcemapping.js

### DIFF
--- a/npm/packs/flag-icon-css/abp.resourcemapping.js
+++ b/npm/packs/flag-icon-css/abp.resourcemapping.js
@@ -1,0 +1,6 @@
+module.exports = {
+    mappings: {
+        "@node_modules/flag-icon-css/css/*": "@libs/flag-icon-css/css",
+        "@node_modules/flag-icon-css/flags/1x1/*": "@libs/flag-icon-css/flags/1x1"
+    }
+}


### PR DESCRIPTION
### Description

Related to https://github.com/abpframework/abp/issues/16303#issuecomment-1514363120

We should keep the `abp.resourcemapping.js` file, even if we don't use the related package in our code anymore. Because, our customers can use the related package even if they upgrade their project versions.

### Checklist

- [X] I fully tested it as developer / designer and created unit / integration tests
- [X] I documented it (or no need to document or I will create a separate documentation issue)

