### PR TITLE
Updated Installation sections in some documents

### DIFF
--- a/docs/en/API/Dynamic-CSharp-API-Clients.md
+++ b/docs/en/API/Dynamic-CSharp-API-Clients.md
@@ -38,20 +38,15 @@ Implement this class in your service application. You can use [auto API controll
 
 ## Client Proxy Generation
 
-First, add [Volo.Abp.Http.Client](https://www.nuget.org/packages/Volo.Abp.Http.Client) nuget package to your client project:
+> The startup templates already comes pre-configured for the client proxy generation, in the `HttpApi.Client` project.
+
+If you're not using a startup template, then execute the following command in the folder that contains the .csproj file of your client project:
 
 ````
-Install-Package Volo.Abp.Http.Client
+abp add-package Volo.Abp.Http.Client
 ````
 
-Then add `AbpHttpClientModule` dependency to your module:
-
-````csharp
-[DependsOn(typeof(AbpHttpClientModule))] //add the dependency
-public class MyClientAppModule : AbpModule
-{
-}
-````
+> If you haven't done it yet, you first need to install the [ABP CLI](../CLI.md). For other installation options, see [the package description page](https://abp.io/package-detail/Volo.Abp.Http.Client).
 
 Now, it's ready to create the client proxies. Example:
 
@@ -73,8 +68,6 @@ public class MyClientAppModule : AbpModule
 ````
 
 `AddHttpClientProxies` method gets an assembly, finds all service interfaces in the given assembly, creates and registers proxy classes.
-
-> The startup templates already comes pre-configured for the client proxy generation, in the `HttpApi.Client` project.
 
 ### Endpoint Configuration
 

--- a/docs/en/API/Swagger-Integration.md
+++ b/docs/en/API/Swagger-Integration.md
@@ -21,6 +21,8 @@ Open a command line window in the folder of the `Web` or `HttpApi.Host` project 
 abp add-package Volo.Abp.Swashbuckle
 ```
 
+> If you haven't done it yet, you first need to install the [ABP CLI](../CLI.md). For other installation options, see [the package description page](https://abp.io/package-detail/Volo.Abp.Swashbuckle).
+
 ### Manual Installation
 
 If you want to manually install;

--- a/docs/en/Application-Startup.md
+++ b/docs/en/Application-Startup.md
@@ -18,11 +18,13 @@ If you [create a new console application with Visual Studio](https://learn.micro
 
 This example uses the [top level statements](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/tutorials/top-level-statements), so it consists of only a single line of code.
 
-The first step is to install the [Volo.Abp.Core](https://www.nuget.org/packages/Volo.Abp.Core) NuGet package, which is the most core NuGet package of the ABP framework. You can install it using the [Package Manager Console](https://learn.microsoft.com/en-us/nuget/consume-packages/install-use-packages-powershell) in Visual Studio:
+The first step is to install the [Volo.Abp.Core](https://www.nuget.org/packages/Volo.Abp.Core) NuGet package, which is the most core NuGet package of the ABP framework. You can install it using the ABP CLI. Execute the following command in the folder of the .csproj file that you want to install the package on:
 
 ````bash
-Install-Package Volo.Abp.Core
+abp add-package Volo.Abp.Core
 ````
+
+> If you haven't done it yet, you first need to install the [ABP CLI](CLI.md). For other installation options, see [the package description page](https://abp.io/package-detail/Volo.Abp.Core).
 
 Alternatively, you can use a command-line terminal in the root folder of the project (the folder containing the `MyConsoleDemo.csproj` file, for this example):
 

--- a/docs/en/Autofac-Integration.md
+++ b/docs/en/Autofac-Integration.md
@@ -6,27 +6,14 @@
 
 > All the [startup templates](Startup-Templates/Index.md) and samples are Autofac integrated. So, most of the time you don't need to manually install this package.
 
-Install [Volo.Abp.Autofac](https://www.nuget.org/packages/Volo.Abp.Autofac) nuget package to your project (for a multi-projects application, it's suggested to add to the executable/web project).
+If you're not using a startup template, you can use the [ABP CLI](CLI.md) to install it to your project. Execute the following command in the folder that contains the .csproj file of your project (suggested to add it to the executable/web project):
 
+````bash
+abp add-package Volo.Abp.Autofac
 ````
-Install-Package Volo.Abp.Autofac
-````
 
-Then add `AbpAutofacModule` dependency to your module:
-
-```csharp
-using Volo.Abp.Modularity;
-using Volo.Abp.Autofac;
-
-namespace MyCompany.MyProject
-{
-    [DependsOn(typeof(AbpAutofacModule))]
-    public class MyModule : AbpModule
-    {
-        //...
-    }
-}
-```
+> If you haven't done it yet, you first need to install the [ABP CLI](CLI.md). For other installation options, see [the package description page](https://abp.io/package-detail/Volo.Abp.Autofac).
+>
 
 Finally, configure `AbpApplicationCreationOptions` to replace default dependency injection services by Autofac. It depends on the application type.
 

--- a/docs/en/Background-Jobs-Hangfire.md
+++ b/docs/en/Background-Jobs-Hangfire.md
@@ -16,6 +16,8 @@ Open a command line window in the folder of the project (.csproj file) and type 
 abp add-package Volo.Abp.BackgroundJobs.HangFire
 ````
 
+>  If you haven't done it yet, you first need to install the [ABP CLI](CLI.md). For other installation options, see [the package description page](https://abp.io/package-detail/Volo.Abp.BackgroundJobs.HangFire).
+
 ### Manual Installation
 
 If you want to manually install;

--- a/docs/en/Entity-Framework-Core.md
+++ b/docs/en/Entity-Framework-Core.md
@@ -7,24 +7,11 @@ This document explains how to integrate EF Core as an ORM provider to ABP based 
 `Volo.Abp.EntityFrameworkCore` is the main NuGet package for the EF Core integration. Install it to your project (for a layered application, to your data/infrastructure layer):
 
 ```` shell
-Install-Package Volo.Abp.EntityFrameworkCore
+abp add-package Volo.Abp.EntityFrameworkCore
 ````
 
-Then add `AbpEntityFrameworkCoreModule` module dependency (`DependsOn` attribute) to your [module](Module-Development-Basics.md):
-
-````c#
-using Volo.Abp.EntityFrameworkCore;
-using Volo.Abp.Modularity;
-
-namespace MyCompany.MyProject
-{
-    [DependsOn(typeof(AbpEntityFrameworkCoreModule))]
-    public class MyModule : AbpModule
-    {
-        //...
-    }
-}
-````
+> If you haven't done it yet, you first need to install the [ABP CLI](CLI.md). For other installation options, see [the package description page](https://abp.io/package-detail/Volo.Abp.EntityFrameworkCore).
+>
 
 > Note: Instead, you can directly download a [startup template](https://abp.io/Templates) with EF Core pre-installed.
 

--- a/docs/en/Getting-Started-AspNetCore-Application.md
+++ b/docs/en/Getting-Started-AspNetCore-Application.md
@@ -18,11 +18,13 @@ This tutorial explains how to start ABP from scratch with minimal dependencies. 
 
 ## Install Volo.Abp.AspNetCore.Mvc Package
 
-Volo.Abp.AspNetCore.Mvc is the AspNet Core MVC integration package for ABP. So, install it on your project:
+You can use the [ABP CLI](CLI.md) to install the Volo.Abp.AspNetCore.Mvc package to your project. Execute the following command in the folder of the .csproj file that you want to install the package on:
 
+````bash
+abp add-package Volo.Abp.AspNetCore.Mvc
 ````
-Install-Package Volo.Abp.AspNetCore.Mvc
-````
+
+> If you haven't done it yet, you first need to install the [ABP CLI](CLI.md). For other installation options, see [the package description page](https://abp.io/package-detail/Volo.Abp.AspNetCore.Mvc).
 
 ## Create the First ABP Module
 

--- a/docs/en/Localization.md
+++ b/docs/en/Localization.md
@@ -6,11 +6,13 @@ ABP's localization system is seamlessly integrated to the `Microsoft.Extensions.
 
 > This package is already installed by default with the startup template. So, most of the time, you don't need to install it manually.
 
-Volo.Abp.Localization is the core package of the localization system. Install it to your project using the package manager console (PMC):
+You can use the [ABP CLI](CLI.md) to install the Volo.Abp.Localization package to your project. Execute the following command in the folder of the .csproj file that you want to install the package on:
 
+```bash
+abp add-package Volo.Abp.Localization
 ```
-Install-Package Volo.Abp.Localization
-```
+
+> If you haven't done it yet, you first need to install the [ABP CLI](CLI.md). For other installation options, see [the package description page](https://abp.io/package-detail/Volo.Abp.Localization).
 
 Then you can add **AbpLocalizationModule** dependency to your module:
 

--- a/docs/en/Modules/Virtual-File-Explorer.md
+++ b/docs/en/Modules/Virtual-File-Explorer.md
@@ -10,9 +10,13 @@ Virtual File Explorer Module provided a simple UI to view all files in [virtual 
 
 #### 1- Use ABP CLI
 
-It is recommended to use the ABP CLI to install the module, open the CMD window in the solution file (`.sln`) directory, and run the following command:
+It is recommended to use the [ABP CLI](../CLI.md) to install the module, open the CMD window in the solution file (`.sln`) directory, and run the following command:
 
-`abp add-module Volo.VirtualFileExplorer`
+```
+abp add-module Volo.VirtualFileExplorer
+```
+
+> If you haven't done it yet, you first need to install the [ABP CLI](../CLI.md). For other installation options, see [the package description page](https://abp.io/package-detail/Volo.Abp.VirtualFileExplorer.Web).
 
 #### 2- Manually install
 

--- a/docs/en/MongoDB.md
+++ b/docs/en/MongoDB.md
@@ -4,11 +4,13 @@ This document explains how to integrate MongoDB as a database provider to ABP ba
 
 ## Installation
 
-`Volo.Abp.MongoDB` is the main nuget package for the MongoDB integration. Install it to your project (for a layered application, to your data/infrastructure layer):
+`Volo.Abp.MongoDB` is the main NuGet package for the MongoDB integration. Install it to your project (for a layered application, to your data/infrastructure layer), You can use the [ABP CLI](CLI.md) to install it to your project. Execute the following command in the folder of the .csproj file of the layer:
 
 ```
-Install-Package Volo.Abp.MongoDB
+abp add-package Volo.Abp.MongoDB
 ```
+
+> If you haven't done it yet, you first need to install the [ABP CLI](CLI.md). For other installation options, see [the package description page](https://abp.io/package-detail/Volo.Abp.MongoDB).
 
 Then add `AbpMongoDbModule` module dependency to your [module](Module-Development-Basics.md):
 

--- a/docs/en/PlugIn-Modules.md
+++ b/docs/en/PlugIn-Modules.md
@@ -61,7 +61,7 @@ Create a simple **Class Library Project** in a solution:
 
 ![simple-plugin-library](images/simple-plugin-library.png)
 
-You can the add ABP Framework packages that you need to use in the module. At least, you should add the `Volo.Abp.Core` package to the project, Execute the following command in the folder of the .csproj file that you want to install the package on:
+You can add the ABP Framework packages that you need to use in the module. At least, you should add the `Volo.Abp.Core` package to the project, Execute the following command in the folder of the .csproj file that you want to install the package on:
 
 ````bash
 abp add-package Volo.Abp.Core

--- a/docs/en/PlugIn-Modules.md
+++ b/docs/en/PlugIn-Modules.md
@@ -61,11 +61,13 @@ Create a simple **Class Library Project** in a solution:
 
 ![simple-plugin-library](images/simple-plugin-library.png)
 
-You can add ABP Framework packages you need to use in the module. At least, you should add the `Volo.Abp.Core` package to the project:
+You can the add ABP Framework packages that you need to use in the module. At least, you should add the `Volo.Abp.Core` package to the project, Execute the following command in the folder of the .csproj file that you want to install the package on:
 
+````bash
+abp add-package Volo.Abp.Core
 ````
-Install-Package Volo.Abp.Core
-````
+
+ If you haven't done it yet, you first need to install the [ABP CLI](CLI.md). For other installation options, see [the package description page](https://abp.io/package-detail/Volo.Abp.Core).
 
 Every [module](Module-Development-Basics.md) must declare a class derived from the `AbpModule`. Here, a simple module class that resolves a service and initializes it on the application startup:
 

--- a/docs/en/SMS-Sending.md
+++ b/docs/en/SMS-Sending.md
@@ -17,6 +17,8 @@ Open a command line window in the folder of the project (.csproj file) and type 
 abp add-package Volo.Abp.Sms
 ```
 
+> If you haven't done it yet, you first need to install the [ABP CLI](CLI.md). For other installation options, see [the package description page](https://abp.io/package-detail/Volo.Abp.Sms).
+
 ### Manual Installation
 
 If you want to manually install;

--- a/docs/en/SignalR-Integration.md
+++ b/docs/en/SignalR-Integration.md
@@ -18,6 +18,8 @@ abp add-package Volo.Abp.AspNetCore.SignalR
 
 > You typically want to add this package to the web or API layer of your application, depending on your architecture.
 
+> If you haven't done it yet, you first need to install the [ABP CLI](CLI.md). For other installation options, see [the package description page](https://abp.io/package-detail/Volo.Abp.AspNetCore.SignalR).
+
 #### Manual Installation
 
 If you want to manually install;

--- a/docs/en/UI/AspNetCore/Bundling-Minification.md
+++ b/docs/en/UI/AspNetCore/Bundling-Minification.md
@@ -12,7 +12,7 @@ ABP offers a simple, dynamic, powerful, modular and built-in way.
 
 > This package is already installed by default with the startup templates. So, most of the time, you don't need to install it manually.
 
-If you're not using a startup template, then execute the following command in the folder that contains the .csproj file of your project:
+If you're not using a startup template, you can use the [ABP CLI](../../CLI.md) to install it to your project. Execute the following command in the folder that contains the .csproj file of your project:
 
 ````
 abp add-package Volo.Abp.AspNetCore.Mvc.UI.Bundling
@@ -294,7 +294,7 @@ Using the built-in contributors for standard packages;
 
 > This package is already installed by default in the startup templates. So, most of the time, you don't need to install it manually.
 
-If you're not using a startup template, then execute the following command in the folder that contains the .csproj file of your project:
+If you're not using a startup template, you can use the [ABP CLI](../../CLI.md) to install it to your project. Execute the following command in the folder that contains the .csproj file of your project:
 
 ````
 abp add-package Volo.Abp.AspNetCore.Mvc.UI.Packages

--- a/docs/en/UI/AspNetCore/Bundling-Minification.md
+++ b/docs/en/UI/AspNetCore/Bundling-Minification.md
@@ -12,27 +12,13 @@ ABP offers a simple, dynamic, powerful, modular and built-in way.
 
 > This package is already installed by default with the startup templates. So, most of the time, you don't need to install it manually.
 
-Install the `Volo.Abp.AspNetCore.Mvc.UI.Bundling` nuget package to your project:
+If you're not using a startup template, then execute the following command in the folder that contains the .csproj file of your project:
 
 ````
-install-package Volo.Abp.AspNetCore.Mvc.UI.Bundling
+abp add-package Volo.Abp.AspNetCore.Mvc.UI.Bundling
 ````
 
-Then you can add the `AbpAspNetCoreMvcUiBundlingModule` dependency to your module:
-
-````C#
-using Volo.Abp.Modularity;
-using Volo.Abp.AspNetCore.Mvc.UI.Bundling;
-
-namespace MyCompany.MyProject
-{
-    [DependsOn(typeof(AbpAspNetCoreMvcUiBundlingModule))]
-    public class MyWebModule : AbpModule
-    {
-        //...
-    }
-}
-````
+> If you haven't done it yet, you first need to install the [ABP CLI](../../CLI.md). For other installation options, see [the package description page](https://abp.io/package-detail/Volo.Abp.AspNetCore.Mvc.UI.Bundling).
 
 ## Razor Bundling Tag Helpers
 
@@ -308,28 +294,13 @@ Using the built-in contributors for standard packages;
 
 > This package is already installed by default in the startup templates. So, most of the time, you don't need to install it manually.
 
-Standard package contributors are defined in the `Volo.Abp.AspNetCore.Mvc.UI.Packages` NuGet package. 
-To install it to your project:
+If you're not using a startup template, then execute the following command in the folder that contains the .csproj file of your project:
 
 ````
-install-package Volo.Abp.AspNetCore.Mvc.UI.Packages
+abp add-package Volo.Abp.AspNetCore.Mvc.UI.Packages
 ````
 
-Then add the `AbpAspNetCoreMvcUiPackagesModule` module dependency to your own module;
-
-````C#
-using Volo.Abp.Modularity;
-using Volo.Abp.AspNetCore.Mvc.UI.Bundling;
-
-namespace MyCompany.MyProject
-{
-    [DependsOn(typeof(AbpAspNetCoreMvcUiPackagesModule))]
-    public class MyWebModule : AbpModule
-    {
-        //...
-    }
-}
-````
+> If you haven't done it yet, you first need to install the [ABP CLI](../../CLI.md). For other installation options, see [the package description page](https://abp.io/package-detail/Volo.Abp.AspNetCore.Mvc.UI.Packages).
 
 ### Bundle Inheritance
 


### PR DESCRIPTION
Resolves #16811

1. Sent the missing ABP Platform package pages to @yekalkan to add. 
these two only: 
![image](https://github.com/abpframework/abp/assets/94292623/78037e54-8075-4250-9b74-184f39791e1a)
![image](https://github.com/abpframework/abp/assets/94292623/8da0a180-975e-408f-a48d-0d90545d6264)

2. Replaced all the `install-package` commands with `abp add-package` except the missing ones, and didn't delete the "For Manual installation:" sections since they were repeated frequently (please tell me if they should be deleted)

