### PR TITLE
Extend StandardMenus with nested static classes per StandardLayouts

### DIFF
--- a/docs/en/AspNet-Boilerplate-Migration-Guide.md
+++ b/docs/en/AspNet-Boilerplate-Migration-Guide.md
@@ -685,7 +685,7 @@ public class AbpTenantManagementWebMainMenuContributor : IMenuContributor
     public async Task ConfigureMenuAsync(MenuConfigurationContext context)
     {
         //Add items only to the main menu
-        if (context.Menu.Name != StandardMenus.Main)
+        if (context.Menu.Name != StandardMenus.Application.Main)
         {
             return;
         }

--- a/docs/en/UI/AspNetCore/Customization-User-Interface.md
+++ b/docs/en/UI/AspNetCore/Customization-User-Interface.md
@@ -293,12 +293,14 @@ There are some common ways to **customize the layout** described in the next sec
 
 ### Menu Contributors
 
-There are two **standard menus** defined by the ABP Framework:
+There are four **standard menus** defined by the ABP Framework per **standard layouts**:
 
 ![bookstore-menus-highlighted](../../images/bookstore-menus-highlighted.png)
 
-* `StandardMenus.Main`: The main menu of the application.
-* `StandardMenus.User`: The user menu (generally at the top right of the screen).
+* `StandardMenus.{StandardLayoutName}.Main`: The main menu of the current layout (Application, Public, Account).
+* `StandardMenus.{StandardLayoutName}.User`: The user menu (generally at the top right of the screen).
+* `StandardMenus.{StandardLayoutName}.Shortcut`: The shortcut menu (generally at the right sidebar).
+* `StandardMenus.{StandardLayoutName}.Footer`: The footer navigation items.
 
 Rendering the menus is a responsibility of the theme, but **menu items** are determined by the modules and your application code. Just implement the `IMenuContributor` interface and **manipulate the menu items** in the `ConfigureMenuAsync` method.
 

--- a/docs/en/UI/AspNetCore/Navigation-Menu.md
+++ b/docs/en/UI/AspNetCore/Navigation-Menu.md
@@ -28,7 +28,7 @@ namespace MyProject.Web.Menus
     {
         public async Task ConfigureMenuAsync(MenuConfigurationContext context)
         {
-            if (context.Menu.Name == StandardMenus.Main)
+            if (context.Menu.Name == StandardMenus.Application.Main)
             {
                 await ConfigureMainMenuAsync(context);
             }
@@ -55,7 +55,7 @@ namespace MyProject.Web.Menus
 }
 ```
 
-* This example adds items only to the main menu (`StandardMenus.Main`: see the *Standard Menus* section below).
+* This example adds items only to the main menu (`StandardMenus.Application.Main`: see the *Standard Menus* section below).
 * It gets a `IStringLocalizer` from `context` to [localize](../../Localization.md) the display names of the menu items.
 * Adds the Customers and Orders as children of the CRM menu.
 
@@ -197,7 +197,7 @@ namespace MyProject.Web.Menus
     {
         public async Task ConfigureMenuAsync(MenuConfigurationContext context)
         {
-            if (context.Menu.Name == StandardMenus.Main)
+            if (context.Menu.Name == StandardMenus.Application.Main)
             {
                 await ConfigureMainMenuAsync(context);
             }
@@ -234,10 +234,12 @@ namespace MyProject.Web.Menus
 
 ## Standard Menus
 
-A menu is a **named** component. An application may contain more than one menus with different, unique names. There are two pre-defined standard menus:
+A menu is a **named** component. An application may contain more than one menus with different, unique names. There are four pre-defined standard menus per standard layouts:
 
-* `Main`: The main menu of the application. Contains links to the page of the application. Defined as a constant: `Volo.Abp.UI.Navigation.StandardMenus.Main`.
-* `User`: User profile menu. Defined as a constant: `Volo.Abp.UI.Navigation.StandardMenus.User`.
+* `Main`: The main menu of the current layout. Defined as a constant: `Volo.Abp.UI.Navigation.StandardMenus.{StandardLayoutName}.Main`.
+* `User`: User profile menu. This can be different in different layouts. Defined as a constant: `Volo.Abp.UI.Navigation.StandardMenus.{StandardLayoutName}.User`.
+* `Shortcut`: Contains the shortcuts of menus to simplify your navigation. Defined as a constant: `Volo.Abp.UI.Navigation.StandardMenus.{StandardLayoutName}.Shortcut`.
+* `Footer`: The footer navigation menu items. Defined as a constant: `Volo.Abp.UI.Navigation.StandardMenus.{StandardLayoutName}.Shortcut`.
 
 The `Main` menu already covered above. The `User` menu is available when a user has logged in:
 
@@ -246,7 +248,7 @@ The `Main` menu already covered above. The `User` menu is available when a user 
 You can add items to the `User` menu by checking the `context.Menu.Name` as shown below:
 
 ```csharp
-if (context.Menu.Name == StandardMenus.User)
+if (context.Menu.Name == StandardMenus.Public.User)
 {
     //...add items
 }
@@ -276,7 +278,7 @@ namespace MyProject.Web.Pages
         
         public async Task OnGetAsync()
         {
-            var mainMenu = await _menuManager.GetAsync(StandardMenus.Main);
+            var mainMenu = await _menuManager.GetAsync(StandardMenus.Application.Main);
             
             foreach (var menuItem in mainMenu.Items)
             {

--- a/docs/en/UI/AspNetCore/Theming.md
+++ b/docs/en/UI/AspNetCore/Theming.md
@@ -277,7 +277,7 @@ public class MainNavbarMenuViewComponent : AbpViewComponent
 
     public async Task<IViewComponentResult> InvokeAsync()
     {
-        var menu = await _menuManager.GetAsync(StandardMenus.Main);
+        var menu = await _menuManager.GetAsync(StandardMenus.Application.Main);
         return View("~/Themes/Basic/Components/Menu/Default.cshtml", menu);
     }
 }
@@ -318,10 +318,10 @@ Language Selection toolbar item is generally a dropdown that is used to switch b
 
 ##### User Menu
 
-User menu includes links related to the user account. `IMenuManager` is used just like the Main Menu, but this time with `StandardMenus.User` parameter like shown below:
+User menu includes links related to the user account. `IMenuManager` is used just like the Main Menu, but this time with `StandardMenus.Application.User` parameter like shown below:
 
 ````csharp
-var menu = await _menuManager.GetAsync(StandardMenus.User);
+var menu = await _menuManager.GetAsync(StandardMenus.Application.User);
 ````
 
 [ICurrentUser](../../CurrentUser.md) and [ICurrentTenant](../../Multi-Tenancy.md) services can be used to obtain the current user and tenant names.

--- a/docs/en/UI/Blazor/Navigation-Menu.md
+++ b/docs/en/UI/Blazor/Navigation-Menu.md
@@ -28,7 +28,7 @@ namespace MyProject.Web.Menus
     {
         public async Task ConfigureMenuAsync(MenuConfigurationContext context)
         {
-            if (context.Menu.Name == StandardMenus.Main)
+            if (context.Menu.Name == StandardMenus.Application.Main)
             {
                 await ConfigureMainMenuAsync(context);
             }
@@ -55,7 +55,7 @@ namespace MyProject.Web.Menus
 }
 ```
 
-* This example adds items only to the main menu (`StandardMenus.Main`: see the *Standard Menus* section below).
+* This example adds items only to the main menu (`StandardMenus.Application.Main`: see the *Standard Menus* section below).
 * It gets a `IStringLocalizer` from `context` to [localize](../../Localization.md) the display names of the menu items.
 * Adds the Customers and Orders as children of the CRM menu.
 
@@ -178,7 +178,7 @@ namespace MyProject.Web.Menus
     {
         public async Task ConfigureMenuAsync(MenuConfigurationContext context)
         {
-            if (context.Menu.Name == StandardMenus.Main)
+            if (context.Menu.Name == StandardMenus.Application.Main)
             {
                 await ConfigureMainMenuAsync(context);
             }
@@ -217,8 +217,8 @@ namespace MyProject.Web.Menus
 
 A menu is a **named** component. An application may contain more than one menus with different, unique names. There are two pre-defined standard menus:
 
-* `Main`: The main menu of the application. Contains links to the page of the application. Defined as a constant: `Volo.Abp.UI.Navigation.StandardMenus.Main`.
-* `User`: User profile menu. Defined as a constant: `Volo.Abp.UI.Navigation.StandardMenus.User`.
+* `Main`: The main menu of the application. Contains links to the page of the application. Defined as a constant: `Volo.Abp.UI.Navigation.StandardMenus.Application.Main`.
+* `User`: User profile menu. Defined as a constant: `Volo.Abp.UI.Navigation.StandardMenus.Application.User`.
 
 The `Main` menu already covered above. The `User` menu is available when a user has logged in:
 
@@ -227,7 +227,7 @@ The `Main` menu already covered above. The `User` menu is available when a user 
 You can add items to the `User` menu by checking the `context.Menu.Name` as shown below:
 
 ```csharp
-if (context.Menu.Name == StandardMenus.User)
+if (context.Menu.Name == StandardMenus.Application.User)
 {
     //...add items
 }
@@ -252,7 +252,7 @@ public partial class NavMenu
     
     protected override async Task OnInitializedAsync()
     {
-        var menu = await _menuManager.GetAsync(StandardMenus.Main);
+        var menu = await _menuManager.GetAsync(StandardMenus.Application.Main);
         //...
     }
 }

--- a/docs/en/UI/Blazor/Theming.md
+++ b/docs/en/UI/Blazor/Theming.md
@@ -164,7 +164,7 @@ public partial class NavMenu
     
     protected override async Task OnInitializedAsync()
     {
-        var menu = await _menuManager.GetAsync(StandardMenus.Main);
+        var menu = await _menuManager.GetAsync(StandardMenus.Application.Main);
         //...
     }
 }
@@ -252,10 +252,10 @@ NavigationManager.NavigateTo(
 
 ##### User Menu
 
-User menu includes links related to the user account. `IMenuManager` is used just like the Main Menu, but this time with `StandardMenus.User` parameter like shown below:
+User menu includes links related to the user account. `IMenuManager` is used just like the Main Menu, but this time with `StandardMenus.Application.User` parameter like shown below:
 
 ````csharp
-var menu = await _menuManager.GetAsync(StandardMenus.User);
+var menu = await _menuManager.GetAsync(StandardMenus.Application.User);
 ````
 
 [ICurrentUser](../../CurrentUser.md) and [ICurrentTenant](../../Multi-Tenancy.md) services can be used to obtain the current user and tenant names.

--- a/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/AbpNavigationOptions.cs
+++ b/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/AbpNavigationOptions.cs
@@ -9,7 +9,7 @@ public class AbpNavigationOptions
     public List<IMenuContributor> MenuContributors { get; }
 
     /// <summary>
-    /// Includes the <see cref="StandardMenus.Main"/> by default.
+    /// Includes the <see cref="StandardMenus.Application.Main"/> by default.
     /// </summary>
     public List<string> MainMenuNames { get; }
 
@@ -19,7 +19,7 @@ public class AbpNavigationOptions
 
         MainMenuNames = new List<string>
             {
-                StandardMenus.Main
+                StandardMenus.Application.Main
             };
     }
 }

--- a/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/DefaultMenuContributor.cs
+++ b/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/DefaultMenuContributor.cs
@@ -15,7 +15,7 @@ public class DefaultMenuContributor : IMenuContributor
     {
         var l = context.GetLocalizer<AbpUiNavigationResource>();
 
-        if (context.Menu.Name == StandardMenus.Main)
+        if (context.Menu.Name == StandardMenus.Application.Main)
         {
             context.Menu.AddItem(
                 new ApplicationMenuItem(

--- a/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/MenuManager.cs
+++ b/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/MenuManager.cs
@@ -40,7 +40,7 @@ public class MenuManager : IMenuManager, ITransientDependency
     {
         if (menuNames.IsNullOrEmpty())
         {
-            return new ApplicationMenu(StandardMenus.Main);
+            return new ApplicationMenu(StandardMenus.Application.Main);
         }
 
         var menus = new List<ApplicationMenu>();

--- a/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/StandardMenus.cs
+++ b/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/StandardMenus.cs
@@ -2,13 +2,27 @@ namespace Volo.Abp.UI.Navigation;
 
 public static class StandardMenus
 {
-    /* TODO: Consider to create nested class like
-     * StandardMenus.Application.Main
-     * StandardMenus.Application.User
-     * StandardMenus.Application.Shortcut
-     */
-
-    public const string Main = "Main";
-    public const string User = "User";
-    public const string Shortcut = "Shortcut";
+    public static class Application
+    {
+        public const string Main = "Application.Main";
+        public const string User = "Application.User";
+        public const string Shortcut = "Application.Shortcut";
+        public const string Footer = "Application.Footer";
+    }
+    
+    public static class Public
+    {
+        public const string Main = "Public.Main";
+        public const string User = "Public.User";
+        public const string Shortcut = "Public.Shortcut";
+        public const string Footer = "Public.Footer";
+    }
+    
+    public static class Account
+    {
+        public const string Main = "Account.Main";
+        public const string User = "Account.User";
+        public const string Shortcut = "Account.Shortcut";
+        public const string Footer = "Account.Footer";
+    }
 }

--- a/framework/test/Volo.Abp.UI.Navigation.Tests/Volo/Abp/Ui/Navigation/MenuManager_Tests.cs
+++ b/framework/test/Volo.Abp.UI.Navigation.Tests/Volo/Abp/Ui/Navigation/MenuManager_Tests.cs
@@ -42,9 +42,9 @@ public class MenuManager_Tests : AbpIntegratedTest<AbpUiNavigationTestModule>
     [Fact]
     public async Task Should_Get_Menu()
     {
-        var mainMenu = await _menuManager.GetAsync(StandardMenus.Main);
+        var mainMenu = await _menuManager.GetAsync(StandardMenus.Application.Main);
 
-        mainMenu.Name.ShouldBe(StandardMenus.Main);
+        mainMenu.Name.ShouldBe(StandardMenus.Application.Main);
         mainMenu.DisplayName.ShouldBe("Main Menu");
         mainMenu.Items.Count.ShouldBe(5);
         mainMenu.Items[0].Name.ShouldBe("Dashboard");
@@ -61,7 +61,7 @@ public class MenuManager_Tests : AbpIntegratedTest<AbpUiNavigationTestModule>
     {
         var mainMenu = await _menuManager.GetMainMenuAsync();
 
-        mainMenu.Name.ShouldBe(StandardMenus.Main);
+        mainMenu.Name.ShouldBe(StandardMenus.Application.Main);
 
         mainMenu.Items.Count.ShouldBe(6);
 
@@ -74,7 +74,7 @@ public class MenuManager_Tests : AbpIntegratedTest<AbpUiNavigationTestModule>
     {
         var mainMenu = await _menuManager.GetMainMenuAsync();
 
-        mainMenu.Name.ShouldBe(StandardMenus.Main);
+        mainMenu.Name.ShouldBe(StandardMenus.Application.Main);
         mainMenu.Items.Count.ShouldBe(6);
 
         mainMenu.Items[2].GroupName.ShouldBe("Layouts");
@@ -95,7 +95,7 @@ public class MenuManager_Tests : AbpIntegratedTest<AbpUiNavigationTestModule>
     {
         public Task ConfigureMenuAsync(MenuConfigurationContext context)
         {
-            if (context.Menu.Name != StandardMenus.Main)
+            if (context.Menu.Name != StandardMenus.Application.Main)
             {
                 return Task.CompletedTask;
             }
@@ -120,7 +120,7 @@ public class MenuManager_Tests : AbpIntegratedTest<AbpUiNavigationTestModule>
     {
         public Task ConfigureMenuAsync(MenuConfigurationContext context)
         {
-            if (context.Menu.Name != StandardMenus.Main)
+            if (context.Menu.Name != StandardMenus.Application.Main)
             {
                 return Task.CompletedTask;
             }
@@ -176,7 +176,7 @@ public class MenuManager_Tests : AbpIntegratedTest<AbpUiNavigationTestModule>
     {
         public Task ConfigureMenuAsync(MenuConfigurationContext context)
         {
-            if (context.Menu.Name != StandardMenus.Main)
+            if (context.Menu.Name != StandardMenus.Application.Main)
             {
                 return Task.CompletedTask;
             }

--- a/modules/account/src/Volo.Abp.Account.Blazor/AbpAccountBlazorUserMenuContributor.cs
+++ b/modules/account/src/Volo.Abp.Account.Blazor/AbpAccountBlazorUserMenuContributor.cs
@@ -8,7 +8,7 @@ public class AbpAccountBlazorUserMenuContributor : IMenuContributor
 {
     public Task ConfigureMenuAsync(MenuConfigurationContext context)
     {
-        if (context.Menu.Name != StandardMenus.User)
+        if (context.Menu.Name != StandardMenus.Application.User)
         {
             return Task.CompletedTask;
         }

--- a/modules/account/src/Volo.Abp.Account.Web/AbpAccountUserMenuContributor.cs
+++ b/modules/account/src/Volo.Abp.Account.Web/AbpAccountUserMenuContributor.cs
@@ -11,7 +11,7 @@ public class AbpAccountUserMenuContributor : IMenuContributor
 {
     public virtual Task ConfigureMenuAsync(MenuConfigurationContext context)
     {
-        if (context.Menu.Name != StandardMenus.User)
+        if (context.Menu.Name != StandardMenus.Application.User)
         {
             return Task.CompletedTask;
         }

--- a/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.Server.BasicTheme/Themes/Basic/LoginDisplay.razor.cs
+++ b/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.Server.BasicTheme/Themes/Basic/LoginDisplay.razor.cs
@@ -15,7 +15,7 @@ public partial class LoginDisplay : IDisposable
 
     protected override async Task OnInitializedAsync()
     {
-        Menu = await MenuManager.GetAsync(StandardMenus.User);
+        Menu = await MenuManager.GetAsync(StandardMenus.Application.User);
 
         Navigation.LocationChanged += OnLocationChanged;
     }

--- a/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.WebAssembly.BasicTheme/Themes/Basic/LoginDisplay.razor.cs
+++ b/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.WebAssembly.BasicTheme/Themes/Basic/LoginDisplay.razor.cs
@@ -23,7 +23,7 @@ public partial class LoginDisplay : IDisposable
 
     protected async override Task OnInitializedAsync()
     {
-        Menu = await MenuManager.GetAsync(StandardMenus.User);
+        Menu = await MenuManager.GetAsync(StandardMenus.Application.User);
 
         Navigation.LocationChanged += OnLocationChanged;
 
@@ -37,7 +37,7 @@ public partial class LoginDisplay : IDisposable
 
     private async void ApplicationConfigurationChanged()
     {
-        Menu = await MenuManager.GetAsync(StandardMenus.User);
+        Menu = await MenuManager.GetAsync(StandardMenus.Application.User);
         await InvokeAsync(StateHasChanged);
     }
 

--- a/modules/basic-theme/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic/Themes/Basic/Components/Toolbar/UserMenu/UserMenuViewComponent.cs
+++ b/modules/basic-theme/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic/Themes/Basic/Components/Toolbar/UserMenu/UserMenuViewComponent.cs
@@ -15,7 +15,7 @@ public class UserMenuViewComponent : AbpViewComponent
 
     public virtual async Task<IViewComponentResult> InvokeAsync()
     {
-        var menu = await MenuManager.GetAsync(StandardMenus.User);
+        var menu = await MenuManager.GetAsync(StandardMenus.Application.User);
         return View("~/Themes/Basic/Components/Toolbar/UserMenu/Default.cshtml", menu);
     }
 }

--- a/modules/basic-theme/test/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.Demo/Pages/Menus/BootstrapDemoMenuContributor.cs
+++ b/modules/basic-theme/test/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.Demo/Pages/Menus/BootstrapDemoMenuContributor.cs
@@ -10,7 +10,7 @@ public class BootstrapDemoMenuContributor : IMenuContributor
 {
     public Task ConfigureMenuAsync(MenuConfigurationContext context)
     {
-        if (context.Menu.Name == StandardMenus.Main)
+        if (context.Menu.Name == StandardMenus.Application.Main)
         {
             AddMainMenuItems(context);
         }

--- a/modules/basic-theme/test/Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic.Demo/Menus/BasicThemeDemoMenuContributor.cs
+++ b/modules/basic-theme/test/Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic.Demo/Menus/BasicThemeDemoMenuContributor.cs
@@ -9,7 +9,7 @@ public class BasicThemeDemoMenuContributor : IMenuContributor
 {
     public Task ConfigureMenuAsync(MenuConfigurationContext context)
     {
-        if (context.Menu.Name == StandardMenus.Main)
+        if (context.Menu.Name == StandardMenus.Application.Main)
         {
             AddMainMenuItems(context);
         }

--- a/modules/basic-theme/test/Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic.Demo/Pages/Components/Index.cshtml
+++ b/modules/basic-theme/test/Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic.Demo/Pages/Components/Index.cshtml
@@ -15,7 +15,7 @@
 Here is the ABP Component List
 
 <ul>
-    @foreach (var menu in (await Model._menuManager.GetAsync(StandardMenus.Main)).Items.First(x => x.Name == BasicThemeDemoMenus.Components.Root).Items)
+    @foreach (var menu in (await Model._menuManager.GetAsync(StandardMenus.Application.Main)).Items.First(x => x.Name == BasicThemeDemoMenus.Components.Root).Items)
     {
         <li><a href="@menu.Url">@menu.DisplayName</a></li>
     }

--- a/modules/blogging/src/Volo.Blogging.Admin.Web/Navigation/BloggingAdminMenuContributor.cs
+++ b/modules/blogging/src/Volo.Blogging.Admin.Web/Navigation/BloggingAdminMenuContributor.cs
@@ -9,7 +9,7 @@ namespace Volo.Blogging.Admin
     {
         public async Task ConfigureMenuAsync(MenuConfigurationContext context)
         {
-            if (context.Menu.Name == StandardMenus.Main)
+            if (context.Menu.Name == StandardMenus.Application.Main)
             {
                 await ConfigureMainMenuAsync(context);
             }

--- a/modules/cms-kit/host/Volo.CmsKit.Web.Host/CmsKitWebHostMenuContributor.cs
+++ b/modules/cms-kit/host/Volo.CmsKit.Web.Host/CmsKitWebHostMenuContributor.cs
@@ -22,7 +22,7 @@ public class CmsKitWebHostMenuContributor : IMenuContributor
 
     public Task ConfigureMenuAsync(MenuConfigurationContext context)
     {
-        if (context.Menu.Name == StandardMenus.User)
+        if (context.Menu.Name == StandardMenus.Application.User)
         {
             AddLogoutItemToMenu(context);
         }

--- a/modules/cms-kit/src/Volo.CmsKit.Admin.Web/Menus/CmsKitAdminMenuContributor.cs
+++ b/modules/cms-kit/src/Volo.CmsKit.Admin.Web/Menus/CmsKitAdminMenuContributor.cs
@@ -16,7 +16,7 @@ public class CmsKitAdminMenuContributor : IMenuContributor
 {
     public async Task ConfigureMenuAsync(MenuConfigurationContext context)
     {
-        if (context.Menu.Name == StandardMenus.Main)
+        if (context.Menu.Name == StandardMenus.Application.Main)
         {
             await ConfigureMainMenuAsync(context);
         }

--- a/modules/docs/src/Volo.Docs.Admin.Web/Navigation/DocsMenuContributor.cs
+++ b/modules/docs/src/Volo.Docs.Admin.Web/Navigation/DocsMenuContributor.cs
@@ -12,7 +12,7 @@ namespace Volo.Docs.Admin.Navigation
     {
         public async Task ConfigureMenuAsync(MenuConfigurationContext context)
         {
-            if (context.Menu.Name == StandardMenus.Main)
+            if (context.Menu.Name == StandardMenus.Application.Main)
             {
                 await ConfigureMainMenuAsync(context);
             }

--- a/modules/identity/src/Volo.Abp.Identity.Blazor/AbpIdentityWebMainMenuContributor.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Blazor/AbpIdentityWebMainMenuContributor.cs
@@ -9,7 +9,7 @@ public class AbpIdentityWebMainMenuContributor : IMenuContributor
 {
     public virtual Task ConfigureMenuAsync(MenuConfigurationContext context)
     {
-        if (context.Menu.Name != StandardMenus.Main)
+        if (context.Menu.Name != StandardMenus.Application.Main)
         {
             return Task.CompletedTask;
         }

--- a/modules/identity/src/Volo.Abp.Identity.Web/Navigation/AbpIdentityWebMainMenuContributor.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Web/Navigation/AbpIdentityWebMainMenuContributor.cs
@@ -12,7 +12,7 @@ public class AbpIdentityWebMainMenuContributor : IMenuContributor
 {
     public virtual Task ConfigureMenuAsync(MenuConfigurationContext context)
     {
-        if (context.Menu.Name != StandardMenus.Main)
+        if (context.Menu.Name != StandardMenus.Application.Main)
         {
             return Task.CompletedTask;
         }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Blazor/Menus/SettingManagementMenuContributor.cs
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Blazor/Menus/SettingManagementMenuContributor.cs
@@ -12,7 +12,7 @@ public class SettingManagementMenuContributor : IMenuContributor
 {
     public async Task ConfigureMenuAsync(MenuConfigurationContext context)
     {
-        if (context.Menu.Name == StandardMenus.Main)
+        if (context.Menu.Name == StandardMenus.Application.Main)
         {
             await ConfigureMainMenuAsync(context);
         }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Web/Navigation/SettingManagementMainMenuContributor.cs
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Web/Navigation/SettingManagementMainMenuContributor.cs
@@ -12,7 +12,7 @@ public class SettingManagementMainMenuContributor : IMenuContributor
 {
     public virtual async Task ConfigureMenuAsync(MenuConfigurationContext context)
     {
-        if (context.Menu.Name != StandardMenus.Main)
+        if (context.Menu.Name != StandardMenus.Application.Main)
         {
             return;
         }

--- a/modules/tenant-management/src/Volo.Abp.TenantManagement.Blazor/Navigation/TenantManagementBlazorMenuContributor.cs
+++ b/modules/tenant-management/src/Volo.Abp.TenantManagement.Blazor/Navigation/TenantManagementBlazorMenuContributor.cs
@@ -9,7 +9,7 @@ public class TenantManagementBlazorMenuContributor : IMenuContributor
 {
     public virtual Task ConfigureMenuAsync(MenuConfigurationContext context)
     {
-        if (context.Menu.Name != StandardMenus.Main)
+        if (context.Menu.Name != StandardMenus.Application.Main)
         {
             return Task.CompletedTask;
         }

--- a/modules/tenant-management/src/Volo.Abp.TenantManagement.Web/Navigation/AbpTenantManagementWebMainMenuContributor.cs
+++ b/modules/tenant-management/src/Volo.Abp.TenantManagement.Web/Navigation/AbpTenantManagementWebMainMenuContributor.cs
@@ -12,7 +12,7 @@ public class AbpTenantManagementWebMainMenuContributor : IMenuContributor
 {
     public virtual Task ConfigureMenuAsync(MenuConfigurationContext context)
     {
-        if (context.Menu.Name != StandardMenus.Main)
+        if (context.Menu.Name != StandardMenus.Application.Main)
         {
             return Task.CompletedTask;
         }

--- a/modules/virtual-file-explorer/src/Volo.Abp.VirtualFileExplorer.Web/Navigation/VirtualFileExplorerMenuContributor.cs
+++ b/modules/virtual-file-explorer/src/Volo.Abp.VirtualFileExplorer.Web/Navigation/VirtualFileExplorerMenuContributor.cs
@@ -10,7 +10,7 @@ public class VirtualFileExplorerMenuContributor : IMenuContributor
 {
     public virtual Task ConfigureMenuAsync(MenuConfigurationContext context)
     {
-        if (context.Menu.Name != StandardMenus.Main)
+        if (context.Menu.Name != StandardMenus.Application.Main)
         {
             return Task.CompletedTask;
         }

--- a/templates/app-nolayers/aspnet-core/MyCompanyName.MyProjectName.Blazor.Server.Mongo/Menus/MyProjectNameMenuContributor.cs
+++ b/templates/app-nolayers/aspnet-core/MyCompanyName.MyProjectName.Blazor.Server.Mongo/Menus/MyProjectNameMenuContributor.cs
@@ -10,7 +10,7 @@ public class MyProjectNameMenuContributor : IMenuContributor
 {
     public async Task ConfigureMenuAsync(MenuConfigurationContext context)
     {
-        if (context.Menu.Name == StandardMenus.Main)
+        if (context.Menu.Name == StandardMenus.Application.Main)
         {
             await ConfigureMainMenuAsync(context);
         }

--- a/templates/app-nolayers/aspnet-core/MyCompanyName.MyProjectName.Blazor.Server/Menus/MyProjectNameMenuContributor.cs
+++ b/templates/app-nolayers/aspnet-core/MyCompanyName.MyProjectName.Blazor.Server/Menus/MyProjectNameMenuContributor.cs
@@ -10,7 +10,7 @@ public class MyProjectNameMenuContributor : IMenuContributor
 {
     public async Task ConfigureMenuAsync(MenuConfigurationContext context)
     {
-        if (context.Menu.Name == StandardMenus.Main)
+        if (context.Menu.Name == StandardMenus.Application.Main)
         {
             await ConfigureMainMenuAsync(context);
         }

--- a/templates/app-nolayers/aspnet-core/MyCompanyName.MyProjectName.Blazor.WebAssembly/Client/Menus/MyProjectNameMenuContributor.cs
+++ b/templates/app-nolayers/aspnet-core/MyCompanyName.MyProjectName.Blazor.WebAssembly/Client/Menus/MyProjectNameMenuContributor.cs
@@ -21,11 +21,11 @@ public class MyProjectNameMenuContributor : IMenuContributor
 
     public async Task ConfigureMenuAsync(MenuConfigurationContext context)
     {
-        if (context.Menu.Name == StandardMenus.Main)
+        if (context.Menu.Name == StandardMenus.Application.Main)
         {
             await ConfigureMainMenuAsync(context);
         }
-        else if (context.Menu.Name == StandardMenus.User)
+        else if (context.Menu.Name == StandardMenus.Application.User)
         {
             await ConfigureUserMenuAsync(context);
         }

--- a/templates/app-nolayers/aspnet-core/MyCompanyName.MyProjectName.Mvc.Mongo/Menus/MyProjectNameMenuContributor.cs
+++ b/templates/app-nolayers/aspnet-core/MyCompanyName.MyProjectName.Mvc.Mongo/Menus/MyProjectNameMenuContributor.cs
@@ -10,7 +10,7 @@ public class MyProjectNameMenuContributor : IMenuContributor
 {
     public async Task ConfigureMenuAsync(MenuConfigurationContext context)
     {
-        if (context.Menu.Name == StandardMenus.Main)
+        if (context.Menu.Name == StandardMenus.Application.Main)
         {
             await ConfigureMainMenuAsync(context);
         }

--- a/templates/app-nolayers/aspnet-core/MyCompanyName.MyProjectName.Mvc/Menus/MyProjectNameMenuContributor.cs
+++ b/templates/app-nolayers/aspnet-core/MyCompanyName.MyProjectName.Mvc/Menus/MyProjectNameMenuContributor.cs
@@ -10,7 +10,7 @@ public class MyProjectNameMenuContributor : IMenuContributor
 {
     public async Task ConfigureMenuAsync(MenuConfigurationContext context)
     {
-        if (context.Menu.Name == StandardMenus.Main)
+        if (context.Menu.Name == StandardMenus.Application.Main)
         {
             await ConfigureMainMenuAsync(context);
         }

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.Server.Tiered/Menus/MyProjectNameMenuContributor.cs
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.Server.Tiered/Menus/MyProjectNameMenuContributor.cs
@@ -25,11 +25,11 @@ public class MyProjectNameMenuContributor : IMenuContributor
 
     public async Task ConfigureMenuAsync(MenuConfigurationContext context)
     {
-        if (context.Menu.Name == StandardMenus.Main)
+        if (context.Menu.Name == StandardMenus.Application.Main)
         {
             await ConfigureMainMenuAsync(context);
         }
-        else if (context.Menu.Name == StandardMenus.User)
+        else if (context.Menu.Name == StandardMenus.Application.User)
         {
             await ConfigureUserMenuAsync(context);
         }

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.Server/Menus/MyProjectNameMenuContributor.cs
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.Server/Menus/MyProjectNameMenuContributor.cs
@@ -12,7 +12,7 @@ public class MyProjectNameMenuContributor : IMenuContributor
 {
     public async Task ConfigureMenuAsync(MenuConfigurationContext context)
     {
-        if (context.Menu.Name == StandardMenus.Main)
+        if (context.Menu.Name == StandardMenus.Application.Main)
         {
             await ConfigureMainMenuAsync(context);
         }

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor/Menus/MyProjectNameMenuContributor.cs
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor/Menus/MyProjectNameMenuContributor.cs
@@ -25,11 +25,11 @@ public class MyProjectNameMenuContributor : IMenuContributor
 
     public async Task ConfigureMenuAsync(MenuConfigurationContext context)
     {
-        if (context.Menu.Name == StandardMenus.Main)
+        if (context.Menu.Name == StandardMenus.Application.Main)
         {
             await ConfigureMainMenuAsync(context);
         }
-        else if (context.Menu.Name == StandardMenus.User)
+        else if (context.Menu.Name == StandardMenus.Application.User)
         {
             await ConfigureUserMenuAsync(context);
         }

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Web.Host/Menus/MyProjectNameMenuContributor.cs
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Web.Host/Menus/MyProjectNameMenuContributor.cs
@@ -25,11 +25,11 @@ public class MyProjectNameMenuContributor : IMenuContributor
 
     public async Task ConfigureMenuAsync(MenuConfigurationContext context)
     {
-        if (context.Menu.Name == StandardMenus.Main)
+        if (context.Menu.Name == StandardMenus.Application.Main)
         {
             await ConfigureMainMenuAsync(context);
         }
-        else if (context.Menu.Name == StandardMenus.User)
+        else if (context.Menu.Name == StandardMenus.Application.User)
         {
             await ConfigureUserMenuAsync(context);
         }

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Web/Menus/MyProjectNameMenuContributor.cs
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Web/Menus/MyProjectNameMenuContributor.cs
@@ -12,7 +12,7 @@ public class MyProjectNameMenuContributor : IMenuContributor
 {
     public async Task ConfigureMenuAsync(MenuConfigurationContext context)
     {
-        if (context.Menu.Name == StandardMenus.Main)
+        if (context.Menu.Name == StandardMenus.Application.Main)
         {
             await ConfigureMainMenuAsync(context);
         }

--- a/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.Blazor.Host/MyProjectNameHostMenuContributor.cs
+++ b/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.Blazor.Host/MyProjectNameHostMenuContributor.cs
@@ -17,7 +17,7 @@ public class MyProjectNameHostMenuContributor : IMenuContributor
 
     public async Task ConfigureMenuAsync(MenuConfigurationContext context)
     {
-        if (context.Menu.Name == StandardMenus.User)
+        if (context.Menu.Name == StandardMenus.Application.User)
         {
             await ConfigureUserMenuAsync(context);
         }

--- a/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.Blazor.Server.Host/Menus/MyProjectNameMenuContributor.cs
+++ b/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.Blazor.Server.Host/Menus/MyProjectNameMenuContributor.cs
@@ -11,7 +11,7 @@ public class MyProjectNameMenuContributor : IMenuContributor
 {
     public async Task ConfigureMenuAsync(MenuConfigurationContext context)
     {
-        if (context.Menu.Name == StandardMenus.Main)
+        if (context.Menu.Name == StandardMenus.Application.Main)
         {
             await ConfigureMainMenuAsync(context);
         }

--- a/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.Web.Host/MyProjectNameWebHostMenuContributor.cs
+++ b/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.Web.Host/MyProjectNameWebHostMenuContributor.cs
@@ -22,7 +22,7 @@ public class MyProjectNameWebHostMenuContributor : IMenuContributor
 
     public Task ConfigureMenuAsync(MenuConfigurationContext context)
     {
-        if (context.Menu.Name == StandardMenus.User)
+        if (context.Menu.Name == StandardMenus.Application.User)
         {
             AddLogoutItemToMenu(context);
         }

--- a/templates/module/aspnet-core/src/MyCompanyName.MyProjectName.Blazor/Menus/MyProjectNameMenuContributor.cs
+++ b/templates/module/aspnet-core/src/MyCompanyName.MyProjectName.Blazor/Menus/MyProjectNameMenuContributor.cs
@@ -7,7 +7,7 @@ public class MyProjectNameMenuContributor : IMenuContributor
 {
     public async Task ConfigureMenuAsync(MenuConfigurationContext context)
     {
-        if (context.Menu.Name == StandardMenus.Main)
+        if (context.Menu.Name == StandardMenus.Application.Main)
         {
             await ConfigureMainMenuAsync(context);
         }

--- a/templates/module/aspnet-core/src/MyCompanyName.MyProjectName.Web/Menus/MyProjectNameMenuContributor.cs
+++ b/templates/module/aspnet-core/src/MyCompanyName.MyProjectName.Web/Menus/MyProjectNameMenuContributor.cs
@@ -7,7 +7,7 @@ public class MyProjectNameMenuContributor : IMenuContributor
 {
     public async Task ConfigureMenuAsync(MenuConfigurationContext context)
     {
-        if (context.Menu.Name == StandardMenus.Main)
+        if (context.Menu.Name == StandardMenus.Application.Main)
         {
             await ConfigureMainMenuAsync(context);
         }


### PR DESCRIPTION
### Description

Resolves #16305 

This PR is extending `StandardMenus` with nested static classes per `StandardLayouts` with extra `Footer` menu name.

### Checklist

- [x] I fully tested it as theme developer / designer with Mvc app template
- [x] I documented it (need to document in other cultures)

### How to test it?
```pwsh
abp new Acme.BookStore -t app -ts "PathToAbpLocalRepo\templates\app" --local-framework-ref --abp-path "PathToAbpLocalRepo"
```