### PR TITLE
Use `EphemeralMongo` to replace `Mongo2Go`.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -49,15 +49,19 @@ jobs:
       with:
         dotnet-version: 7.0.100
 
+    - name: chown
+      run: |
+        sudo chown -R $USER:$USER /home/runneradmin
+
     - name: Build All
-      run: .\build-all.ps1 -f
-      working-directory: .\build
-      shell: powershell
+      run: ./build-all.ps1
+      working-directory: ./build
+      shell: pwsh
 
     - name: Test All
-      run: .\test-all.ps1 -f
-      working-directory: .\build
-      shell: powershell
+      run: ./test-all.ps1
+      working-directory: ./build
+      shell: pwsh
 
     - name: Codecov
       uses: codecov/codecov-action@v2

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -41,7 +41,7 @@ permissions:
 
 jobs:
   build-test:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft }}
     steps:
     - uses: actions/checkout@v2

--- a/framework/src/Volo.Abp.MongoDB/Volo.Abp.MongoDB.csproj
+++ b/framework/src/Volo.Abp.MongoDB/Volo.Abp.MongoDB.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" Version="2.15.1" />
+    <PackageReference Include="MongoDB.Driver" Version="2.19.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/framework/test/Volo.Abp.MongoDB.Tests/Volo.Abp.MongoDB.Tests.csproj
+++ b/framework/test/Volo.Abp.MongoDB.Tests/Volo.Abp.MongoDB.Tests.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mongo2Go" Version="$(Mongo2GoPackageVersion)" />
+    <PackageReference Include="EphemeralMongo6" Version="1.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
   </ItemGroup>
 

--- a/framework/test/Volo.Abp.MongoDB.Tests/Volo.Abp.MongoDB.Tests.csproj
+++ b/framework/test/Volo.Abp.MongoDB.Tests/Volo.Abp.MongoDB.Tests.csproj
@@ -15,10 +15,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="EphemeralMongo.Core" Version="1.0.0" />
-    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
-    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
-    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
+    <PackageReference Include="EphemeralMongo.Core" Version="1.1.0" />
+    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
   </ItemGroup>
 

--- a/framework/test/Volo.Abp.MongoDB.Tests/Volo.Abp.MongoDB.Tests.csproj
+++ b/framework/test/Volo.Abp.MongoDB.Tests/Volo.Abp.MongoDB.Tests.csproj
@@ -15,7 +15,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="EphemeralMongo6" Version="1.1.0" />
+    <PackageReference Include="EphemeralMongo.Core" Version="1.0.0" />
+    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
   </ItemGroup>
 

