### PR TITLE
Mongo eventbox enhancements

### DIFF
--- a/docs/en/Distributed-Event-Bus.md
+++ b/docs/en/Distributed-Event-Bus.md
@@ -438,19 +438,23 @@ Enabling the event outbox and inbox systems require a few manual steps for your 
 
 ### Enabling event outbox
 
-Open your `DbContext` class (EF Core or MongoDB), implement the `IHasEventOutbox` interface. You should end up by adding a `DbSet` property into your `DbContext` class:
+Enabling event outbox depends on your database provider.
+
+#### Enabling event outbox for Entity Framework Core
+
+Open your `DbContext` class, implement the `IHasEventOutbox` interface.  You should end up by adding a `DbSet` property into your `DbContext` class:
 
 ```csharp
 public DbSet<OutgoingEventRecord> OutgoingEvents { get; set; }
 ```
 
-Add the following lines inside the `OnModelCreating` method of your `DbContext` class (only for EF Core):
+Add the following lines inside the `OnModelCreating` method of your `DbContext` class:
 
 ```csharp
 builder.ConfigureEventOutbox();
 ```
 
-For EF Core, use the standard `Add-Migration` and `Update-Database` commands to apply changes into your database (you can skip this step for MongoDB). If you want to use the command-line terminal, run the following commands in the root directory of the database integration project:
+Use the standard `Add-Migration` and `Update-Database` commands to apply changes into your database. If you want to use the command-line terminal, run the following commands in the root directory of the database integration project:
 
 ```bash
 dotnet ef migrations add "Added_Event_Outbox"
@@ -469,23 +473,55 @@ Configure<AbpDistributedEventBusOptions>(options =>
 });
 ````
 
-> **IMPORTANT**: Outbox sending service uses distributed locks to ensure only a single instance of your application consumes the outbox queue concurrently. Distributed locking key should be unique per database. The `config` object (in the preceding code example) has a `DatabaseName` property, which is used in the distributed lock key to ensure the uniqueness. `DatabaseName` is automatically set by the `UseDbContext` method, getting the database name from the `ConnectionStringName` attribute of the `YourDbContext` class. So, if you have multiple databases in your system, ensure that you use the same connection string name for the same database, but different connection string names for different databases. If you can't ensure that, you can manually set `config.DatabaseName` (after the `UseDbContext` line) to ensure that uniqueness.
+#### Enabling event outbox for MongoDB
+
+Open your `DbContext` class, implement the `IHasEventOutbox` interface.  You should end up by adding a `IMongoCollection` property into your `DbContext` class:
+
+```csharp
+public IMongoCollection<OutgoingEventRecord> OutgoingEvents => Collection<OutgoingEventRecord>();
+```
+
+Add the following lines inside the `CreateModel` method of your `DbContext` class:
+
+```csharp
+modelBuilder.ConfigureEventOutbox();
+```
+
+Finally, write the following configuration code inside the `ConfigureServices` method of your [module class](Module-Development-Basics.md) (replace `YourDbContext` with your own `DbContext` class):
+
+````csharp
+Configure<AbpDistributedEventBusOptions>(options =>
+{
+    options.Outboxes.Configure(config =>
+    {
+        config.UseMongoDbContext<MyProjectNameDbContext>();
+    });
+});
+````
+
+#### Distributed Locking for Outbox
+
+> **IMPORTANT**: Outbox sending service uses distributed locks to ensure only a single instance of your application consumes the outbox queue concurrently. Distributed locking key should be unique per database. The `config` object (in the `options.Outboxes.Configure(...)` method) has a `DatabaseName` property, which is used in the distributed lock key to ensure the uniqueness. `DatabaseName` is automatically set by the `UseDbContext` method, getting the database name from the `ConnectionStringName` attribute of the `YourDbContext` class. So, if you have multiple databases in your system, ensure that you use the same connection string name for the same database, but different connection string names for different databases. If you can't ensure that, you can manually set `config.DatabaseName` (after the `UseDbContext` line) to ensure that uniqueness.
 
 ### Enabling event inbox
 
-Open your `DbContext` class (EF Core or MongoDB), implement the `IHasEventInbox` interface. You should end up by adding a `DbSet` property into your `DbContext` class:
+Enabling event inbox depends on your database provider.
+
+#### Enabling event inbox for Entity Framework Core
+
+Open your `DbContext` class, implement the `IHasEventInbox` interface. You should end up by adding a `DbSet` property into your `DbContext` class:
 
 ```csharp
 public DbSet<IncomingEventRecord> IncomingEvents { get; set; }
 ```
 
-Add the following lines inside the `OnModelCreating` method of your `DbContext` class (only for EF Core):
+Add the following lines inside the `OnModelCreating` method of your `DbContext` class:
 
 ```csharp
 builder.ConfigureEventInbox();
 ```
 
-For EF Core, use the standard `Add-Migration` and `Update-Database` commands to apply changes into your database (you can skip this step for MongoDB). If you want to use the command-line terminal, run the following commands in the root directory of the database integration project:
+Use the standard `Add-Migration` and `Update-Database` commands to apply changes into your database. If you want to use the command-line terminal, run the following commands in the root directory of the database integration project:
 
 ```bash
 dotnet ef migrations add "Added_Event_Inbox"
@@ -504,7 +540,35 @@ Configure<AbpDistributedEventBusOptions>(options =>
 });
 ````
 
