### PR TITLE
Add `AbpIdentityUserValidator`.

### DIFF
--- a/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpIdentityAspNetCoreModule.cs
+++ b/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpIdentityAspNetCoreModule.cs
@@ -16,7 +16,8 @@ public class AbpIdentityAspNetCoreModule : AbpModule
             builder
                 .AddDefaultTokenProviders()
                 .AddTokenProvider<LinkUserTokenProvider>(LinkUserTokenProviderConsts.LinkUserTokenProviderName)
-                .AddSignInManager<AbpSignInManager>();
+                .AddSignInManager<AbpSignInManager>()
+                .AddUserValidator<AbpIdentityUserValidator>();
         });
     }
 

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/ar.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/ar.json
@@ -48,7 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "اسم الدور '{0}' غير صالح.",
     "Volo.Abp.Identity:InvalidToken": "غير صالح token.",
     "Volo.Abp.Identity:InvalidUserName": "اسم المستخدم '{0}' غير صالح ، يمكن أن يحتوي على أحرف أو أرقام فقط.",
-    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "لااسم المستخدم '{0}' غير صالح ، لا يمكنك استخدام البريد الإلكتروني لمستخدم آخر كاسم المستخدم الخاص بك.",
+    "InvalidUserName": "لااسم المستخدم '{0}' غير صالح .",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "يوجد مستخدم لديه معلومات تسجيل الدخول هذه بالفعل.",
     "Volo.Abp.Identity:PasswordMismatch": "كلمة مرور غير صحيحة.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "يجب أن تحتوي كلمات المرور على رقم واحد على الأقل ('0' - '9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/ar.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/ar.json
@@ -48,6 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "اسم الدور '{0}' غير صالح.",
     "Volo.Abp.Identity:InvalidToken": "غير صالح token.",
     "Volo.Abp.Identity:InvalidUserName": "اسم المستخدم '{0}' غير صالح ، يمكن أن يحتوي على أحرف أو أرقام فقط.",
+    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "لااسم المستخدم '{0}' غير صالح ، لا يمكنك استخدام البريد الإلكتروني لمستخدم آخر كاسم المستخدم الخاص بك.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "يوجد مستخدم لديه معلومات تسجيل الدخول هذه بالفعل.",
     "Volo.Abp.Identity:PasswordMismatch": "كلمة مرور غير صحيحة.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "يجب أن تحتوي كلمات المرور على رقم واحد على الأقل ('0' - '9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/cs.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/cs.json
@@ -48,7 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "Role '{0}' je neplatná.",
     "Volo.Abp.Identity:InvalidToken": "Neplatný token.",
     "Volo.Abp.Identity:InvalidUserName": "Uživatelské jméno '{0}' je neplatné, může obsahovat pouze písmena a číslice.",
-    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Uživatelské jméno '{0}' je neplatné, Nemůžete použít email jiného uživatele jako své uživatelské jméno.",
+    "InvalidUserName": "Uživatelské jméno '{0}' je neplatné.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Uživatel s tímto přihlášením již existuje.",
     "Volo.Abp.Identity:PasswordMismatch": "Chybné heslo.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Hesla musí obsahovat alespoň jednu číslici ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/cs.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/cs.json
@@ -48,6 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "Role '{0}' je neplatná.",
     "Volo.Abp.Identity:InvalidToken": "Neplatný token.",
     "Volo.Abp.Identity:InvalidUserName": "Uživatelské jméno '{0}' je neplatné, může obsahovat pouze písmena a číslice.",
+    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Uživatelské jméno '{0}' je neplatné, Nemůžete použít email jiného uživatele jako své uživatelské jméno.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Uživatel s tímto přihlášením již existuje.",
     "Volo.Abp.Identity:PasswordMismatch": "Chybné heslo.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Hesla musí obsahovat alespoň jednu číslici ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/de.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/de.json
@@ -48,7 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "Der Rollenname '{0}' ist ungültig.",
     "Volo.Abp.Identity:InvalidToken": "Ungültiger Token.",
     "Volo.Abp.Identity:InvalidUserName": "Der Benutzername '{0}' ist ungültig und darf nur Buchstaben oder Ziffern enthalten.",
-    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Der Benutzername '{0}' ist ungültig, Sie können nicht die E-Mail-Adresse eines anderen Benutzers als Ihren Benutzernamen verwenden.",
+    "InvalidUserName": "Der Benutzername '{0}' ist ungültig.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Ein Benutzer mit diesem Login existiert bereits.",
     "Volo.Abp.Identity:PasswordMismatch": "Falsches Passwort.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Passwörter müssen mindestens eine Ziffer haben ('0' - '9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/de.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/de.json
@@ -48,6 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "Der Rollenname '{0}' ist ungültig.",
     "Volo.Abp.Identity:InvalidToken": "Ungültiger Token.",
     "Volo.Abp.Identity:InvalidUserName": "Der Benutzername '{0}' ist ungültig und darf nur Buchstaben oder Ziffern enthalten.",
+    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Der Benutzername '{0}' ist ungültig, Sie können nicht die E-Mail-Adresse eines anderen Benutzers als Ihren Benutzernamen verwenden.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Ein Benutzer mit diesem Login existiert bereits.",
     "Volo.Abp.Identity:PasswordMismatch": "Falsches Passwort.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Passwörter müssen mindestens eine Ziffer haben ('0' - '9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/el.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/el.json
@@ -47,7 +47,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "Το όνομα ρόλου '{0}' δεν είναι έγκυρο.",
     "Volo.Abp.Identity:InvalidToken": "Μη έγκυρο διακριτικό.",
     "Volo.Abp.Identity:InvalidUserName": "Το όνομα χρήστη '{0}' δεν είναι έγκυρο, μπορεί να περιέχει μόνο γράμματα ή ψηφία.",
-    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Το όνομα χρήστη '{0}' δεν είναι έγκυρο, Δεν μπορείτε να χρησιμοποιήσετε το email ενός άλλου χρήστη ως όνομα χρήστη.",
+    "InvalidUserName": "Το όνομα χρήστη '{0}' δεν είναι έγκυρο.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Ένας χρήστης με αυτήν τη σύνδεση υπάρχει ήδη.",
     "Volo.Abp.Identity:PasswordMismatch": "Λάθος κωδικός.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Οι κωδικοί πρόσβασης πρέπει να έχουν τουλάχιστον ένα ψηφίο ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/el.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/el.json
@@ -47,6 +47,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "Το όνομα ρόλου '{0}' δεν είναι έγκυρο.",
     "Volo.Abp.Identity:InvalidToken": "Μη έγκυρο διακριτικό.",
     "Volo.Abp.Identity:InvalidUserName": "Το όνομα χρήστη '{0}' δεν είναι έγκυρο, μπορεί να περιέχει μόνο γράμματα ή ψηφία.",
+    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Το όνομα χρήστη '{0}' δεν είναι έγκυρο, Δεν μπορείτε να χρησιμοποιήσετε το email ενός άλλου χρήστη ως όνομα χρήστη.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Ένας χρήστης με αυτήν τη σύνδεση υπάρχει ήδη.",
     "Volo.Abp.Identity:PasswordMismatch": "Λάθος κωδικός.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Οι κωδικοί πρόσβασης πρέπει να έχουν τουλάχιστον ένα ψηφίο ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/en-GB.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/en-GB.json
@@ -47,6 +47,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "Role name '{0}' is invalid.",
     "Volo.Abp.Identity:InvalidToken": "Invalid token.",
     "Volo.Abp.Identity:InvalidUserName": "Username '{0}' is invalid, it should only contain letters or digits.",
+    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Username '{0}' is invalid, You cannot use another user's email as your Username.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "A user with this login already exists.",
     "Volo.Abp.Identity:PasswordMismatch": "Incorrect password.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Passwords must have at least one digit ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/en-GB.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/en-GB.json
@@ -47,7 +47,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "Role name '{0}' is invalid.",
     "Volo.Abp.Identity:InvalidToken": "Invalid token.",
     "Volo.Abp.Identity:InvalidUserName": "Username '{0}' is invalid, it should only contain letters or digits.",
-    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Username '{0}' is invalid, You cannot use another user's email as your Username.",
+    "InvalidUserName": "Username '{0}' is invalid.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "A user with this login already exists.",
     "Volo.Abp.Identity:PasswordMismatch": "Incorrect password.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Passwords must have at least one digit ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/en.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/en.json
@@ -48,7 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "Role name '{0}' is invalid.",
     "Volo.Abp.Identity:InvalidToken": "Invalid token.",
     "Volo.Abp.Identity:InvalidUserName": "Username '{0}' is invalid, can only contain letters or digits.",
-    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Username '{0}' is invalid, You cannot use another user's email as your Username.",
+    "InvalidUserName": "Username '{0}' is invalid.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "A user with this login already exists.",
     "Volo.Abp.Identity:PasswordMismatch": "Incorrect password.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Passwords must have at least one digit ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/en.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/en.json
@@ -48,6 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "Role name '{0}' is invalid.",
     "Volo.Abp.Identity:InvalidToken": "Invalid token.",
     "Volo.Abp.Identity:InvalidUserName": "Username '{0}' is invalid, can only contain letters or digits.",
+    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Username '{0}' is invalid, You cannot use another user's email as your Username.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "A user with this login already exists.",
     "Volo.Abp.Identity:PasswordMismatch": "Incorrect password.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Passwords must have at least one digit ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/es.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/es.json
@@ -48,6 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "El nombre de rol '{0}' no es válido.",
     "Volo.Abp.Identity:InvalidToken": "token no válido",
     "Volo.Abp.Identity:InvalidUserName": "Nombre de usuario '{0}' no es válido. Sólo puede contener letras o dígitos",
+    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Nombre de usuario '{0}' no es válido. No puedes usar el e-mail de otro usuario como tu nombre de usuario.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Usuario con este inicio de sesión en uso.",
     "Volo.Abp.Identity:PasswordMismatch": "Contraseña incorrecta.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Contraseñas deben tener al menos un dígito ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/es.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/es.json
@@ -48,7 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "El nombre de rol '{0}' no es válido.",
     "Volo.Abp.Identity:InvalidToken": "token no válido",
     "Volo.Abp.Identity:InvalidUserName": "Nombre de usuario '{0}' no es válido. Sólo puede contener letras o dígitos",
-    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Nombre de usuario '{0}' no es válido. No puedes usar el e-mail de otro usuario como tu nombre de usuario.",
+    "InvalidUserName": "Nombre de usuario '{0}' no es válido.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Usuario con este inicio de sesión en uso.",
     "Volo.Abp.Identity:PasswordMismatch": "Contraseña incorrecta.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Contraseñas deben tener al menos un dígito ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/fa.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/fa.json
@@ -47,7 +47,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "عنوان نقش/وظیفه {0} نامعتبر است.",
     "Volo.Abp.Identity:InvalidToken": "گذرواژه وارد شده معتبر نیست.",
     "Volo.Abp.Identity:InvalidUserName": "نام کاربری '{0}' نامعتبر است، نام کاربری فقط می تواند شامل حروف یا ارقام باشد.",
-    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "شما نمی توانید از ایمیل کاربر دیگری به عنوان نام کاربری خود استفاده کنید.",
+    "InvalidUserName": "ام کاربری '{0}' نامعتبر است",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "یک کاربر با این نام کاربری از قبل موجود می باشد.",
     "Volo.Abp.Identity:PasswordMismatch": "گذرواژه اشتباه است.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "گذرواژه ها باید حداقل یک رقم داشته باشند ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/fa.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/fa.json
@@ -47,6 +47,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "عنوان نقش/وظیفه {0} نامعتبر است.",
     "Volo.Abp.Identity:InvalidToken": "گذرواژه وارد شده معتبر نیست.",
     "Volo.Abp.Identity:InvalidUserName": "نام کاربری '{0}' نامعتبر است، نام کاربری فقط می تواند شامل حروف یا ارقام باشد.",
+    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "شما نمی توانید از ایمیل کاربر دیگری به عنوان نام کاربری خود استفاده کنید.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "یک کاربر با این نام کاربری از قبل موجود می باشد.",
     "Volo.Abp.Identity:PasswordMismatch": "گذرواژه اشتباه است.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "گذرواژه ها باید حداقل یک رقم داشته باشند ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/fi.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/fi.json
@@ -48,7 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "Roolin nimi {0} on virheellinen.",
     "Volo.Abp.Identity:InvalidToken": "Virheellinen tunnus.",
     "Volo.Abp.Identity:InvalidUserName": "Käyttäjätunnus {0} on virheellinen, voi sisältää vain kirjaimia tai numeroita.",
-    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Käyttäjätunnus {0} on virheellinen, Et voi käyttää toisen käyttäjän sähköpostiosoitetta käyttäjänimenä.",
+    "InvalidUserName": "Käyttäjätunnus {0} on virheellinen.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Käyttäjä, jolla on tämä sisäänkirjautuminen, on jo olemassa.",
     "Volo.Abp.Identity:PasswordMismatch": "Väärä salasana.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Salasanoissa on oltava vähintään yksi numero ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/fi.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/fi.json
@@ -48,6 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "Roolin nimi {0} on virheellinen.",
     "Volo.Abp.Identity:InvalidToken": "Virheellinen tunnus.",
     "Volo.Abp.Identity:InvalidUserName": "Käyttäjätunnus {0} on virheellinen, voi sisältää vain kirjaimia tai numeroita.",
+    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Käyttäjätunnus {0} on virheellinen, Et voi käyttää toisen käyttäjän sähköpostiosoitetta käyttäjänimenä.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Käyttäjä, jolla on tämä sisäänkirjautuminen, on jo olemassa.",
     "Volo.Abp.Identity:PasswordMismatch": "Väärä salasana.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Salasanoissa on oltava vähintään yksi numero ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/fr.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/fr.json
@@ -48,6 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "Le nom de rôle '{0}' n’est pas valide.",
     "Volo.Abp.Identity:InvalidToken": "Jeton non valide.",
     "Volo.Abp.Identity:InvalidUserName": "Le nom d’utilisateur '{0}' n’est pas valide, ne peut contenir que des lettres ou des chiffres.",
+    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Le nom d’utilisateur '{0}' n’est pas valide,Vous ne pouvez pas utiliser l’e-mail d’un autre utilisateur comme nom d’utilisateur.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Un utilisateur avec cette connexion existe déjà.",
     "Volo.Abp.Identity:PasswordMismatch": "Mot de passe incorrect.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Les mots de passe doivent avoir au moins un chiffre ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/fr.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/fr.json
@@ -48,7 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "Le nom de rôle '{0}' n’est pas valide.",
     "Volo.Abp.Identity:InvalidToken": "Jeton non valide.",
     "Volo.Abp.Identity:InvalidUserName": "Le nom d’utilisateur '{0}' n’est pas valide, ne peut contenir que des lettres ou des chiffres.",
-    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Le nom d’utilisateur '{0}' n’est pas valide,Vous ne pouvez pas utiliser l’e-mail d’un autre utilisateur comme nom d’utilisateur.",
+    "InvalidUserName": "Le nom d’utilisateur '{0}' n’est pas valide.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Un utilisateur avec cette connexion existe déjà.",
     "Volo.Abp.Identity:PasswordMismatch": "Mot de passe incorrect.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Les mots de passe doivent avoir au moins un chiffre ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/hi.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/hi.json
@@ -48,7 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "भूमिका नाम '{0}' अमान्य है।",
     "Volo.Abp.Identity:InvalidToken": "अमान्य टोकन।",
     "Volo.Abp.Identity:InvalidUserName": "उपयोगकर्ता नाम '{0}' अमान्य है, इसमें केवल अक्षर या अंक हो सकते हैं।",
-    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "उपयोगकर्ता नाम '{0}' अमान्य है, आप दूसरे उपयोगकर्ता का ईमेल नाम उपयोग नहीं कर सकते।",
+    "InvalidUserName": "उपयोगकर्ता नाम '{0}' अमान्य है",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "इस लॉगिन वाला उपयोगकर्ता पहले से मौजूद है।",
     "Volo.Abp.Identity:PasswordMismatch": "गलत पासवर्ड।",
     "Volo.Abp.Identity:PasswordRequiresDigit": "पासवर्ड में कम से कम एक अंक ('0'-'9') होना चाहिए।",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/hi.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/hi.json
@@ -48,6 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "भूमिका नाम '{0}' अमान्य है।",
     "Volo.Abp.Identity:InvalidToken": "अमान्य टोकन।",
     "Volo.Abp.Identity:InvalidUserName": "उपयोगकर्ता नाम '{0}' अमान्य है, इसमें केवल अक्षर या अंक हो सकते हैं।",
+    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "उपयोगकर्ता नाम '{0}' अमान्य है, आप दूसरे उपयोगकर्ता का ईमेल नाम उपयोग नहीं कर सकते।",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "इस लॉगिन वाला उपयोगकर्ता पहले से मौजूद है।",
     "Volo.Abp.Identity:PasswordMismatch": "गलत पासवर्ड।",
     "Volo.Abp.Identity:PasswordRequiresDigit": "पासवर्ड में कम से कम एक अंक ('0'-'9') होना चाहिए।",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/hr.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/hr.json
@@ -48,7 +48,7 @@
         "Volo.Abp.Identity:InvalidRoleName": "Naziv uloge '{0}' nije valjan.",
         "Volo.Abp.Identity:InvalidToken": "Pogrešan token.",
         "Volo.Abp.Identity:InvalidUserName": "Korisničko ime '{0}' nije važeće, može sadržavati samo slova ili znamenke.",
-        "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Korisničko ime '{0}' nije važeće, Ne možete koristiti e-poštu drugog korisnika kao svoje korisničko ime.",
+        "InvalidUserName": "Korisničko ime '{0}' nije važeće.",
         "Volo.Abp.Identity:LoginAlreadyAssociated": "Korisnik s ovom prijavom već postoji.",
         "Volo.Abp.Identity:PasswordMismatch": "Netočna lozinka.",
         "Volo.Abp.Identity:PasswordRequiresDigit": "Lozinke moraju imati najmanje jednu znamenku ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/hr.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/hr.json
@@ -48,6 +48,7 @@
         "Volo.Abp.Identity:InvalidRoleName": "Naziv uloge '{0}' nije valjan.",
         "Volo.Abp.Identity:InvalidToken": "Pogrešan token.",
         "Volo.Abp.Identity:InvalidUserName": "Korisničko ime '{0}' nije važeće, može sadržavati samo slova ili znamenke.",
+        "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Korisničko ime '{0}' nije važeće, Ne možete koristiti e-poštu drugog korisnika kao svoje korisničko ime.",
         "Volo.Abp.Identity:LoginAlreadyAssociated": "Korisnik s ovom prijavom već postoji.",
         "Volo.Abp.Identity:PasswordMismatch": "Netočna lozinka.",
         "Volo.Abp.Identity:PasswordRequiresDigit": "Lozinke moraju imati najmanje jednu znamenku ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/hu.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/hu.json
@@ -48,6 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "'{0}' szerepkör név érvénytelen.",
     "Volo.Abp.Identity:InvalidToken": "Érvénytelen token.",
     "Volo.Abp.Identity:InvalidUserName": "'{0}' felhasználónév érvénytelen, csak betűket és számokat tartalmazhat.",
+    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "'{0}' felhasználónév érvénytelen, Nem használhatja más felhasználó email címét felhasználónévként.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Az ilyen bejelentkezéssel rendelkező felhasználó már létezik.",
     "Volo.Abp.Identity:PasswordMismatch": "Érvénytelen jelszó.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "A jelszavaknak legalább egy számjegyet kell rendelkezniük ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/hu.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/hu.json
@@ -48,7 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "'{0}' szerepkör név érvénytelen.",
     "Volo.Abp.Identity:InvalidToken": "Érvénytelen token.",
     "Volo.Abp.Identity:InvalidUserName": "'{0}' felhasználónév érvénytelen, csak betűket és számokat tartalmazhat.",
-    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "'{0}' felhasználónév érvénytelen, Nem használhatja más felhasználó email címét felhasználónévként.",
+    "InvalidUserName": "'{0}' felhasználónév érvénytelen.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Az ilyen bejelentkezéssel rendelkező felhasználó már létezik.",
     "Volo.Abp.Identity:PasswordMismatch": "Érvénytelen jelszó.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "A jelszavaknak legalább egy számjegyet kell rendelkezniük ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/is.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/is.json
@@ -48,6 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "Hlutverkanafnið '{0}' er ógilt.",
     "Volo.Abp.Identity:InvalidToken": "Ógilt token.",
     "Volo.Abp.Identity:InvalidUserName": "Notandanafnið '{0}' er ógilt, getur aðeins innihaldið bókstafi eða tölustafi.",
+    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Notandanafnið '{0}' er ógilt, Þú getur ekki notað netfang annars notanda sem notendanafn.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Notandi með þessa innskráningu er þegar til.",
     "Volo.Abp.Identity:PasswordMismatch": "Rangt lykilorð.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Lykilorð verða að hafa að minnsta kosti einn staf ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/is.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/is.json
@@ -48,7 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "Hlutverkanafnið '{0}' er ógilt.",
     "Volo.Abp.Identity:InvalidToken": "Ógilt token.",
     "Volo.Abp.Identity:InvalidUserName": "Notandanafnið '{0}' er ógilt, getur aðeins innihaldið bókstafi eða tölustafi.",
-    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Notandanafnið '{0}' er ógilt, Þú getur ekki notað netfang annars notanda sem notendanafn.",
+    "InvalidUserName": "Notandanafnið '{0}' er ógilt.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Notandi með þessa innskráningu er þegar til.",
     "Volo.Abp.Identity:PasswordMismatch": "Rangt lykilorð.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Lykilorð verða að hafa að minnsta kosti einn staf ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/it.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/it.json
@@ -48,6 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "Il nome del ruolo '{0}' non è valido.",
     "Volo.Abp.Identity:InvalidToken": "Token non valido.",
     "Volo.Abp.Identity:InvalidUserName": "Il nome utente '{0}' non è valido, può contenere solo lettere o cifre.",
+    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Il nome utente '{0}' non è valido, Non puoi utilizzare l'email di un altro utente come nome utente.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Esiste già un utente con questo account.",
     "Volo.Abp.Identity:PasswordMismatch": "Password errata.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "La password deve contenere almeno una cifra ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/it.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/it.json
@@ -48,7 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "Il nome del ruolo '{0}' non è valido.",
     "Volo.Abp.Identity:InvalidToken": "Token non valido.",
     "Volo.Abp.Identity:InvalidUserName": "Il nome utente '{0}' non è valido, può contenere solo lettere o cifre.",
-    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Il nome utente '{0}' non è valido, Non puoi utilizzare l'email di un altro utente come nome utente.",
+    "InvalidUserName": "Il nome utente '{0}' non è valido.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Esiste già un utente con questo account.",
     "Volo.Abp.Identity:PasswordMismatch": "Password errata.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "La password deve contenere almeno una cifra ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/nl.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/nl.json
@@ -48,7 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "Rol naam '{0}' is ongeldig.",
     "Volo.Abp.Identity:InvalidToken": "Ongeldig token.",
     "Volo.Abp.Identity:InvalidUserName": "Gebruikersnaam '{0}' is ongeldig, mag alleen letters of cijfers bevatten.",
-    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Gebruikersnaam '{0}' is ongeldig, U kunt het e-mailadres van een andere gebruiker niet als uw gebruikersnaam gebruiken.",
+    "InvalidUserName": "Gebruikersnaam '{0}' is ongeldig.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Er bestaat al een gebruiker met deze login.",
     "Volo.Abp.Identity:PasswordMismatch": "Incorrect wachtwoord.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Wachtwoorden moeten minimaal één cijfer bevatten ('0' - '9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/nl.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/nl.json
@@ -48,6 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "Rol naam '{0}' is ongeldig.",
     "Volo.Abp.Identity:InvalidToken": "Ongeldig token.",
     "Volo.Abp.Identity:InvalidUserName": "Gebruikersnaam '{0}' is ongeldig, mag alleen letters of cijfers bevatten.",
+    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Gebruikersnaam '{0}' is ongeldig, U kunt het e-mailadres van een andere gebruiker niet als uw gebruikersnaam gebruiken.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Er bestaat al een gebruiker met deze login.",
     "Volo.Abp.Identity:PasswordMismatch": "Incorrect wachtwoord.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Wachtwoorden moeten minimaal één cijfer bevatten ('0' - '9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/pl-PL.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/pl-PL.json
@@ -48,7 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "Rola '{0}' jest niepoprawna.",
     "Volo.Abp.Identity:InvalidToken": "Niepoprawny token.",
     "Volo.Abp.Identity:InvalidUserName": "Nazwa użytkownika '{0}' jest niepoprawna, może zawierać tylko litery i cyfry.",
-    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Nazwa użytkownika '{0}' jest niepoprawna, Nie możesz użyć adresu e-mail innego użytkownika jako swojej nazwy użytkownika.",
+    "InvalidUserName": "Nazwa użytkownika '{0}' jest niepoprawna.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Użytkownik o tym loginie już istnieje.",
     "Volo.Abp.Identity:PasswordMismatch": "Niepoprawne hasło.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Hasło musi zawierać przynajmniej jedną cyfrę ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/pl-PL.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/pl-PL.json
@@ -48,6 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "Rola '{0}' jest niepoprawna.",
     "Volo.Abp.Identity:InvalidToken": "Niepoprawny token.",
     "Volo.Abp.Identity:InvalidUserName": "Nazwa użytkownika '{0}' jest niepoprawna, może zawierać tylko litery i cyfry.",
+    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Nazwa użytkownika '{0}' jest niepoprawna, Nie możesz użyć adresu e-mail innego użytkownika jako swojej nazwy użytkownika.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Użytkownik o tym loginie już istnieje.",
     "Volo.Abp.Identity:PasswordMismatch": "Niepoprawne hasło.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Hasło musi zawierać przynajmniej jedną cyfrę ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/pt-BR.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/pt-BR.json
@@ -48,7 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "Perfil '{0}' inválido.",
     "Volo.Abp.Identity:InvalidToken": "Token inválido.",
     "Volo.Abp.Identity:InvalidUserName": "Usuário '{0}' é inválido, somente pode conter letras ou números.",
-    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Usuário '{0}' é inválido, Você não pode usar o e-mail de outro usuário como seu nome de usuário.",
+    "InvalidUserName": "Usuário '{0}' é inválido.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Um usuário com este login já existe.",
     "Volo.Abp.Identity:PasswordMismatch": "Senha incorreta.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Senhas devem possuir pelo menos um dígito ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/pt-BR.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/pt-BR.json
@@ -48,6 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "Perfil '{0}' inválido.",
     "Volo.Abp.Identity:InvalidToken": "Token inválido.",
     "Volo.Abp.Identity:InvalidUserName": "Usuário '{0}' é inválido, somente pode conter letras ou números.",
+    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Usuário '{0}' é inválido, Você não pode usar o e-mail de outro usuário como seu nome de usuário.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Um usuário com este login já existe.",
     "Volo.Abp.Identity:PasswordMismatch": "Senha incorreta.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Senhas devem possuir pelo menos um dígito ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/ro-RO.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/ro-RO.json
@@ -48,6 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "Numele de rol '{0}' este invalid.",
     "Volo.Abp.Identity:InvalidToken": "Invalid token.",
     "Volo.Abp.Identity:InvalidUserName": "Numele de utilizator '{0}' este invalid, poate conţine doar litere şi cifre.",
+    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Numele de utilizator '{0}' este invalid, Nu puteţi folosi adresa de email a altui utilizator ca nume de utilizator.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Un utilizator cu această autentificare există deja.",
     "Volo.Abp.Identity:PasswordMismatch": "Parolă incorectă.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Parolele trebuie să conţină cel puţin o cifră ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/ro-RO.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/ro-RO.json
@@ -48,7 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "Numele de rol '{0}' este invalid.",
     "Volo.Abp.Identity:InvalidToken": "Invalid token.",
     "Volo.Abp.Identity:InvalidUserName": "Numele de utilizator '{0}' este invalid, poate conţine doar litere şi cifre.",
-    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Numele de utilizator '{0}' este invalid, Nu puteţi folosi adresa de email a altui utilizator ca nume de utilizator.",
+    "InvalidUserName": "Numele de utilizator '{0}' este invalid.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Un utilizator cu această autentificare există deja.",
     "Volo.Abp.Identity:PasswordMismatch": "Parolă incorectă.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Parolele trebuie să conţină cel puţin o cifră ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/ru.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/ru.json
@@ -48,6 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "Имя роли '{0}' недопустимо.",
     "Volo.Abp.Identity:InvalidToken": "Недопустимый маркер.",
     "Volo.Abp.Identity:InvalidUserName": "Имя пользователя '{0}' недопустимо и может содержать только буквы или цифры.",
+    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Имя пользователя '{0}' недопустимо Вы не можете использовать электронную почту другого пользователя в качестве своего имени пользователя.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Пользователь с таким логином уже существует.",
     "Volo.Abp.Identity:PasswordMismatch": "Неверный пароль.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Пароль должен содержать по крайней мере одну цифру.",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/ru.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/ru.json
@@ -48,7 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "Имя роли '{0}' недопустимо.",
     "Volo.Abp.Identity:InvalidToken": "Недопустимый маркер.",
     "Volo.Abp.Identity:InvalidUserName": "Имя пользователя '{0}' недопустимо и может содержать только буквы или цифры.",
-    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Имя пользователя '{0}' недопустимо Вы не можете использовать электронную почту другого пользователя в качестве своего имени пользователя.",
+    "InvalidUserName": "Имя пользователя '{0}' недопустимо.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Пользователь с таким логином уже существует.",
     "Volo.Abp.Identity:PasswordMismatch": "Неверный пароль.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Пароль должен содержать по крайней мере одну цифру.",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/sk.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/sk.json
@@ -48,7 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "Názov roly '{0}' je neplatný.",
     "Volo.Abp.Identity:InvalidToken": "Neplatný token.",
     "Volo.Abp.Identity:InvalidUserName": "Používateľské meno '{0}' je neplatné, môže obsahovať len písmená alebo číslice.",
-    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Používateľské meno '{0}' je neplatné, Nemôžete použiť email iného používateľa ako svoje používateľské meno.",
+    "InvalidUserName": "Používateľské meno '{0}' je neplatné.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Používateľ s týmto prihlasovacím menom už existuje.",
     "Volo.Abp.Identity:PasswordMismatch": "Nesprávne heslo.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Heslá musia obsahovať aspoň jednu číslicu ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/sk.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/sk.json
@@ -48,6 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "Názov roly '{0}' je neplatný.",
     "Volo.Abp.Identity:InvalidToken": "Neplatný token.",
     "Volo.Abp.Identity:InvalidUserName": "Používateľské meno '{0}' je neplatné, môže obsahovať len písmená alebo číslice.",
+    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Používateľské meno '{0}' je neplatné, Nemôžete použiť email iného používateľa ako svoje používateľské meno.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Používateľ s týmto prihlasovacím menom už existuje.",
     "Volo.Abp.Identity:PasswordMismatch": "Nesprávne heslo.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Heslá musia obsahovať aspoň jednu číslicu ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/sl.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/sl.json
@@ -48,7 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "Naziv vloge '{0}' ni veljaven.",
     "Volo.Abp.Identity:InvalidToken": "Neveljaven žeton.",
     "Volo.Abp.Identity:InvalidUserName": "Uporabniško ime '{0}' ni veljavno, vsebuje lahko le črke in številke.",
-    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Uporabniško ime '{0}' ni veljavno, Ne morete uporabiti e-poštnega naslova drugega uporabnika kot svojega uporabniškega imena.",
+    "InvalidUserName": "Uporabniško ime '{0}' ni veljavno.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Uporabnik s to prijavo že obstaja.",
     "Volo.Abp.Identity:PasswordMismatch": "Nepravilno geslo.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Gesla morajo imeti vsaj eno številko ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/sl.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/sl.json
@@ -48,6 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "Naziv vloge '{0}' ni veljaven.",
     "Volo.Abp.Identity:InvalidToken": "Neveljaven žeton.",
     "Volo.Abp.Identity:InvalidUserName": "Uporabniško ime '{0}' ni veljavno, vsebuje lahko le črke in številke.",
+    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Uporabniško ime '{0}' ni veljavno, Ne morete uporabiti e-poštnega naslova drugega uporabnika kot svojega uporabniškega imena.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Uporabnik s to prijavo že obstaja.",
     "Volo.Abp.Identity:PasswordMismatch": "Nepravilno geslo.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Gesla morajo imeti vsaj eno številko ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/tr.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/tr.json
@@ -48,7 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "'{0}' rol ismi geçersizdir.",
     "Volo.Abp.Identity:InvalidToken": "Geçersiz token.",
     "Volo.Abp.Identity:InvalidUserName": "'{0}' kullanıcı adı geçersiz, sadece harf ve rakamlardan oluşmalı.",
-    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "'{0}' kullanıcı adı geçersiz, Başka bir kullanıcının e-posta adresini kullanıcı adı olarak kullanamazsınız.",
+    "InvalidUserName": "'{0}' kullanıcı adı geçersiz.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Bu giriş bilgilerine sahip bir kullanıcı zaten var.",
     "Volo.Abp.Identity:PasswordMismatch": "Hatalı şifre.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Şifre en az bir sayı içermeli ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/tr.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/tr.json
@@ -48,6 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "'{0}' rol ismi geçersizdir.",
     "Volo.Abp.Identity:InvalidToken": "Geçersiz token.",
     "Volo.Abp.Identity:InvalidUserName": "'{0}' kullanıcı adı geçersiz, sadece harf ve rakamlardan oluşmalı.",
+    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "'{0}' kullanıcı adı geçersiz, Başka bir kullanıcının e-posta adresini kullanıcı adı olarak kullanamazsınız.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Bu giriş bilgilerine sahip bir kullanıcı zaten var.",
     "Volo.Abp.Identity:PasswordMismatch": "Hatalı şifre.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Şifre en az bir sayı içermeli ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/vi.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/vi.json
@@ -48,7 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "Tên người dùng '{0}' Không hợp lệ.",
     "Volo.Abp.Identity:InvalidToken": "Token không hợp lệ.",
     "Volo.Abp.Identity:InvalidUserName": "Tên người dùng '{0}' không hợp lệ, chỉ có thể chứa chữ cái hoặc chữ số.",
-    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Tên người dùng '{0}' không hợp lệ, Bạn không thể sử dụng email của người dùng khác làm tên người dùng của mình.",
+    "InvalidUserName": "Tên người dùng '{0}' không hợp lệ.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Một người dùng có thông tin đăng nhập này đã tồn tại.",
     "Volo.Abp.Identity:PasswordMismatch": "Mật khẩu không đúng.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Mật khẩu phải có ít nhất một chữ số ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/vi.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/vi.json
@@ -48,6 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "Tên người dùng '{0}' Không hợp lệ.",
     "Volo.Abp.Identity:InvalidToken": "Token không hợp lệ.",
     "Volo.Abp.Identity:InvalidUserName": "Tên người dùng '{0}' không hợp lệ, chỉ có thể chứa chữ cái hoặc chữ số.",
+    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "Tên người dùng '{0}' không hợp lệ, Bạn không thể sử dụng email của người dùng khác làm tên người dùng của mình.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "Một người dùng có thông tin đăng nhập này đã tồn tại.",
     "Volo.Abp.Identity:PasswordMismatch": "Mật khẩu không đúng.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "Mật khẩu phải có ít nhất một chữ số ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/zh-Hans.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/zh-Hans.json
@@ -48,7 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "角色名 '{0}' 无效.",
     "Volo.Abp.Identity:InvalidToken": "token无效.",
     "Volo.Abp.Identity:InvalidUserName": "用户名 '{0}' 无效, 只能包含字母或数字.",
-    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "用户名 '{0}' 无效, 不能使用其他用户的邮箱作为你的用户名.",
+    "InvalidUserName": "用户名 '{0}' 无效.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "此登录名的用户已存在.",
     "Volo.Abp.Identity:PasswordMismatch": "密码错误.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "密码至少包含一位数字 ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/zh-Hans.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/zh-Hans.json
@@ -48,6 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "角色名 '{0}' 无效.",
     "Volo.Abp.Identity:InvalidToken": "token无效.",
     "Volo.Abp.Identity:InvalidUserName": "用户名 '{0}' 无效, 只能包含字母或数字.",
+    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "用户名 '{0}' 无效, 不能使用其他用户的邮箱作为你的用户名.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "此登录名的用户已存在.",
     "Volo.Abp.Identity:PasswordMismatch": "密码错误.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "密码至少包含一位数字 ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/zh-Hant.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/zh-Hant.json
@@ -48,7 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "角色名 '{0}' 無效.",
     "Volo.Abp.Identity:InvalidToken": "token無效.",
     "Volo.Abp.Identity:InvalidUserName": "使用者名稱 '{0}' 無效, 只能包含字母或數字.",
-    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "使用者名稱 '{0}' 無效, 不能使用其他使用者的電子信箱作為你的使用者名稱.",
+    "InvalidUserName": "使用者名稱 '{0}' 無效.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "此登入名的使用者已存在.",
     "Volo.Abp.Identity:PasswordMismatch": "密碼錯誤.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "密碼至少包含一位數字 ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/zh-Hant.json
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/Localization/zh-Hant.json
@@ -48,6 +48,7 @@
     "Volo.Abp.Identity:InvalidRoleName": "角色名 '{0}' 無效.",
     "Volo.Abp.Identity:InvalidToken": "token無效.",
     "Volo.Abp.Identity:InvalidUserName": "使用者名稱 '{0}' 無效, 只能包含字母或數字.",
+    "Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername": "使用者名稱 '{0}' 無效, 不能使用其他使用者的電子信箱作為你的使用者名稱.",
     "Volo.Abp.Identity:LoginAlreadyAssociated": "此登入名的使用者已存在.",
     "Volo.Abp.Identity:PasswordMismatch": "密碼錯誤.",
     "Volo.Abp.Identity:PasswordRequiresDigit": "密碼至少包含一位數字 ('0'-'9').",

--- a/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/AbpIdentityUserValidator.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/AbpIdentityUserValidator.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Localization;
+using Volo.Abp.Identity.Localization;
+
+namespace Volo.Abp.Identity
+{
+    public class AbpIdentityUserValidator : IUserValidator<IdentityUser>
+    {
+        protected IStringLocalizer<IdentityResource> Localizer { get; }
+
+        public AbpIdentityUserValidator(IStringLocalizer<IdentityResource> localizer)
+        {
+            Localizer = localizer;
+        }
+
+        public virtual async Task<IdentityResult> ValidateAsync(UserManager<IdentityUser> manager, IdentityUser user)
+        {
+            var describer = new IdentityErrorDescriber();
+
+            Check.NotNull(manager, nameof(manager));
+            Check.NotNull(user, nameof(user));
+
+            var errors = new List<IdentityError>();
+
+            var userName = await manager.GetUserNameAsync(user);
+            if (userName == null)
+            {
+                errors.Add(describer.InvalidUserName(null));
+            }
+            else
+            {
+                var owner = await manager.FindByEmailAsync(userName);
+                if (owner != null && !string.Equals(await manager.GetUserIdAsync(owner), await manager.GetUserIdAsync(user)))
+                {
+                    errors.Add(new IdentityError
+                    {
+                        Code = "InvalidUserName",
+                        Description = Localizer["Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername", userName]
+                    });
+                }
+            }
+
+            return errors.Count > 0 ? IdentityResult.Failed(errors.ToArray()) : IdentityResult.Success;
+        }
+    }
+}

--- a/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/AbpIdentityUserValidator.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/AbpIdentityUserValidator.cs
@@ -37,7 +37,7 @@ namespace Volo.Abp.Identity
                     errors.Add(new IdentityError
                     {
                         Code = "InvalidUserName",
-                        Description = Localizer["Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername", userName]
+                        Description = Localizer["InvalidUserName", userName]
                     });
                 }
             }

