### PR TITLE
Allow Setting Extended Property as ReadOnly on the UI for Blazor

### DIFF
--- a/framework/src/Volo.Abp.BlazoriseUI/Components/ObjectExtending/CheckExtensionProperty.razor
+++ b/framework/src/Volo.Abp.BlazoriseUI/Components/ObjectExtending/CheckExtensionProperty.razor
@@ -8,7 +8,7 @@
 {
     <Validation Validator="@Validate" MessageLocalizer="@LH.Localize">
         <Field>
-            <Check TValue="bool" @bind-Checked="@Value">
+            <Check TValue="bool" @bind-Checked="@Value" Disabled="IsReadonlyField">
                 <ChildContent>
                     @PropertyInfo.GetLocalizedDisplayName(StringLocalizerFactory)
                 </ChildContent>

--- a/framework/src/Volo.Abp.BlazoriseUI/Components/ObjectExtending/DateTimeExtensionProperty.razor
+++ b/framework/src/Volo.Abp.BlazoriseUI/Components/ObjectExtending/DateTimeExtensionProperty.razor
@@ -13,6 +13,7 @@
             <DateEdit TValue="DateTime?"
                       InputMode="@(PropertyInfo.IsDate() ? DateInputMode.Date : DateInputMode.DateTime)"
                       Pattern="@PropertyInfo.GetDateEditInputFormatOrNull()"
+                      Disabled="IsReadonlyField"
                       @bind-Date="@Value">
                 <Feedback>
                     <ValidationError/>

--- a/framework/src/Volo.Abp.BlazoriseUI/Components/ObjectExtending/ExtensionProperties.razor
+++ b/framework/src/Volo.Abp.BlazoriseUI/Components/ObjectExtending/ExtensionProperties.razor
@@ -25,6 +25,7 @@
                 __builder.AddAttribute(1, "PropertyInfo", propertyInfo);
                 __builder.AddAttribute(2, "Entity", Entity);
                 __builder.AddAttribute(3, "LH", LH);
+                __builder.AddAttribute(4, "EditForm", EditForm);
                 __builder.CloseComponent();
             }
         }

--- a/framework/src/Volo.Abp.BlazoriseUI/Components/ObjectExtending/ExtensionProperties.razor
+++ b/framework/src/Volo.Abp.BlazoriseUI/Components/ObjectExtending/ExtensionProperties.razor
@@ -25,7 +25,7 @@
                 __builder.AddAttribute(1, "PropertyInfo", propertyInfo);
                 __builder.AddAttribute(2, "Entity", Entity);
                 __builder.AddAttribute(3, "LH", LH);
-                __builder.AddAttribute(4, "EditForm", EditForm);
+                __builder.AddAttribute(4, "ModalType", ModalType);
                 __builder.CloseComponent();
             }
         }

--- a/framework/src/Volo.Abp.BlazoriseUI/Components/ObjectExtending/ExtensionProperties.razor.cs
+++ b/framework/src/Volo.Abp.BlazoriseUI/Components/ObjectExtending/ExtensionProperties.razor.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Localization;
 using Volo.Abp.AspNetCore.Components.Web;
 using Volo.Abp.Data;
+using Volo.Abp.ObjectExtending;
 
 namespace Volo.Abp.BlazoriseUI.Components.ObjectExtending;
 
@@ -16,4 +17,7 @@ public partial class ExtensionProperties<TEntityType, TResourceType> : Component
 
     [Parameter]
     public TEntityType Entity { get; set; }
+    
+    [Parameter]
+    public bool? EditForm { get; set; }
 }

--- a/framework/src/Volo.Abp.BlazoriseUI/Components/ObjectExtending/ExtensionProperties.razor.cs
+++ b/framework/src/Volo.Abp.BlazoriseUI/Components/ObjectExtending/ExtensionProperties.razor.cs
@@ -19,5 +19,5 @@ public partial class ExtensionProperties<TEntityType, TResourceType> : Component
     public TEntityType Entity { get; set; }
     
     [Parameter]
-    public bool? EditForm { get; set; }
+    public ExtensionPropertyModalType? ModalType { get; set; }
 }

--- a/framework/src/Volo.Abp.BlazoriseUI/Components/ObjectExtending/ExtensionPropertyComponentBase.cs
+++ b/framework/src/Volo.Abp.BlazoriseUI/Components/ObjectExtending/ExtensionPropertyComponentBase.cs
@@ -33,6 +33,9 @@ public abstract class ExtensionPropertyComponentBase<TEntity, TResourceType> : O
     [Parameter]
     public AbpBlazorMessageLocalizerHelper<TResourceType> LH { get; set; }
 
