### PR TITLE
Limit forms on settings

### DIFF
--- a/npm/ng-packs/packages/setting-management/config/src/lib/components/email-setting-group/email-setting-group.component.html
+++ b/npm/ng-packs/packages/setting-management/config/src/lib/components/email-setting-group/email-setting-group.component.html
@@ -2,7 +2,7 @@
 
 <hr class="my-3" />
 
-<form *ngIf="form" [formGroup]="form" (ngSubmit)="submit()" [validateOnSubmit]="true">
+<form *ngIf="form" [formGroup]="form" class="abp-md-form"  (ngSubmit)="submit()" [validateOnSubmit]="true">
   <div class="mb-3 form-group">
     <label class="form-label"
       >{{ 'AbpSettingManagement::DefaultFromDisplayName' | abpLocalization


### PR DESCRIPTION
### Description
Limit forms on settings (540px)
Related https://github.com/volosoft/volo/issues/13437 

<img width="1688" alt="image" src="https://github.com/abpframework/abp/assets/2217899/1ef6dc37-d933-40ea-b56e-e5af49af0f07">

TODO: Describe what this PR has changed, add screenshot or animated GIF if available, write if it is a breaking change, and how to fix the breaking changes for existing applications if so.

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?
