### PR TITLE
Fix Dynamic Widget Parameter Cast Problem

### DIFF
--- a/modules/cms-kit/src/Volo.CmsKit.Common.Web/Pages/CmsKit/Components/Contents/ContentFragment.cshtml
+++ b/modules/cms-kit/src/Volo.CmsKit.Common.Web/Pages/CmsKit/Components/Contents/ContentFragment.cshtml
@@ -1,11 +1,13 @@
-﻿@using System.Dynamic
+﻿@using Microsoft.AspNetCore.Mvc.ViewComponents
 @using Volo.Abp.Data
+@using Volo.Abp.Reflection
 @using Volo.CmsKit.Web.Renderers;
 @using Volo.CmsKit.Web.Pages.CmsKit.Components.Contents;
 
 @model ContentFragmentViewComponent
 
 @inject IMarkdownToHtmlRenderer MarkdownRenderer
+@inject IViewComponentSelector ViewComponentSelector
 
 @foreach (var contentFragment in Model.ContentDto.ContentFragments)
 {
@@ -15,6 +17,23 @@
     }
     else if (contentFragment.Type == "Widget")
     {
-        @await Component.InvokeAsync(contentFragment.GetProperty<string>("Type"), contentFragment.ExtraProperties.ConvertToDynamicObject())
+        var componentName = contentFragment.GetProperty<string>("Type");
+        var descriptor = ViewComponentSelector.SelectComponent(componentName);
+        var componentParameters = descriptor.Parameters;
+        var parameters = new Dictionary<string, object>(contentFragment.ExtraProperties);
+
+        foreach (var componentParameter in componentParameters)
+        {
+            if (string.IsNullOrWhiteSpace(componentParameter.Name))
+            {
+                continue;
+            }
+            if(parameters.TryGetValue(componentParameter.Name, out var value))
+            {
+                parameters[componentParameter.Name] = TypeHelper.ConvertFrom(componentParameter.ParameterType, value);
+            }
+        }
+
+        @await Component.InvokeAsync(componentName, parameters)
     }
 }


### PR DESCRIPTION
### Description

When the dynamic widget was added in the page feature of the cms kit, only string parameters could be used, and no cast operation was performed. Added cast operation.

### Checklist

- [x] I fully tested it as developer

### How to test it?

Add dynamic widgets in cms kit's page feature and use parameters other than string.
