### PR TITLE
Catch and ignore the `Exception` from `ValidationAttributeHelper`.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/ModelBinding/Metadata/AbpModelMetadataProvider.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/ModelBinding/Metadata/AbpModelMetadataProvider.cs
@@ -40,11 +40,11 @@ public class AbpModelMetadataProvider : DefaultModelMetadataProvider
     {
         foreach (var validationAttribute in detail.ModelAttributes.Attributes.OfType<ValidationAttribute>())
         {
-            NormalizeValidationAttrbute(validationAttribute);
+            NormalizeValidationAttribute(validationAttribute);
         }
     }
 
-    protected virtual void NormalizeValidationAttrbute(ValidationAttribute validationAttribute)
+    protected virtual void NormalizeValidationAttribute(ValidationAttribute validationAttribute)
     {
         if (validationAttribute.ErrorMessage == null)
         {

--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/Validation/ValidationAttributeHelper.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/Validation/ValidationAttributeHelper.cs
@@ -1,14 +1,15 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.ComponentModel.DataAnnotations;
 using System.Reflection;
 
 namespace Volo.Abp.AspNetCore.Mvc.Validation;
 
 public static class ValidationAttributeHelper
 {
-    private static readonly PropertyInfo ValidationAttributeErrorMessageStringProperty = typeof(ValidationAttribute)
+    private readonly static PropertyInfo ValidationAttributeErrorMessageStringProperty = typeof(ValidationAttribute)
         .GetProperty("ErrorMessageString", BindingFlags.Instance | BindingFlags.NonPublic)!;
 
-    private static readonly PropertyInfo ValidationAttributeCustomErrorMessageSetProperty = typeof(ValidationAttribute)
+    private readonly static PropertyInfo ValidationAttributeCustomErrorMessageSetProperty = typeof(ValidationAttribute)
         .GetProperty("CustomErrorMessageSet", BindingFlags.Instance | BindingFlags.NonPublic)!;
 
     public static void SetDefaultErrorMessage(ValidationAttribute validationAttribute)
@@ -24,7 +25,14 @@ public static class ValidationAttributeHelper
             }
         }
 
-        validationAttribute.ErrorMessage =
-            ValidationAttributeErrorMessageStringProperty.GetValue(validationAttribute) as string;
+        try
+        {
+            var errorMessageString = ValidationAttributeErrorMessageStringProperty.GetValue(validationAttribute) as string;
+            validationAttribute.ErrorMessage = errorMessageString;
+        }
+        catch (Exception e)
+        {
+            // ignored
+        }
     }
 }


### PR DESCRIPTION
Fix #17379

We cannot ensure that the attribute used by customers is legal, we just simply catch it.

```
The following combinations are illegal and throw InvalidOperationException:
 1) Both ErrorMessage and ErrorMessageResourceName are set
 2) None of ErrorMessage, ErrorMessageResourceName, and DefaultErrorMessage are set.
 3) Must set both or neither of ErrorMessageResourceType and ErrorMessageResourceName
```