### PR TITLE
Allow LeptonX modules to be added with `add-module` command

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/AbpCliCoreModule.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/AbpCliCoreModule.cs
@@ -63,9 +63,6 @@ public class AbpCliCoreModule : AbpModule
             options.Commands[InstallLibsCommand.Name] = typeof(InstallLibsCommand);
             options.Commands[CleanCommand.Name] = typeof(CleanCommand);
             options.Commands[CliCommand.Name] = typeof(CliCommand);
-            
-            options.DisabledModulesToAddToSolution.Add("Volo.Abp.LeptonXTheme.Pro");
-            options.DisabledModulesToAddToSolution.Add("Volo.Abp.LeptonXTheme.Lite");
         });
 
         Configure<AbpCliServiceProxyOptions>(options =>

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/AddModuleCommand.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/AddModuleCommand.cs
@@ -75,7 +75,19 @@ public class AddModuleCommand : IConsoleCommand, ITransientDependency
         var version = commandLineArgs.Options.GetOrNull(Options.Version.Short, Options.Version.Long);
         if (version == null)
         {
-            version = SolutionPackageVersionFinder.Find(solutionFile);
+            if (commandLineArgs.Target.Contains("LeptonX"))
+            {
+                version = SolutionPackageVersionFinder.FindByCsprojVersion(solutionFile, excludedKeywords: null, includedKeyword: "LeptonX");
+
+                if (version.Contains("*"))
+                {
+                    version = SolutionPackageVersionFinder.FindByDllVersion(solutionFile, "Volo.Abp.*LeptonX*");
+                }
+            }
+            else
+            {
+                version = SolutionPackageVersionFinder.FindByCsprojVersion(solutionFile);
+            }
         }
 
         var moduleInfo = await SolutionModuleAdder.AddAsync(

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/ProjectCreationCommandBase.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/ProjectCreationCommandBase.cs
@@ -195,7 +195,7 @@ public abstract class ProjectCreationCommandBase
 
             var microserviceSolutionName = Path.GetFileName(slnPath).RemovePostFix(".sln");
 
-            version ??= SolutionPackageVersionFinder.Find(slnPath);
+            version ??= SolutionPackageVersionFinder.FindByCsprojVersion(slnPath);
             solutionName = SolutionName.Parse(microserviceSolutionName, projectName);
             outputFolder = MicroserviceServiceTemplateBase.CalculateTargetFolder(outputFolderRoot, solutionName.ProjectName);
             uiFramework = uiFramework == UiFramework.NotSpecified ? FindMicroserviceSolutionUiFramework(outputFolderRoot) : uiFramework;

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/SolutionModuleAdder.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/SolutionModuleAdder.cs
@@ -103,7 +103,6 @@ public class SolutionModuleAdder : ITransientDependency
         await PublishEventAsync(1, "Retrieving module info...");
         var module = await GetModuleInfoAsync(moduleName, newTemplate, newProTemplate);
 
-
         await PublishEventAsync(2, "Removing incompatible packages from module...");
         module = RemoveIncompatiblePackages(module, version);
 
@@ -259,6 +258,11 @@ public class SolutionModuleAdder : ITransientDependency
             {
                 projectsToRemove.AddRange(await FindProjectsToRemoveByTarget(module, NuGetPackageTarget.BlazorServer, isProjectTiered));
             }
+        }
+
+        if (!projectFiles.Any(p => p.EndsWith(".MauiBlazor.csproj")))
+        {
+            projectsToRemove.AddRange(await FindProjectsToRemoveByTarget(module, NuGetPackageTarget.MauiBlazor, isProjectTiered));
         }
 
         if (!projectFiles.Any(p => p.EndsWith(".Web.csproj")) && !webPackagesWillBeAddedToBlazorServerProject)

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/SolutionPackageVersionFinder.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/SolutionPackageVersionFinder.cs
@@ -1,8 +1,10 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Xml;
 using NuGet.Versioning;
+using NUglify.Helpers;
 using Volo.Abp.Cli.Utils;
 using Volo.Abp.DependencyInjection;
 
@@ -10,13 +12,31 @@ namespace Volo.Abp.Cli.ProjectModification;
 
 public class SolutionPackageVersionFinder : ITransientDependency
 {
-    public string Find(string solutionFile, string packagePrefix = "Volo.Abp", string excludedKeywords = "LeptonX")
+    public string FindByDllVersion(string solutionFile, string dllName = "Volo.Abp*")
+    {
+        var projectFilesUnderSrc = GetProjectFilesOfSolution(solutionFile);
+        foreach (var projectFile in projectFilesUnderSrc)
+        {
+            var dllFiles = Directory.GetFiles(Path.GetDirectoryName(projectFile)!, $"{dllName}.dll", SearchOption.AllDirectories);
+
+            if (dllFiles.Any())
+            {
+                var version =  FileVersionInfo.GetVersionInfo(dllFiles.First());
+
+                return $"{version.FileMajorPart}.{version.FileMinorPart}.{version.FileBuildPart}";
+            }
+        }
+
+        return null;
+    }
+    
+    public string FindByCsprojVersion(string solutionFile, string packagePrefix = "Volo.Abp", string excludedKeywords = "LeptonX", string includedKeyword = null)
     {
         var projectFilesUnderSrc = GetProjectFilesOfSolution(solutionFile);
         foreach (var projectFile in projectFilesUnderSrc)
         {
             var content = File.ReadAllText(projectFile);
-            if (TryParseVersionFromCsprojViaXmlDocument(content, out var s, packagePrefix, excludedKeywords))
+            if (TryParseVersionFromCsprojViaXmlDocument(content, out var s, packagePrefix, excludedKeywords, includedKeyword))
             {
                 return s;
             }
@@ -25,7 +45,7 @@ public class SolutionPackageVersionFinder : ITransientDependency
         return null;
     }
 
-    private static bool TryParseVersionFromCsprojViaXmlDocument(string content, out string version, string packagePrefix, string excludedKeywords)
+    private static bool TryParseVersionFromCsprojViaXmlDocument(string content, out string version, string packagePrefix, string excludedKeywords, string includedKeyword)
     {
         var doc = new XmlDocument() { PreserveWhitespace = true };
         using (var stream = StreamHelper.GenerateStreamFromString(content))
@@ -39,7 +59,12 @@ public class SolutionPackageVersionFinder : ITransientDependency
             {
                 var packageId = node!.Attributes["Include"]?.Value;
 
-                if (excludedKeywords.Split(',').Any(ek => packageId!.Contains(ek)))
+                if (!excludedKeywords.IsNullOrWhiteSpace() && excludedKeywords.Split(',').Any(ek => packageId!.Contains(ek)))
+                {
+                    continue;
+                }
+
+                if (!includedKeyword.IsNullOrWhiteSpace() && !packageId!.Contains(includedKeyword))
                 {
                     continue;
                 }
@@ -65,17 +90,17 @@ public class SolutionPackageVersionFinder : ITransientDependency
         }
     }
 
-    public static bool TryParseVersionFromCsprojFile(string csprojContent, out string version, string packagePrefix = "Volo.Abp", string excludedKeywords = "LeptonX")
+    public static bool TryParseVersionFromCsprojFile(string csprojContent, out string version, string packagePrefix = "Volo.Abp", string excludedKeywords = "LeptonX", string includedKeywords = null)
     {
-        return TryParseVersionFromCsprojViaXmlDocument(csprojContent, out version, packagePrefix, excludedKeywords);
+        return TryParseVersionFromCsprojViaXmlDocument(csprojContent, out version, packagePrefix, excludedKeywords, includedKeywords);
     }
 
 
-    public static bool TryParseSemanticVersionFromCsprojFile(string csprojContent, out SemanticVersion version, string packagePrefix = "Volo.Abp", string excludedKeywords = "LeptonX")
+    public static bool TryParseSemanticVersionFromCsprojFile(string csprojContent, out SemanticVersion version, string packagePrefix = "Volo.Abp", string excludedKeywords = "LeptonX", string includedKeywords = null)
     {
         try
         {
-            if (TryParseVersionFromCsprojViaXmlDocument(csprojContent, out var versionText, packagePrefix, excludedKeywords))
+            if (TryParseVersionFromCsprojViaXmlDocument(csprojContent, out var versionText, packagePrefix, excludedKeywords, includedKeywords))
             {
                 return SemanticVersion.TryParse(versionText, out version);
             }


### PR DESCRIPTION
resolves https://github.com/volosoft/volo/issues/14537

-----------
@gizemmutukurt 
branches: abp: `volo/issues/14537`, volo: `rel-7.2`
Test if `Lepton X Pro` can be replaced with source code on `Suite`'s modules page.