+    [Parameter]
+    public bool? EditForm { get; set; }
+
     protected virtual void Validate(ValidatorEventArgs e)
     {
         e.Status = ValidationStatus.Success;
@@ -71,6 +74,8 @@ public abstract class ExtensionPropertyComponentBase<TEntity, TResourceType> : O
         }
     }
 
+    protected bool IsReadonlyField => EditForm.HasValue && EditForm.Value && PropertyInfo.UI.EditModal.IsReadOnly;
+    
     private static string GetDefaultErrorMessage(ValidationAttribute validationAttribute)
     {
         if (validationAttribute is StringLengthAttribute stringLengthAttribute && stringLengthAttribute.MinimumLength != 0)

--- a/framework/src/Volo.Abp.BlazoriseUI/Components/ObjectExtending/ExtensionPropertyComponentBase.cs
+++ b/framework/src/Volo.Abp.BlazoriseUI/Components/ObjectExtending/ExtensionPropertyComponentBase.cs
@@ -34,7 +34,7 @@ public abstract class ExtensionPropertyComponentBase<TEntity, TResourceType> : O
     public AbpBlazorMessageLocalizerHelper<TResourceType> LH { get; set; }
 
     [Parameter]
-    public bool? EditForm { get; set; }
+    public ExtensionPropertyModalType? ModalType { get; set; }
 
     protected virtual void Validate(ValidatorEventArgs e)
     {
@@ -68,13 +68,13 @@ public abstract class ExtensionPropertyComponentBase<TEntity, TResourceType> : O
             }
 
             e.MemberNames = result.MemberNames;
-            e.Status = ValidationStatus.Error;
+            e.Status = ValidationStatus.Error; 
             e.ErrorText = errorMessage;
             break;
         }
     }
 
