### PR TITLE
Add appsettings.secrets.json file to default configuration in tests

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.TestBase/Volo/Abp/AspNetCore/TestBase/AbpAspNetCoreIntegratedTestBase.cs
+++ b/framework/src/Volo.Abp.AspNetCore.TestBase/Volo/Abp/AspNetCore/TestBase/AbpAspNetCoreIntegratedTestBase.cs
@@ -42,6 +42,7 @@ public abstract class AbpAspNetCoreIntegratedTestBase<TStartupModule> : AbpTestB
     protected virtual IHostBuilder CreateHostBuilder()
     {
         return Host.CreateDefaultBuilder()
+            .AddAppSettingsSecretsJson()
             .ConfigureWebHostDefaults(webBuilder =>
             {
                 if (typeof(TStartupModule).IsAssignableTo<IAbpModule>())

--- a/framework/src/Volo.Abp.AspNetCore.TestBase/Volo/Abp/AspNetCore/TestBase/AbpWebApplicationFactoryIntegratedTest.cs
+++ b/framework/src/Volo.Abp.AspNetCore.TestBase/Volo/Abp/AspNetCore/TestBase/AbpWebApplicationFactoryIntegratedTest.cs
@@ -27,7 +27,9 @@ public abstract class AbpWebApplicationFactoryIntegratedTest<TProgram> : WebAppl
 
     protected override IHost CreateHost(IHostBuilder builder)
     {
-        builder.ConfigureServices(ConfigureServices);
+        builder
+            .AddAppSettingsSecretsJson()
+            .ConfigureServices(ConfigureServices);
         return base.CreateHost(builder);
     }
 

--- a/framework/src/Volo.Abp.Core/Microsoft/Extensions/Configuration/ConfigurationHelper.cs
+++ b/framework/src/Volo.Abp.Core/Microsoft/Extensions/Configuration/ConfigurationHelper.cs
@@ -18,11 +18,12 @@ public static class ConfigurationHelper
 
         var builder = new ConfigurationBuilder()
             .SetBasePath(options.BasePath!)
-            .AddJsonFile(options.FileName + ".json", optional: options.Optional, reloadOnChange: options.ReloadOnChange);
+            .AddJsonFile(options.FileName + ".json", optional: options.Optional, reloadOnChange: options.ReloadOnChange)
+            .AddJsonFile(options.FileName + ".secrets.json", optional: true, reloadOnChange: options.ReloadOnChange);
 
         if (!options.EnvironmentName.IsNullOrEmpty())
         {
-            builder = builder.AddJsonFile($"{options.FileName}.{options.EnvironmentName}.json", optional: options.Optional, reloadOnChange: options.ReloadOnChange);
+            builder = builder.AddJsonFile($"{options.FileName}.{options.EnvironmentName}.json", optional: true, reloadOnChange: options.ReloadOnChange);
         }
 
         if (options.EnvironmentName == "Development")


### PR DESCRIPTION
* Added appsettings.secrets.json to base test classes for asp.net core integrated tests.
* Made environment specific config file optional.