### PR TITLE
Added support for binary-encoded CloudEvents

### DIFF
--- a/docs/en/Dapr/Index.md
+++ b/docs/en/Dapr/Index.md
@@ -209,7 +209,7 @@ ABP provides the following endpoints to receive events from Dapr:
 * `dapr/subscribe`: Dapr uses this endpoint to get a list of subscriptions from the application. ABP automatically returns all the subscriptions for your distributed event handler classes and custom controller actions with the `Topic` attribute.
 * `api/abp/dapr/event`: The unified endpoint to receive all the events from Dapr. ABP dispatches the events to your event handlers based on the topic name.
 
-> **Since ABP will call `MapSubscribeHandler` internally, you should not manually call it anymore.** You can use the `app.UseCloudEvents()` middleware in your ASP.NET Core pipeline if you want to support the [CloudEvents](https://cloudevents.io/) standard.
+> **Since ABP will call `MapSubscribeHandler` internally, you should not manually call it anymore.** You must also add the `app.UseCloudEvents()` middleware in your ASP.NET Core pipeline if you plan to support receiving [Raw pub/sub messages](https://docs.dapr.io/developing-applications/building-blocks/pubsub/pubsub-raw/) which can be configured using the AbpSubscribeOptions class.
 
 ### Usage
 

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.Dapr.EventBus/Volo/Abp/AspNetCore/Mvc/Dapr/EventBus/AbpAspNetCoreMvcDaprEventBusModule.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.Dapr.EventBus/Volo/Abp/AspNetCore/Mvc/Dapr/EventBus/AbpAspNetCoreMvcDaprEventBusModule.cs
@@ -52,7 +52,7 @@ public class AbpAspNetCoreMvcDaprEventBusModule : AbpModule
                                 Metadata = new AbpMetadata
                                 {
                                     {
-                                        AbpMetadata.RawPayload, "true"
+                                        AbpMetadata.RawPayload, subscribeOptions.EnableRawPayload.ToString().ToLower()
                                     }
                                 }
                             };

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.Dapr.EventBus/Volo/Abp/AspNetCore/Mvc/Dapr/EventBus/Controllers/AbpAspNetCoreMvcDaprEventsController.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.Dapr.EventBus/Volo/Abp/AspNetCore/Mvc/Dapr/EventBus/Controllers/AbpAspNetCoreMvcDaprEventsController.cs
@@ -21,6 +21,9 @@ public class AbpAspNetCoreMvcDaprEventsController : AbpController
         var daprSerializer = HttpContext.RequestServices.GetRequiredService<IDaprSerializer>();
         var body = (await JsonDocument.ParseAsync(HttpContext.Request.Body));
 
+        if (body.RootElement.TryGetProperty("data_base64", out var base64EncodedData))
+            body = JsonDocument.Parse(base64EncodedData.GetBytesFromBase64());
+
         var id = body.RootElement.GetProperty("id").GetString();
         var pubSubName = body.RootElement.GetProperty("pubsubname").GetString();
         var topic = body.RootElement.GetProperty("topic").GetString();

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.Dapr.EventBus/Volo/Abp/AspNetCore/Mvc/Dapr/EventBus/Controllers/AbpAspNetCoreMvcDaprEventsController.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.Dapr.EventBus/Volo/Abp/AspNetCore/Mvc/Dapr/EventBus/Controllers/AbpAspNetCoreMvcDaprEventsController.cs
@@ -21,11 +21,6 @@ public class AbpAspNetCoreMvcDaprEventsController : AbpController
         var daprSerializer = HttpContext.RequestServices.GetRequiredService<IDaprSerializer>();
         var body = (await JsonDocument.ParseAsync(HttpContext.Request.Body));
 
-        if (body.RootElement.TryGetProperty("data_base64", out var base64EncodedData))
-        {
-            body = JsonDocument.Parse(base64EncodedData.GetBytesFromBase64());
-        }
-
         var id = body.RootElement.GetProperty("id").GetString();
         var pubSubName = body.RootElement.GetProperty("pubsubname").GetString();
         var topic = body.RootElement.GetProperty("topic").GetString();

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.Dapr.EventBus/Volo/Abp/AspNetCore/Mvc/Dapr/EventBus/Controllers/AbpAspNetCoreMvcDaprEventsController.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.Dapr.EventBus/Volo/Abp/AspNetCore/Mvc/Dapr/EventBus/Controllers/AbpAspNetCoreMvcDaprEventsController.cs
@@ -22,7 +22,9 @@ public class AbpAspNetCoreMvcDaprEventsController : AbpController
         var body = (await JsonDocument.ParseAsync(HttpContext.Request.Body));
 
         if (body.RootElement.TryGetProperty("data_base64", out var base64EncodedData))
+        {
             body = JsonDocument.Parse(base64EncodedData.GetBytesFromBase64());
+        }
 
         var id = body.RootElement.GetProperty("id").GetString();
         var pubSubName = body.RootElement.GetProperty("pubsubname").GetString();


### PR DESCRIPTION
The CloudEvent format adopted by Dapr permits events to be encoded using either "application/json" or "application/octet-stream" types as indicated by the "datacontenttype" field of the event.

When the event is encoded using the "application/octet-stream" type, the payload is a base64 string in the "data_base64" property and there is no "data" property. As such, the current controller code will fail with a KeyNotFoundException. This condition was occurring using redis configured as the Dapr StateStore.

The below fix checks for a "data_base64" property which is effectively mutually exclusive with a "data" property. If so, it decodes the payload which is an application/json encoded CloudEvent. See below:

**Example Request Body:**
{
    "data_base64": "eyJkYXRhIjp7ImF3YXJkZWRTdGFnZSI6IkNsb3NlZCIsImRlYWxOYW1lIjoiVGVzdERlYWwiLCJpZCI6IlJhbmRvbUlEIiwic3RhdHVzIjoiQWN0aXZlbHkgQmlkZGluZyJ9LCJkYXRhY29udGVudHR5cGUiOiJhcHBsaWNhdGlvbi9qc29uIiwiaWQiOiIzYTNmNmEwMC0zYmRkLTQ5MjAtOTk5Yy0zNzYzZjVmYmE2N2UiLCJwdWJzdWJuYW1lIjoia3Jlc3QtcHVic3ViIiwic291cmNlIjoia3Jlc3QtcG9sYXJpc3NlcnZpY2UiLCJzcGVjdmVyc2lvbiI6IjEuMCIsInRpbWUiOiIyMDIzLTA1LTE3VDIyOjQ0OjUwWiIsInRvcGljIjoiUG9sYXJpcy5EZWFsQ3JlYXRlZCIsInRyYWNlaWQiOiIwMC00YTg3NDc3MGJlYWJmMTY4N2FjZmMyYTcyOTEyYTlhNi1iYzliMzY0MjIxNGY1OTg5LTAxIiwidHJhY2VwYXJlbnQiOiIwMC00YTg3NDc3MGJlYWJmMTY4N2FjZmMyYTcyOTEyYTlhNi1iYzliMzY0MjIxNGY1OTg5LTAxIiwidHJhY2VzdGF0ZSI6IiIsInR5cGUiOiJjb20uZGFwci5ldmVudC5zZW50In0=",
    "datacontenttype": "application/octet-stream",
    "id": "4287a39c-1024-4a15-9603-d68105ad992f",
    "pubsubname": "pubsub",
    "source": "Dapr",
    "specversion": "1.0",
    "topic": "Polaris.DealCreated",
    "type": "com.dapr.event.sent"
}

**Decoded data_base64 contents **
{
    "data": {
        "awardedStage": "Closed",
        "dealName": "TestDeal",
        "id": "RandomID",
        "status": "Actively Bidding"
    },
    "datacontenttype": "application/json",
    "id": "3a3f6a00-3bdd-4920-999c-3763f5fba67e",
    "pubsubname": "pubsub",
    "source": "polarisservice",
    "specversion": "1.0",
    "time": "2023-05-17T22:44:50Z",
    "topic": "Polaris.DealCreated",
    "traceid": "00-4a874770beabf1687acfc2a72912a9a6-bc9b3642214f5989-01",
    "traceparent": "00-4a874770beabf1687acfc2a72912a9a6-bc9b3642214f5989-01",
    "tracestate": "",
    "type": "com.dapr.event.sent"
}