-    protected bool IsReadonlyField => EditForm.HasValue && EditForm.Value && PropertyInfo.UI.EditModal.IsReadOnly;
+    protected bool IsReadonlyField => ModalType is ExtensionPropertyModalType.EditModal && PropertyInfo.UI.EditModal.IsReadOnly;
     
     private static string GetDefaultErrorMessage(ValidationAttribute validationAttribute)
     {

--- a/framework/src/Volo.Abp.BlazoriseUI/Components/ObjectExtending/ExtensionPropertyModalType.cs
+++ b/framework/src/Volo.Abp.BlazoriseUI/Components/ObjectExtending/ExtensionPropertyModalType.cs
@@ -1,0 +1,7 @@
+﻿namespace Volo.Abp.BlazoriseUI.Components.ObjectExtending;
+
+public enum ExtensionPropertyModalType : byte
+{
+    CreateModal = 0,
+    EditModal = 1
+}

--- a/framework/src/Volo.Abp.BlazoriseUI/Components/ObjectExtending/LookupExtensionProperty.razor
+++ b/framework/src/Volo.Abp.BlazoriseUI/Components/ObjectExtending/LookupExtensionProperty.razor
@@ -15,6 +15,7 @@
                   SelectedValueChanged="@SelectedValueChanged"
                   SearchChanged="@SearchFilterChangedAsync"
                   Validator="@Validate"
-                  MinLength="0">
+                  MinLength="0"
+                  Disabled="IsReadonlyField">
     </Autocomplete>
 </Field>

--- a/framework/src/Volo.Abp.BlazoriseUI/Components/ObjectExtending/SelectExtensionProperty.razor
+++ b/framework/src/Volo.Abp.BlazoriseUI/Components/ObjectExtending/SelectExtensionProperty.razor
@@ -10,7 +10,7 @@
             <ChildContent>
                 @foreach (var item in SelectItems)
                 {
-                    <SelectItem Value="@item.Value">@item.Text</SelectItem>
+                    <SelectItem Value="@item.Value" Disabled="IsReadonlyField">@item.Text</SelectItem>
                 }
             </ChildContent>
             <Feedback>

--- a/framework/src/Volo.Abp.BlazoriseUI/Components/ObjectExtending/TextExtensionProperty.razor
+++ b/framework/src/Volo.Abp.BlazoriseUI/Components/ObjectExtending/TextExtensionProperty.razor
@@ -9,7 +9,7 @@
     <Validation Validator="@Validate" MessageLocalizer="@LH.Localize">
         <Field>
             <FieldLabel>@PropertyInfo.GetLocalizedDisplayName(StringLocalizerFactory)</FieldLabel>
-            <TextEdit @bind-Text="@Value" Role="@PropertyInfo.GetTextRole()" InputMode="@PropertyInfo.GetTextInputMode()">
+            <TextEdit @bind-Text="@Value" Role="@PropertyInfo.GetTextRole()" InputMode="@PropertyInfo.GetTextInputMode()" Disabled="IsReadonlyField">
                  <Feedback>
                     <ValidationError/>
                 </Feedback>

--- a/framework/src/Volo.Abp.BlazoriseUI/Components/ObjectExtending/TimeExtensionProperty.razor
+++ b/framework/src/Volo.Abp.BlazoriseUI/Components/ObjectExtending/TimeExtensionProperty.razor
@@ -9,7 +9,7 @@
     <Validation Validator="@Validate" MessageLocalizer="@LH.Localize">
         <Field>
             <FieldLabel>@PropertyInfo.GetLocalizedDisplayName(StringLocalizerFactory)</FieldLabel>-->
-            <TimeEdit TValue="TimeSpan?" @bind-Time="@Value">
+            <TimeEdit TValue="TimeSpan?" @bind-Time="@Value" Disabled="IsReadonlyField">
                  <Feedback>
                     <ValidationError/>
                 </Feedback>

--- a/framework/src/Volo.Abp.ObjectExtending/Volo/Abp/ObjectExtending/ObjectExtensionPropertyInfo.cs
+++ b/framework/src/Volo.Abp.ObjectExtending/Volo/Abp/ObjectExtending/ObjectExtensionPropertyInfo.cs
@@ -60,6 +60,8 @@ public class ObjectExtensionPropertyInfo : IHasNameWithLocalizableDisplayName, I
     [NotNull]
     public ExtensionPropertyLookupConfiguration Lookup { get; set; }
 
+    public ExtensionPropertyUI UI { get; set; }
+
     public ObjectExtensionPropertyInfo(
         [NotNull] ObjectExtensionInfo objectExtension,
         [NotNull] Type type,
@@ -76,10 +78,26 @@ public class ObjectExtensionPropertyInfo : IHasNameWithLocalizableDisplayName, I
         Attributes.AddRange(ExtensionPropertyHelper.GetDefaultAttributes(Type));
         DefaultValue = TypeHelper.GetDefaultValue(Type);
         Lookup = new ExtensionPropertyLookupConfiguration();
+        UI = new ExtensionPropertyUI();
     }
 
     public object GetDefaultValue()
     {
         return ExtensionPropertyHelper.GetDefaultValue(Type, DefaultValueFactory, DefaultValue);
+    }
+
+    public class ExtensionPropertyUI
+    {
+        public ExtensionPropertyUIEditModal EditModal { get; set; }
+
+        public ExtensionPropertyUI()
+        {
+            EditModal = new ExtensionPropertyUIEditModal();
+        }
+    }
+
+    public class ExtensionPropertyUIEditModal
+    {
+        public bool IsReadOnly { get; set; }
     }
 }

--- a/modules/identity/src/Volo.Abp.Identity.Blazor/Pages/Identity/RoleManagement.razor
+++ b/modules/identity/src/Volo.Abp.Identity.Blazor/Pages/Identity/RoleManagement.razor
@@ -92,7 +92,7 @@
                                     </Feedback>
                                 </TextEdit>
                             </Field>
-                            <ExtensionProperties TEntityType="IdentityRoleUpdateDto" TResourceType="IdentityResource" Entity="@EditingEntity" LH="@LH"  ModalType="ExtensionPropertyModalType.CreateModal" />
+                            <ExtensionProperties TEntityType="IdentityRoleUpdateDto" TResourceType="IdentityResource" Entity="@EditingEntity" LH="@LH"  ModalType="ExtensionPropertyModalType.EditModal" />
                         </Validation>
                         <Field>
                             <Check TValue="bool" @bind-Checked="@EditingEntity.IsDefault">@L["DisplayName:IsDefault"]</Check>

--- a/modules/identity/src/Volo.Abp.Identity.Blazor/Pages/Identity/RoleManagement.razor
+++ b/modules/identity/src/Volo.Abp.Identity.Blazor/Pages/Identity/RoleManagement.razor
@@ -54,7 +54,7 @@
                                     </Feedback>
                                 </TextEdit>
                             </Field>
-                            <ExtensionProperties TEntityType="IdentityRoleCreateDto" TResourceType="IdentityResource" Entity="@NewEntity" LH="@LH"/>
+                            <ExtensionProperties TEntityType="IdentityRoleCreateDto" TResourceType="IdentityResource" Entity="@NewEntity" LH="@LH" ModalType="ExtensionPropertyModalType.CreateModal" />
                         </Validation>
                         <Field>
                             <Check TValue="bool" @bind-Checked="@NewEntity.IsDefault">@L["DisplayName:IsDefault"]</Check>
