### PR TITLE
Removed Acme.BookStore.Web in swagger ui in tiered mvc

### DIFF
--- a/docs/en/Tutorials/Part-1.md
+++ b/docs/en/Tutorials/Part-1.md
@@ -436,7 +436,7 @@ ABP can [**automagically**](../API/Auto-API-Controllers.md) configure your appli
 
 ### Swagger UI
 
-The startup template is configured to run the [Swagger UI](https://swagger.io/tools/swagger-ui/) using the [Swashbuckle.AspNetCore](https://github.com/domaindrivendev/Swashbuckle.AspNetCore) library. Run the application ({{if UI=="MVC"}}`Acme.BookStore.Web`{{else}}`Acme.BookStore.HttpApi.Host`{{end}}) by pressing `CTRL+F5` and navigate to `https://localhost:<port>/swagger/` on your browser. Replace `<port>` with your own port number.
+The startup template is configured to run the [Swagger UI](https://swagger.io/tools/swagger-ui/) using the [Swashbuckle.AspNetCore](https://github.com/domaindrivendev/Swashbuckle.AspNetCore) library. Run the application `Acme.BookStore.HttpApi.Host` by pressing `CTRL+F5` and navigate to `https://localhost:<port>/swagger/` on your browser. Replace `<port>` with your own port number.
 
 You will see some built-in service endpoints as well as the `Book` service and its REST-style endpoints:
 


### PR DESCRIPTION
### Description

There is no open issue for this PR. 

`Tutorials Part 1 Auto API Controllers` explains how to launch the **swagger UI**. The markdown file has a condition depending on the UI to run the relevant project. However since we are talking about API controller, the only project we have to run to see the swagger UI that we work in our tutorial is `HttpApi.Host`. `Web `project has no relationship with API Controllers. If we run the Web project to see the Books controller endpoints, we can not.

### Checklist

- [ ] no need to document

