### PR TITLE
Dynamic layout must solve layout oninit.

### DIFF
--- a/npm/ng-packs/packages/core/src/lib/components/dynamic-layout.component.ts
+++ b/npm/ng-packs/packages/core/src/lib/components/dynamic-layout.component.ts
@@ -1,4 +1,4 @@
-import { Component, Injector, isDevMode, Optional, SkipSelf, Type } from '@angular/core';
+import { Component, Injector, isDevMode, OnInit, Optional, SkipSelf, Type } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { eLayoutType } from '../enums/common';
 import { ABP } from '../models';
@@ -16,7 +16,7 @@ import { TreeNode } from '../utils/tree-utils';
   template: ` <ng-container *ngIf="isLayoutVisible" [ngComponentOutlet]="layout"></ng-container> `,
   providers: [SubscriptionService],
 })
-export class DynamicLayoutComponent {
+export class DynamicLayoutComponent implements OnInit {
   layout?: Type<any>;
   layoutKey?: eLayoutType;
 
@@ -51,6 +51,13 @@ export class DynamicLayoutComponent {
 
     this.checkLayoutOnNavigationEnd();
     this.listenToLanguageChange();
+  }
+
+  ngOnInit(): void {
+    if(this.layout){
+      return;
+    }
+    this.getLayout()
   }
 
   private checkLayoutOnNavigationEnd() {

--- a/npm/ng-packs/packages/oauth/src/lib/guards/oauth.guard.ts
+++ b/npm/ng-packs/packages/oauth/src/lib/guards/oauth.guard.ts
@@ -23,14 +23,8 @@ export class AbpOAuthGuard implements IAbpGuard {
     if (hasValidAccessToken) {
       return true;
     }
-
-    return of(false).pipe(
-      tap(() => this.httpErrorReporter.reportError({ status: 401 } as HttpErrorResponse)),
-      delay(1500),
-      tap(() => {
-        const params = { returnUrl: state.url };
-        this.authService.navigateToLogin(params);
-      }),
-    );
+    const params = { returnUrl: state.url };
+    this.authService.navigateToLogin(params);
+    return false;
   }
 }


### PR DESCRIPTION
Update guard

### Description
in our demo, home does not have guard. So  always, There is a triggered navigation-end event. But if a user want to add Guard on Home page. Dynamic layout can not resolve.  It fixed.  


Resolves #17061 

TODO: Describe what this PR has changed, add screenshot or animated GIF if available, write if it is a breaking change, and how to fix the breaking changes for existing applications if so.

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?
Create an add, add auth guard on Home page. When you logged-in and redirect o home-page, it should not be blank