@@ -92,7 +92,7 @@
                                     </Feedback>
                                 </TextEdit>
                             </Field>
-                            <ExtensionProperties TEntityType="IdentityRoleUpdateDto" TResourceType="IdentityResource" Entity="@EditingEntity" LH="@LH"/>
+                            <ExtensionProperties TEntityType="IdentityRoleUpdateDto" TResourceType="IdentityResource" Entity="@EditingEntity" LH="@LH"  ModalType="ExtensionPropertyModalType.CreateModal" />
                         </Validation>
                         <Field>
                             <Check TValue="bool" @bind-Checked="@EditingEntity.IsDefault">@L["DisplayName:IsDefault"]</Check>

--- a/modules/identity/src/Volo.Abp.Identity.Blazor/Pages/Identity/UserManagement.razor
+++ b/modules/identity/src/Volo.Abp.Identity.Blazor/Pages/Identity/UserManagement.razor
@@ -132,7 +132,7 @@
                                     <Field>
                                         <Check TValue="bool" @bind-Checked="@NewEntity.LockoutEnabled">@L["DisplayName:LockoutEnabled"]</Check>
                                     </Field>
-                                    <ExtensionProperties TEntityType="IdentityUserCreateDto" TResourceType="IdentityResource" Entity="@NewEntity" LH="@LH" />
+                                    <ExtensionProperties TEntityType="IdentityUserCreateDto" TResourceType="IdentityResource" Entity="@NewEntity" LH="@LH" ModalType="ExtensionPropertyModalType.CreateModal" />
                                 </TabPanel>
                                 <TabPanel Name="Roles">
                                     @if (NewUserRoles != null)
@@ -253,7 +253,7 @@
                                     <Field>
                                         <Check TValue="bool" @bind-Checked="EditingEntity.LockoutEnabled">@L["DisplayName:LockoutEnabled"]</Check>
                                     </Field>
-                                    <ExtensionProperties TEntityType="IdentityUserUpdateDto" TResourceType="IdentityResource" Entity="@EditingEntity" LH="@LH" />
+                                    <ExtensionProperties TEntityType="IdentityUserUpdateDto" TResourceType="IdentityResource" Entity="@EditingEntity" LH="@LH" ModalType="ExtensionPropertyModalType.EditModal" />
                                 </TabPanel>
                                 <TabPanel Name="Roles">
                                     @if (EditUserRoles != null)

--- a/modules/tenant-management/src/Volo.Abp.TenantManagement.Blazor/Pages/TenantManagement/TenantManagement.razor
+++ b/modules/tenant-management/src/Volo.Abp.TenantManagement.Blazor/Pages/TenantManagement/TenantManagement.razor
@@ -81,7 +81,7 @@
                             <ValidationError Style="display: block" />
                          </Field>
                         </Validation>
-                        <ExtensionProperties TEntityType="TenantCreateDto" TResourceType="AbpTenantManagementResource" Entity="@NewEntity" LH="@LH"/>
+                        <ExtensionProperties TEntityType="TenantCreateDto" TResourceType="AbpTenantManagementResource" Entity="@NewEntity" LH="@LH" ModalType="ExtensionPropertyModalType.CreateModal" />
                     </Validations>
                 </ModalBody>
                 <ModalFooter>
@@ -116,7 +116,7 @@
                             </Field>
                         </Validation>
                     </Validations>
-                    <ExtensionProperties TEntityType="TenantUpdateDto" TResourceType="AbpTenantManagementResource" Entity="@EditingEntity" LH="@LH"/>
+                    <ExtensionProperties TEntityType="TenantUpdateDto" TResourceType="AbpTenantManagementResource" Entity="@EditingEntity" LH="@LH" ModalType="ExtensionPropertyModalType.EditModal" />
                 </ModalBody>
                 <ModalFooter>
                     <Button Color="Color.Secondary" Clicked="CloseEditModalAsync">@L["Cancel"]</Button>


### PR DESCRIPTION
### Description

Resolves https://github.com/abpframework/abp/issues/12249

> I will update commercial modules too, when this PR is merged.

### Checklist

- [X] I fully tested it as developer / designer and created unit / integration tests
- [X] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

Extend a property and set it as readonly for edit form. https://docs.abp.io/en/abp/latest/Object-Extensions#addorupdateproperty

```csharp
ObjectExtensionManager.Instance
   .AddOrUpdateProperty<IdentityUser, string>("SocialNo", property => 
   {
       property.UI.EditForm.IsReadOnly = true;
   });
```
