### PR TITLE
Fix Tag Helper Floating labels

### DIFF
--- a/docs/en/UI/AspNetCore/Tag-Helpers/Form-elements.md
+++ b/docs/en/UI/AspNetCore/Tag-Helpers/Form-elements.md
@@ -87,6 +87,7 @@ You can set some of the attributes on your c# property, or directly on HTML tag.
 * `readonly`: Sets the input as read-only.
 * `label`: Sets the label of input.
 * `required-symbol`: Adds the required symbol `(*)` to the label when the input is required. The default value is `True`.
+* `FloatingLabel`: Sets the label as floating label. The default value is `False`.
 
 `asp-format`, `name` and `value` attributes of [Asp.Net Core Input Tag Helper](https://docs.microsoft.com/en-us/aspnet/core/mvc/views/working-with-forms?view=aspnetcore-7.0#the-input-tag-helper) are also valid for `abp-input` tag helper.
 

--- a/docs/en/UI/AspNetCore/Tag-Helpers/Form-elements.md
+++ b/docs/en/UI/AspNetCore/Tag-Helpers/Form-elements.md
@@ -87,7 +87,7 @@ You can set some of the attributes on your c# property, or directly on HTML tag.
 * `readonly`: Sets the input as read-only.
 * `label`: Sets the label of input.
 * `required-symbol`: Adds the required symbol `(*)` to the label when the input is required. The default value is `True`.
-* `FloatingLabel`: Sets the label as floating label. The default value is `False`.
+* `floating-label`: Sets the label as floating label. The default value is `False`.
 
 `asp-format`, `name` and `value` attributes of [Asp.Net Core Input Tag Helper](https://docs.microsoft.com/en-us/aspnet/core/mvc/views/working-with-forms?view=aspnetcore-7.0#the-input-tag-helper) are also valid for `abp-input` tag helper.
 

--- a/docs/zh-Hans/UI/AspNetCore/Tag-Helpers/Form-elements.md
+++ b/docs/zh-Hans/UI/AspNetCore/Tag-Helpers/Form-elements.md
@@ -196,6 +196,8 @@ Model:
   - `AbpFormControlSize.Large`
 - `label`: 为输入设置标签。
 - `display-required-symbol`: 如果输入是必需的，则向标签添加必需符号 (*)。默认为 `True`。
+- `FloatingLabel`: 设置输入的标签是否应该是浮动的。默认为 `False`。
+
 
 ### 标签和本地化
 

--- a/docs/zh-Hans/UI/AspNetCore/Tag-Helpers/Form-elements.md
+++ b/docs/zh-Hans/UI/AspNetCore/Tag-Helpers/Form-elements.md
@@ -196,7 +196,7 @@ Model:
   - `AbpFormControlSize.Large`
 - `label`: 为输入设置标签。
 - `display-required-symbol`: 如果输入是必需的，则向标签添加必需符号 (*)。默认为 `True`。
-- `FloatingLabel`: 设置输入的标签是否应该是浮动的。默认为 `False`。
+- `floating-label`: 设置输入的标签是否应该是浮动的。默认为 `False`。
 
 
 ### 标签和本地化

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpInputTagHelperService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpInputTagHelperService.cs
@@ -101,7 +101,7 @@ public class AbpInputTagHelperService : AbpTagHelperService<AbpInputTagHelper>
 
     protected virtual string GetContent(TagHelperContext context, TagHelperOutput output, string label, string inputHtml, string validation, string infoHtml, bool isCheckbox)
     {
-        var innerContent = isCheckbox ?
+        var innerContent = isCheckbox || TagHelper.FloatingLabel ?
             inputHtml + label :
             label + inputHtml;
 


### PR DESCRIPTION
### Description

Resolves https://github.com/abpframework/abp/issues/16994

Fix Tag Helper Floating labels

<img width="1048" alt="image" src="https://github.com/abpframework/abp/assets/16813853/772475af-5432-4d96-ba41-526789d38ddc">


### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)
