### PR TITLE
AngularUI: Remove confirmation for 401 status code

### DIFF
--- a/npm/ng-packs/packages/oauth/src/lib/guards/oauth.guard.ts
+++ b/npm/ng-packs/packages/oauth/src/lib/guards/oauth.guard.ts
@@ -1,11 +1,10 @@
 import { Injectable, inject } from '@angular/core';
 import { UrlTree, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
-import { HttpErrorResponse } from '@angular/common/http';
 
-import { Observable, delay, of, tap } from 'rxjs';
+import { Observable } from 'rxjs';
 import { OAuthService } from 'angular-oauth2-oidc';
 
-import { AuthService, HttpErrorReporterService, IAbpGuard } from '@abp/ng.core';
+import { AuthService, IAbpGuard } from '@abp/ng.core';
 
 @Injectable({
   providedIn: 'root',
@@ -13,7 +12,6 @@ import { AuthService, HttpErrorReporterService, IAbpGuard } from '@abp/ng.core';
 export class AbpOAuthGuard implements IAbpGuard {
   protected readonly oAuthService = inject(OAuthService);
   protected readonly authService = inject(AuthService);
-  protected readonly httpErrorReporter = inject(HttpErrorReporterService);
 
   canActivate(
     route: ActivatedRouteSnapshot,
@@ -23,6 +21,7 @@ export class AbpOAuthGuard implements IAbpGuard {
     if (hasValidAccessToken) {
       return true;
     }
+
     const params = { returnUrl: state.url };
     this.authService.navigateToLogin(params);
     return false;

--- a/npm/ng-packs/packages/theme-shared/src/lib/services/status-code-error-handler.service.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/services/status-code-error-handler.service.ts
@@ -77,12 +77,9 @@ export class StatusCodeErrorHandlerService implements CustomHttpErrorHandlerServ
 
     switch (this.status) {
       case 401:
+        this.authService.navigateToLogin();
+        break;
       case 404:
-        if (this.status === 401) {
-          this.authService.navigateToLogin();
-          return;
-        }
-
         if (canCreateCustomError) {
           this.showPage();
           break;

--- a/npm/ng-packs/packages/theme-shared/src/lib/services/status-code-error-handler.service.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/services/status-code-error-handler.service.ts
@@ -78,15 +78,16 @@ export class StatusCodeErrorHandlerService implements CustomHttpErrorHandlerServ
     switch (this.status) {
       case 401:
       case 404:
+        if (this.status === 401) {
+          this.authService.navigateToLogin();
+          return;
+        }
+
         if (canCreateCustomError) {
           this.showPage();
           break;
         }
-        this.showConfirmation(title, message).subscribe(() => {
-          if (this.status === 401) {
-            this.navigateToLogin();
-          }
-        });
+        this.showConfirmation(title, message).subscribe();
         break;
 
       case 403:

--- a/npm/ng-packs/packages/theme-shared/src/lib/services/status-code-error-handler.service.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/services/status-code-error-handler.service.ts
@@ -77,13 +77,17 @@ export class StatusCodeErrorHandlerService implements CustomHttpErrorHandlerServ
 
     switch (this.status) {
       case 401:
-        this.authService.navigateToLogin();
-        break;
       case 404:
         if (canCreateCustomError) {
           this.showPage();
           break;
         }
+
+        if (this.status === 401) {
+          this.authService.navigateToLogin();
+          break;
+        }
+
         this.showConfirmation(title, message).subscribe();
         break;
 


### PR DESCRIPTION
### Description

**I separate PR because 7.4+ version error handler updated**

Resolves for 7.4 version #17529 

TODO: Remove confirmation modal for 401 status code, `this PR also resolves for commercial side`


### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests

### How to test it?
Send request before authenticate, it'll return 401 instead 403 and error handler will display a confirmation and it'll redirect to login. Try for password flow it works same for code flow