### PR TITLE
Normalize ElementId for navigation menu items

### DIFF
--- a/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/ApplicationMenuGroup.cs
+++ b/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/ApplicationMenuGroup.cs
@@ -68,7 +68,7 @@ public class ApplicationMenuGroup
 
     private string NormalizeElementId(string elementId)
     {
-        return elementId?.Replace(".", "");
+        return elementId?.Replace(".", "_");
     }
 
     public override string ToString()

--- a/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/ApplicationMenuItem.cs
+++ b/framework/src/Volo.Abp.UI.Navigation/Volo/Abp/Ui/Navigation/ApplicationMenuItem.cs
@@ -160,7 +160,7 @@ public class ApplicationMenuItem : IHasMenuItems, IHasSimpleStateCheckers<Applic
     
     private string NormalizeElementId(string elementId)
     {
-        return elementId?.Replace(".", "");
+        return elementId?.Replace(".", "_");
     }
 
     public override string ToString()


### PR DESCRIPTION
### Description

Related: https://github.com/volosoft/volo/issues/14148

Use `_` to replace `.` instead of empty

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

