### PR TITLE
Add Nx Code Generator for encapsulating ABP Schematics on NX repositories without 'angular.json' file

### DIFF
--- a/npm/ng-packs/.eslintrc.json
+++ b/npm/ng-packs/.eslintrc.json
@@ -34,6 +34,11 @@
       "files": ["*.js", "*.jsx"],
       "extends": ["plugin:@nx/javascript"],
       "rules": {}
+    },
+    {
+      "files": "*.json",
+      "parser": "jsonc-eslint-parser",
+      "rules": {}
     }
   ]
 }

--- a/npm/ng-packs/.vscode/settings.json
+++ b/npm/ng-packs/.vscode/settings.json
@@ -38,5 +38,6 @@
     "statusBarItem.hoverBackground": "#258ecd",
     "statusBar.foreground": "#e7e7e7"
   },
-  "peacock.color": "#1D70A2"
+  "peacock.color": "#1D70A2",
+  "eslint.validate": ["json"]
 }

--- a/npm/ng-packs/package.json
+++ b/npm/ng-packs/package.json
@@ -80,13 +80,18 @@
     "@ng-bootstrap/ng-bootstrap": "^14.0.0",
     "@ngneat/spectator": "^10.0.0",
     "@ngx-validate/core": "^0.2.0",
+    "@nx/angular": "16.1.4",
     "@nx/cypress": "16.1.4",
     "@nx/eslint-plugin": "16.1.4",
-    "@nx/jest": "16.1.4",
+    "@nx/jest": "16.2.2",
+    "@nx/js": "16.2.2",
     "@nx/linter": "16.1.4",
     "@nx/workspace": "16.1.4",
     "@popperjs/core": "~2.11.2",
     "@schematics/angular": "~16.0.1",
+    "@swc-node/register": "~1.4.2",
+    "@swc/cli": "~0.1.62",
+    "@swc/core": "~1.3.51",
     "@swimlane/ngx-datatable": "^20.0.0",
     "@types/jest": "29.4.4",
     "@types/node": "16.11.7",
@@ -106,6 +111,7 @@
     "jest-canvas-mock": "^2.3.1",
     "jest-environment-jsdom": "29.4.3",
     "jest-preset-angular": "13.1.0",
+    "jsonc-eslint-parser": "^2.1.0",
     "jsonc-parser": "^2.3.0",
     "just-clone": "^6.1.1",
     "just-compare": "^2.3.0",
@@ -129,14 +135,16 @@
     "tslib": "^2.3.0",
     "tslint": "~6.1.0",
     "typescript": "5.0.4",
-    "zone.js": "~0.13.0",
-    "@nx/angular": "16.1.4"
+    "zone.js": "~0.13.0"
   },
   "lint-staged": {
     "**/*.{js,jsx,ts,tsx,html,css,scss}": [
       "npx prettier --write --config .prettierrc "
     ]
   },
-  "dependencies": {}
+  "dependencies": {
+    "@nx/devkit": "16.2.2",
+    "@nx/plugin": "^16.2.2",
+    "@swc/helpers": "~0.5.0"
+  }
 }
-

--- a/npm/ng-packs/packages/generators/.eslintrc.json
+++ b/npm/ng-packs/packages/generators/.eslintrc.json
@@ -1,0 +1,25 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["./package.json", "./generators.json"],
+      "parser": "jsonc-eslint-parser",
+      "rules": {
+        "@nx/nx-plugin-checks": "error"
+      }
+    }
+  ]
+}

