### PR TITLE
revert default value of breadcrumb

### DIFF
--- a/npm/ng-packs/packages/components/page/src/page.component.ts
+++ b/npm/ng-packs/packages/components/page/src/page.component.ts
@@ -25,7 +25,7 @@ export class PageComponent {
     return this._toolbarData;
   }
 
-  @Input() breadcrumb = false;
+  @Input() breadcrumb = true;
 
   pageParts = {
     title: PageParts.title,


### PR DESCRIPTION
The breadcrumb value be able to override via strategy files. But the default value is false. It couldn't so It must be true  (again)