### PR TITLE
Add tooltip support on extensible table

### DIFF
--- a/npm/ng-packs/packages/theme-shared/extensions/src/lib/components/extensible-table/extensible-table.component.html
+++ b/npm/ng-packs/packages/theme-shared/extensions/src/lib/components/extensible-table/extensible-table.component.html
@@ -25,10 +25,22 @@
   <ng-container *ngFor="let prop of propList; let i = index; trackBy: trackByFn">
     <ngx-datatable-column
       [width]="columnWidths[i + 1] || 200"
-      [name]="prop.displayName | abpLocalization"
+      [name]="prop.displayName | abpLocalization "
       [prop]="prop.name"
       [sortable]="prop.sortable"
     >
+    <ng-template ngx-datatable-header-template let-column="column" >
+      <span     
+      *ngIf="prop.tooltip; else elseBlock"
+      [ngbTooltip]="prop.tooltip | abpLocalization" 
+      container="body"
+      >
+      {{column.name}} <i class="fa fa-info-circle" aria-hidden="true"></i>
+      </span>
+      <ng-template #elseBlock>
+        {{column.name}}
+      </ng-template>
+    </ng-template>
       <ng-template let-row="row" let-i="index" ngx-datatable-cell-template>
         <ng-container *abpPermission="prop.permission; runChangeDetection: false">
           <ng-container *ngIf="row['_' + prop.name]?.visible">

--- a/npm/ng-packs/packages/theme-shared/extensions/src/lib/models/entity-props.ts
+++ b/npm/ng-packs/packages/theme-shared/extensions/src/lib/models/entity-props.ts
@@ -30,6 +30,7 @@ export class EntityProp<R = any> extends Prop<R> {
   readonly action?: ActionCallback<R>;
   readonly component?: Type<any>;
   readonly enumList?: Array<ABP.Option<any>>;
+  readonly tooltip?: string;
 
   constructor(options: EntityPropOptions<R>) {
     super(
@@ -40,7 +41,7 @@ export class EntityProp<R = any> extends Prop<R> {
       options.visible,
       options.isExtra,
     );
-
+    
     this.columnWidth = options.columnWidth;
     this.sortable = options.sortable || false;
     this.valueResolver =
@@ -55,6 +56,7 @@ export class EntityProp<R = any> extends Prop<R> {
     if (options.enumList) {
       this.enumList = options.enumList;
     }
+    this.tooltip = options.tooltip;
   }
 
   static create<R = any>(options: EntityPropOptions<R>) {

--- a/npm/ng-packs/packages/theme-shared/extensions/src/lib/ui-extensions.module.ts
+++ b/npm/ng-packs/packages/theme-shared/extensions/src/lib/ui-extensions.module.ts
@@ -5,6 +5,7 @@ import {
   NgbDatepickerModule,
   NgbDropdownModule,
   NgbTimepickerModule,
+  NgbTooltipModule,
   NgbTypeaheadModule,
 } from '@ng-bootstrap/ng-bootstrap';
 import { NgxValidateCoreModule } from '@ngx-validate/core';
@@ -48,6 +49,7 @@ import { CreateInjectorPipe } from './pipes/create-injector.pipe';
     NgbDropdownModule,
     NgbTimepickerModule,
     NgbTypeaheadModule,
+    NgbTooltipModule
   ],
 })
 export class BaseUiExtensionsModule {}


### PR DESCRIPTION
### Description
Resolves https://github.com/abpframework/abp/issues/16865

TODO: Describe what this PR has changed, add screenshot or animated GIF if available, write if it is a breaking change, and how to fix the breaking changes for existing applications if so.

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [ ] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?
 Run the app.
Add tooltip text on Entity-property. 
related table should has tooltip like

<img width="1706" alt="image" src="https://github.com/abpframework/abp/assets/2217899/207fdef3-b56f-4f60-8f65-0226f7026abb">
