### PR TITLE
Imporve console template with `HostApplicationBuilder`

### DIFF
--- a/framework/src/Volo.Abp.Core/Microsoft/Extensions/Configuration/AbpConfigurationExtensions.cs
+++ b/framework/src/Volo.Abp.Core/Microsoft/Extensions/Configuration/AbpConfigurationExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.Hosting;
+
+namespace Microsoft.Extensions.Configuration;
+
+public static class AbpConfigurationExtensions
+{
+    public static IConfigurationBuilder AddAppSettingsSecretsJson(
+        this IConfigurationBuilder builder,
+        bool optional = true,
+        bool reloadOnChange = true,
+        string path = AbpHostingHostBuilderExtensions.AppSettingsSecretJsonPath)
+    {
+        return builder.AddJsonFile(path: path, optional: optional, reloadOnChange: reloadOnChange);
+    }
+}

--- a/framework/src/Volo.Abp.Core/Microsoft/Extensions/Hosting/AbpHostExtensions.cs
+++ b/framework/src/Volo.Abp.Core/Microsoft/Extensions/Hosting/AbpHostExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Volo.Abp;
+using Volo.Abp.Threading;
+
+namespace Microsoft.Extensions.Hosting;
+
+public static class AbpHostExtensions
+{
+    public static async Task InitializeAsync(this IHost host)
+    {
+        var application = host.Services.GetRequiredService<IAbpApplicationWithExternalServiceProvider>();
+        var applicationLifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
+
+        applicationLifetime.ApplicationStopping.Register(() => AsyncHelper.RunSync(() => application.ShutdownAsync()));
+        applicationLifetime.ApplicationStopped.Register(() => application.Dispose());
+
+        await application.InitializeAsync(host.Services);
+    }
+}

--- a/templates/console/src/MyCompanyName.MyProjectName/MyProjectNameHostedService.cs
+++ b/templates/console/src/MyCompanyName.MyProjectName/MyProjectNameHostedService.cs
@@ -7,13 +7,11 @@ namespace MyCompanyName.MyProjectName;
 
 public class MyProjectNameHostedService : IHostedService
 {
-    private readonly IAbpApplicationWithExternalServiceProvider _abpApplication;
     private readonly HelloWorldService _helloWorldService;
 
-    public MyProjectNameHostedService(HelloWorldService helloWorldService, IAbpApplicationWithExternalServiceProvider abpApplication)
+    public MyProjectNameHostedService(HelloWorldService helloWorldService)
     {
         _helloWorldService = helloWorldService;
-        _abpApplication = abpApplication;
     }
 
     public async Task StartAsync(CancellationToken cancellationToken)
@@ -21,8 +19,8 @@ public class MyProjectNameHostedService : IHostedService
         await _helloWorldService.SayHelloAsync();
     }
 
-    public async Task StopAsync(CancellationToken cancellationToken)
+    public Task StopAsync(CancellationToken cancellationToken)
     {
-        await _abpApplication.ShutdownAsync();
+        return Task.CompletedTask;
     }
 }

--- a/templates/console/src/MyCompanyName.MyProjectName/Program.cs
+++ b/templates/console/src/MyCompanyName.MyProjectName/Program.cs
@@ -3,12 +3,10 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Hosting.Internal;
 using Microsoft.Extensions.Logging;
 using Serilog;
 using Serilog.Events;
 using Volo.Abp;
-using Volo.Abp.Threading;
 
 namespace MyCompanyName.MyProjectName;
 
@@ -37,22 +35,15 @@ public class Program
             builder.Configuration.AddAppSettingsSecretsJson();
             builder.Logging.ClearProviders().AddSerilog();
 
-            builder.Services.AddAutofacServiceProviderFactory();
-
-            builder.Services.AddSingleton<IHostLifetime, ConsoleLifetime>();
+            builder.ConfigureContainer(builder.Services.AddAutofacServiceProviderFactory());
 
             builder.Services.AddHostedService<MyProjectNameHostedService>();
+
             await builder.Services.AddApplicationAsync<MyProjectNameModule>();
 
             var host = builder.Build();
 
-            var application = host.Services.GetRequiredService<IAbpApplicationWithExternalServiceProvider>();
-            var applicationLifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
-
-            applicationLifetime.ApplicationStopping.Register(() => AsyncHelper.RunSync(() => application.ShutdownAsync()));
-            applicationLifetime.ApplicationStopped.Register(() => application.Dispose());
-
-            await application.InitializeAsync(host.Services);
+            await host.InitializeAsync();
 
             await host.RunAsync();
 

--- a/templates/console/src/MyCompanyName.MyProjectName/Properties/launchSettings.json
+++ b/templates/console/src/MyCompanyName.MyProjectName/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "MyCompanyName.MyProjectName": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Description

- Improving console templates with `HostApplicationBuilder`. For better use of `AddApplicationAsync`, similar usage to `WebApplicationBuilder`.
- Add `launchSettings.json` to allow reading of `appsettings.development.json` and dotnet user secret configuration.

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [ ] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

Run the console template.

