### PR TITLE
Move invoke code after setting OpenIdConnectOptions for override flexibility

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Authentication.OpenIdConnect/Microsoft/Extensions/DependencyInjection/AbpOpenIdConnectExtensions.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Authentication.OpenIdConnect/Microsoft/Extensions/DependencyInjection/AbpOpenIdConnectExtensions.cs
@@ -28,8 +28,6 @@ public static class AbpOpenIdConnectExtensions
         {
             options.ClaimActions.MapAbpClaimTypes();
 
-            configureOptions?.Invoke(options);
-
             options.Events ??= new OpenIdConnectEvents();
             var authorizationCodeReceived = options.Events.OnAuthorizationCodeReceived ?? (_ => Task.CompletedTask);
 
@@ -63,6 +61,8 @@ public static class AbpOpenIdConnectExtensions
                     logger?.LogException(ex);
                 }
             };
+
+            configureOptions?.Invoke(options);
         });
     }
 

--- a/framework/src/Volo.Abp.AspNetCore.Authentication.OpenIdConnect/Microsoft/Extensions/DependencyInjection/AbpOpenIdConnectExtensions.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Authentication.OpenIdConnect/Microsoft/Extensions/DependencyInjection/AbpOpenIdConnectExtensions.cs
@@ -37,16 +37,7 @@ public static class AbpOpenIdConnectExtensions
                 return authorizationCodeReceived.Invoke(receivedContext);
             };
 
-            options.Events.OnRemoteFailure = remoteFailureContext =>
-            {
-                if (remoteFailureContext.Failure is OpenIdConnectProtocolException &&
-                    remoteFailureContext.Failure.Message.Contains("access_denied"))
-                {
-                    remoteFailureContext.HandleResponse();
-                    remoteFailureContext.Response.Redirect($"{remoteFailureContext.Request.PathBase}/");
-                }
-                return Task.CompletedTask;
-            };
+            options.AccessDeniedPath = "/";
             
             options.Events.OnTokenValidated = async (context) =>
             {


### PR DESCRIPTION
### Description

Moved the invoke code after setting the Abp options to allow developers to override them.

While inspecting the codes, I noticed that there is an AccessDeniedPath property. After inspecting the Abp code, it seems to be doing the same thing, so I refactored it
<img width="1290" alt="image" src="https://github.com/abpframework/abp/assets/74354599/dcc767da-0a97-4495-93f5-fe0a20ebb0ef">

