### PR TITLE
CLI: Add .npmrc file before searching for the nightly package versions

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/NpmPackagesUpdater.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/NpmPackagesUpdater.cs
@@ -64,6 +64,18 @@ public class NpmPackagesUpdater : ITransientDependency
 
         _npmGlobalPackagesChecker.Check();
 
+        foreach (var file in fileList)
+        {
+            if (includePreviews)
+            {
+                await CreateNpmrcFileAsync(Path.GetDirectoryName(file));
+            }
+            else if (switchToStable)
+            {
+                await DeleteNpmrcFileAsync(Path.GetDirectoryName(file));
+            }
+        }
+
         var packagesUpdated = new ConcurrentDictionary<string, bool>();
 
         async Task UpdateAsync(string file)
@@ -79,15 +91,6 @@ public class NpmPackagesUpdater : ITransientDependency
         foreach (var file in packagesUpdated.Where(x => x.Value))
         {
             var fileDirectory = Path.GetDirectoryName(file.Key).EnsureEndsWith(Path.DirectorySeparatorChar);
-
-            if (includePreviews)
-            {
-                await CreateNpmrcFileAsync(Path.GetDirectoryName(file.Key));
-            }
-            else if (switchToStable)
-            {
-                await DeleteNpmrcFileAsync(Path.GetDirectoryName(file.Key));
-            }
 
             if (await NpmrcFileExistAsync(fileDirectory))
             {


### PR DESCRIPTION
### Description

We need to generate the `.npmrc` file before searching for the nightly package versions:

https://github.com/abpframework/abp/blob/dd1176ca2c649f6902c2f7b789dd1c7329649a38/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/NpmPackagesUpdater.cs#L343

Prior to this PR, we were first searching for the version and then added the `.npmrc` file if it's needed, and therefore while listing the versions registries in the `.npmrc` files were ignored. Thus, the npm package version update process was not working correctly the first time it was executed but was working as expected in the subsequent executions. This PR fixes this problem by adding the `.npmrc` file before listing nightly npm package versions.

![image](https://github.com/abpframework/abp/assets/43685404/7f26e2bb-e185-4a2e-8012-9db0c6679486)

### Checklist

- [X] I fully tested it as developer / designer and created unit / integration tests
- [X] I documented it (or no need to document or I will create a separate documentation issue)

