### PR TITLE
fix IRemoteStreamContent issue on generate service

### DIFF
--- a/npm/ng-packs/packages/schematics/src/constants/volo.ts
+++ b/npm/ng-packs/packages/schematics/src/constants/volo.ts
@@ -1,2 +1,5 @@
 export const VOLO_REGEX = /^Volo\.Abp\.(Application\.Dtos|ObjectExtending)/;
-export const VOLO_REMOTE_STREAM_CONTENT = 'Volo.Abp.Content.IRemoteStreamContent'
+export const VOLO_REMOTE_STREAM_CONTENT = [
+  'Volo.Abp.Content.IRemoteStreamContent',
+  'Volo.Abp.Content.RemoteStreamContent',
+];

--- a/npm/ng-packs/packages/schematics/src/enums/binding-source-id.ts
+++ b/npm/ng-packs/packages/schematics/src/enums/binding-source-id.ts
@@ -3,4 +3,5 @@ export enum eBindingSourceId {
   Model = 'ModelBinding',
   Path = 'Path',
   Query = 'Query',
+  FormFile = 'FormFile',
 }

--- a/npm/ng-packs/packages/schematics/src/models/method.ts
+++ b/npm/ng-packs/packages/schematics/src/models/method.ts
@@ -59,6 +59,7 @@ export class Body {
       case eBindingSourceId.Query:
         this.params.push(paramName === value ? value : `${getParamName(paramName)}: ${value}`);
         break;
+      case eBindingSourceId.FormFile:
       case eBindingSourceId.Body:
         this.body = value;
         break;
@@ -78,7 +79,7 @@ export class Body {
   }
 
   isBlobMethod() {
-    return this.responseTypeWithNamespace === VOLO_REMOTE_STREAM_CONTENT;
+    return VOLO_REMOTE_STREAM_CONTENT.some(x => x === this.responseTypeWithNamespace);
   }
 
   private setUrlQuotes() {

--- a/npm/ng-packs/packages/schematics/src/utils/service.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/service.ts
@@ -104,11 +104,10 @@ export function createActionToSignatureMapper() {
     ];
 
     signature.parameters = parameters.map(p => {
-      const isFormData = isRemoteStreamContent(p.typeSimple);
-      if (isFormData) {
-        const formDataParameter = new Property({ name: p.name, type: 'FormData' });
-        formDataParameter.setOptional(false);
-        return formDataParameter;
+      const isFormData = isRemoteStreamContent(p.type);
+      const isFormArray = isRemoteStreamContentArray(p.type);
+      if (isFormData || isFormArray) {
+        return new Property({ name: p.name, type: 'FormData' });
       }
       const type = adaptType(p.typeSimple);
       const parameter = new Property({ name: p.name, type });
@@ -124,6 +123,10 @@ export function createActionToSignatureMapper() {
 
 export function isRemoteStreamContent(type: string) {
   return VOLO_REMOTE_STREAM_CONTENT.some(x => x === type);
+}
+
+export function isRemoteStreamContentArray(type: string) {
+  return VOLO_REMOTE_STREAM_CONTENT.map(x => `${x}[]`).some(x => x === type);
 }
 
 function getMethodNameFromAction(action: Action): string {


### PR DESCRIPTION
### Description
When we have File as parameter or response in AppService, we couldn't create proxy well. this pr be able to fix that. 

Resolves #15919 
 
### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

Test:
The code be able to create  (the code works with `RemoteStreamContent` and `IRemoteStreamContent` same way) 
-  services like that already create before  the changes. (it should break anything)
-  `public IRemoteStreamContent Download()`
- `public void Upload(IRemoteStreamContent file)`
- `public void Upload(string foo, IRemoteStreamContent file)`
- `public void Upload(string foo, IRemoteStreamContent file,IRemoteStreamContent file2)`
- `public void UploadMulti(IRemoteStreamContent[] file)`
- `public void UploadMulti(string foo, IRemoteStreamContent[] file)`

the code  does not support Poco has IRemoteStreamContent as property.