--- a/framework/test/Volo.Abp.MongoDB.Tests/Volo/Abp/MongoDB/AbpMongoDbTestModule.cs
+++ b/framework/test/Volo.Abp.MongoDB.Tests/Volo/Abp/MongoDB/AbpMongoDbTestModule.cs
@@ -21,14 +21,9 @@ public class AbpMongoDbTestModule : AbpModule
 {
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        var stringArray = MongoDbFixture.ConnectionString.Split('?');
-        var connectionString = stringArray[0].EnsureEndsWith('/') +
-                                   "Db_" +
-                               Guid.NewGuid().ToString("N") + "/?" + stringArray[1];
-
         Configure<AbpDbConnectionOptions>(options =>
         {
-            options.ConnectionStrings.Default = connectionString;
+            options.ConnectionStrings.Default = MongoDbFixture.GetRandomConnectionString();
         });
 
         context.Services.AddMongoDbContext<TestAppMongoDbContext>(options =>

--- a/framework/test/Volo.Abp.MongoDB.Tests/Volo/Abp/MongoDB/MongoDbFixture.cs
+++ b/framework/test/Volo.Abp.MongoDB.Tests/Volo/Abp/MongoDB/MongoDbFixture.cs
@@ -1,17 +1,31 @@
 using System;
-using Mongo2Go;
+using EphemeralMongo;
 
 namespace Volo.Abp.MongoDB;
 
 public class MongoDbFixture : IDisposable
 {
-    private static readonly MongoDbRunner MongoDbRunner;
-    public static readonly string ConnectionString;
+    public readonly static IMongoRunner MongoDbRunner;
 
     static MongoDbFixture()
     {
-        MongoDbRunner = MongoDbRunner.Start(singleNodeReplSet: true, singleNodeReplSetWaitTimeout: 20);
-        ConnectionString = MongoDbRunner.ConnectionString;
+        MongoDbRunner = MongoRunner.Run(new MongoRunnerOptions
+        {
+            UseSingleNodeReplicaSet = true,
+            KillMongoProcessesWhenCurrentProcessExits = true
+        });
+    }
+
+    public static string GetRandomConnectionString()
+    {
+        return GetConnectionString("Db_" + Guid.NewGuid().ToString("N"));
+    }
+
+    public static string GetConnectionString(string databaseName)
+    {
+        var stringArray = MongoDbRunner.ConnectionString.Split('?');
+        var connectionString = stringArray[0].EnsureEndsWith('/') + databaseName + "/?" + stringArray[1];
+        return connectionString;
     }
 
     public void Dispose()

--- a/framework/test/Volo.Abp.MongoDB.Tests/Volo/Abp/MongoDB/MongoDbFixture.cs
+++ b/framework/test/Volo.Abp.MongoDB.Tests/Volo/Abp/MongoDB/MongoDbFixture.cs
@@ -11,8 +11,7 @@ public class MongoDbFixture : IDisposable
     {
         MongoDbRunner = MongoRunner.Run(new MongoRunnerOptions
         {
-            UseSingleNodeReplicaSet = true,
-            KillMongoProcessesWhenCurrentProcessExits = true
+            UseSingleNodeReplicaSet = true
         });
     }
 

--- a/framework/test/Volo.Abp.MongoDB.Tests/Volo/Abp/MongoDB/Transactions/Transaction_Tests.cs
+++ b/framework/test/Volo.Abp.MongoDB.Tests/Volo/Abp/MongoDB/Transactions/Transaction_Tests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace Volo.Abp.MongoDB.Transactions;
 
+[Collection(MongoTestCollection.Name)]
 public class Transaction_Tests : TestAppTestBase<AbpMongoDbTestModule>
 {
     private readonly IBasicRepository<Person, Guid> _personRepository;

--- a/modules/audit-logging/src/Volo.Abp.AuditLogging.MongoDB/Volo/Abp/AuditLogging/MongoDB/MongoAuditLogRepository.cs
+++ b/modules/audit-logging/src/Volo.Abp.AuditLogging.MongoDB/Volo/Abp/AuditLogging/MongoDB/MongoAuditLogRepository.cs
@@ -262,7 +262,7 @@ public class MongoAuditLogRepository : MongoDbRepository<IAuditLoggingMongoDbCon
                 .WhereIf(auditLogId.HasValue, e => e.Id == auditLogId)
                 .WhereIf(startTime.HasValue, e => e.ChangeTime >= startTime)
                 .WhereIf(endTime.HasValue, e => e.ChangeTime <= endTime)
-                .WhereIf(changeType.HasValue, e => e.ChangeType == changeType)
+                .WhereIf(changeType.HasValue, e => e.ChangeType == changeType.Value)
                 .WhereIf(!string.IsNullOrWhiteSpace(entityId), e => e.EntityId == entityId)
                 .WhereIf(!string.IsNullOrWhiteSpace(entityTypeFullName),
                     e => e.EntityTypeFullName.Contains(entityTypeFullName));

--- a/modules/audit-logging/test/Volo.Abp.AuditLogging.MongoDB.Tests/Volo.Abp.AuditLogging.MongoDB.Tests.csproj
+++ b/modules/audit-logging/test/Volo.Abp.AuditLogging.MongoDB.Tests/Volo.Abp.AuditLogging.MongoDB.Tests.csproj
@@ -14,10 +14,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="EphemeralMongo.Core" Version="1.0.0" />
-    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
-    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
-    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
+    <PackageReference Include="EphemeralMongo.Core" Version="1.1.0" />
+    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
   </ItemGroup>
 
 </Project>

--- a/modules/audit-logging/test/Volo.Abp.AuditLogging.MongoDB.Tests/Volo.Abp.AuditLogging.MongoDB.Tests.csproj
+++ b/modules/audit-logging/test/Volo.Abp.AuditLogging.MongoDB.Tests/Volo.Abp.AuditLogging.MongoDB.Tests.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="Mongo2Go" Version="$(Mongo2GoPackageVersion)" />
+    <PackageReference Include="EphemeralMongo6" Version="1.1.0" />
   </ItemGroup>
 
 </Project>

--- a/modules/audit-logging/test/Volo.Abp.AuditLogging.MongoDB.Tests/Volo.Abp.AuditLogging.MongoDB.Tests.csproj
+++ b/modules/audit-logging/test/Volo.Abp.AuditLogging.MongoDB.Tests/Volo.Abp.AuditLogging.MongoDB.Tests.csproj
@@ -14,7 +14,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="EphemeralMongo6" Version="1.1.0" />
+    <PackageReference Include="EphemeralMongo.Core" Version="1.0.0" />
+    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
   </ItemGroup>
 
 </Project>

--- a/modules/audit-logging/test/Volo.Abp.AuditLogging.MongoDB.Tests/Volo/Abp/AuditLogging/MongoDB/AbpAuditLoggingMongoDbTestModule.cs
+++ b/modules/audit-logging/test/Volo.Abp.AuditLogging.MongoDB.Tests/Volo/Abp/AuditLogging/MongoDB/AbpAuditLoggingMongoDbTestModule.cs
@@ -13,14 +13,9 @@ public class AbpAuditLoggingMongoDbTestModule : AbpModule
 {
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        var stringArray = MongoDbFixture.ConnectionString.Split('?');
-        var connectionString = stringArray[0].EnsureEndsWith('/') +
-                                   "Db_" +
-                               Guid.NewGuid().ToString("N") + "/?" + stringArray[1];
-
         Configure<AbpDbConnectionOptions>(options =>
         {
-            options.ConnectionStrings.Default = connectionString;
+            options.ConnectionStrings.Default = MongoDbFixture.GetRandomConnectionString();
         });
     }
 }

--- a/modules/audit-logging/test/Volo.Abp.AuditLogging.MongoDB.Tests/Volo/Abp/AuditLogging/MongoDB/MongoDbFixture.cs
+++ b/modules/audit-logging/test/Volo.Abp.AuditLogging.MongoDB.Tests/Volo/Abp/AuditLogging/MongoDB/MongoDbFixture.cs
@@ -1,17 +1,31 @@
 using System;
-using Mongo2Go;
+using EphemeralMongo;
 
 namespace Volo.Abp.AuditLogging.MongoDB;
 
 public class MongoDbFixture : IDisposable
 {
-    private static readonly MongoDbRunner MongoDbRunner;
-    public static readonly string ConnectionString;
+    public readonly static IMongoRunner MongoDbRunner;
 
     static MongoDbFixture()
     {
-        MongoDbRunner = MongoDbRunner.Start(singleNodeReplSet: true, singleNodeReplSetWaitTimeout: 20);
-        ConnectionString = MongoDbRunner.ConnectionString;
+        MongoDbRunner = MongoRunner.Run(new MongoRunnerOptions
+        {
+            UseSingleNodeReplicaSet = true,
+            KillMongoProcessesWhenCurrentProcessExits = true
+        });
+    }
+
+    public static string GetRandomConnectionString()
+    {
+        return GetConnectionString("Db_" + Guid.NewGuid().ToString("N"));
+    }
+
+    public static string GetConnectionString(string databaseName)
+    {
+        var stringArray = MongoDbRunner.ConnectionString.Split('?');
+        var connectionString = stringArray[0].EnsureEndsWith('/') + databaseName + "/?" + stringArray[1];
+        return connectionString;
     }
 
     public void Dispose()

--- a/modules/audit-logging/test/Volo.Abp.AuditLogging.MongoDB.Tests/Volo/Abp/AuditLogging/MongoDB/MongoDbFixture.cs
+++ b/modules/audit-logging/test/Volo.Abp.AuditLogging.MongoDB.Tests/Volo/Abp/AuditLogging/MongoDB/MongoDbFixture.cs
@@ -11,8 +11,7 @@ public class MongoDbFixture : IDisposable
     {
         MongoDbRunner = MongoRunner.Run(new MongoRunnerOptions
         {
-            UseSingleNodeReplicaSet = true,
-            KillMongoProcessesWhenCurrentProcessExits = true
+            UseSingleNodeReplicaSet = true
         });
     }
 

--- a/modules/background-jobs/test/Volo.Abp.BackgroundJobs.MongoDB.Tests/Volo.Abp.BackgroundJobs.MongoDB.Tests.csproj
+++ b/modules/background-jobs/test/Volo.Abp.BackgroundJobs.MongoDB.Tests/Volo.Abp.BackgroundJobs.MongoDB.Tests.csproj
@@ -14,10 +14,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="EphemeralMongo.Core" Version="1.0.0" />
-    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
-    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
-    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
+    <PackageReference Include="EphemeralMongo.Core" Version="1.1.0" />
+    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
   </ItemGroup>
 
 </Project>

--- a/modules/background-jobs/test/Volo.Abp.BackgroundJobs.MongoDB.Tests/Volo.Abp.BackgroundJobs.MongoDB.Tests.csproj
+++ b/modules/background-jobs/test/Volo.Abp.BackgroundJobs.MongoDB.Tests/Volo.Abp.BackgroundJobs.MongoDB.Tests.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="Mongo2Go" Version="$(Mongo2GoPackageVersion)" />
+    <PackageReference Include="EphemeralMongo6" Version="1.1.0" />
   </ItemGroup>
 
 </Project>

--- a/modules/background-jobs/test/Volo.Abp.BackgroundJobs.MongoDB.Tests/Volo.Abp.BackgroundJobs.MongoDB.Tests.csproj
+++ b/modules/background-jobs/test/Volo.Abp.BackgroundJobs.MongoDB.Tests/Volo.Abp.BackgroundJobs.MongoDB.Tests.csproj
@@ -14,7 +14,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="EphemeralMongo6" Version="1.1.0" />
+    <PackageReference Include="EphemeralMongo.Core" Version="1.0.0" />
+    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
   </ItemGroup>
 
 </Project>

--- a/modules/background-jobs/test/Volo.Abp.BackgroundJobs.MongoDB.Tests/Volo/Abp/BackgroundJobs/MongoDB/AbpBackgroundJobsMongoDbTestModule.cs
+++ b/modules/background-jobs/test/Volo.Abp.BackgroundJobs.MongoDB.Tests/Volo/Abp/BackgroundJobs/MongoDB/AbpBackgroundJobsMongoDbTestModule.cs
@@ -13,14 +13,9 @@ public class AbpBackgroundJobsMongoDbTestModule : AbpModule
 {
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        var stringArray = MongoDbFixture.ConnectionString.Split('?');
-        var connectionString = stringArray[0].EnsureEndsWith('/') +
-                                   "Db_" +
-                               Guid.NewGuid().ToString("N") + "/?" + stringArray[1];
-
         Configure<AbpDbConnectionOptions>(options =>
         {
-            options.ConnectionStrings.Default = connectionString;
+            options.ConnectionStrings.Default = MongoDbFixture.GetRandomConnectionString();
         });
     }
 }

--- a/modules/background-jobs/test/Volo.Abp.BackgroundJobs.MongoDB.Tests/Volo/Abp/BackgroundJobs/MongoDB/MongoDbFixture.cs
+++ b/modules/background-jobs/test/Volo.Abp.BackgroundJobs.MongoDB.Tests/Volo/Abp/BackgroundJobs/MongoDB/MongoDbFixture.cs
@@ -11,8 +11,7 @@ public class MongoDbFixture : IDisposable
     {
         MongoDbRunner = MongoRunner.Run(new MongoRunnerOptions
         {
-            UseSingleNodeReplicaSet = true,
-            KillMongoProcessesWhenCurrentProcessExits = true
+            UseSingleNodeReplicaSet = true
         });
     }
 

--- a/modules/background-jobs/test/Volo.Abp.BackgroundJobs.MongoDB.Tests/Volo/Abp/BackgroundJobs/MongoDB/MongoDbFixture.cs
+++ b/modules/background-jobs/test/Volo.Abp.BackgroundJobs.MongoDB.Tests/Volo/Abp/BackgroundJobs/MongoDB/MongoDbFixture.cs
@@ -1,17 +1,31 @@
 using System;
-using Mongo2Go;
+using EphemeralMongo;
 
 namespace Volo.Abp.BackgroundJobs.MongoDB;
 
 public class MongoDbFixture : IDisposable
 {
-    private static readonly MongoDbRunner MongoDbRunner;
-    public static readonly string ConnectionString;
+    public readonly static IMongoRunner MongoDbRunner;
 
     static MongoDbFixture()
     {
-        MongoDbRunner = MongoDbRunner.Start(singleNodeReplSet: true, singleNodeReplSetWaitTimeout: 20);
-        ConnectionString = MongoDbRunner.ConnectionString;
+        MongoDbRunner = MongoRunner.Run(new MongoRunnerOptions
+        {
+            UseSingleNodeReplicaSet = true,
+            KillMongoProcessesWhenCurrentProcessExits = true
+        });
+    }
+
+    public static string GetRandomConnectionString()
+    {
+        return GetConnectionString("Db_" + Guid.NewGuid().ToString("N"));
+    }
+
+    public static string GetConnectionString(string databaseName)
+    {
+        var stringArray = MongoDbRunner.ConnectionString.Split('?');
+        var connectionString = stringArray[0].EnsureEndsWith('/') + databaseName + "/?" + stringArray[1];
+        return connectionString;
     }
 
     public void Dispose()

--- a/modules/blob-storing-database/test/Volo.Abp.BlobStoring.Database.MongoDB.Tests/MongoDB/BlobStoringDatabaseMongoDbTestModule.cs
+++ b/modules/blob-storing-database/test/Volo.Abp.BlobStoring.Database.MongoDB.Tests/MongoDB/BlobStoringDatabaseMongoDbTestModule.cs
@@ -13,14 +13,9 @@ public class BlobStoringDatabaseMongoDbTestModule : AbpModule
 {
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        var stringArray = MongoDbFixture.ConnectionString.Split('?');
-        var connectionString = stringArray[0].EnsureEndsWith('/') +
-                                   "Db_" +
-                               Guid.NewGuid().ToString("N") + "/?" + stringArray[1];
-
         Configure<AbpDbConnectionOptions>(options =>
         {
-            options.ConnectionStrings.Default = connectionString;
+            options.ConnectionStrings.Default = MongoDbFixture.GetRandomConnectionString();
         });
     }
 }

--- a/modules/blob-storing-database/test/Volo.Abp.BlobStoring.Database.MongoDB.Tests/MongoDB/MongoDbFixture.cs
+++ b/modules/blob-storing-database/test/Volo.Abp.BlobStoring.Database.MongoDB.Tests/MongoDB/MongoDbFixture.cs
@@ -11,8 +11,7 @@ public class MongoDbFixture : IDisposable
     {
         MongoDbRunner = MongoRunner.Run(new MongoRunnerOptions
         {
-            UseSingleNodeReplicaSet = true,
-            KillMongoProcessesWhenCurrentProcessExits = true
+            UseSingleNodeReplicaSet = true
         });
     }
 

--- a/modules/blob-storing-database/test/Volo.Abp.BlobStoring.Database.MongoDB.Tests/MongoDB/MongoDbFixture.cs
+++ b/modules/blob-storing-database/test/Volo.Abp.BlobStoring.Database.MongoDB.Tests/MongoDB/MongoDbFixture.cs
@@ -1,17 +1,31 @@
 using System;
-using Mongo2Go;
+using EphemeralMongo;
 
 namespace Volo.Abp.BlobStoring.Database.MongoDB;
 
 public class MongoDbFixture : IDisposable
 {
-    private static readonly MongoDbRunner MongoDbRunner;
-    public static readonly string ConnectionString;
+    public readonly static IMongoRunner MongoDbRunner;
 
     static MongoDbFixture()
     {
-        MongoDbRunner = MongoDbRunner.Start(singleNodeReplSet: true, singleNodeReplSetWaitTimeout: 20);
-        ConnectionString = MongoDbRunner.ConnectionString;
+        MongoDbRunner = MongoRunner.Run(new MongoRunnerOptions
+        {
+            UseSingleNodeReplicaSet = true,
+            KillMongoProcessesWhenCurrentProcessExits = true
+        });
+    }
+
+    public static string GetRandomConnectionString()
+    {
+        return GetConnectionString("Db_" + Guid.NewGuid().ToString("N"));
+    }
+
+    public static string GetConnectionString(string databaseName)
+    {
+        var stringArray = MongoDbRunner.ConnectionString.Split('?');
+        var connectionString = stringArray[0].EnsureEndsWith('/') + databaseName + "/?" + stringArray[1];
+        return connectionString;
     }
 
     public void Dispose()

--- a/modules/blob-storing-database/test/Volo.Abp.BlobStoring.Database.MongoDB.Tests/Volo.Abp.BlobStoring.Database.MongoDB.Tests.csproj
+++ b/modules/blob-storing-database/test/Volo.Abp.BlobStoring.Database.MongoDB.Tests/Volo.Abp.BlobStoring.Database.MongoDB.Tests.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="Mongo2Go" Version="$(Mongo2GoPackageVersion)" />
+    <PackageReference Include="EphemeralMongo6" Version="1.1.0" />
     <ProjectReference Include="..\..\src\Volo.Abp.BlobStoring.Database.MongoDB\Volo.Abp.BlobStoring.Database.MongoDB.csproj" />
     <ProjectReference Include="..\Volo.Abp.BlobStoring.Database.TestBase\Volo.Abp.BlobStoring.Database.TestBase.csproj" />
   </ItemGroup>

--- a/modules/blob-storing-database/test/Volo.Abp.BlobStoring.Database.MongoDB.Tests/Volo.Abp.BlobStoring.Database.MongoDB.Tests.csproj
+++ b/modules/blob-storing-database/test/Volo.Abp.BlobStoring.Database.MongoDB.Tests/Volo.Abp.BlobStoring.Database.MongoDB.Tests.csproj
@@ -7,7 +7,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="EphemeralMongo6" Version="1.1.0" />
+    <PackageReference Include="EphemeralMongo.Core" Version="1.0.0" />
+    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
     <ProjectReference Include="..\..\src\Volo.Abp.BlobStoring.Database.MongoDB\Volo.Abp.BlobStoring.Database.MongoDB.csproj" />
     <ProjectReference Include="..\Volo.Abp.BlobStoring.Database.TestBase\Volo.Abp.BlobStoring.Database.TestBase.csproj" />
   </ItemGroup>

--- a/modules/blob-storing-database/test/Volo.Abp.BlobStoring.Database.MongoDB.Tests/Volo.Abp.BlobStoring.Database.MongoDB.Tests.csproj
+++ b/modules/blob-storing-database/test/Volo.Abp.BlobStoring.Database.MongoDB.Tests/Volo.Abp.BlobStoring.Database.MongoDB.Tests.csproj
@@ -7,10 +7,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="EphemeralMongo.Core" Version="1.0.0" />
-    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
-    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
-    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
+    <PackageReference Include="EphemeralMongo.Core" Version="1.1.0" />
+    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
     <ProjectReference Include="..\..\src\Volo.Abp.BlobStoring.Database.MongoDB\Volo.Abp.BlobStoring.Database.MongoDB.csproj" />
     <ProjectReference Include="..\Volo.Abp.BlobStoring.Database.TestBase\Volo.Abp.BlobStoring.Database.TestBase.csproj" />
   </ItemGroup>

--- a/modules/blogging/test/Volo.Blogging.MongoDB.Tests/Volo.Blogging.MongoDB.Tests.csproj
+++ b/modules/blogging/test/Volo.Blogging.MongoDB.Tests/Volo.Blogging.MongoDB.Tests.csproj
@@ -7,10 +7,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="EphemeralMongo.Core" Version="1.0.0" />
-    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
-    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
-    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
+    <PackageReference Include="EphemeralMongo.Core" Version="1.1.0" />
+    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
     <ProjectReference Include="..\..\src\Volo.Blogging.MongoDB\Volo.Blogging.MongoDB.csproj" />
     <ProjectReference Include="..\Volo.Blogging.TestBase\Volo.Blogging.TestBase.csproj" />
   </ItemGroup>

--- a/modules/blogging/test/Volo.Blogging.MongoDB.Tests/Volo.Blogging.MongoDB.Tests.csproj
+++ b/modules/blogging/test/Volo.Blogging.MongoDB.Tests/Volo.Blogging.MongoDB.Tests.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="Mongo2Go" Version="$(Mongo2GoPackageVersion)" />
+    <PackageReference Include="EphemeralMongo6" Version="1.1.0" />
     <ProjectReference Include="..\..\src\Volo.Blogging.MongoDB\Volo.Blogging.MongoDB.csproj" />
     <ProjectReference Include="..\Volo.Blogging.TestBase\Volo.Blogging.TestBase.csproj" />
   </ItemGroup>

--- a/modules/blogging/test/Volo.Blogging.MongoDB.Tests/Volo.Blogging.MongoDB.Tests.csproj
+++ b/modules/blogging/test/Volo.Blogging.MongoDB.Tests/Volo.Blogging.MongoDB.Tests.csproj
@@ -7,7 +7,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="EphemeralMongo6" Version="1.1.0" />
+    <PackageReference Include="EphemeralMongo.Core" Version="1.0.0" />
+    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
     <ProjectReference Include="..\..\src\Volo.Blogging.MongoDB\Volo.Blogging.MongoDB.csproj" />
     <ProjectReference Include="..\Volo.Blogging.TestBase\Volo.Blogging.TestBase.csproj" />
   </ItemGroup>

--- a/modules/blogging/test/Volo.Blogging.MongoDB.Tests/Volo/Blogging/MongoDB/BloggingMongoDBTestModule.cs
+++ b/modules/blogging/test/Volo.Blogging.MongoDB.Tests/Volo/Blogging/MongoDB/BloggingMongoDBTestModule.cs
@@ -13,14 +13,9 @@ namespace Volo.Blogging.MongoDB
     {
         public override void ConfigureServices(ServiceConfigurationContext context)
         {
-            var stringArray = MongoDbFixture.ConnectionString.Split('?');
-            var connectionString = stringArray[0].EnsureEndsWith('/')  +
-                                       "Db_" +
-                                   Guid.NewGuid().ToString("N") + "/?" + stringArray[1];
-
             Configure<AbpDbConnectionOptions>(options =>
             {
-                options.ConnectionStrings.Default = connectionString;
+                options.ConnectionStrings.Default = MongoDbFixture.GetRandomConnectionString();
             });
         }
     }

--- a/modules/blogging/test/Volo.Blogging.MongoDB.Tests/Volo/Blogging/MongoDB/MongoDbFixture.cs
+++ b/modules/blogging/test/Volo.Blogging.MongoDB.Tests/Volo/Blogging/MongoDB/MongoDbFixture.cs
@@ -1,22 +1,33 @@
 using System;
-using Mongo2Go;
+using EphemeralMongo;
 
-namespace Volo.Blogging.MongoDB
+public class MongoDbFixture : IDisposable
 {
-    public class MongoDbFixture : IDisposable
+    public readonly static IMongoRunner MongoDbRunner;
+
+    static MongoDbFixture()
     {
-        private static readonly MongoDbRunner MongoDbRunner;
-        public static readonly string ConnectionString;
-
-        static MongoDbFixture()
+        MongoDbRunner = MongoRunner.Run(new MongoRunnerOptions
         {
-            MongoDbRunner = MongoDbRunner.Start(singleNodeReplSet: true, singleNodeReplSetWaitTimeout: 20);
-            ConnectionString = MongoDbRunner.ConnectionString;
-        }
+            UseSingleNodeReplicaSet = true,
+            KillMongoProcessesWhenCurrentProcessExits = true
+        });
+    }
 
-        public void Dispose()
-        {
-            MongoDbRunner?.Dispose();
-        }
+    public static string GetRandomConnectionString()
+    {
+        return GetConnectionString("Db_" + Guid.NewGuid().ToString("N"));
+    }
+
+    public static string GetConnectionString(string databaseName)
+    {
+        var stringArray = MongoDbRunner.ConnectionString.Split('?');
+        var connectionString = stringArray[0].EnsureEndsWith('/') + databaseName + "/?" + stringArray[1];
+        return connectionString;
+    }
+
+    public void Dispose()
+    {
+        MongoDbRunner?.Dispose();
     }
 }

--- a/modules/blogging/test/Volo.Blogging.MongoDB.Tests/Volo/Blogging/MongoDB/MongoDbFixture.cs
+++ b/modules/blogging/test/Volo.Blogging.MongoDB.Tests/Volo/Blogging/MongoDB/MongoDbFixture.cs
@@ -9,8 +9,7 @@ public class MongoDbFixture : IDisposable
     {
         MongoDbRunner = MongoRunner.Run(new MongoRunnerOptions
         {
-            UseSingleNodeReplicaSet = true,
-            KillMongoProcessesWhenCurrentProcessExits = true
+            UseSingleNodeReplicaSet = true
         });
     }
 

--- a/modules/cms-kit/src/Volo.CmsKit.MongoDB/Volo/CmsKit/MongoDB/Pages/MongoPageRepository.cs
+++ b/modules/cms-kit/src/Volo.CmsKit.MongoDB/Volo/CmsKit/MongoDB/Pages/MongoPageRepository.cs
@@ -30,7 +30,7 @@ public class MongoPageRepository : MongoDbRepository<ICmsKitMongoDbContext, Page
             .WhereIf<Page, IMongoQueryable<Page>>(
                 !filter.IsNullOrWhiteSpace(),
                 u =>
-                    u.Title.ToLower().Contains(filter) || u.Slug.Contains(filter)
+                    u.Title.ToLower().Contains(filter.ToLower()) || u.Slug.Contains(filter)
             ).CountAsync(cancellation);
     }
 

--- a/modules/cms-kit/src/Volo.CmsKit.MongoDB/Volo/CmsKit/MongoDB/Tags/MongoTagRepository.cs
+++ b/modules/cms-kit/src/Volo.CmsKit.MongoDB/Volo/CmsKit/MongoDB/Tags/MongoTagRepository.cs
@@ -99,7 +99,7 @@ public class MongoTagRepository : MongoDbRepository<ICmsKitMongoDbContext, Volo.
         if (!filter.IsNullOrWhiteSpace())
         {
             mongoQueryable = mongoQueryable.Where(x =>
-                    x.Name.ToLower().Contains(filter) ||
+                    x.Name.ToLower().Contains(filter.ToLower()) ||
                     x.EntityType.ToLower().Contains(filter));
         }
 

--- a/modules/cms-kit/test/Volo.CmsKit.MongoDB.Tests/MongoDB/CmsKitMongoDbTestModule.cs
+++ b/modules/cms-kit/test/Volo.CmsKit.MongoDB.Tests/MongoDB/CmsKitMongoDbTestModule.cs
@@ -13,14 +13,9 @@ public class CmsKitMongoDbTestModule : AbpModule
 {
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        var stringArray = MongoDbFixture.ConnectionString.Split('?');
-        var connectionString = stringArray[0].EnsureEndsWith('/') +
-                                   "Db_" +
-                               Guid.NewGuid().ToString("N") + "/?" + stringArray[1];
-
         Configure<AbpDbConnectionOptions>(options =>
         {
-            options.ConnectionStrings.Default = connectionString;
+            options.ConnectionStrings.Default = MongoDbFixture.GetRandomConnectionString();
         });
     }
 }

--- a/modules/cms-kit/test/Volo.CmsKit.MongoDB.Tests/MongoDB/MongoDbFixture.cs
+++ b/modules/cms-kit/test/Volo.CmsKit.MongoDB.Tests/MongoDB/MongoDbFixture.cs
@@ -11,8 +11,7 @@ public class MongoDbFixture : IDisposable
     {
         MongoDbRunner = MongoRunner.Run(new MongoRunnerOptions
         {
-            UseSingleNodeReplicaSet = true,
-            KillMongoProcessesWhenCurrentProcessExits = true
+            UseSingleNodeReplicaSet = true
         });
     }
 

--- a/modules/cms-kit/test/Volo.CmsKit.MongoDB.Tests/MongoDB/MongoDbFixture.cs
+++ b/modules/cms-kit/test/Volo.CmsKit.MongoDB.Tests/MongoDB/MongoDbFixture.cs
@@ -1,17 +1,31 @@
 using System;
-using Mongo2Go;
+using EphemeralMongo;
 
 namespace Volo.CmsKit.MongoDB;
 
 public class MongoDbFixture : IDisposable
 {
-    private static readonly MongoDbRunner MongoDbRunner;
-    public static readonly string ConnectionString;
+    public readonly static IMongoRunner MongoDbRunner;
 
     static MongoDbFixture()
     {
-        MongoDbRunner = MongoDbRunner.Start(singleNodeReplSet: true, singleNodeReplSetWaitTimeout: 20);
-        ConnectionString = MongoDbRunner.ConnectionString;
+        MongoDbRunner = MongoRunner.Run(new MongoRunnerOptions
+        {
+            UseSingleNodeReplicaSet = true,
+            KillMongoProcessesWhenCurrentProcessExits = true
+        });
+    }
+
+    public static string GetRandomConnectionString()
+    {
+        return GetConnectionString("Db_" + Guid.NewGuid().ToString("N"));
+    }
+
+    public static string GetConnectionString(string databaseName)
+    {
+        var stringArray = MongoDbRunner.ConnectionString.Split('?');
+        var connectionString = stringArray[0].EnsureEndsWith('/') + databaseName + "/?" + stringArray[1];
+        return connectionString;
     }
 
     public void Dispose()

--- a/modules/cms-kit/test/Volo.CmsKit.MongoDB.Tests/Volo.CmsKit.MongoDB.Tests.csproj
+++ b/modules/cms-kit/test/Volo.CmsKit.MongoDB.Tests/Volo.CmsKit.MongoDB.Tests.csproj
@@ -7,10 +7,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="EphemeralMongo.Core" Version="1.0.0" />
-    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
-    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
-    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
+    <PackageReference Include="EphemeralMongo.Core" Version="1.1.0" />
+    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
     <ProjectReference Include="..\..\src\Volo.CmsKit.MongoDB\Volo.CmsKit.MongoDB.csproj" />
     <ProjectReference Include="..\Volo.CmsKit.TestBase\Volo.CmsKit.TestBase.csproj" />
   </ItemGroup>

--- a/modules/cms-kit/test/Volo.CmsKit.MongoDB.Tests/Volo.CmsKit.MongoDB.Tests.csproj
+++ b/modules/cms-kit/test/Volo.CmsKit.MongoDB.Tests/Volo.CmsKit.MongoDB.Tests.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="Mongo2Go" Version="$(Mongo2GoPackageVersion)" />
+    <PackageReference Include="EphemeralMongo6" Version="1.1.0" />
     <ProjectReference Include="..\..\src\Volo.CmsKit.MongoDB\Volo.CmsKit.MongoDB.csproj" />
     <ProjectReference Include="..\Volo.CmsKit.TestBase\Volo.CmsKit.TestBase.csproj" />
   </ItemGroup>

--- a/modules/cms-kit/test/Volo.CmsKit.MongoDB.Tests/Volo.CmsKit.MongoDB.Tests.csproj
+++ b/modules/cms-kit/test/Volo.CmsKit.MongoDB.Tests/Volo.CmsKit.MongoDB.Tests.csproj
@@ -7,7 +7,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="EphemeralMongo6" Version="1.1.0" />
+    <PackageReference Include="EphemeralMongo.Core" Version="1.0.0" />
+    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
     <ProjectReference Include="..\..\src\Volo.CmsKit.MongoDB\Volo.CmsKit.MongoDB.csproj" />
     <ProjectReference Include="..\Volo.CmsKit.TestBase\Volo.CmsKit.TestBase.csproj" />
   </ItemGroup>

--- a/modules/docs/test/Volo.Docs.MongoDB.Tests/Volo.Docs.MongoDB.Tests.csproj
+++ b/modules/docs/test/Volo.Docs.MongoDB.Tests/Volo.Docs.MongoDB.Tests.csproj
@@ -7,7 +7,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="EphemeralMongo6" Version="1.1.0" />
+    <PackageReference Include="EphemeralMongo.Core" Version="1.0.0" />
+    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/modules/docs/test/Volo.Docs.MongoDB.Tests/Volo.Docs.MongoDB.Tests.csproj
+++ b/modules/docs/test/Volo.Docs.MongoDB.Tests/Volo.Docs.MongoDB.Tests.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="Mongo2Go" Version="$(Mongo2GoPackageVersion)" />
+    <PackageReference Include="EphemeralMongo6" Version="1.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/modules/docs/test/Volo.Docs.MongoDB.Tests/Volo.Docs.MongoDB.Tests.csproj
+++ b/modules/docs/test/Volo.Docs.MongoDB.Tests/Volo.Docs.MongoDB.Tests.csproj
@@ -7,10 +7,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="EphemeralMongo.Core" Version="1.0.0" />
-    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
-    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
-    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
+    <PackageReference Include="EphemeralMongo.Core" Version="1.1.0" />
+    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/modules/docs/test/Volo.Docs.MongoDB.Tests/Volo/Docs/MongoDB/DocsMongoDBTestModule.cs
+++ b/modules/docs/test/Volo.Docs.MongoDB.Tests/Volo/Docs/MongoDB/DocsMongoDBTestModule.cs
@@ -13,14 +13,9 @@ namespace Volo.Docs.MongoDB
     {
         public override void ConfigureServices(ServiceConfigurationContext context)
         {
-            var stringArray = MongoDbFixture.ConnectionString.Split('?');
-            var connectionString = stringArray[0].EnsureEndsWith('/')  +
-                                       "Db_" +
-                                   Guid.NewGuid().ToString("N") + "/?" + stringArray[1];
-
             Configure<AbpDbConnectionOptions>(options =>
             {
-                options.ConnectionStrings.Default = connectionString;
+                options.ConnectionStrings.Default = MongoDbFixture.GetRandomConnectionString();
             });
         }
     }

--- a/modules/docs/test/Volo.Docs.MongoDB.Tests/Volo/Docs/MongoDB/MongoDbFixture.cs
+++ b/modules/docs/test/Volo.Docs.MongoDB.Tests/Volo/Docs/MongoDB/MongoDbFixture.cs
@@ -9,8 +9,7 @@ public class MongoDbFixture : IDisposable
     {
         MongoDbRunner = MongoRunner.Run(new MongoRunnerOptions
         {
-            UseSingleNodeReplicaSet = true,
-            KillMongoProcessesWhenCurrentProcessExits = true
+            UseSingleNodeReplicaSet = true
         });
     }
 

--- a/modules/docs/test/Volo.Docs.MongoDB.Tests/Volo/Docs/MongoDB/MongoDbFixture.cs
+++ b/modules/docs/test/Volo.Docs.MongoDB.Tests/Volo/Docs/MongoDB/MongoDbFixture.cs
@@ -1,22 +1,33 @@
 using System;
-using Mongo2Go;
+using EphemeralMongo;
 
-namespace Volo.Docs.MongoDB
+public class MongoDbFixture : IDisposable
 {
-    public class MongoDbFixture : IDisposable
+    public readonly static IMongoRunner MongoDbRunner;
+
+    static MongoDbFixture()
     {
-        private static readonly MongoDbRunner MongoDbRunner;
-        public static readonly string ConnectionString;
-
-        static MongoDbFixture()
+        MongoDbRunner = MongoRunner.Run(new MongoRunnerOptions
         {
-            MongoDbRunner = MongoDbRunner.Start(singleNodeReplSet: true, singleNodeReplSetWaitTimeout: 20);
-            ConnectionString = MongoDbRunner.ConnectionString;
-        }
+            UseSingleNodeReplicaSet = true,
+            KillMongoProcessesWhenCurrentProcessExits = true
+        });
+    }
 
-        public void Dispose()
-        {
-            MongoDbRunner?.Dispose();
-        }
+    public static string GetRandomConnectionString()
+    {
+        return GetConnectionString("Db_" + Guid.NewGuid().ToString("N"));
+    }
+
+    public static string GetConnectionString(string databaseName)
+    {
+        var stringArray = MongoDbRunner.ConnectionString.Split('?');
+        var connectionString = stringArray[0].EnsureEndsWith('/') + databaseName + "/?" + stringArray[1];
+        return connectionString;
+    }
+
+    public void Dispose()
+    {
+        MongoDbRunner?.Dispose();
     }
 }

--- a/modules/feature-management/test/Volo.Abp.FeatureManagement.MongoDB.Tests/Volo.Abp.FeatureManagement.MongoDB.Tests.csproj
+++ b/modules/feature-management/test/Volo.Abp.FeatureManagement.MongoDB.Tests/Volo.Abp.FeatureManagement.MongoDB.Tests.csproj
@@ -14,10 +14,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="EphemeralMongo.Core" Version="1.0.0" />
-    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
-    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
-    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
+    <PackageReference Include="EphemeralMongo.Core" Version="1.1.0" />
+    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
   </ItemGroup>
 
 </Project>

--- a/modules/feature-management/test/Volo.Abp.FeatureManagement.MongoDB.Tests/Volo.Abp.FeatureManagement.MongoDB.Tests.csproj
+++ b/modules/feature-management/test/Volo.Abp.FeatureManagement.MongoDB.Tests/Volo.Abp.FeatureManagement.MongoDB.Tests.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="Mongo2Go" Version="$(Mongo2GoPackageVersion)" />
+    <PackageReference Include="EphemeralMongo6" Version="1.1.0" />
   </ItemGroup>
 
 </Project>

--- a/modules/feature-management/test/Volo.Abp.FeatureManagement.MongoDB.Tests/Volo.Abp.FeatureManagement.MongoDB.Tests.csproj
+++ b/modules/feature-management/test/Volo.Abp.FeatureManagement.MongoDB.Tests/Volo.Abp.FeatureManagement.MongoDB.Tests.csproj
@@ -14,7 +14,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="EphemeralMongo6" Version="1.1.0" />
+    <PackageReference Include="EphemeralMongo.Core" Version="1.0.0" />
+    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
   </ItemGroup>
 
 </Project>

--- a/modules/feature-management/test/Volo.Abp.FeatureManagement.MongoDB.Tests/Volo/Abp/FeatureManagement/MongoDB/AbpFeatureManagementMongoDbTestModule.cs
+++ b/modules/feature-management/test/Volo.Abp.FeatureManagement.MongoDB.Tests/Volo/Abp/FeatureManagement/MongoDB/AbpFeatureManagementMongoDbTestModule.cs
@@ -12,14 +12,10 @@ public class AbpFeatureManagementMongoDbTestModule : AbpModule
 {
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        var stringArray = MongoDbFixture.ConnectionString.Split('?');
-        var connectionString = stringArray[0].EnsureEndsWith('/') +
-                                   "Db_" +
-                               Guid.NewGuid().ToString("N") + "/?" + stringArray[1];
-
         Configure<AbpDbConnectionOptions>(options =>
         {
-            options.ConnectionStrings.Default = connectionString;
+            options.ConnectionStrings.Default = MongoDbFixture.GetRandomConnectionString();
         });
+
     }
 }

