### PR TITLE
add schematics build on build:all

### DIFF
--- a/npm/ng-packs/package.json
+++ b/npm/ng-packs/package.json
@@ -7,7 +7,7 @@
     "nx": "nx",
     "start": "nx serve",
     "build": "ng build",
-    "build:all": "nx run-many --target=build --all --exclude=dev-app,schematics --prod  ",
+    "build:all": "nx run-many --target=build --all --exclude=dev-app,schematics --prod &&  npm run build:schematics",
     "test": "ng test --detect-open-handles=true --run-in-band=true --watch-all=true",
     "test:all": "nx run-many --target=test --all",
     "lint-staged": "lint-staged",


### PR DESCRIPTION
When you run `yarn run build:all` , schematics build did not working. It added