### PR TITLE
Change deprecated @angular-devkit/build-ng-packagr  builder

### DIFF
--- a/docs/en/UI/Angular/Basic-Theme.md
+++ b/docs/en/UI/Angular/Basic-Theme.md
@@ -72,7 +72,7 @@ Or, you can download the [source code](https://github.com/abpframework/abp/blob/
             "prefix": "abp",
             "architect": {
                 "build": {
-                    "builder": "@angular-devkit/build-ng-packagr:build",
+                    "builder": "@angular-devkit/build-angular:ng-packagr",
                     "options": {
                         "tsConfig": "projects/theme-basic/tsconfig.lib.json",
                         "project": "projects/theme-basic/ng-package.json"

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/AngularSourceCodeAdder.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/AngularSourceCodeAdder.cs
@@ -91,7 +91,7 @@ public class AngularSourceCodeAdder : ITransientDependency
                 new JProperty("prefix", "abp"),
                 new JProperty("architect", new JObject(
                     new JProperty("build", new JObject(
-                        new JProperty("builder", "@angular-devkit/build-ng-packagr:build"),
+                        new JProperty("builder", "@angular-devkit/build-angular:ng-packagr"),
                         new JProperty("options", new JObject(
                             new JProperty("tsConfig", $"projects/{project}/tsconfig.lib.json"),
                             new JProperty("project", $"projects/{project}/ng-package.json")

--- a/modules/cms-kit/angular/angular.json
+++ b/modules/cms-kit/angular/angular.json
@@ -10,7 +10,7 @@
       "prefix": "lib",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-ng-packagr:build",
+          "builder": "@angular-devkit/build-angular:ng-packagr",
           "options": {
             "tsConfig": "projects/cms-kit/tsconfig.lib.json",
             "project": "projects/cms-kit/ng-package.json"

--- a/npm/packs/utils/angular.json
+++ b/npm/packs/utils/angular.json
@@ -10,7 +10,7 @@
       "prefix": "lib",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-ng-packagr:build",
+          "builder": "@angular-devkit/build-angular:ng-packagr",
           "options": {
             "tsConfig": "projects/utils/tsconfig.lib.json",
             "project": "projects/utils/ng-package.json"


### PR DESCRIPTION
### Description

Resolves #16334 (write the related issue number if available)
@angular-devkit/build-angular:ng-packagr are deprecated.  it changed with `@angular-devkit/build-angular:ng-packagr` .We already removed on packages but we forgotted the abp add-module command and docs.

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?
- Create a project with abp cli 
- run add module command.
Added module's builder should be `@angular-devkit/build-angular:ng-packagr`