### PR TITLE
Use DatabaseName instead of config name for event box distributed lock names

### DIFF
--- a/docs/en/Distributed-Event-Bus.md
+++ b/docs/en/Distributed-Event-Bus.md
@@ -469,6 +469,8 @@ Configure<AbpDistributedEventBusOptions>(options =>
 });
 ````
 
+> **IMPORTANT**: Outbox sending service uses distributed locks to ensure only a single instance of your application consumes the outbox queue concurrently. Distributed locking key should be unique per database. The `config` object (in the preceding code example) has a `DatabaseName` property, which is used in the distributed lock key to ensure the uniqueness. `DatabaseName` is automatically set by the `UseDbContext` method, getting the database name from the `ConnectionStringName` attribute of the `YourDbContext` class. So, if you have multiple databases in your system, ensure that you use the same connection string name for the same database, but different connection string names for different databases. If you can't ensure that, you can manually set `config.DatabaseName` (after the `UseDbContext` line) to ensure that uniqueness.
+
 ### Enabling event inbox
 
 Open your `DbContext` class (EF Core or MongoDB), implement the `IHasEventInbox` interface. You should end up by adding a `DbSet` property into your `DbContext` class:
@@ -502,6 +504,8 @@ Configure<AbpDistributedEventBusOptions>(options =>
 });
 ````
 
+**IMPORTANT**: Inbox processing service uses distributed locks to ensure only a single instance of your application consumes the inbox queue concurrently. Distributed locking key should be unique per database. The `config` object (in the preceding code example) has a `DatabaseName` property, which is used in the distributed lock key to ensure the uniqueness. `DatabaseName` is automatically set by the `UseDbContext` method, getting the database name from the `ConnectionStringName` attribute of the `YourDbContext` class. So, if you have multiple databases in your system, ensure that you use the same connection string name for the same database, but different connection string names for different databases. If you can't ensure that, you can manually set `config.DatabaseName` (after the `UseDbContext` line) to ensure that uniqueness.
+
 ### Additional Configuration
 
 > The default configuration will be enough for most cases. However, there are some options you may want to set for outbox and inbox.
@@ -525,6 +529,7 @@ Here, the following properties are available on the `config` object:
 * `IsSendingEnabled` (default: `true`): You can set to `false` to disable sending outbox events to the actual event bus. If you disable this, events can still be added to outbox, but not sent. This can be helpful if you have multiple applications (or application instances) writing to outbox, but use one of them to send the events.
 * `Selector`: A predicate to filter the event (ETO) types to be used for this configuration. Should return `true` to select the event. It selects all the events by default. This is especially useful if you want to ignore some ETO types from the outbox, or want to define named outbox configurations and group events within these configurations. See the *Named Configurations* section.
 * `ImplementationType`: Type of the class that implements the database operations for the outbox. This is normally set when you call `UseDbContext` as shown before. See *Implementing a Custom Outbox/Inbox Database Provider* section for advanced usages.
+* `DatabaseName`: Unique database name for the database that is used for this outbox configuration. See the **IMPORTANT** paragraph at the end of the *Enabling event outbox* section.
 
 #### Inbox configuration
 
@@ -546,6 +551,7 @@ Here, the following properties are available on the `config` object:
 * `EventSelector`: A predicate to filter the event (ETO) types to be used for this configuration. This is especially useful if you want to ignore some ETO types from the inbox, or want to define named inbox configurations and group events within these configurations. See the *Named Configurations* section.
 * `HandlerSelector`: A predicate to filter the event handled types (classes implementing the `IDistributedEventHandler<TEvent>` interface) to be used for this configuration. This is especially useful if you want to ignore some event handler types from inbox processing, or want to define named inbox configurations and group event handlers within these configurations. See the *Named Configurations* section.
 * `ImplementationType`: Type of the class that implements the database operations for the inbox. This is normally set when you call `UseDbContext` as shown before. See *Implementing a Custom Outbox/Inbox Database Provider* section for advanced usages.
+* `DatabaseName`: Unique database name for the database that is used for this outbox configuration. See the **IMPORTANT** paragraph at the end of the *Enabling event inbox* section.
 
 #### AbpEventBusBoxesOptions
 

