### PR TITLE
Initialize the api version of `input`.

### DIFF
--- a/framework/src/Volo.Abp.Http/Volo/Abp/Http/ProxyScripting/Generators/JQuery/JQueryProxyScriptGenerator.cs
+++ b/framework/src/Volo.Abp.Http/Volo/Abp/Http/ProxyScripting/Generators/JQuery/JQueryProxyScriptGenerator.cs
@@ -114,7 +114,21 @@ public class JQueryProxyScriptGenerator : IProxyScriptGenerator, ITransientDepen
         if (versionParam != null)
         {
             var version = FindBestApiVersion(action);
-            script.AppendLine($"      var {ProxyScriptingJsFuncHelper.NormalizeJsVariableName(versionParam.Name)} = api_version ? api_version : '{version}';");
+            if (parameterList.Contains("api_version"))
+            {
+                script.AppendLine($"      var {ProxyScriptingJsFuncHelper.NormalizeJsVariableName(versionParam.Name)} = api_version ? api_version : '{version}';");
+            }
+            else
+            {
+                var apiVersion = action.Parameters.FirstOrDefault(p =>
+                    p.BindingSourceId.IsIn(ParameterBindingSources.ModelBinding, ParameterBindingSources.Query) &&
+                    p.Name == "api-version");
+                if (apiVersion != null && parameterList.Contains(apiVersion.NameOnMethod))
+                {
+                    var apiVersionVariable = ProxyScriptingJsFuncHelper.GetParamNameInJsFunc(apiVersion);
+                    script.AppendLine($"      {apiVersionVariable} = {apiVersionVariable} ? {apiVersionVariable} : '{version}';");
+                }
+            }
         }
 
         script.AppendLine("      return abp.ajax($.extend(true, {");


### PR DESCRIPTION
This is not a breaking change. It fixes a bug when you are using the `AbpApiVersioning`.

Before:
```js
volo.abp.getUser = function(input, ajaxParams) {
  var api_version = api_version ? api_version : '1.0';
  return abp.ajax($.extend(true, {
    url: abp.appPath + 'api/user' + abp.utils.buildQueryString([{ name: 'userId', value: input.userId }, { name: 'api-version', value: input.api_version }]) + '',
    type: 'GET'
  }, ajaxParams));
};
```

After:

```js

volo.abp.getUser = function(input, ajaxParams) {
  input.api_version = input.api_version ? input.api_version : '1.0';
  return abp.ajax($.extend(true, {
    url: abp.appPath + 'api/user' + abp.utils.buildQueryString([{ name: 'userId', value: input.userId }, { name: 'api-version', value: input.api_version }]) + '',
    type: 'GET'
  }, ajaxParams));
};
```