### PR TITLE
fix(): ensure new password is different from current password

### DIFF
--- a/modules/account/src/Volo.Abp.Account.Application.Contracts/Volo/Abp/Account/ChangePasswordInput.cs
+++ b/modules/account/src/Volo.Abp.Account.Application.Contracts/Volo/Abp/Account/ChangePasswordInput.cs
@@ -1,11 +1,16 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using Volo.Abp.Account.Localization;
 using Volo.Abp.Auditing;
 using Volo.Abp.Identity;
 using Volo.Abp.Validation;
 
 namespace Volo.Abp.Account;
 
-public class ChangePasswordInput
+public class ChangePasswordInput : IValidatableObject
 {
     [DisableAuditing]
     [DynamicStringLength(typeof(IdentityUserConsts), nameof(IdentityUserConsts.MaxPasswordLength))]
@@ -15,4 +20,17 @@ public class ChangePasswordInput
     [DisableAuditing]
     [DynamicStringLength(typeof(IdentityUserConsts), nameof(IdentityUserConsts.MaxPasswordLength))]
     public string NewPassword { get; set; }
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (CurrentPassword == NewPassword) 
+        {
+            var localizer = validationContext.GetRequiredService<IStringLocalizer<AccountResource>>();
+
+            yield return new ValidationResult(
+                localizer["NewPasswordSameAsOld"],
+                new[] { nameof(CurrentPassword), nameof(NewPassword) }
+            );
+        }
+    }
 }

--- a/modules/account/src/Volo.Abp.Account.Blazor/Pages/Account/AccountManage.razor.cs
+++ b/modules/account/src/Volo.Abp.Account.Blazor/Pages/Account/AccountManage.razor.cs
@@ -48,6 +48,12 @@ public partial class AccountManage
             return;
         }
 
+        if (ChangePasswordModel.CurrentPassword == ChangePasswordModel.NewPassword) 
+        {
+            await UiMessageService.Warn(L["NewPasswordSameAsOld"]);
+            return;
+        }
+
         await ProfileAppService.ChangePasswordAsync(new ChangePasswordInput
         {
             CurrentPassword = ChangePasswordModel.CurrentPassword,


### PR DESCRIPTION
### Description

This pr ensures that the new password always divers from the current password when changing passwords.
Currently its only validated in the mvc js. With this change its always validated.

### Checklist

- [x ] I fully tested it as developer / designer and created unit / integration tests
- [ ] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

There are three ways to test it.
1. Run the added unit test for profile app service.
2. Start HttpApi, authorize and make a request against the ChangePassword-Endpoint
3. Create demo project and change password in frontend.

Each method provides an error message saying "The new password should be different from the old password".
