### PR TITLE
Use constants instead of strings for FeatureManagement.ManageHostFeatures

### DIFF
--- a/modules/feature-management/src/Volo.Abp.FeatureManagement.Application/Volo/Abp/FeatureManagement/FeatureAppService.cs
+++ b/modules/feature-management/src/Volo.Abp.FeatureManagement.Application/Volo/Abp/FeatureManagement/FeatureAppService.cs
@@ -121,7 +121,7 @@ public class FeatureAppService : FeatureManagementAppServiceBase, IFeatureAppSer
         string policyName;
         if (providerName == TenantFeatureValueProvider.ProviderName && CurrentTenant.Id == null && providerKey == null)
         {
-            policyName = "FeatureManagement.ManageHostFeatures";
+            policyName = FeatureManagementPermissions.ManageHostFeatures;
         }
         else
         {


### PR DESCRIPTION
Use constants instead of strings for FeatureManagement.ManageHostFeatures