### PR TITLE
Revert "Update OpenIddict to 4.3.0"

### DIFF
--- a/modules/openiddict/src/Volo.Abp.OpenIddict.AspNetCore/Volo.Abp.OpenIddict.AspNetCore.csproj
+++ b/modules/openiddict/src/Volo.Abp.OpenIddict.AspNetCore/Volo.Abp.OpenIddict.AspNetCore.csproj
@@ -20,8 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenIddict.Server.AspNetCore" Version="4.3.0" />
-    <PackageReference Include="OpenIddict.Validation.AspNetCore" Version="4.3.0" />
-    <PackageReference Include="OpenIddict.Validation.ServerIntegration" Version="4.3.0" />
+    <PackageReference Include="OpenIddict.Server.AspNetCore" Version="4.2.0" />
+    <PackageReference Include="OpenIddict.Validation.AspNetCore" Version="4.2.0" />
+    <PackageReference Include="OpenIddict.Validation.ServerIntegration" Version="4.2.0" />
   </ItemGroup>
 </Project>

--- a/modules/openiddict/src/Volo.Abp.OpenIddict.Domain.Shared/Volo.Abp.OpenIddict.Domain.Shared.csproj
+++ b/modules/openiddict/src/Volo.Abp.OpenIddict.Domain.Shared/Volo.Abp.OpenIddict.Domain.Shared.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenIddict.Abstractions" Version="4.3.0" />
+    <PackageReference Include="OpenIddict.Abstractions" Version="4.2.0" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="$(MicrosoftPackageVersion)" />
   </ItemGroup>
 

--- a/modules/openiddict/src/Volo.Abp.OpenIddict.Domain/Volo.Abp.OpenIddict.Domain.csproj
+++ b/modules/openiddict/src/Volo.Abp.OpenIddict.Domain/Volo.Abp.OpenIddict.Domain.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenIddict.Core" Version="4.3.0" />
+    <PackageReference Include="OpenIddict.Core" Version="4.2.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Reverts abpframework/abp#16440

There is a bug in Microsoft.IdentityModel.Tokens version 6.30.0 https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/2059 mentioned here. This package comes to us in OpenIddict version 4.3.0. For this reason, I downgraded the OpenIddict package to a previous version.