### PR TITLE
Change deprecated  EmailSettingService with newer one

### DIFF
--- a/npm/ng-packs/packages/setting-management/config/src/lib/components/email-setting-group/email-setting-group.component.ts
+++ b/npm/ng-packs/packages/setting-management/config/src/lib/components/email-setting-group/email-setting-group.component.ts
@@ -4,7 +4,7 @@ import { Component, OnInit } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
 import { finalize } from 'rxjs/operators';
 import { SettingManagementPolicyNames } from '../../enums/policy-names';
-import { EmailSettingsService } from '../../proxy/email-settings.service';
+import { EmailSettingsService } from '@abp/ng.setting-management/proxy';
 import { EmailSettingsDto } from '../../proxy/models';
 
 @Component({


### PR DESCRIPTION
Resolves #17138

This service is only imported at email-setting-group.component.ts

![image](https://github.com/abpframework/abp/assets/72804437/88feddd5-0654-4ae3-8c17-c6ccb19fa181)