### PR TITLE
decreasing margin for form prop

### DIFF
--- a/npm/ng-packs/packages/theme-shared/extensions/src/lib/components/extensible-form/extensible-form-prop.component.html
+++ b/npm/ng-packs/packages/theme-shared/extensions/src/lib/components/extensible-form/extensible-form-prop.component.html
@@ -7,7 +7,7 @@
     </ng-container>
   </ng-template>
 
-  <div [ngClass]="containerClassName" class="mb-3">
+  <div [ngClass]="containerClassName" class="mb-2">
     <ng-template ngSwitchCase="input">
       <ng-template [ngTemplateOutlet]="label"></ng-template>
       <input

--- a/npm/ng-packs/packages/theme-shared/extensions/src/lib/components/extensible-form/extensible-form-prop.component.ts
+++ b/npm/ng-packs/packages/theme-shared/extensions/src/lib/components/extensible-form/extensible-form-prop.component.ts
@@ -61,7 +61,7 @@ export class ExtensibleFormPropComponent implements OnChanges, AfterViewInit {
 
   asterisk = '';
 
-  containerClassName = 'mb-3';
+  containerClassName = 'mb-2';
 
   options$: Observable<ABP.Option<any>[]> = of([]);
 


### PR DESCRIPTION
### Description

Resolves [#14794](https://github.com/volosoft/volo/issues/14794)

decreasing gap between checkbox

![Screenshot_2](https://github.com/abpframework/abp/assets/72804437/5105dd18-7733-4832-8a7e-192a2186a894)
![Screenshot_3](https://github.com/abpframework/abp/assets/72804437/6d5eb473-c6c7-421b-8a6a-eb20fe8be94d)

## But decreasing margin is affecting other form props

for example, previous ***new claim type*** form
![Screenshot_5](https://github.com/abpframework/abp/assets/72804437/15bf0342-c81f-4426-acb7-29ba00ea6a69)

after decreasing margin it will look like this
![image](https://github.com/abpframework/abp/assets/72804437/7505590c-f4d8-4928-8913-334a12b5428a)