### PR TITLE
Fix service-type all

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/ProxyCommandBase.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/ProxyCommandBase.cs
@@ -79,7 +79,7 @@ public abstract class ProxyCommandBase<T> : IConsoleCommand, ITransientDependenc
                 ? ServiceType.Application
                 : serviceTypeArg.ToLower() == "integration"
                     ? ServiceType.Integration
-                    : null;
+                    : ServiceType.All;
         }
 
         var withoutContracts = commandLineArgs.Options.ContainsKey(Options.WithoutContracts.Short) ||


### PR DESCRIPTION
### Description

when we are using abp cli and send " --service-type  all" 
it couldn't pass the all value angular or another generatore. This commit must be fixed.

Related #16314 
<img width="1519" alt="image" src="https://user-images.githubusercontent.com/2217899/235647837-e66bf31a-4b7f-46db-baa1-d6b247d24284.png">


todo service is  integration service
<img width="736" alt="image" src="https://user-images.githubusercontent.com/2217899/235648223-51b1400a-699a-4229-a20e-3d6ca7411e31.png">