--- a/npm/ng-packs/packages/generators/README.md
+++ b/npm/ng-packs/packages/generators/README.md
@@ -1,0 +1,11 @@
+# generators
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build generators` to build the library.
+
+## Running unit tests
+
+Run `nx test generators` to execute the unit tests via [Jest](https://jestjs.io).

--- a/npm/ng-packs/packages/generators/generators.json
+++ b/npm/ng-packs/packages/generators/generators.json
@@ -1,0 +1,9 @@
+{
+  "generators": {
+    "generate-proxy": {
+      "factory": "./src/generators/generate-proxy/generator",
+      "schema": "./src/generators/generate-proxy/schema.json",
+      "description": "generate-proxy generator"
+    }
+  }
+}

--- a/npm/ng-packs/packages/generators/jest.config.ts
+++ b/npm/ng-packs/packages/generators/jest.config.ts
@@ -1,0 +1,10 @@
+/* eslint-disable */
+export default {
+  displayName: 'generators',
+  preset: '../../jest.preset.js',
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../coverage/packages/generators',
+};

--- a/npm/ng-packs/packages/generators/package.json
+++ b/npm/ng-packs/packages/generators/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@abp/generators",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "generators": "./generators.json"
+}

--- a/npm/ng-packs/packages/generators/project.json
+++ b/npm/ng-packs/packages/generators/project.json
@@ -1,0 +1,66 @@
+{
+  "name": "generators",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/generators/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/packages/generators",
+        "main": "packages/generators/src/index.ts",
+        "tsConfig": "packages/generators/tsconfig.lib.json",
+        "assets": [
+          "packages/generators/*.md",
+          {
+            "input": "./packages/generators/src",
+            "glob": "**/!(*.ts)",
+            "output": "./src"
+          },
+          {
+            "input": "./packages/generators/src",
+            "glob": "**/*.d.ts",
+            "output": "./src"
+          },
+          {
+            "input": "./packages/generators",
+            "glob": "generators.json",
+            "output": "."
+          },
+          {
+            "input": "./packages/generators",
+            "glob": "executors.json",
+            "output": "."
+          }
+        ]
+      }
+    },
+    "lint": {
+      "executor": "@nx/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": [
+          "packages/generators/**/*.ts",
+          "packages/generators/package.json",
+          "packages/generators/generators.json"
+        ]
+      }
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "packages/generators/jest.config.ts",
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "codeCoverage": true
+        }
+      }
+    }
+  },
+  "tags": []
+}

--- a/npm/ng-packs/packages/generators/src/generators/generate-proxy/files/src/index.ts.template
+++ b/npm/ng-packs/packages/generators/src/generators/generate-proxy/files/src/index.ts.template
@@ -1,0 +1,1 @@
+const variable = "<%= name %>";

--- a/npm/ng-packs/packages/generators/src/generators/generate-proxy/generator.spec.ts
+++ b/npm/ng-packs/packages/generators/src/generators/generate-proxy/generator.spec.ts
@@ -1,0 +1,20 @@
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { Tree, readProjectConfiguration } from '@nx/devkit';
+
+import { generateProxyGenerator } from './generator';
+import { GenerateProxyGeneratorSchema } from './schema';
+
+describe('generate-proxy generator', () => {
+  let tree: Tree;
+  const options: GenerateProxyGeneratorSchema = { name: 'test' };
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should run successfully', async () => {
+    await generateProxyGenerator(tree, options);
+    const config = readProjectConfiguration(tree, 'test');
+    expect(config).toBeDefined();
+  });
+});

--- a/npm/ng-packs/packages/generators/src/generators/generate-proxy/generator.ts
+++ b/npm/ng-packs/packages/generators/src/generators/generate-proxy/generator.ts
@@ -1,0 +1,17 @@
+import { addProjectConfiguration, formatFiles, generateFiles, Tree } from '@nx/devkit';
+import * as path from 'path';
+import { GenerateProxyGeneratorSchema } from './schema';
+
+export async function generateProxyGenerator(tree: Tree, options: GenerateProxyGeneratorSchema) {
+  const projectRoot = `libs/${options.name}`;
+  addProjectConfiguration(tree, options.name, {
+    root: projectRoot,
+    projectType: 'library',
+    sourceRoot: `${projectRoot}/src`,
+    targets: {},
+  });
+  generateFiles(tree, path.join(__dirname, 'files'), projectRoot, options);
+  await formatFiles(tree);
+}
+
+export default generateProxyGenerator;

--- a/npm/ng-packs/packages/generators/src/generators/generate-proxy/generator.ts
+++ b/npm/ng-packs/packages/generators/src/generators/generate-proxy/generator.ts
@@ -1,17 +1,15 @@
-import { addProjectConfiguration, formatFiles, generateFiles, Tree } from '@nx/devkit';
-import * as path from 'path';
 import { GenerateProxyGeneratorSchema } from './schema';
+import { Tree } from '@nrwl/devkit';
+import { wrapAngularDevkitSchematic } from '@nx/devkit/ngcli-adapter';
 
-export async function generateProxyGenerator(tree: Tree, options: GenerateProxyGeneratorSchema) {
-  const projectRoot = `libs/${options.name}`;
-  addProjectConfiguration(tree, options.name, {
-    root: projectRoot,
-    projectType: 'library',
-    sourceRoot: `${projectRoot}/src`,
-    targets: {},
+export default async function (host: Tree, schema: GenerateProxyGeneratorSchema) {
+  const runAngularLibrarySchematic = wrapAngularDevkitSchematic('@abp/ng.schematics', 'proxy-add');
+
+  await runAngularLibrarySchematic(host, {
+    ...schema,
   });
-  generateFiles(tree, path.join(__dirname, 'files'), projectRoot, options);
-  await formatFiles(tree);
-}
 
-export default generateProxyGenerator;
+  return () => {
+    console.log(`proxy added '${schema.target}`);
+  };
+}

--- a/npm/ng-packs/packages/generators/src/generators/generate-proxy/schema.d.ts
+++ b/npm/ng-packs/packages/generators/src/generators/generate-proxy/schema.d.ts
@@ -1,0 +1,3 @@
+export interface GenerateProxyGeneratorSchema {
+  name: string;
+}

