### PR TITLE
Removed duplicated ApplyDataFilters usage for MongoDbRepository.FindAsync

### DIFF
--- a/framework/src/Volo.Abp.MongoDB/Volo/Abp/Domain/Repositories/MongoDB/MongoDbRepository.cs
+++ b/framework/src/Volo.Abp.MongoDB/Volo/Abp/Domain/Repositories/MongoDB/MongoDbRepository.cs
@@ -800,7 +800,9 @@ public class MongoDbRepository<TMongoDbContext, TEntity, TKey>
     {
         cancellationToken = GetCancellationToken(cancellationToken);
 
-        return await ApplyDataFilters(await GetMongoQueryableAsync(cancellationToken)).Where(x => x.Id!.Equals(id)).FirstOrDefaultAsync(cancellationToken);
+        return await (await GetMongoQueryableAsync(cancellationToken))
+            .Where(x => x.Id!.Equals(id))
+            .FirstOrDefaultAsync(cancellationToken);
     }
 
     public virtual Task DeleteAsync(


### PR DESCRIPTION
Removed `ApplyDataFilters` call for the `FindAsync` method of mongodb repository. Because the `GetMongoQueryableAsync` method already calls it.

Can you double-check if there is a problem on that?