--- a/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/AbpIdentityUserValidator_Tests.cs
+++ b/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/AbpIdentityUserValidator_Tests.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Localization;
+using Shouldly;
+using Volo.Abp.Identity.Localization;
+using Xunit;
+
+namespace Volo.Abp.Identity.AspNetCore;
+
+public class AbpIdentityUserValidator_Tests : AbpIdentityAspNetCoreTestBase
+{
+    private readonly IdentityUserManager _identityUserManager;
+    private readonly IStringLocalizer<IdentityResource> Localizer;
+
+    public AbpIdentityUserValidator_Tests()
+    {
+        _identityUserManager = GetRequiredService<IdentityUserManager>();
+        Localizer = GetRequiredService<IStringLocalizer<IdentityResource>>();
+    }
+
+    [Fact]
+    public async Task Test()
+    {
+        var user1 = new IdentityUser(Guid.NewGuid(), "user1", "user1@volosoft.com");
+        var identityResult = await _identityUserManager.CreateAsync(user1);
+        identityResult.Succeeded.ShouldBeTrue();
+
+        var user2 = new IdentityUser(Guid.NewGuid(), "user1@volosoft.com", "user2@volosoft.com");
+        identityResult = await _identityUserManager.CreateAsync(user2);
+        identityResult.Succeeded.ShouldBeFalse();
+        identityResult.Errors.Count().ShouldBe(1);
+        identityResult.Errors.First().Code.ShouldBe("InvalidUserName");
+        identityResult.Errors.First().Description.ShouldBe(Localizer["Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername", "user1@volosoft.com"]);
+    }
+}