--- a/npm/ng-packs/packages/generators/src/generators/generate-proxy/schema.d.ts
+++ b/npm/ng-packs/packages/generators/src/generators/generate-proxy/schema.d.ts
@@ -1,3 +1,9 @@
 export interface GenerateProxyGeneratorSchema {
-  name: string;
+  module: string;
+  apiName: string;
+  source: string;
+  target: string;
+  url: string;
+  serviceType: string;
+  entryPoint: string;
 }

--- a/npm/ng-packs/packages/generators/src/generators/generate-proxy/schema.json
+++ b/npm/ng-packs/packages/generators/src/generators/generate-proxy/schema.json
@@ -1,18 +1,94 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "https://json-schema.org/schema",
   "$id": "GenerateProxy",
   "title": "",
   "type": "object",
   "properties": {
-    "name": {
+    "module": {
+      "description": "Backend module name",
       "type": "string",
-      "description": "",
       "$default": {
         "$source": "argv",
         "index": 0
       },
-      "x-prompt": "What name would you like to use?"
+      "x-prompt": "Please enter backend module name. (default: \"app\")"
+    },
+    "apiName": {
+      "description": "Backend api name, a.k.a. remoteServiceName",
+      "type": "string",
+      "$default": {
+        "$source": "argv",
+        "index": 1
+      },
+      "x-prompt": "Please enter backend api name, a.k.a. remoteServiceName. (default: \"default\")"
+    },
+    "source": {
+      "description": "Source Angular project for API definition URL & root namespace resolution",
+      "type": "string",
+      "$default": {
+        "$source": "argv",
+        "index": 2
+      },
+      "x-prompt": "Please enter source Angular project for API definition URL & root namespace resolution. (default: workspace \"defaultProject\")"
+    },
+    "target": {
+      "description": "Target Angular project to place the generated code",
+      "type": "string",
+      "$default": {
+        "$source": "argv",
+        "index": 3
+      },
+      "x-prompt": "Please enter target Angular project to place the generated code. (default: workspace \"defaultProject\")"
+    },
+    "url": {
+      "description": "Url for API definition",
+      "type": "string",
+      "$default": {
+        "$source": "argv",
+        "index": 4
+      },
+      "x-prompt": "Please enter URL for API definition (default: API Name's url in environment file)"
+    },
+    "serviceType": {
+      "description": "Service type to the generated code",
+      "type": "string",
+      "$default": {
+        "$source": "argv",
+        "index": 5
+      },
+      "enum": [
+        "application",
+        "integration",
+        "all"
+      ],
+      "x-prompt": {
+        "message": "Specifies the service type to generate. `application`, `integration` and `all`, Default value: `application`",
+        "type": "list",
+        "items": [
+          {
+            "value": "all",
+            "label": "All"
+          },
+          {
+            "value": "application",
+            "label": "Application"
+          },
+          {
+            "value": "integration",
+            "label": "Integration"
+          }
+        ]
+      }
+    },
+    "entryPoint": {
+      "description": "Target Angular project to place the generated code",
+      "type": "string",
+      "$default": {
+        "$source": "argv",
+        "index": 6
+      },
+      "x-prompt": "Please enter target entry point to place the generated code. (default: null)"
     }
   },
-  "required": ["name"]
+  "required": []
 }

--- a/npm/ng-packs/packages/generators/src/generators/generate-proxy/schema.json
+++ b/npm/ng-packs/packages/generators/src/generators/generate-proxy/schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "$id": "GenerateProxy",
+  "title": "",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      },
+      "x-prompt": "What name would you like to use?"
+    }
+  },
+  "required": ["name"]
+}

--- a/npm/ng-packs/packages/generators/tsconfig.json
+++ b/npm/ng-packs/packages/generators/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs"
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/npm/ng-packs/packages/generators/tsconfig.lib.json
+++ b/npm/ng-packs/packages/generators/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/npm/ng-packs/packages/generators/tsconfig.spec.json
+++ b/npm/ng-packs/packages/generators/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
+}

--- a/npm/ng-packs/tsconfig.base.json
+++ b/npm/ng-packs/tsconfig.base.json
@@ -14,6 +14,7 @@
     "baseUrl": "./",
     "allowSyntheticDefaultImports": true,
     "paths": {
+      "@abp/generators": ["packages/generators/src/index.ts"],
       "@abp/ng.account": ["packages/account/src/public-api.ts"],
       "@abp/ng.account.core": ["packages/account-core/src/public-api.ts"],
       "@abp/ng.account.core/proxy": ["packages/account-core/proxy/src/public-api.ts"],


### PR DESCRIPTION
### Description
Nx  can work withut angular json but our Abp Schematics won't. The pr constain  nx generator work with angular schematics with or without angular.json.

Resolves #16515 
<img width="1641" alt="image" src="https://github.com/abpframework/abp/assets/2217899/21dafa6f-85fd-4811-bf4e-ed8b45061505">


### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?
- Run backend app on nx project (like our abp repo)
- execute `npx nx g @abp/generators:generate-proxy   --module=identity --api-name=AbpIdentity --target=identity  --project=identity  --no-interactive --dry-run`
