### PR TITLE
Exract generic as array (or not)

### DIFF
--- a/npm/ng-packs/packages/schematics/src/utils/generics.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/generics.ts
@@ -67,21 +67,23 @@ export function generateRefWithPlaceholders(sourceType: string) {
 }
 
 export function extractSimpleGenerics(sourceType: string) {
-  const { identifier, generics } = extractGenerics(sourceType);
+  const { identifier, generics, array } = extractGenerics(sourceType);
 
   return {
     identifier: getLastSegment(identifier),
     generics: generics.map(getLastSegment),
+    array
   };
 }
 
 export function extractGenerics(sourceType: string) {
+  const isArray = /\[\]$/.test(sourceType);
   const regex = /(?<identifier>[^<]+)(<(?<generics>.+)>)?/g;
   const { identifier = '', generics = '' } = regex.exec(sourceType)?.groups ?? {};
-
-  return {
+   return {
     identifier,
     generics: generics.split(/,\s*/).filter(Boolean),
+    array: isArray ? '[]':'' 
   };
 }
 

--- a/npm/ng-packs/packages/schematics/src/utils/rule.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/rule.ts
@@ -25,6 +25,9 @@ export function applyWithOverwrite(source: Source, rules: Rule[]): Rule {
 export function mergeAndAllowDelete(host: Tree, rule: Rule) {
   return async (tree: Tree, context: SchematicContext) => {
     const nextTree = await callRule(rule, tree, context).toPromise();
+    if(!nextTree){
+      return;
+    }
     host.merge(nextTree, MergeStrategy.AllowDeleteConflict);
   };
 }

--- a/npm/ng-packs/packages/schematics/src/utils/type.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/type.ts
@@ -14,10 +14,8 @@ export function createTypeSimplifier() {
     );
 
     type = /any</.test(type) ? 'any' : type;
-
-    const { identifier, generics } = extractSimpleGenerics(type);
-
-    return generics.length ? `${identifier}<${generics.join(', ')}>` : identifier;
+     const { identifier, generics, array} = extractSimpleGenerics(type);
+    return generics.length ? `${identifier}<${generics.join(', ')}>${array}` : identifier;
   });
 
   return (type: string) => {


### PR DESCRIPTION
Related  #16743

the issue fix "when generic is array, converted code should be array too". But "missing identitiy import" still exists

### Description

- [x]  When the value is generic and array, generated model had issue . it fixed.
- [ ] abp based type did not import .(IdentityUserDto) 


Resolves 16743(write the related issue number if available)

TODO: Describe what this PR has changed, add screenshot or animated GIF if available, write if it is a breaking change, and how to fix the breaking changes for existing applications if so.

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

Please describe how this can be tested by the test engineers if it is not already explicit - or remove this section if no need to description.