-**IMPORTANT**: Inbox processing service uses distributed locks to ensure only a single instance of your application consumes the inbox queue concurrently. Distributed locking key should be unique per database. The `config` object (in the preceding code example) has a `DatabaseName` property, which is used in the distributed lock key to ensure the uniqueness. `DatabaseName` is automatically set by the `UseDbContext` method, getting the database name from the `ConnectionStringName` attribute of the `YourDbContext` class. So, if you have multiple databases in your system, ensure that you use the same connection string name for the same database, but different connection string names for different databases. If you can't ensure that, you can manually set `config.DatabaseName` (after the `UseDbContext` line) to ensure that uniqueness.
+#### Enabling event inbox for MongoDB
+
+Open your `DbContext` class, implement the `IHasEventInbox` interface.  You should end up by adding a `IMongoCollection` property into your `DbContext` class:
+
+```csharp
+public IMongoCollection<IncomingEventRecord> IncomingEvents => Collection<IncomingEventRecord>();
+```
+
+Add the following lines inside the `CreateModel` method of your `DbContext` class:
+
+```csharp
+modelBuilder.ConfigureEventInbox();
+```
+
+Finally, write the following configuration code inside the `ConfigureServices` method of your [module class](Module-Development-Basics.md) (replace `YourDbContext` with your own `DbContext` class):
+
+````csharp
+Configure<AbpDistributedEventBusOptions>(options =>
+{
+    options.Inboxes.Configure(config =>
+    {
+        config.UseMongoDbContext<MyProjectNameDbContext>();
+    });
+});
+````
+
+#### Distributed Locking for Inbox
+
+> **IMPORTANT**: Inbox processing service uses distributed locks to ensure only a single instance of your application consumes the inbox queue concurrently. Distributed locking key should be unique per database. The `config` object (in the `options.Inboxes.Configure(...)` method) has a `DatabaseName` property, which is used in the distributed lock key to ensure the uniqueness. `DatabaseName` is automatically set by the `UseDbContext` method, getting the database name from the `ConnectionStringName` attribute of the `YourDbContext` class. So, if you have multiple databases in your system, ensure that you use the same connection string name for the same database, but different connection string names for different databases. If you can't ensure that, you can manually set `config.DatabaseName` (after the `UseDbContext` line) to ensure that uniqueness.
 
 ### Additional Configuration
 
@@ -529,7 +593,7 @@ Here, the following properties are available on the `config` object:
 * `IsSendingEnabled` (default: `true`): You can set to `false` to disable sending outbox events to the actual event bus. If you disable this, events can still be added to outbox, but not sent. This can be helpful if you have multiple applications (or application instances) writing to outbox, but use one of them to send the events.
 * `Selector`: A predicate to filter the event (ETO) types to be used for this configuration. Should return `true` to select the event. It selects all the events by default. This is especially useful if you want to ignore some ETO types from the outbox, or want to define named outbox configurations and group events within these configurations. See the *Named Configurations* section.
 * `ImplementationType`: Type of the class that implements the database operations for the outbox. This is normally set when you call `UseDbContext` as shown before. See *Implementing a Custom Outbox/Inbox Database Provider* section for advanced usages.
-* `DatabaseName`: Unique database name for the database that is used for this outbox configuration. See the **IMPORTANT** paragraph at the end of the *Enabling event outbox* section.
+* `DatabaseName`: Unique database name for the database that is used for this outbox configuration. See the **IMPORTANT** paragraph at the end of the *Enabling event outbox/inbox*  sections.
 
 #### Inbox configuration
 

--- a/framework/src/Volo.Abp.MongoDB/Volo/Abp/MongoDB/DistributedEvents/EventInboxMongoModelBuilderExtensions.cs
+++ b/framework/src/Volo.Abp.MongoDB/Volo/Abp/MongoDB/DistributedEvents/EventInboxMongoModelBuilderExtensions.cs
@@ -1,0 +1,16 @@
+﻿using Volo.Abp.Data;
+
+namespace Volo.Abp.MongoDB.DistributedEvents;
+
+public static class EventInboxMongoModelBuilderExtensions
+{
+    public static void ConfigureEventInbox(this IMongoModelBuilder builder)
+    {
+        Check.NotNull(builder, nameof(builder));
+
+        builder.Entity<IncomingEventRecord>(b =>
+        {
+            b.CollectionName = AbpCommonDbProperties.DbTablePrefix + "EventInbox";
+        });
+    }
+}

--- a/framework/src/Volo.Abp.MongoDB/Volo/Abp/MongoDB/DistributedEvents/EventOutboxMongoModelBuilderExtensions.cs
+++ b/framework/src/Volo.Abp.MongoDB/Volo/Abp/MongoDB/DistributedEvents/EventOutboxMongoModelBuilderExtensions.cs
@@ -1,0 +1,17 @@
+﻿using JetBrains.Annotations;
+using Volo.Abp.Data;
+
+namespace Volo.Abp.MongoDB.DistributedEvents;
+
+public static class EventOutboxMongoModelBuilderExtensions
+{
+    public static void ConfigureEventOutbox([NotNull] this IMongoModelBuilder builder)
+    {
+        Check.NotNull(builder, nameof(builder));
+
+        builder.Entity<IncomingEventRecord>(b =>
+        {
+            b.CollectionName = AbpCommonDbProperties.DbTablePrefix + "EventOutbox";
+        });
+    }
+}


### PR DESCRIPTION
* Define `ConfigureEventInbox` and `ConfigureEventOutbox` methods for mongodb event box collections.
* Revisit the documentation for event boxes.

This is actually not a breaking change unless you call `ConfigureEventInbox` / `ConfigureEventOutbox` methods in your DbContext. However, it is recommended (and documented) and if you do it, mongodb collection names will be changed. So, it should be carefully done since existing (non-processed) event records are not automatically moved to new collection and they will be lost. Existing applications with event records should rename the collection manually while deploying their solutions.