### PR TITLE
AngularUI: Fix enum prop can't display on table

### DIFF
--- a/npm/ng-packs/packages/theme-shared/extensions/src/lib/components/extensible-table/extensible-table.component.ts
+++ b/npm/ng-packs/packages/theme-shared/extensions/src/lib/components/extensible-table/extensible-table.component.ts
@@ -121,7 +121,7 @@ export class ExtensibleTableComponent<R = any> implements OnChanges {
   }
 
   private getEnum(rowValue: any, list: Array<ABP.Option<any>>) {
-    if (!list) return rowValue;
+    if (!list || list.length < 1) return rowValue;
     const { key } = list.find(({ value }) => value === rowValue) || {};
     return key;
   }


### PR DESCRIPTION
Resolves #17090 

![image](https://github.com/abpframework/abp/assets/49063256/d83fd740-8862-4da9-92ec-b39be12d676a)

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests

### How to test it?
- **Follow [Module entity extensions document](https://docs.abp.io/en/abp/7.0/Module-Entity-Extensions)**
- **Create enum in `MyProjectNameModuleExtensionConfigurator` class and add as ExtraProperty**
```cs
public enum UserType
{
  Regular,
  Moderator,
  SuperUser
}
``` 
- **Run backend (HostWithIds project)**
- **Go to users page and edit any user**
- **It should be able to display & edit User Type field**
- **It should be able to display column & value on table**