--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/DistributedEvents/EfCoreInboxConfigExtensions.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/DistributedEvents/EfCoreInboxConfigExtensions.cs
@@ -1,3 +1,4 @@
+using Volo.Abp.Data;
 using Volo.Abp.EventBus.Distributed;
 
 namespace Volo.Abp.EntityFrameworkCore.DistributedEvents;
@@ -8,5 +9,6 @@ public static class EfCoreInboxConfigExtensions
         where TDbContext : IHasEventInbox
     {
         outboxConfig.ImplementationType = typeof(IDbContextEventInbox<TDbContext>);
+        outboxConfig.DatabaseName = ConnectionStringNameAttribute.GetConnStringName<TDbContext>();
     }
 }

--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/DistributedEvents/EfCoreOutboxConfigExtensions.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/DistributedEvents/EfCoreOutboxConfigExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Volo.Abp.EventBus.Distributed;
+﻿using Volo.Abp.Data;
+using Volo.Abp.EventBus.Distributed;
 
 namespace Volo.Abp.EntityFrameworkCore.DistributedEvents;
 
@@ -8,5 +9,6 @@ public static class EfCoreOutboxConfigExtensions
         where TDbContext : IHasEventOutbox
     {
         outboxConfig.ImplementationType = typeof(IDbContextEventOutbox<TDbContext>);
+        outboxConfig.DatabaseName = ConnectionStringNameAttribute.GetConnStringName<TDbContext>();
     }
 }

--- a/framework/src/Volo.Abp.EventBus.Abstractions/Volo/Abp/EventBus/Distributed/InboxConfig.cs
+++ b/framework/src/Volo.Abp.EventBus.Abstractions/Volo/Abp/EventBus/Distributed/InboxConfig.cs
@@ -8,6 +8,13 @@ public class InboxConfig
     [NotNull]
     public string Name { get; }
 
+    [NotNull]
+    public string DatabaseName {
+        get => _databaseName;
+        set => _databaseName = Check.NotNullOrWhiteSpace(value, nameof(DatabaseName));
+    }
+    [NotNull] private string _databaseName;
+
     public Type ImplementationType { get; set; }
 
     public Func<Type, bool> EventSelector { get; set; }

--- a/framework/src/Volo.Abp.EventBus.Abstractions/Volo/Abp/EventBus/Distributed/OutboxConfig.cs
+++ b/framework/src/Volo.Abp.EventBus.Abstractions/Volo/Abp/EventBus/Distributed/OutboxConfig.cs
@@ -7,6 +7,13 @@ public class OutboxConfig
 {
     [NotNull]
     public string Name { get; }
+    
+    [NotNull]
+    public string DatabaseName {
+        get => _databaseName;
+        set => _databaseName = Check.NotNullOrWhiteSpace(value, nameof(DatabaseName));
+    }
+    [NotNull] private string _databaseName;
 
     public Type ImplementationType { get; set; }
 

--- a/framework/src/Volo.Abp.EventBus/Volo/Abp/EventBus/Distributed/InboxProcessor.cs
+++ b/framework/src/Volo.Abp.EventBus/Volo/Abp/EventBus/Distributed/InboxProcessor.cs
@@ -27,7 +27,7 @@ public class InboxProcessor : IInboxProcessor, ITransientDependency
 
     protected DateTime? LastCleanTime { get; set; }
 
-    protected string DistributedLockName => "AbpInbox_" + InboxConfig.Name;
+    protected string DistributedLockName { get; private set; }
     public ILogger<InboxProcessor> Logger { get; set; }
     protected CancellationTokenSource StoppingTokenSource { get; }
     protected CancellationToken StoppingToken { get; }
@@ -64,6 +64,7 @@ public class InboxProcessor : IInboxProcessor, ITransientDependency
     {
         InboxConfig = inboxConfig;
         Inbox = (IEventInbox)ServiceProvider.GetRequiredService(inboxConfig.ImplementationType);
+        DistributedLockName = $"AbpInbox_{InboxConfig.DatabaseName}";
         Timer.Start(cancellationToken);
         return Task.CompletedTask;
     }

--- a/framework/src/Volo.Abp.EventBus/Volo/Abp/EventBus/Distributed/OutboxSender.cs
+++ b/framework/src/Volo.Abp.EventBus/Volo/Abp/EventBus/Distributed/OutboxSender.cs
@@ -22,7 +22,7 @@ public class OutboxSender : IOutboxSender, ITransientDependency
     protected IEventOutbox Outbox { get; private set; }
     protected OutboxConfig OutboxConfig { get; private set; }
     protected AbpEventBusBoxesOptions EventBusBoxesOptions { get; }
-    protected string DistributedLockName => "AbpOutbox_" + OutboxConfig.Name;
+    protected string DistributedLockName { get; private set; }
     public ILogger<OutboxSender> Logger { get; set; }
 
     protected CancellationTokenSource StoppingTokenSource { get; }
@@ -51,6 +51,7 @@ public class OutboxSender : IOutboxSender, ITransientDependency
     {
         OutboxConfig = outboxConfig;
         Outbox = (IEventOutbox)ServiceProvider.GetRequiredService(outboxConfig.ImplementationType);
+        DistributedLockName = $"AbpOutbox_{OutboxConfig.DatabaseName}";
         Timer.Start(cancellationToken);
         return Task.CompletedTask;
     }

--- a/framework/src/Volo.Abp.MongoDB/Volo/Abp/MongoDB/DistributedEvents/MongoDbInboxConfigExtensions.cs
+++ b/framework/src/Volo.Abp.MongoDB/Volo/Abp/MongoDB/DistributedEvents/MongoDbInboxConfigExtensions.cs
@@ -1,3 +1,4 @@
+using Volo.Abp.Data;
 using Volo.Abp.EventBus.Distributed;
 
 namespace Volo.Abp.MongoDB.DistributedEvents;
@@ -8,5 +9,6 @@ public static class MongoDbInboxConfigExtensions
         where TMongoDbContext : IHasEventInbox
     {
         outboxConfig.ImplementationType = typeof(IMongoDbContextEventInbox<TMongoDbContext>);
+        outboxConfig.DatabaseName = ConnectionStringNameAttribute.GetConnStringName<TMongoDbContext>();
     }
 }