--- a/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/AbpIdentityUserValidator_Tests.cs
+++ b/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/AbpIdentityUserValidator_Tests.cs
@@ -31,6 +31,6 @@ public class AbpIdentityUserValidator_Tests : AbpIdentityAspNetCoreTestBase
         identityResult.Succeeded.ShouldBeFalse();
         identityResult.Errors.Count().ShouldBe(1);
         identityResult.Errors.First().Code.ShouldBe("InvalidUserName");
-        identityResult.Errors.First().Description.ShouldBe(Localizer["Volo.Abp.Identity:YouCanNotUseAnotherUsersEmailAsYourUsername", "user1@volosoft.com"]);
+        identityResult.Errors.First().Description.ShouldBe(Localizer["InvalidUserName", "user1@volosoft.com"]);
     }
 }

--- a/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/AbpIdentityUserValidator_Tests.cs
+++ b/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/AbpIdentityUserValidator_Tests.cs
@@ -20,7 +20,7 @@ public class AbpIdentityUserValidator_Tests : AbpIdentityAspNetCoreTestBase
     }
 
     [Fact]
-    public async Task Test()
+    public async Task Can_Not_Use_Another_Users_Email_As_Your_Username_Test()
     {
         var user1 = new IdentityUser(Guid.NewGuid(), "user1", "user1@volosoft.com");
         var identityResult = await _identityUserManager.CreateAsync(user1);


### PR DESCRIPTION
This can prevent a new user's name use another existing user's email.


https://support.abp.io/QA/Questions/5482/Should-not-be-able-to-create-a-user-with-a-username-equal-to-the-email-address-of-another-user