### PR TITLE
OpenIddict data seeding - usings fix

### DIFF
--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.DbMigrator/MyCompanyName.MyProjectName.DbMigrator.csproj
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.DbMigrator/MyCompanyName.MyProjectName.DbMigrator.csproj
@@ -17,10 +17,7 @@
     <!--APPSETTINGS-SECRETS-->
   </ItemGroup>
 
-  <ItemGroup>
-    <!-- <TEMPLATE-REMOVE IF-NOT='TIERED'>  -->
-    <ProjectReference Include="..\..\..\..\..\framework\src\Volo.Abp.Caching.StackExchangeRedis\Volo.Abp.Caching.StackExchangeRedis.csproj" />
-    <!-- </TEMPLATE-REMOVE> -->
+  <ItemGroup>    
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
@@ -30,6 +27,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\..\framework\src\Volo.Abp.Autofac\Volo.Abp.Autofac.csproj" />
+    <!-- <TEMPLATE-REMOVE IF-NOT='TIERED'>  -->
+    <ProjectReference Include="..\..\..\..\..\framework\src\Volo.Abp.Caching.StackExchangeRedis\Volo.Abp.Caching.StackExchangeRedis.csproj" />
+    <!-- </TEMPLATE-REMOVE> -->
     <ProjectReference Include="..\MyCompanyName.MyProjectName.Application.Contracts\MyCompanyName.MyProjectName.Application.Contracts.csproj" />
     <ProjectReference Include="..\MyCompanyName.MyProjectName.EntityFrameworkCore\MyCompanyName.MyProjectName.EntityFrameworkCore.csproj" />
   </ItemGroup>

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.DbMigrator/MyProjectNameDbMigratorModule.cs
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.DbMigrator/MyProjectNameDbMigratorModule.cs
@@ -1,7 +1,7 @@
 ﻿using MyCompanyName.MyProjectName.EntityFrameworkCore;
 using Volo.Abp.Autofac;
-using Volo.Abp.Caching;
 //<TEMPLATE-REMOVE IF-NOT='TIERED'>
+using Volo.Abp.Caching;
 using Volo.Abp.Caching.StackExchangeRedis;
 //</TEMPLATE-REMOVE>
 using Volo.Abp.Modularity;

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Domain/OpenIddict/OpenIddictDataSeedContributor.cs
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Domain/OpenIddict/OpenIddictDataSeedContributor.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Localization;
-using Microsoft.Extensions.Logging;
 using OpenIddict.Abstractions;
 using Volo.Abp;
 using Volo.Abp.Authorization.Permissions;


### PR DESCRIPTION
### Description

Related to #16700

- [x] I fully tested it as developer / designer and created unit / integration tests

Test result:

[openiddict-dataseed.webm](https://github.com/abpframework/abp/assets/25867/b6d04952-9b9a-4b1e-bcb4-3303b18b0f7c)

**Known Issue:**
If you try to update the **client secret**, it won't be updated. Openiddict-core uses internal [ObfuscateClient method](https://github.com/openiddict/openiddict-core/blob/8777dc99227006ba95698bc31e2071b97dce51cb/src/OpenIddict.Core/Managers/OpenIddictApplicationManager.cs#L1373) for it. There is no easy way to check if the secret is changed.