### PR TITLE
Do not auto discover generic event handlers

### DIFF
--- a/framework/src/Volo.Abp.EventBus/Volo/Abp/EventBus/AbpEventBusModule.cs
+++ b/framework/src/Volo.Abp.EventBus/Volo/Abp/EventBus/AbpEventBusModule.cs
@@ -49,6 +49,11 @@ public class AbpEventBusModule : AbpModule
 
         services.OnRegistered(context =>
         {
+            if (context.ImplementationType.IsGenericTypeDefinition)
+            {
+                return;
+            }
+
             if (ReflectionHelper.IsAssignableToGenericType(context.ImplementationType, typeof(ILocalEventHandler<>)))
             {
                 localHandlers.Add(context.ImplementationType);

--- a/framework/test/Volo.Abp.EventBus.Tests/Volo/Abp/EventBus/Distributed/MyGenericDistributedEventHandler.cs
+++ b/framework/test/Volo.Abp.EventBus.Tests/Volo/Abp/EventBus/Distributed/MyGenericDistributedEventHandler.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Threading.Tasks;
+using Volo.Abp.MultiTenancy;
+
+namespace Volo.Abp.EventBus.Distributed;
+
+public class MyGenericDistributedEventHandler<TEvent> : IDistributedEventHandler<TEvent>
+{
+    private readonly ICurrentTenant _currentTenant;
+
+    public MyGenericDistributedEventHandler(ICurrentTenant currentTenant)
+    {
+        _currentTenant = currentTenant;
+    }
+
+    public static Guid? TenantId { get; set; }
+
+    public Task HandleEventAsync(TEvent eventData)
+    {
+        TenantId = _currentTenant.Id;
+        return Task.CompletedTask;
+    }
+}

--- a/framework/test/Volo.Abp.EventBus.Tests/Volo/Abp/EventBus/EventBusTestModule.cs
+++ b/framework/test/Volo.Abp.EventBus.Tests/Volo/Abp/EventBus/EventBusTestModule.cs
@@ -1,3 +1,6 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Volo.Abp.EventBus.Distributed;
 using Volo.Abp.Modularity;
 
 namespace Volo.Abp.EventBus;
@@ -5,4 +8,18 @@ namespace Volo.Abp.EventBus;
 [DependsOn(typeof(AbpEventBusModule))]
 public class EventBusTestModule : AbpModule
 {
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        context.Services.TryAddTransient(typeof(MyGenericDistributedEventHandler<>));
+    }
+
+    public override void OnApplicationInitialization(ApplicationInitializationContext context)
+    {
+        var distributedEventBus = context.ServiceProvider.GetRequiredService<IDistributedEventBus>();
+        var scopeFactory = context.ServiceProvider.GetRequiredService<IServiceScopeFactory>();
+
+        var eventType = typeof(MySimpleEventData);
+        var myHandlerType = typeof(MyGenericDistributedEventHandler<>).MakeGenericType(eventType);
+        distributedEventBus.Subscribe(eventType, new IocEventHandlerFactory(scopeFactory, myHandlerType));
+    }
 }


### PR DESCRIPTION
### Description

Adding a GenericTypeDefinition (a generic type without arguments) to the `AbpLocalEventBusOptions.Handlers` or `AbpDistributedEventBusOptions.Handlers` makes no sense.

It cannot be determined which event should be subscribed.

And it makes KafkaDistributedEventBus broken:

```plaintext
Volo.Abp.AbpInitializationException: An error occurred during the initialize Volo.Abp.Modularity.OnApplicationInitializationModuleLifecycleContributor phase of the module Volo.Abp.EventBus.Kafka.AbpEventBusKafkaModule, Volo.Abp.EventBus.Kafka, Version=7.2.1.0, Culture=neutral, PublicKeyToken=null: Value cannot be null. (Parameter 'key'). See the inner exception for details.
 ---> System.ArgumentNullException: Value cannot be null. (Parameter 'key')
   at System.ThrowHelper.ThrowArgumentNullException(String name)
   at System.Collections.Concurrent.ConcurrentDictionary`2.set_Item(TKey key, TValue value)
   at Volo.Abp.EventBus.Kafka.KafkaDistributedEventBus.<GetOrCreateHandlerFactories>b__38_0(Type type)
   at System.Collections.Concurrent.ConcurrentDictionary`2.GetOrAdd(TKey key, Func`2 valueFactory)
   at Volo.Abp.EventBus.Kafka.KafkaDistributedEventBus.GetOrCreateHandlerFactories(Type eventType)
   at Volo.Abp.EventBus.Kafka.KafkaDistributedEventBus.Subscribe(Type eventType, IEventHandlerFactory factory)
   at Volo.Abp.EventBus.EventBusBase.SubscribeHandlers(ITypeList`1 handlers)
   at Volo.Abp.EventBus.Kafka.KafkaDistributedEventBus.Initialize()
   at Volo.Abp.EventBus.Kafka.AbpEventBusKafkaModule.OnApplicationInitialization(ApplicationInitializationContext context)
   at Volo.Abp.Modularity.AbpModule.OnApplicationInitializationAsync(ApplicationInitializationContext context)
   at Volo.Abp.Modularity.OnApplicationInitializationModuleLifecycleContributor.InitializeAsync(ApplicationInitializationContext context, IAbpModule module)
   at Volo.Abp.Modularity.ModuleManager.InitializeModulesAsync(ApplicationInitializationContext context)
```

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

Take the `MyGenericDistributedEventHandler` class to your tests with Kafka Event Bus, then register it to your service collection like `EventBusTestModule`.

It would be broken without this patch.