### PR TITLE
Fix search for latest branch when no version

### DIFF
--- a/modules/docs/src/Volo.Docs.Web/Pages/Documents/Project/Index.cshtml.cs
+++ b/modules/docs/src/Volo.Docs.Web/Pages/Documents/Project/Index.cshtml.cs
@@ -327,6 +327,11 @@ namespace Volo.Docs.Pages.Documents.Project
                     $"{DocsAppConsts.Latest}",
                     DocsAppConsts.Latest,
                     true);
+                
+                if(string.Equals(Version, DocsAppConsts.Latest, StringComparison.OrdinalIgnoreCase))
+                {
+                    Version = RemoveVersionPrefix(Project.LatestVersionBranchName);
+                }
             }
 
             VersionSelectItems = versions.Select(v => new SelectListItem


### PR DESCRIPTION
Resolves #16894 

When the version is not found, the latest version is retrieved from the database.


