### PR TITLE
Add AbpSecurityIgnoreAttribute

### DIFF
--- a/docs/en/UI/AspNetCore/Security-Headers.md
+++ b/docs/en/UI/AspNetCore/Security-Headers.md
@@ -74,3 +74,26 @@ Configure<AbpSecurityHeadersOptions>(options =>
     });
 });
 ```
+
+### Ignore Abp Security Headers
+
+You can ignore the Abp Security Headers for some actions or pages. You can use the `IgnoreAbpSecurityHeaderAttribute` attribute for this.
+
+**Example:**
+
+```csharp
+@using Volo.Abp.AspNetCore.Security
+@attribute [IgnoreAbpSecurityHeaderAttribute]
+```
+
+**Example:**
+
+```csharp
+[IgnoreAbpSecurityHeaderAttribute]
+public class IndexModel : AbpPageModel
+{
+    public void OnGet()
+    {
+    }
+}
+```

--- a/framework/src/Volo.Abp.AspNetCore/Volo/Abp/AspNetCore/Security/AbpSecurityHeadersMiddleware.cs
+++ b/framework/src/Volo.Abp.AspNetCore/Volo/Abp/AspNetCore/Security/AbpSecurityHeadersMiddleware.cs
@@ -35,15 +35,11 @@ public class AbpSecurityHeadersMiddleware : IMiddleware, ITransientDependency
             x.Contains("text/html") || x.Contains("*/*") || x.Contains("application/xhtml+xml"));
             
         var endpoint = context.GetEndpoint();
-        
-        if (endpoint != null)
+
+        if (endpoint?.Metadata.GetMetadata<IgnoreAbpSecurityHeaderAttribute>() != null)
         {
-            var ignore = endpoint.Metadata.GetMetadata<IgnoreAbpSecurityHeaderAttribute>() != null;
-            if (ignore)
-            {
-                await next.Invoke(context);
-                return;
-            }
+            await next.Invoke(context);
+            return;
         }
 
         if (!requestAcceptTypeHtml 

--- a/framework/src/Volo.Abp.AspNetCore/Volo/Abp/AspNetCore/Security/IgnoreAbpSecurityHeader.cs
+++ b/framework/src/Volo.Abp.AspNetCore/Volo/Abp/AspNetCore/Security/IgnoreAbpSecurityHeader.cs
@@ -2,6 +2,7 @@
 
 namespace Volo.Abp.AspNetCore.Security;
 
+[AttributeUsage(AttributeTargets.Class)]
 public class IgnoreAbpSecurityHeaderAttribute : Attribute
 {
     

--- a/framework/src/Volo.Abp.AspNetCore/Volo/Abp/AspNetCore/Security/IgnoreAbpSecurityHeader.cs
+++ b/framework/src/Volo.Abp.AspNetCore/Volo/Abp/AspNetCore/Security/IgnoreAbpSecurityHeader.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 
 namespace Volo.Abp.AspNetCore.Security;
-
-[AttributeUsage(AttributeTargets.Class)]
 public class IgnoreAbpSecurityHeaderAttribute : Attribute
 {
     

--- a/framework/src/Volo.Abp.AspNetCore/Volo/Abp/AspNetCore/Security/IgnoreAbpSecurityHeader.cs
+++ b/framework/src/Volo.Abp.AspNetCore/Volo/Abp/AspNetCore/Security/IgnoreAbpSecurityHeader.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 
 namespace Volo.Abp.AspNetCore.Security;
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
 public class IgnoreAbpSecurityHeaderAttribute : Attribute
 {
     

--- a/framework/src/Volo.Abp.AspNetCore/Volo/Abp/AspNetCore/Security/IgnoreAbpSecurityHeader.cs
+++ b/framework/src/Volo.Abp.AspNetCore/Volo/Abp/AspNetCore/Security/IgnoreAbpSecurityHeader.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace Volo.Abp.AspNetCore.Security;
+
+public class IgnoreAbpSecurityHeaderAttribute : Attribute
+{
+    
+}

--- a/modules/openiddict/src/Volo.Abp.OpenIddict.AspNetCore/Volo/Abp/OpenIddict/Controllers/AuthorizeController.cs
+++ b/modules/openiddict/src/Volo.Abp.OpenIddict.AspNetCore/Volo/Abp/OpenIddict/Controllers/AuthorizeController.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Primitives;
 using OpenIddict.Abstractions;
 using OpenIddict.Server.AspNetCore;
+using Volo.Abp.AspNetCore.Security;
 using Volo.Abp.OpenIddict.ViewModels.Authorization;
 
 namespace Volo.Abp.OpenIddict.Controllers;
@@ -19,7 +20,7 @@ namespace Volo.Abp.OpenIddict.Controllers;
 public class AuthorizeController : AbpOpenIdDictControllerBase
 {
     [HttpGet, HttpPost]
-    [IgnoreAntiforgeryToken]
+    [IgnoreAntiforgeryToken, IgnoreAbpSecurityHeader]
     public virtual async Task<IActionResult> HandleAsync()
     {
         var request = await GetOpenIddictServerRequestAsync(HttpContext);

--- a/modules/openiddict/src/Volo.Abp.OpenIddict.AspNetCore/Volo/Abp/OpenIddict/Controllers/AuthorizeController.cs
+++ b/modules/openiddict/src/Volo.Abp.OpenIddict.AspNetCore/Volo/Abp/OpenIddict/Controllers/AuthorizeController.cs
@@ -21,6 +21,7 @@ public class AuthorizeController : AbpOpenIdDictControllerBase
 {
     [HttpGet, HttpPost]
     [IgnoreAntiforgeryToken]
+    [IgnoreAbpSecurityHeader]
     public virtual async Task<IActionResult> HandleAsync()
     {
         var request = await GetOpenIddictServerRequestAsync(HttpContext);

--- a/modules/openiddict/src/Volo.Abp.OpenIddict.AspNetCore/Volo/Abp/OpenIddict/Controllers/AuthorizeController.cs
+++ b/modules/openiddict/src/Volo.Abp.OpenIddict.AspNetCore/Volo/Abp/OpenIddict/Controllers/AuthorizeController.cs
@@ -20,7 +20,7 @@ namespace Volo.Abp.OpenIddict.Controllers;
 public class AuthorizeController : AbpOpenIdDictControllerBase
 {
     [HttpGet, HttpPost]
-    [IgnoreAntiforgeryToken, IgnoreAbpSecurityHeader]
+    [IgnoreAntiforgeryToken]
     public virtual async Task<IActionResult> HandleAsync()
     {
         var request = await GetOpenIddictServerRequestAsync(HttpContext);


### PR DESCRIPTION
### Description

An attribute has been created to disable all headers added with Abp Security Header based on action or page.

### Checklist

- [x] I fully tested it as developer
- [x] I documented it
