### PR TITLE
Delete the moved v7.4 migration guide

### DIFF
--- a/docs/en/Migration-Guides/docs/en/Migration-Guides/Abp-7_4.md
+++ b/docs/en/Migration-Guides/docs/en/Migration-Guides/Abp-7_4.md
@@ -1,8 +1,0 @@
-# ABP Version 7.4 Migration Guide
-
-This document is a guide for upgrading ABP v7.3 solutions to ABP v7.4. There are a few changes in this version that may affect your applications, please read it carefully and apply the necessary changes to your application.
-
-## TemplateDefinition
-
-The `LocalizationResource(Type)` of `TemplateDefinition` class is changed to `LocalizationResourceName(string)`.
-


### PR DESCRIPTION
Migration Guide for v7.4 has been moved with the PR: https://github.com/abpframework/abp/pull/17346 So, we can remove this file.