### PR TITLE
cms-kit - emoji problem in different browsers and mobile

### DIFF
--- a/modules/cms-kit/src/Volo.CmsKit.Public.Web/Pages/CmsKit/Shared/Components/ReactionSelection/default.js
+++ b/modules/cms-kit/src/Volo.CmsKit.Public.Web/Pages/CmsKit/Shared/Components/ReactionSelection/default.js
@@ -60,7 +60,7 @@ $(document).ready(function () {
             $selectIcon.popover({
                 placement: 'left',
                 html: true,
-                trigger: 'focus',
+                trigger: 'click',
                 title: l('PickYourReaction'),
                 content: $popoverContent.html()
             }).on('shown.bs.popover', function () {


### PR DESCRIPTION
Emojis were not working in mobile browsers and different desktop browsers (safari etc.). The reason is that we use `trigger: 'focus'` instead of `trigger: 'click'` would be more accurate.