### PR TITLE
CMS Kit: Fix icon of the global resource menu item

### DIFF
--- a/modules/cms-kit/src/Volo.CmsKit.Admin.Web/Menus/CmsKitAdminMenuContributor.cs
+++ b/modules/cms-kit/src/Volo.CmsKit.Admin.Web/Menus/CmsKitAdminMenuContributor.cs
@@ -97,7 +97,7 @@ public class CmsKitAdminMenuContributor : IMenuContributor
                 CmsKitAdminMenus.GlobalResources.GlobalResourcesMenu,
                 l["GlobalResources"],
                 "/Cms/GlobalResources",
-                "bi bi-code-slash",
+                "fa fa-code",
                 order: 4)
             .RequireFeatures(CmsKitFeatures.GlobalResourceEnable)
             .RequireGlobalFeatures(typeof(GlobalResourcesFeature))


### PR DESCRIPTION
We use font-awesome classes for icons in the application modules, and themes are respecting that. For example, the basic theme only renders icons if the class name starts with `fa`:

https://github.com/abpframework/abp/blob/a37c0aa0fbb672119fa51f151816a0d2e08cf232/modules/basic-theme/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic/Themes/Basic/Components/Menu/Default.cshtml#L34-L37

So, we should not use the bootstrap icon classes for icons and use font-awesome always.