### PR TITLE
Downgrade OpenIddict version

### DIFF
--- a/modules/openiddict/src/Volo.Abp.OpenIddict.Domain.Shared/Volo.Abp.OpenIddict.Domain.Shared.csproj
+++ b/modules/openiddict/src/Volo.Abp.OpenIddict.Domain.Shared/Volo.Abp.OpenIddict.Domain.Shared.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenIddict.Abstractions" Version="4.3.0" />
+    <PackageReference Include="OpenIddict.Abstractions" Version="4.2.0" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="$(MicrosoftPackageVersion)" />
   </ItemGroup>
 

--- a/modules/openiddict/src/Volo.Abp.OpenIddict.Domain/Volo.Abp.OpenIddict.Domain.csproj
+++ b/modules/openiddict/src/Volo.Abp.OpenIddict.Domain/Volo.Abp.OpenIddict.Domain.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenIddict.Core" Version="4.3.0" />
+    <PackageReference Include="OpenIddict.Core" Version="4.2.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Description

There is a bug in Microsoft.IdentityModel.Tokens version 6.30.0 https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/2059 mentioned here. This package comes to us in OpenIddict version 4.3.0. For this reason, I downgraded the OpenIddict package to a previous version.