### PR TITLE
remove unnecessary name

### DIFF
--- a/framework/src/Volo.Abp.TextTemplating.Core/Volo/Abp/TextTemplating/ITemplateDefinitionContext.cs
+++ b/framework/src/Volo.Abp.TextTemplating.Core/Volo/Abp/TextTemplating/ITemplateDefinitionContext.cs
@@ -4,7 +4,7 @@ namespace Volo.Abp.TextTemplating;
 
 public interface ITemplateDefinitionContext
 {
-    IReadOnlyList<TemplateDefinition> GetAll(string name);
+    IReadOnlyList<TemplateDefinition> GetAll();
 
     TemplateDefinition GetOrNull(string name);
 

--- a/framework/src/Volo.Abp.TextTemplating.Core/Volo/Abp/TextTemplating/TemplateDefinitionContext.cs
+++ b/framework/src/Volo.Abp.TextTemplating.Core/Volo/Abp/TextTemplating/TemplateDefinitionContext.cs
@@ -12,7 +12,7 @@ public class TemplateDefinitionContext : ITemplateDefinitionContext
         Templates = templates;
     }
 
-    public IReadOnlyList<TemplateDefinition> GetAll()
+    public virtual IReadOnlyList<TemplateDefinition> GetAll()
     {
         return Templates.Values.ToImmutableList();
     }
@@ -20,11 +20,6 @@ public class TemplateDefinitionContext : ITemplateDefinitionContext
     public virtual TemplateDefinition GetOrNull(string name)
     {
         return Templates.GetOrDefault(name);
-    }
-
-    public virtual IReadOnlyList<TemplateDefinition> GetAll()
-    {
-        return Templates.Values.ToImmutableList();
     }
 
     public virtual void Add(params TemplateDefinition[] definitions)

--- a/framework/src/Volo.Abp.TextTemplating.Core/Volo/Abp/TextTemplating/TemplateDefinitionContext.cs
+++ b/framework/src/Volo.Abp.TextTemplating.Core/Volo/Abp/TextTemplating/TemplateDefinitionContext.cs
@@ -12,7 +12,7 @@ public class TemplateDefinitionContext : ITemplateDefinitionContext
         Templates = templates;
     }
 
-    public IReadOnlyList<TemplateDefinition> GetAll(string name)
+    public IReadOnlyList<TemplateDefinition> GetAll()
     {
         return Templates.Values.ToImmutableList();
     }


### PR DESCRIPTION
### Description

ITemplateDefinitionContext\'s GetAll method does not require a name parameter
​
### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)