--- a/modules/feature-management/test/Volo.Abp.FeatureManagement.MongoDB.Tests/Volo/Abp/FeatureManagement/MongoDB/MongoDbFixture.cs
+++ b/modules/feature-management/test/Volo.Abp.FeatureManagement.MongoDB.Tests/Volo/Abp/FeatureManagement/MongoDB/MongoDbFixture.cs
@@ -1,17 +1,31 @@
 using System;
-using Mongo2Go;
+using EphemeralMongo;
 
 namespace Volo.Abp.FeatureManagement.MongoDB;
 
 public class MongoDbFixture : IDisposable
 {
-    private static readonly MongoDbRunner MongoDbRunner;
-    public static readonly string ConnectionString;
+    public readonly static IMongoRunner MongoDbRunner;
 
     static MongoDbFixture()
     {
-        MongoDbRunner = MongoDbRunner.Start(singleNodeReplSet: true, singleNodeReplSetWaitTimeout: 20);
-        ConnectionString = MongoDbRunner.ConnectionString;
+        MongoDbRunner = MongoRunner.Run(new MongoRunnerOptions
+        {
+            UseSingleNodeReplicaSet = true,
+            KillMongoProcessesWhenCurrentProcessExits = true
+        });
+    }
+
+    public static string GetRandomConnectionString()
+    {
+        return GetConnectionString("Db_" + Guid.NewGuid().ToString("N"));
+    }
+
+    public static string GetConnectionString(string databaseName)
+    {
+        var stringArray = MongoDbRunner.ConnectionString.Split('?');
+        var connectionString = stringArray[0].EnsureEndsWith('/') + databaseName + "/?" + stringArray[1];
+        return connectionString;
     }
 
     public void Dispose()

--- a/modules/feature-management/test/Volo.Abp.FeatureManagement.MongoDB.Tests/Volo/Abp/FeatureManagement/MongoDB/MongoDbFixture.cs
+++ b/modules/feature-management/test/Volo.Abp.FeatureManagement.MongoDB.Tests/Volo/Abp/FeatureManagement/MongoDB/MongoDbFixture.cs
@@ -11,8 +11,7 @@ public class MongoDbFixture : IDisposable
     {
         MongoDbRunner = MongoRunner.Run(new MongoRunnerOptions
         {
-            UseSingleNodeReplicaSet = true,
-            KillMongoProcessesWhenCurrentProcessExits = true
+            UseSingleNodeReplicaSet = true
         });
     }
 

--- a/modules/identity/test/Volo.Abp.Identity.MongoDB.Tests/Volo.Abp.Identity.MongoDB.Tests.csproj
+++ b/modules/identity/test/Volo.Abp.Identity.MongoDB.Tests/Volo.Abp.Identity.MongoDB.Tests.csproj
@@ -20,10 +20,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="EphemeralMongo.Core" Version="1.0.0" />
-    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
-    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
-    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
+    <PackageReference Include="EphemeralMongo.Core" Version="1.1.0" />
+    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
   </ItemGroup>
 
 </Project>

--- a/modules/identity/test/Volo.Abp.Identity.MongoDB.Tests/Volo.Abp.Identity.MongoDB.Tests.csproj
+++ b/modules/identity/test/Volo.Abp.Identity.MongoDB.Tests/Volo.Abp.Identity.MongoDB.Tests.csproj
@@ -20,7 +20,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="EphemeralMongo6" Version="1.1.0" />
+    <PackageReference Include="EphemeralMongo.Core" Version="1.0.0" />
+    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
   </ItemGroup>
 
 </Project>

--- a/modules/identity/test/Volo.Abp.Identity.MongoDB.Tests/Volo.Abp.Identity.MongoDB.Tests.csproj
+++ b/modules/identity/test/Volo.Abp.Identity.MongoDB.Tests/Volo.Abp.Identity.MongoDB.Tests.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="Mongo2Go" Version="$(Mongo2GoPackageVersion)" />
+    <PackageReference Include="EphemeralMongo6" Version="1.1.0" />
   </ItemGroup>
 
 </Project>

--- a/modules/identity/test/Volo.Abp.Identity.MongoDB.Tests/Volo/Abp/Identity/MongoDB/AbpIdentityMongoDbTestModule.cs
+++ b/modules/identity/test/Volo.Abp.Identity.MongoDB.Tests/Volo/Abp/Identity/MongoDB/AbpIdentityMongoDbTestModule.cs
@@ -15,14 +15,9 @@ public class AbpIdentityMongoDbTestModule : AbpModule
 {
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        var stringArray = MongoDbFixture.ConnectionString.Split('?');
-        var connectionString = stringArray[0].EnsureEndsWith('/') +
-                                   "Db_" +
-                               Guid.NewGuid().ToString("N") + "/?" + stringArray[1];
-
         Configure<AbpDbConnectionOptions>(options =>
         {
-            options.ConnectionStrings.Default = connectionString;
+            options.ConnectionStrings.Default = MongoDbFixture.GetRandomConnectionString();
         });
 
         Configure<AbpUnitOfWorkDefaultOptions>(options =>

--- a/modules/identity/test/Volo.Abp.Identity.MongoDB.Tests/Volo/Abp/Identity/MongoDB/MongoDbFixture.cs
+++ b/modules/identity/test/Volo.Abp.Identity.MongoDB.Tests/Volo/Abp/Identity/MongoDB/MongoDbFixture.cs
@@ -1,17 +1,31 @@
 using System;
-using Mongo2Go;
+using EphemeralMongo;
 
 namespace Volo.Abp.Identity.MongoDB;
 
 public class MongoDbFixture : IDisposable
 {
-    private static readonly MongoDbRunner MongoDbRunner;
-    public static readonly string ConnectionString;
+    public readonly static IMongoRunner MongoDbRunner;
 
     static MongoDbFixture()
     {
-        MongoDbRunner = MongoDbRunner.Start(singleNodeReplSet: true, singleNodeReplSetWaitTimeout: 20);
-        ConnectionString = MongoDbRunner.ConnectionString;
+        MongoDbRunner = MongoRunner.Run(new MongoRunnerOptions
+        {
+            UseSingleNodeReplicaSet = true,
+            KillMongoProcessesWhenCurrentProcessExits = true
+        });
+    }
+
+    public static string GetRandomConnectionString()
+    {
+        return GetConnectionString("Db_" + Guid.NewGuid().ToString("N"));
+    }
+
+    public static string GetConnectionString(string databaseName)
+    {
+        var stringArray = MongoDbRunner.ConnectionString.Split('?');
+        var connectionString = stringArray[0].EnsureEndsWith('/') + databaseName + "/?" + stringArray[1];
+        return connectionString;
     }
 
     public void Dispose()

--- a/modules/identity/test/Volo.Abp.Identity.MongoDB.Tests/Volo/Abp/Identity/MongoDB/MongoDbFixture.cs
+++ b/modules/identity/test/Volo.Abp.Identity.MongoDB.Tests/Volo/Abp/Identity/MongoDB/MongoDbFixture.cs
@@ -11,8 +11,7 @@ public class MongoDbFixture : IDisposable
     {
         MongoDbRunner = MongoRunner.Run(new MongoRunnerOptions
         {
-            UseSingleNodeReplicaSet = true,
-            KillMongoProcessesWhenCurrentProcessExits = true
+            UseSingleNodeReplicaSet = true
         });
     }
 

--- a/modules/identityserver/test/Volo.Abp.IdentityServer.MongoDB.Tests/Volo.Abp.IdentityServer.MongoDB.Tests.csproj
+++ b/modules/identityserver/test/Volo.Abp.IdentityServer.MongoDB.Tests/Volo.Abp.IdentityServer.MongoDB.Tests.csproj
@@ -20,10 +20,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="EphemeralMongo.Core" Version="1.0.0" />
-    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
-    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
-    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
+    <PackageReference Include="EphemeralMongo.Core" Version="1.1.0" />
+    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
   </ItemGroup>
 
 </Project>

--- a/modules/identityserver/test/Volo.Abp.IdentityServer.MongoDB.Tests/Volo.Abp.IdentityServer.MongoDB.Tests.csproj
+++ b/modules/identityserver/test/Volo.Abp.IdentityServer.MongoDB.Tests/Volo.Abp.IdentityServer.MongoDB.Tests.csproj
@@ -20,7 +20,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="EphemeralMongo6" Version="1.1.0" />
+    <PackageReference Include="EphemeralMongo.Core" Version="1.0.0" />
+    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
   </ItemGroup>
 
 </Project>

--- a/modules/identityserver/test/Volo.Abp.IdentityServer.MongoDB.Tests/Volo.Abp.IdentityServer.MongoDB.Tests.csproj
+++ b/modules/identityserver/test/Volo.Abp.IdentityServer.MongoDB.Tests/Volo.Abp.IdentityServer.MongoDB.Tests.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="Mongo2Go" Version="$(Mongo2GoPackageVersion)" />
+    <PackageReference Include="EphemeralMongo6" Version="1.1.0" />
   </ItemGroup>
 
 </Project>

--- a/modules/identityserver/test/Volo.Abp.IdentityServer.MongoDB.Tests/Volo/Abp/IdentityServer/AbpIdentityServerMongoDbTestModule.cs
+++ b/modules/identityserver/test/Volo.Abp.IdentityServer.MongoDB.Tests/Volo/Abp/IdentityServer/AbpIdentityServerMongoDbTestModule.cs
@@ -16,14 +16,10 @@ public class AbpIdentityServerMongoDbTestModule : AbpModule
 {
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        var stringArray = MongoDbFixture.ConnectionString.Split('?');
-        var connectionString = stringArray[0].EnsureEndsWith('/') +
-                                   "Db_" +
-                               Guid.NewGuid().ToString("N") + "/?" + stringArray[1];
-
         Configure<AbpDbConnectionOptions>(options =>
         {
-            options.ConnectionStrings.Default = connectionString;
+            options.ConnectionStrings.Default = MongoDbFixture.GetRandomConnectionString();
         });
+
     }
 }

--- a/modules/identityserver/test/Volo.Abp.IdentityServer.MongoDB.Tests/Volo/Abp/IdentityServer/MongoDbFixture.cs
+++ b/modules/identityserver/test/Volo.Abp.IdentityServer.MongoDB.Tests/Volo/Abp/IdentityServer/MongoDbFixture.cs
@@ -1,17 +1,31 @@
 using System;
-using Mongo2Go;
+using EphemeralMongo;
 
 namespace Volo.Abp.IdentityServer;
 
 public class MongoDbFixture : IDisposable
 {
-    private static readonly MongoDbRunner MongoDbRunner;
-    public static readonly string ConnectionString;
+    public readonly static IMongoRunner MongoDbRunner;
 
     static MongoDbFixture()
     {
-        MongoDbRunner = MongoDbRunner.Start(singleNodeReplSet: true, singleNodeReplSetWaitTimeout: 20);
-        ConnectionString = MongoDbRunner.ConnectionString;
+        MongoDbRunner = MongoRunner.Run(new MongoRunnerOptions
+        {
+            UseSingleNodeReplicaSet = true,
+            KillMongoProcessesWhenCurrentProcessExits = true
+        });
+    }
+
+    public static string GetRandomConnectionString()
+    {
+        return GetConnectionString("Db_" + Guid.NewGuid().ToString("N"));
+    }
+
+    public static string GetConnectionString(string databaseName)
+    {
+        var stringArray = MongoDbRunner.ConnectionString.Split('?');
+        var connectionString = stringArray[0].EnsureEndsWith('/') + databaseName + "/?" + stringArray[1];
+        return connectionString;
     }
 
     public void Dispose()

--- a/modules/identityserver/test/Volo.Abp.IdentityServer.MongoDB.Tests/Volo/Abp/IdentityServer/MongoDbFixture.cs
+++ b/modules/identityserver/test/Volo.Abp.IdentityServer.MongoDB.Tests/Volo/Abp/IdentityServer/MongoDbFixture.cs
@@ -11,8 +11,7 @@ public class MongoDbFixture : IDisposable
     {
         MongoDbRunner = MongoRunner.Run(new MongoRunnerOptions
         {
-            UseSingleNodeReplicaSet = true,
-            KillMongoProcessesWhenCurrentProcessExits = true
+            UseSingleNodeReplicaSet = true
         });
     }
 

--- a/modules/openiddict/test/Volo.Abp.OpenIddict.MongoDB.Tests/Volo.Abp.OpenIddict.MongoDB.Tests.csproj
+++ b/modules/openiddict/test/Volo.Abp.OpenIddict.MongoDB.Tests/Volo.Abp.OpenIddict.MongoDB.Tests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="Mongo2Go" Version="$(Mongo2GoPackageVersion)" />
+    <PackageReference Include="EphemeralMongo6" Version="1.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/modules/openiddict/test/Volo.Abp.OpenIddict.MongoDB.Tests/Volo.Abp.OpenIddict.MongoDB.Tests.csproj
+++ b/modules/openiddict/test/Volo.Abp.OpenIddict.MongoDB.Tests/Volo.Abp.OpenIddict.MongoDB.Tests.csproj
@@ -9,10 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="EphemeralMongo.Core" Version="1.0.0" />
-    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
-    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
-    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
+    <PackageReference Include="EphemeralMongo.Core" Version="1.1.0" />
+    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/modules/openiddict/test/Volo.Abp.OpenIddict.MongoDB.Tests/Volo.Abp.OpenIddict.MongoDB.Tests.csproj
+++ b/modules/openiddict/test/Volo.Abp.OpenIddict.MongoDB.Tests/Volo.Abp.OpenIddict.MongoDB.Tests.csproj
@@ -9,7 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="EphemeralMongo6" Version="1.1.0" />
+    <PackageReference Include="EphemeralMongo.Core" Version="1.0.0" />
+    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/modules/openiddict/test/Volo.Abp.OpenIddict.MongoDB.Tests/Volo/Abp/OpenIddict/MongoDB/MongoDbFixture.cs
+++ b/modules/openiddict/test/Volo.Abp.OpenIddict.MongoDB.Tests/Volo/Abp/OpenIddict/MongoDB/MongoDbFixture.cs
@@ -1,17 +1,31 @@
 using System;
-using Mongo2Go;
+using EphemeralMongo;
 
 namespace Volo.Abp.OpenIddict.MongoDB;
 
 public class MongoDbFixture : IDisposable
 {
-    private static readonly MongoDbRunner MongoDbRunner;
-    public static readonly string ConnectionString;
+    public readonly static IMongoRunner MongoDbRunner;
 
     static MongoDbFixture()
     {
-        MongoDbRunner = MongoDbRunner.Start(singleNodeReplSet: true, singleNodeReplSetWaitTimeout: 20);
-        ConnectionString = MongoDbRunner.ConnectionString;
+        MongoDbRunner = MongoRunner.Run(new MongoRunnerOptions
+        {
+            UseSingleNodeReplicaSet = true,
+            KillMongoProcessesWhenCurrentProcessExits = true
+        });
+    }
+
+    public static string GetRandomConnectionString()
+    {
+        return GetConnectionString("Db_" + Guid.NewGuid().ToString("N"));
+    }
+
+    public static string GetConnectionString(string databaseName)
+    {
+        var stringArray = MongoDbRunner.ConnectionString.Split('?');
+        var connectionString = stringArray[0].EnsureEndsWith('/') + databaseName + "/?" + stringArray[1];
+        return connectionString;
     }
 
     public void Dispose()

--- a/modules/openiddict/test/Volo.Abp.OpenIddict.MongoDB.Tests/Volo/Abp/OpenIddict/MongoDB/MongoDbFixture.cs
+++ b/modules/openiddict/test/Volo.Abp.OpenIddict.MongoDB.Tests/Volo/Abp/OpenIddict/MongoDB/MongoDbFixture.cs
@@ -11,8 +11,7 @@ public class MongoDbFixture : IDisposable
     {
         MongoDbRunner = MongoRunner.Run(new MongoRunnerOptions
         {
-            UseSingleNodeReplicaSet = true,
-            KillMongoProcessesWhenCurrentProcessExits = true
+            UseSingleNodeReplicaSet = true
         });
     }
 

--- a/modules/openiddict/test/Volo.Abp.OpenIddict.MongoDB.Tests/Volo/Abp/OpenIddict/MongoDB/OpenIddictMongoDbTestModule.cs
+++ b/modules/openiddict/test/Volo.Abp.OpenIddict.MongoDB.Tests/Volo/Abp/OpenIddict/MongoDB/OpenIddictMongoDbTestModule.cs
@@ -17,12 +17,13 @@ namespace Volo.Abp.OpenIddict.MongoDB;
 public class OpenIddictMongoDbTestModule : AbpModule
 {
     private static string _connectionString;
-    
+
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
+        _connectionString = MongoDbFixture.GetRandomConnectionString();
         Configure<AbpDbConnectionOptions>(options =>
         {
-            options.ConnectionStrings.Default = MongoDbFixture.GetRandomConnectionString();
+            options.ConnectionStrings.Default = _connectionString;
         });
     }
 

--- a/modules/openiddict/test/Volo.Abp.OpenIddict.MongoDB.Tests/Volo/Abp/OpenIddict/MongoDB/OpenIddictMongoDbTestModule.cs
+++ b/modules/openiddict/test/Volo.Abp.OpenIddict.MongoDB.Tests/Volo/Abp/OpenIddict/MongoDB/OpenIddictMongoDbTestModule.cs
@@ -20,14 +20,9 @@ public class OpenIddictMongoDbTestModule : AbpModule
     
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        var stringArray = MongoDbFixture.ConnectionString.Split('?');
-        _connectionString = stringArray[0].EnsureEndsWith('/') +
-                           "Db_" +
-                           Guid.NewGuid().ToString("N") + "/?" + stringArray[1];
-
         Configure<AbpDbConnectionOptions>(options =>
         {
-            options.ConnectionStrings.Default = _connectionString;
+            options.ConnectionStrings.Default = MongoDbFixture.GetRandomConnectionString();
         });
     }
 

--- a/modules/permission-management/test/Volo.Abp.PermissionManagement.MongoDB.Tests/Volo.Abp.PermissionManagement.MongoDB.Tests.csproj
+++ b/modules/permission-management/test/Volo.Abp.PermissionManagement.MongoDB.Tests/Volo.Abp.PermissionManagement.MongoDB.Tests.csproj
@@ -19,7 +19,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="EphemeralMongo6" Version="1.1.0" />
+    <PackageReference Include="EphemeralMongo.Core" Version="1.0.0" />
+    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
   </ItemGroup>
 
 </Project>

--- a/modules/permission-management/test/Volo.Abp.PermissionManagement.MongoDB.Tests/Volo.Abp.PermissionManagement.MongoDB.Tests.csproj
+++ b/modules/permission-management/test/Volo.Abp.PermissionManagement.MongoDB.Tests/Volo.Abp.PermissionManagement.MongoDB.Tests.csproj
@@ -19,10 +19,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="EphemeralMongo.Core" Version="1.0.0" />
-    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
-    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
-    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
+    <PackageReference Include="EphemeralMongo.Core" Version="1.1.0" />
+    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
   </ItemGroup>
 
 </Project>

--- a/modules/permission-management/test/Volo.Abp.PermissionManagement.MongoDB.Tests/Volo.Abp.PermissionManagement.MongoDB.Tests.csproj
+++ b/modules/permission-management/test/Volo.Abp.PermissionManagement.MongoDB.Tests/Volo.Abp.PermissionManagement.MongoDB.Tests.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="Mongo2Go" Version="$(Mongo2GoPackageVersion)" />
+    <PackageReference Include="EphemeralMongo6" Version="1.1.0" />
   </ItemGroup>
 
 </Project>

--- a/modules/permission-management/test/Volo.Abp.PermissionManagement.MongoDB.Tests/Volo/Abp/PermissionManagement/MongoDb/AbpPermissionManagementMongoDbTestModule.cs
+++ b/modules/permission-management/test/Volo.Abp.PermissionManagement.MongoDB.Tests/Volo/Abp/PermissionManagement/MongoDb/AbpPermissionManagementMongoDbTestModule.cs
@@ -12,14 +12,9 @@ public class AbpPermissionManagementMongoDbTestModule : AbpModule
 {
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        var stringArray = MongoDbFixture.ConnectionString.Split('?');
-        var connectionString = stringArray[0].EnsureEndsWith('/') +
-                                   "Db_" +
-                               Guid.NewGuid().ToString("N") + "/?" + stringArray[1];
-
         Configure<AbpDbConnectionOptions>(options =>
         {
-            options.ConnectionStrings.Default = connectionString;
+            options.ConnectionStrings.Default = MongoDbFixture.GetRandomConnectionString();
         });
     }
 }

--- a/modules/permission-management/test/Volo.Abp.PermissionManagement.MongoDB.Tests/Volo/Abp/PermissionManagement/MongoDb/MongoDbFixture.cs
+++ b/modules/permission-management/test/Volo.Abp.PermissionManagement.MongoDB.Tests/Volo/Abp/PermissionManagement/MongoDb/MongoDbFixture.cs
@@ -11,8 +11,7 @@ public class MongoDbFixture : IDisposable
     {
         MongoDbRunner = MongoRunner.Run(new MongoRunnerOptions
         {
-            UseSingleNodeReplicaSet = true,
-            KillMongoProcessesWhenCurrentProcessExits = true
+            UseSingleNodeReplicaSet = true
         });
     }
 

--- a/modules/permission-management/test/Volo.Abp.PermissionManagement.MongoDB.Tests/Volo/Abp/PermissionManagement/MongoDb/MongoDbFixture.cs
+++ b/modules/permission-management/test/Volo.Abp.PermissionManagement.MongoDB.Tests/Volo/Abp/PermissionManagement/MongoDb/MongoDbFixture.cs
@@ -1,17 +1,31 @@
 using System;
-using Mongo2Go;
+using EphemeralMongo;
 
 namespace Volo.Abp.PermissionManagement.MongoDB;
 
 public class MongoDbFixture : IDisposable
 {
-    private static readonly MongoDbRunner MongoDbRunner;
-    public static readonly string ConnectionString;
+    public readonly static IMongoRunner MongoDbRunner;
 
     static MongoDbFixture()
     {
-        MongoDbRunner = MongoDbRunner.Start(singleNodeReplSet: true, singleNodeReplSetWaitTimeout: 20);
-        ConnectionString = MongoDbRunner.ConnectionString;
+        MongoDbRunner = MongoRunner.Run(new MongoRunnerOptions
+        {
+            UseSingleNodeReplicaSet = true,
+            KillMongoProcessesWhenCurrentProcessExits = true
+        });
+    }
+
+    public static string GetRandomConnectionString()
+    {
+        return GetConnectionString("Db_" + Guid.NewGuid().ToString("N"));
+    }
+
+    public static string GetConnectionString(string databaseName)
+    {
+        var stringArray = MongoDbRunner.ConnectionString.Split('?');
+        var connectionString = stringArray[0].EnsureEndsWith('/') + databaseName + "/?" + stringArray[1];
+        return connectionString;
     }
 
     public void Dispose()

--- a/modules/setting-management/test/Volo.Abp.SettingManagement.MongoDB.Tests/Volo.Abp.SettingManagement.MongoDB.Tests.csproj
+++ b/modules/setting-management/test/Volo.Abp.SettingManagement.MongoDB.Tests/Volo.Abp.SettingManagement.MongoDB.Tests.csproj
@@ -18,10 +18,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="EphemeralMongo.Core" Version="1.0.0" />
-    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
-    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
-    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
+    <PackageReference Include="EphemeralMongo.Core" Version="1.1.0" />
+    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
   </ItemGroup>
 
 </Project>

--- a/modules/setting-management/test/Volo.Abp.SettingManagement.MongoDB.Tests/Volo.Abp.SettingManagement.MongoDB.Tests.csproj
+++ b/modules/setting-management/test/Volo.Abp.SettingManagement.MongoDB.Tests/Volo.Abp.SettingManagement.MongoDB.Tests.csproj
@@ -18,7 +18,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="EphemeralMongo6" Version="1.1.0" />
+    <PackageReference Include="EphemeralMongo.Core" Version="1.0.0" />
+    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
   </ItemGroup>
 
 </Project>

--- a/modules/setting-management/test/Volo.Abp.SettingManagement.MongoDB.Tests/Volo.Abp.SettingManagement.MongoDB.Tests.csproj
+++ b/modules/setting-management/test/Volo.Abp.SettingManagement.MongoDB.Tests/Volo.Abp.SettingManagement.MongoDB.Tests.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="Mongo2Go" Version="$(Mongo2GoPackageVersion)" />
+    <PackageReference Include="EphemeralMongo6" Version="1.1.0" />
   </ItemGroup>
 
 </Project>

--- a/modules/setting-management/test/Volo.Abp.SettingManagement.MongoDB.Tests/Volo/Abp/SettingManagement/MongoDB/AbpSettingManagementMongoDbTestModule.cs
+++ b/modules/setting-management/test/Volo.Abp.SettingManagement.MongoDB.Tests/Volo/Abp/SettingManagement/MongoDB/AbpSettingManagementMongoDbTestModule.cs
@@ -13,14 +13,9 @@ public class AbpSettingManagementMongoDbTestModule : AbpModule
 {
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        var stringArray = MongoDbFixture.ConnectionString.Split('?');
-        var connectionString = stringArray[0].EnsureEndsWith('/') +
-                                   "Db_" +
-                               Guid.NewGuid().ToString("N") + "/?" + stringArray[1];
-
         Configure<AbpDbConnectionOptions>(options =>
         {
-            options.ConnectionStrings.Default = connectionString;
+            options.ConnectionStrings.Default = MongoDbFixture.GetRandomConnectionString();
         });
     }
 }

--- a/modules/setting-management/test/Volo.Abp.SettingManagement.MongoDB.Tests/Volo/Abp/SettingManagement/MongoDB/MongoDbFixture.cs
+++ b/modules/setting-management/test/Volo.Abp.SettingManagement.MongoDB.Tests/Volo/Abp/SettingManagement/MongoDB/MongoDbFixture.cs
@@ -1,17 +1,31 @@
 using System;
-using Mongo2Go;
+using EphemeralMongo;
 
 namespace Volo.Abp.SettingManagement.MongoDB;
 
 public class MongoDbFixture : IDisposable
 {
-    private static readonly MongoDbRunner MongoDbRunner;
-    public static readonly string ConnectionString;
+    public readonly static IMongoRunner MongoDbRunner;
 
     static MongoDbFixture()
     {
-        MongoDbRunner = MongoDbRunner.Start(singleNodeReplSet: true, singleNodeReplSetWaitTimeout: 20);
-        ConnectionString = MongoDbRunner.ConnectionString;
+        MongoDbRunner = MongoRunner.Run(new MongoRunnerOptions
+        {
+            UseSingleNodeReplicaSet = true,
+            KillMongoProcessesWhenCurrentProcessExits = true
+        });
+    }
+
+    public static string GetRandomConnectionString()
+    {
+        return GetConnectionString("Db_" + Guid.NewGuid().ToString("N"));
+    }
+
+    public static string GetConnectionString(string databaseName)
+    {
+        var stringArray = MongoDbRunner.ConnectionString.Split('?');
+        var connectionString = stringArray[0].EnsureEndsWith('/') + databaseName + "/?" + stringArray[1];
+        return connectionString;
     }
 
     public void Dispose()

--- a/modules/setting-management/test/Volo.Abp.SettingManagement.MongoDB.Tests/Volo/Abp/SettingManagement/MongoDB/MongoDbFixture.cs
+++ b/modules/setting-management/test/Volo.Abp.SettingManagement.MongoDB.Tests/Volo/Abp/SettingManagement/MongoDB/MongoDbFixture.cs
@@ -11,8 +11,7 @@ public class MongoDbFixture : IDisposable
     {
         MongoDbRunner = MongoRunner.Run(new MongoRunnerOptions
         {
-            UseSingleNodeReplicaSet = true,
-            KillMongoProcessesWhenCurrentProcessExits = true
+            UseSingleNodeReplicaSet = true
         });
     }
 

--- a/modules/tenant-management/test/Volo.Abp.TenantManagement.MongoDB.Tests/Volo.Abp.TenantManagement.MongoDB.Tests.csproj
+++ b/modules/tenant-management/test/Volo.Abp.TenantManagement.MongoDB.Tests/Volo.Abp.TenantManagement.MongoDB.Tests.csproj
@@ -18,10 +18,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="EphemeralMongo.Core" Version="1.0.0" />
-    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
-    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
-    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
+    <PackageReference Include="EphemeralMongo.Core" Version="1.1.0" />
+    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
   </ItemGroup>
 
 </Project>

--- a/modules/tenant-management/test/Volo.Abp.TenantManagement.MongoDB.Tests/Volo.Abp.TenantManagement.MongoDB.Tests.csproj
+++ b/modules/tenant-management/test/Volo.Abp.TenantManagement.MongoDB.Tests/Volo.Abp.TenantManagement.MongoDB.Tests.csproj
@@ -18,7 +18,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="EphemeralMongo6" Version="1.1.0" />
+    <PackageReference Include="EphemeralMongo.Core" Version="1.0.0" />
+    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
   </ItemGroup>
 
 </Project>

--- a/modules/tenant-management/test/Volo.Abp.TenantManagement.MongoDB.Tests/Volo.Abp.TenantManagement.MongoDB.Tests.csproj
+++ b/modules/tenant-management/test/Volo.Abp.TenantManagement.MongoDB.Tests/Volo.Abp.TenantManagement.MongoDB.Tests.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="Mongo2Go" Version="$(Mongo2GoPackageVersion)" />
+    <PackageReference Include="EphemeralMongo6" Version="1.1.0" />
   </ItemGroup>
 
 </Project>

--- a/modules/tenant-management/test/Volo.Abp.TenantManagement.MongoDB.Tests/Volo/Abp/TenantManagement/MongoDb/AbpTenantManagementMongoDbTestModule.cs
+++ b/modules/tenant-management/test/Volo.Abp.TenantManagement.MongoDB.Tests/Volo/Abp/TenantManagement/MongoDb/AbpTenantManagementMongoDbTestModule.cs
@@ -13,14 +13,9 @@ public class AbpTenantManagementMongoDbTestModule : AbpModule
 {
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        var stringArray = MongoDbFixture.ConnectionString.Split('?');
-        var connectionString = stringArray[0].EnsureEndsWith('/') +
-                                   "Db_" +
-                               Guid.NewGuid().ToString("N") + "/?" + stringArray[1];
-
         Configure<AbpDbConnectionOptions>(options =>
         {
-            options.ConnectionStrings.Default = connectionString;
+            options.ConnectionStrings.Default = MongoDbFixture.GetRandomConnectionString();
         });
     }
 }

--- a/modules/tenant-management/test/Volo.Abp.TenantManagement.MongoDB.Tests/Volo/Abp/TenantManagement/MongoDb/MongoDbFixture.cs
+++ b/modules/tenant-management/test/Volo.Abp.TenantManagement.MongoDB.Tests/Volo/Abp/TenantManagement/MongoDb/MongoDbFixture.cs
@@ -1,5 +1,5 @@
 using System;
-using Mongo2Go;
+using EphemeralMongo;
 using MongoDB.Driver;
 using Volo.Abp.MongoDB;
 
@@ -7,13 +7,27 @@ namespace Volo.Abp.TenantManagement.MongoDB;
 
 public class MongoDbFixture : IDisposable
 {
-    private static readonly MongoDbRunner MongoDbRunner;
-    public static readonly string ConnectionString;
+    public readonly static IMongoRunner MongoDbRunner;
 
     static MongoDbFixture()
     {
-        MongoDbRunner = MongoDbRunner.Start(singleNodeReplSet: true, singleNodeReplSetWaitTimeout: 20);
-        ConnectionString = MongoDbRunner.ConnectionString;
+        MongoDbRunner = MongoRunner.Run(new MongoRunnerOptions
+        {
+            UseSingleNodeReplicaSet = true,
+            KillMongoProcessesWhenCurrentProcessExits = true
+        });
+    }
+
+    public static string GetRandomConnectionString()
+    {
+        return GetConnectionString("Db_" + Guid.NewGuid().ToString("N"));
+    }
+
+    public static string GetConnectionString(string databaseName)
+    {
+        var stringArray = MongoDbRunner.ConnectionString.Split('?');
+        var connectionString = stringArray[0].EnsureEndsWith('/') + databaseName + "/?" + stringArray[1];
+        return connectionString;
     }
 
     public void Dispose()

--- a/modules/tenant-management/test/Volo.Abp.TenantManagement.MongoDB.Tests/Volo/Abp/TenantManagement/MongoDb/MongoDbFixture.cs
+++ b/modules/tenant-management/test/Volo.Abp.TenantManagement.MongoDB.Tests/Volo/Abp/TenantManagement/MongoDb/MongoDbFixture.cs
@@ -13,8 +13,7 @@ public class MongoDbFixture : IDisposable
     {
         MongoDbRunner = MongoRunner.Run(new MongoRunnerOptions
         {
-            UseSingleNodeReplicaSet = true,
-            KillMongoProcessesWhenCurrentProcessExits = true
+            UseSingleNodeReplicaSet = true
         });
     }
 

--- a/templates/app/aspnet-core/test/MyCompanyName.MyProjectName.MongoDB.Tests/MongoDb/MyProjectNameMongoDbFixture.cs
+++ b/templates/app/aspnet-core/test/MyCompanyName.MyProjectName.MongoDB.Tests/MongoDb/MyProjectNameMongoDbFixture.cs
@@ -5,13 +5,26 @@ namespace MyCompanyName.MyProjectName.MongoDB;
 
 public class MyProjectNameMongoDbFixture : IDisposable
 {
-    private static readonly MongoDbRunner MongoDbRunner;
-    public static readonly string ConnectionString;
+    public readonly static IMongoRunner MongoDbRunner;
 
     static MyProjectNameMongoDbFixture()
     {
-        MongoDbRunner = MongoDbRunner.Start(singleNodeReplSet: true, singleNodeReplSetWaitTimeout: 20);
-        ConnectionString = MongoDbRunner.ConnectionString;
+        MongoDbRunner = MongoRunner.Run(new MongoRunnerOptions
+        {
+            UseSingleNodeReplicaSet = true
+        });
+    }
+
+    public static string GetRandomConnectionString()
+    {
+        return GetConnectionString("Db_" + Guid.NewGuid().ToString("N"));
+    }
+
+    public static string GetConnectionString(string databaseName)
+    {
+        var stringArray = MongoDbRunner.ConnectionString.Split('?');
+        var connectionString = stringArray[0].EnsureEndsWith('/') + databaseName + "/?" + stringArray[1];
+        return connectionString;
     }
 
     public void Dispose()

--- a/templates/app/aspnet-core/test/MyCompanyName.MyProjectName.MongoDB.Tests/MongoDb/MyProjectNameMongoDbFixture.cs
+++ b/templates/app/aspnet-core/test/MyCompanyName.MyProjectName.MongoDB.Tests/MongoDb/MyProjectNameMongoDbFixture.cs
@@ -1,5 +1,5 @@
 using System;
-using Mongo2Go;
+using EphemeralMongo;
 
 namespace MyCompanyName.MyProjectName.MongoDB;
 

--- a/templates/app/aspnet-core/test/MyCompanyName.MyProjectName.MongoDB.Tests/MongoDb/MyProjectNameMongoDbTestModule.cs
+++ b/templates/app/aspnet-core/test/MyCompanyName.MyProjectName.MongoDB.Tests/MongoDb/MyProjectNameMongoDbTestModule.cs
@@ -12,14 +12,9 @@ public class MyProjectNameMongoDbTestModule : AbpModule
 {
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        var stringArray = MyProjectNameMongoDbFixture.ConnectionString.Split('?');
-        var connectionString = stringArray[0].EnsureEndsWith('/') +
-                                   "Db_" +
-                               Guid.NewGuid().ToString("N") + "/?" + stringArray[1];
-
         Configure<AbpDbConnectionOptions>(options =>
         {
-            options.ConnectionStrings.Default = connectionString;
+            options.ConnectionStrings.Default = MongoDbFixture.GetRandomConnectionString();
         });
     }
 }

--- a/templates/app/aspnet-core/test/MyCompanyName.MyProjectName.MongoDB.Tests/MongoDb/MyProjectNameMongoDbTestModule.cs
+++ b/templates/app/aspnet-core/test/MyCompanyName.MyProjectName.MongoDB.Tests/MongoDb/MyProjectNameMongoDbTestModule.cs
@@ -14,7 +14,7 @@ public class MyProjectNameMongoDbTestModule : AbpModule
     {
         Configure<AbpDbConnectionOptions>(options =>
         {
-            options.ConnectionStrings.Default = MongoDbFixture.GetRandomConnectionString();
+            options.ConnectionStrings.Default = MyProjectNameMongoDbFixture.GetRandomConnectionString();
         });
     }
 }

--- a/templates/app/aspnet-core/test/MyCompanyName.MyProjectName.MongoDB.Tests/MyCompanyName.MyProjectName.MongoDB.Tests.csproj
+++ b/templates/app/aspnet-core/test/MyCompanyName.MyProjectName.MongoDB.Tests/MyCompanyName.MyProjectName.MongoDB.Tests.csproj
@@ -15,10 +15,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="EphemeralMongo.Core" Version="1.0.0" />
-    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
-    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
-    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
+    <PackageReference Include="EphemeralMongo.Core" Version="1.1.0" />
+    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
   </ItemGroup>
 
 </Project>

--- a/templates/app/aspnet-core/test/MyCompanyName.MyProjectName.MongoDB.Tests/MyCompanyName.MyProjectName.MongoDB.Tests.csproj
+++ b/templates/app/aspnet-core/test/MyCompanyName.MyProjectName.MongoDB.Tests/MyCompanyName.MyProjectName.MongoDB.Tests.csproj
@@ -15,7 +15,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="Mongo2Go" Version="3.1.3" />
+    <PackageReference Include="EphemeralMongo.Core" Version="1.0.0" />
+    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
   </ItemGroup>
 
 </Project>

--- a/templates/module/aspnet-core/test/MyCompanyName.MyProjectName.MongoDB.Tests/MongoDB/MongoDbFixture.cs
+++ b/templates/module/aspnet-core/test/MyCompanyName.MyProjectName.MongoDB.Tests/MongoDB/MongoDbFixture.cs
@@ -1,17 +1,31 @@
 using System;
-using Mongo2Go;
+using EphemeralMongo;
 
 namespace MyCompanyName.MyProjectName.MongoDB;
 
 public class MongoDbFixture : IDisposable
 {
-    private static readonly MongoDbRunner MongoDbRunner;
-    public static readonly string ConnectionString;
+    public readonly static IMongoRunner MongoDbRunner;
 
     static MongoDbFixture()
     {
-        MongoDbRunner = MongoDbRunner.Start(singleNodeReplSet: true, singleNodeReplSetWaitTimeout: 20);
-        ConnectionString = MongoDbRunner.ConnectionString;
+        MongoDbRunner = MongoRunner.Run(new MongoRunnerOptions
+        {
+            UseSingleNodeReplicaSet = true,
+            KillMongoProcessesWhenCurrentProcessExits = true
+        });
+    }
+
+    public static string GetRandomConnectionString()
+    {
+        return GetConnectionString("Db_" + Guid.NewGuid().ToString("N"));
+    }
+
+    public static string GetConnectionString(string databaseName)
+    {
+        var stringArray = MongoDbRunner.ConnectionString.Split('?');
+        var connectionString = stringArray[0].EnsureEndsWith('/') + databaseName + "/?" + stringArray[1];
+        return connectionString;
     }
 
     public void Dispose()

--- a/templates/module/aspnet-core/test/MyCompanyName.MyProjectName.MongoDB.Tests/MongoDB/MongoDbFixture.cs
+++ b/templates/module/aspnet-core/test/MyCompanyName.MyProjectName.MongoDB.Tests/MongoDB/MongoDbFixture.cs
@@ -11,8 +11,7 @@ public class MongoDbFixture : IDisposable
     {
         MongoDbRunner = MongoRunner.Run(new MongoRunnerOptions
         {
-            UseSingleNodeReplicaSet = true,
-            KillMongoProcessesWhenCurrentProcessExits = true
+            UseSingleNodeReplicaSet = true
         });
     }
 

--- a/templates/module/aspnet-core/test/MyCompanyName.MyProjectName.MongoDB.Tests/MongoDB/MyProjectNameMongoDbTestModule.cs
+++ b/templates/module/aspnet-core/test/MyCompanyName.MyProjectName.MongoDB.Tests/MongoDB/MyProjectNameMongoDbTestModule.cs
@@ -13,14 +13,9 @@ public class MyProjectNameMongoDbTestModule : AbpModule
 {
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        var stringArray = MongoDbFixture.ConnectionString.Split('?');
-        var connectionString = stringArray[0].EnsureEndsWith('/') +
-                                   "Db_" +
-                               Guid.NewGuid().ToString("N") + "/?" + stringArray[1];
-
         Configure<AbpDbConnectionOptions>(options =>
         {
-            options.ConnectionStrings.Default = connectionString;
+            options.ConnectionStrings.Default = MongoDbFixture.GetRandomConnectionString();
         });
     }
 }

--- a/templates/module/aspnet-core/test/MyCompanyName.MyProjectName.MongoDB.Tests/MyCompanyName.MyProjectName.MongoDB.Tests.csproj
+++ b/templates/module/aspnet-core/test/MyCompanyName.MyProjectName.MongoDB.Tests/MyCompanyName.MyProjectName.MongoDB.Tests.csproj
@@ -10,7 +10,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="Mongo2Go" Version="3.1.3" />
+    <PackageReference Include="EphemeralMongo.Core" Version="1.0.0" />
+    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
     <ProjectReference Include="..\..\src\MyCompanyName.MyProjectName.MongoDB\MyCompanyName.MyProjectName.MongoDB.csproj" />
     <ProjectReference Include="..\MyCompanyName.MyProjectName.TestBase\MyCompanyName.MyProjectName.TestBase.csproj" />
   </ItemGroup>

--- a/templates/module/aspnet-core/test/MyCompanyName.MyProjectName.MongoDB.Tests/MyCompanyName.MyProjectName.MongoDB.Tests.csproj
+++ b/templates/module/aspnet-core/test/MyCompanyName.MyProjectName.MongoDB.Tests/MyCompanyName.MyProjectName.MongoDB.Tests.csproj
@@ -10,10 +10,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="EphemeralMongo.Core" Version="1.0.0" />
-    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
-    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
-    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
+    <PackageReference Include="EphemeralMongo.Core" Version="1.1.0" />
+    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="1.1.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
     <ProjectReference Include="..\..\src\MyCompanyName.MyProjectName.MongoDB\MyCompanyName.MyProjectName.MongoDB.csproj" />
     <ProjectReference Include="..\MyCompanyName.MyProjectName.TestBase\MyCompanyName.MyProjectName.TestBase.csproj" />
   </ItemGroup>


### PR DESCRIPTION
>  Do you need MongoDB 5 or even 6 for your testing or development needs? Check out EphemeralMongo, a project based on Mongo2Go. In addition to supporting multiple MongoDB major versions and the same features, it has a faster startup, and better CI support.
