### PR TITLE
Fix wrongly written SetTableColumnsAsync call to base class method in UserManagement

### DIFF
--- a/modules/identity/src/Volo.Abp.Identity.Blazor/Pages/Identity/UserManagement.razor.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Blazor/Pages/Identity/UserManagement.razor.cs
@@ -217,7 +217,7 @@ public partial class UserManagement
 
         UserManagementTableColumns.AddRange(GetExtensionTableColumns(IdentityModuleExtensionConsts.ModuleName,
             IdentityModuleExtensionConsts.EntityNames.User));
-        return base.SetEntityActionsAsync();
+        return base.SetTableColumnsAsync();
     }
 
     protected override ValueTask SetToolbarItemsAsync()


### PR DESCRIPTION
### Description

Fix wrongly written SetTableColumnsAsync call to base class method in UserManagement

### Checklist

- [ ] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)