--- a/framework/src/Volo.Abp.MongoDB/Volo/Abp/MongoDB/DistributedEvents/MongoDbOutboxConfigExtensions.cs
+++ b/framework/src/Volo.Abp.MongoDB/Volo/Abp/MongoDB/DistributedEvents/MongoDbOutboxConfigExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Volo.Abp.EventBus.Distributed;
+﻿using Volo.Abp.Data;
+using Volo.Abp.EventBus.Distributed;
 
 namespace Volo.Abp.MongoDB.DistributedEvents;
 
@@ -8,5 +9,6 @@ public static class MongoDbOutboxConfigExtensions
         where TMongoDbContext : IHasEventOutbox
     {
         outboxConfig.ImplementationType = typeof(IMongoDbContextEventOutbox<TMongoDbContext>);
+        outboxConfig.DatabaseName = ConnectionStringNameAttribute.GetConnStringName<TMongoDbContext>();
     }
 }


### PR DESCRIPTION
We were using the following distributed lock name to exclusively access distributed event inboxes / outboxes:

````csharp
 protected string DistributedLockName => "AbpOutbox_" + OutboxConfig.Name;
````

In a microservice environment, `OutboxConfig.Name` is `Default` for all microservices by default. In that case, the distributed lock name is `AbpOutbox_Default` for all microservices. So, they share the same lock key. As a result, only a single microservice can use outbox in a time, which results others are waiting. However, since each microservice has different database, they should be able to consume the outbox queue independently from each other.

With this PR, we are using the following naming:

````csharp
DistributedLockName = $"AbpOutbox_{OutboxConfig.DatabaseName}";
````

Developers should care about database names, which are actually the connection string name in appsettings.json. Each database should have a unique and different connection string name. If 2 microservice shares the same database, they should use the same connection string name to access to that database. Otherwise, two application will consume the same database queue, which may result waiting messages are published more than once.

When you configure your outbox:

````csharp
Configure<AbpDistributedEventBusOptions>(options =>
{
    options.Outboxes.Configure(config =>
    {
        config.UseDbContext<YourDbContext>();
    });
});
````

It gets the database name from `ConnectionStringName` attribute that is defined for the `YourDbContext` class. If not defined, full name (with namespace) of the `YourDbContext` class is used as the database name. Optionally, you can manually set `config.DatabaseName` property just after the `UseDbContext` line in the code example above.