### PR TITLE
AngularUI: Add property to EntityAction for customize actions button

### DIFF
--- a/docs/en/UI/Angular/Entity-Action-Extensions.md
+++ b/docs/en/UI/Angular/Entity-Action-Extensions.md
@@ -312,6 +312,8 @@ type EntityActionOptions<R = any> = {
   icon?: string,
   permission?: string,
   visible?: ActionPredicate<R>,
+  btnClass?: string,
+  btnStyle?: string,
 };
 ```
 
@@ -322,6 +324,8 @@ As you see, passing `action` and `text` is enough to create an entity action. He
 - **icon** is the classes that define an icon to be placed before the text. (_default:_ `''`)
 - **permission** is the permission context which will be used to decide if this type of grid action should be displayed to the user or not. (_default:_ `undefined`)
 - **visible** is a predicate that will be used to decide if the current record should have this grid action or not. (_default:_ `() => true`)
+- **btnClass** is the classes that will be applied to the button. (_default:_ `'btn btn-primary'`)
+- **btnStyle** is the styles that will be applied to the button. (_default:_ `''`)
 
 You may find a full example below.
 
@@ -339,6 +343,8 @@ const options: EntityActionOptions<IdentityUserDto> = {
   icon: 'fa fa-unlock',
   permission: 'AbpIdentity.Users.Update',
   visible: data => data.record.isLockedOut,
+  btnClass:'btn-warning',
+  btnStyle: 'margin-right: 5px;',
 };
 
 const action = new EntityAction(options);

--- a/npm/ng-packs/packages/theme-shared/extensions/src/lib/components/grid-actions/grid-actions.component.html
+++ b/npm/ng-packs/packages/theme-shared/extensions/src/lib/components/grid-actions/grid-actions.component.html
@@ -52,7 +52,6 @@
       *abpPermission="action.permission; runChangeDetection: false"
       (click)="action.action(data)"
       type="button"
-      class="btn text-center"
       [class]="action.btnClass"
       [style]="action.btnStyle"
     >

--- a/npm/ng-packs/packages/theme-shared/extensions/src/lib/components/grid-actions/grid-actions.component.html
+++ b/npm/ng-packs/packages/theme-shared/extensions/src/lib/components/grid-actions/grid-actions.component.html
@@ -52,7 +52,9 @@
       *abpPermission="action.permission; runChangeDetection: false"
       (click)="action.action(data)"
       type="button"
-      class="btn btn-primary text-center"
+      class="btn text-center"
+      [class]="action.btnClass"
+      [style]="action.btnStyle"
     >
       <ng-container
         *ngTemplateOutlet="buttonContentTmp; context: { $implicit: action }"

--- a/npm/ng-packs/packages/theme-shared/extensions/src/lib/models/actions.ts
+++ b/npm/ng-packs/packages/theme-shared/extensions/src/lib/models/actions.ts
@@ -29,6 +29,8 @@ export abstract class Action<R = any> {
     public readonly permission: string,
     public readonly visible: ActionPredicate<R> = () => true,
     public readonly action: ActionCallback<R> = () => {},
+    public readonly btnClass?: string,
+    public readonly btnStyle?: string,
   ) {}
 }
 

--- a/npm/ng-packs/packages/theme-shared/extensions/src/lib/models/entity-actions.ts
+++ b/npm/ng-packs/packages/theme-shared/extensions/src/lib/models/entity-actions.ts
@@ -29,7 +29,7 @@ export class EntityAction<R = any> extends Action<R> {
     super(options.permission || '', options.visible, options.action);
     this.text = options.text;
     this.icon = options.icon || '';
-    this.btnClass = options.btnClass || 'btn-primary';
+    this.btnClass = options.btnClass || 'btn btn-primary text-center';
     this.btnStyle = options.btnStyle;
   }
 

--- a/npm/ng-packs/packages/theme-shared/extensions/src/lib/models/entity-actions.ts
+++ b/npm/ng-packs/packages/theme-shared/extensions/src/lib/models/entity-actions.ts
@@ -22,11 +22,15 @@ export class EntityActionsFactory<R = any> extends ActionsFactory<EntityActions<
 export class EntityAction<R = any> extends Action<R> {
   readonly text: string;
   readonly icon: string;
+  readonly btnClass?: string;
+  readonly btnStyle?: string;
 
   constructor(options: EntityActionOptions<R>) {
     super(options.permission || '', options.visible, options.action);
     this.text = options.text;
     this.icon = options.icon || '';
+    this.btnClass = options.btnClass || 'btn-primary';
+    this.btnStyle = options.btnStyle;
   }
 
   static create<R = any>(options: EntityActionOptions<R>) {

--- a/npm/ng-packs/packages/theme-shared/src/lib/models/nav-item.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/models/nav-item.ts
@@ -18,6 +18,7 @@ export class NavItem {
   order?: number;
   requiredPolicy?: string;
   visible?: NavBarPropPredicate<NavItem>;
+  icon?: string;
   constructor(props: Partial<NavItem>) {
     Object.assign(this, props);
   }


### PR DESCRIPTION
### Description

Resolves #17318 


TODO: Add class & style property for customize view entity action button
- It'll work for single button on table not for dropdown
```ts
//npm\ng-packs\packages\identity\src\lib\defaults\default-roles-entity-actions.ts
export const DEFAULT_ROLES_ENTITY_ACTIONS = EntityAction.createMany<IdentityRoleDto>([
  {
    text: 'AbpIdentity::Delete',
    action: data => {
      const component = data.getInjected(RolesComponent);
      component.delete(data.record.id || '', data.record.name || '');
    },
    permission: 'AbpIdentity.Roles.Delete',
    visible: data => !data?.record.isStatic,
    btnClass: 'btn-danger',
    icon: 'fa fa-trash',
  },
]);
```
![image](https://github.com/abpframework/abp/assets/49063256/96b52be5-b4f1-475c-8773-a0089245aed9)

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?
- Customize defaults-entity-action for any module (example: identity)
- Run angular app
- It must change style for actions button on table