### PR TITLE
Normalize ElementId for navigation menu items

### DIFF
--- a/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/ApplicationMenuGroup.cs
+++ b/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/ApplicationMenuGroup.cs
@@ -63,12 +63,12 @@ public class ApplicationMenuGroup
 
     private string GetDefaultElementId()
     {
-        return "MenuGroup" + Name;
+        return "MenuGroup_" + Name;
     }
 
     private string NormalizeElementId(string elementId)
     {
-        return elementId?.Replace("_", "").Replace(".", "");
+        return elementId?.Replace(".", "");
     }
 
     public override string ToString()

--- a/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/ApplicationMenuGroup.cs
+++ b/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/ApplicationMenuGroup.cs
@@ -5,6 +5,7 @@ namespace Volo.Abp.UI.Navigation;
 public class ApplicationMenuGroup
 {
     private string _displayName;
+    private string _elementId;
 
     /// <summary>
     /// Default <see cref="Order"/> value of a group item.
@@ -32,7 +33,12 @@ public class ApplicationMenuGroup
     /// <summary>
     /// Can be used to render the element with a specific Id for DOM selections.
     /// </summary>
-    public string ElementId { get; set; }
+    public string ElementId {
+        get { return _elementId; }
+        set {
+            _elementId = NormalizeElementId(value);
+        }
+    }
 
     /// <summary>
     /// The Display order of the group.
@@ -57,7 +63,12 @@ public class ApplicationMenuGroup
 
     private string GetDefaultElementId()
     {
-        return "MenuGroup_" + Name;
+        return "MenuGroup" + Name;
+    }
+
+    private string NormalizeElementId(string elementId)
+    {
+        return elementId?.Replace("_", "").Replace(".", "");
     }
 
     public override string ToString()

--- a/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/ApplicationMenuItem.cs
+++ b/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/ApplicationMenuItem.cs
@@ -155,12 +155,12 @@ public class ApplicationMenuItem : IHasMenuItems, IHasSimpleStateCheckers<Applic
 
     private string GetDefaultElementId()
     {
-        return "MenuItem" + Name;
+        return "MenuItem_" + Name;
     }
     
     private string NormalizeElementId(string elementId)
     {
-        return elementId?.Replace("_", "").Replace(".", "");
+        return elementId?.Replace(".", "");
     }
 
     public override string ToString()

--- a/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/ApplicationMenuItem.cs
+++ b/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/ApplicationMenuItem.cs
@@ -8,6 +8,7 @@ namespace Volo.Abp.UI.Navigation;
 public class ApplicationMenuItem : IHasMenuItems, IHasSimpleStateCheckers<ApplicationMenuItem>
 {
     private string _displayName;
+    private string _elementId;
 
     /// <summary>
     /// Default <see cref="Order"/> value of a menu item.
@@ -85,7 +86,12 @@ public class ApplicationMenuItem : IHasMenuItems, IHasSimpleStateCheckers<Applic
     /// <summary>
     /// Can be used to render the element with a specific Id for DOM selections.
     /// </summary>
-    public string ElementId { get; set; }
+    public string ElementId {
+        get { return _elementId; }
+        set {
+            _elementId = NormalizeElementId(value);
+        }
+    }
 
     /// <summary>
     /// Can be used to render the element with extra CSS classes.
@@ -149,7 +155,12 @@ public class ApplicationMenuItem : IHasMenuItems, IHasSimpleStateCheckers<Applic
 
     private string GetDefaultElementId()
     {
-        return "MenuItem_" + Name;
+        return "MenuItem" + Name;
+    }
+    
+    private string NormalizeElementId(string elementId)
+    {
+        return elementId?.Replace("_", "").Replace(".", "");
     }
 
     public override string ToString()


### PR DESCRIPTION
### Description

Resolves https://github.com/abpframework/abp/issues/16312

We need to normalize the `ElementId`, to prevent possible problems in matching elements with bootstrap selectors.  

### Checklist

- [X] I fully tested it as developer / designer and created unit / integration tests
- [X] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

Please describe how this can be tested by the test engineers if it is not already explicit - or remove this section if no need to description.
