### PR TITLE
Refactor(dtos.ts): improve generic type naming and ordering

### DIFF
--- a/npm/ng-packs/packages/core/src/lib/models/dtos.ts
+++ b/npm/ng-packs/packages/core/src/lib/models/dtos.ts
@@ -114,14 +114,14 @@ export class CreationAuditedEntityDto<TPrimaryKey = string> extends EntityDto<TP
   }
 }
 
-export class CreationAuditedEntityWithUserDto<
-  TUserDto,
+export class CreationAuditedEntityWithUserDto<  
   TPrimaryKey = string,
+  TUserDto = any
 > extends CreationAuditedEntityDto<TPrimaryKey> {
   creator?: TUserDto;
 
   constructor(
-    initialValues: Partial<CreationAuditedEntityWithUserDto<TUserDto, TPrimaryKey>> = {},
+    initialValues: Partial<CreationAuditedEntityWithUserDto<TPrimaryKey,TUserDto>> = {},
   ) {
     super(initialValues);
   }
@@ -136,14 +136,15 @@ export class AuditedEntityDto<TPrimaryKey = string> extends CreationAuditedEntit
   }
 }
 
+ 
 export class AuditedEntityWithUserDto<
-  TUserDto,
   TPrimaryKey = string,
+  TUserDto = any,
 > extends AuditedEntityDto<TPrimaryKey> {
   creator?: TUserDto;
   lastModifier?: TUserDto;
 
-  constructor(initialValues: Partial<AuditedEntityWithUserDto<TUserDto, TPrimaryKey>> = {}) {
+  constructor(initialValues: Partial<AuditedEntityWithUserDto< TPrimaryKey,TUserDto>> = {}) {
     super(initialValues);
   }
 }
@@ -159,14 +160,14 @@ export class FullAuditedEntityDto<TPrimaryKey = string> extends AuditedEntityDto
 }
 
 export class FullAuditedEntityWithUserDto<
-  TUserDto,
   TPrimaryKey = string,
+  TUserDto = any
 > extends FullAuditedEntityDto<TPrimaryKey> {
   creator?: TUserDto;
   lastModifier?: TUserDto;
   deleter?: TUserDto;
 
-  constructor(initialValues: Partial<FullAuditedEntityWithUserDto<TUserDto, TPrimaryKey>> = {}) {
+  constructor(initialValues: Partial<FullAuditedEntityWithUserDto< TPrimaryKey,TUserDto>> = {}) {
     super(initialValues);
   }
 }

--- a/npm/ng-packs/packages/schematics/src/tests/parse-generic-type.spec.ts
+++ b/npm/ng-packs/packages/schematics/src/tests/parse-generic-type.spec.ts
@@ -1,0 +1,129 @@
+import { parseBaseTypeWithGenericTypes } from '../utils/model';
+import { parseGenerics   } from '../utils/tree';
+
+import {test} from '@jest/globals';
+
+const cases: Array<[string, string[]]> = [
+  [
+    'Volo.Abp.Application.Dtos.AuditedEntityWithUserDto',
+    ['Volo.Abp.Application.Dtos.AuditedEntityWithUserDto'],
+  ],
+  [
+    'Volo.Abp.Application.Dtos.AuditedEntityWithUserDto<Volo.Abp.Identity.IdentityUserDto>',
+    ['Volo.Abp.Application.Dtos.AuditedEntityWithUserDto', 'Volo.Abp.Identity.IdentityUserDto'],
+  ],
+  [
+    'Volo.Abp.Application.Dtos.AuditedEntityWithUserDto<string,Volo.Abp.Identity.IdentityUserDto>',
+    [
+      'Volo.Abp.Application.Dtos.AuditedEntityWithUserDto',
+      'string',
+      'Volo.Abp.Identity.IdentityUserDto'
+    ],
+  ],
+  [
+    'Volo.Abp.Application.Dtos.AuditedEntityWithUserDto<string,Volo.Abp.Identity.IdentityUserDto<number>>',
+    [
+      'Volo.Abp.Application.Dtos.AuditedEntityWithUserDto',
+      'string',
+      'Volo.Abp.Identity.IdentityUserDto',
+      'number',
+    ],
+  ],
+  [
+    'Volo.Abp.Application.Dtos.AuditedEntityWithUserDto<string,Volo.Abp.Identity.IdentityUserDto<Volo.Abp.Core.Dummy<System.String>>>',
+    [
+      'Volo.Abp.Application.Dtos.AuditedEntityWithUserDto',
+      'string',
+      'Volo.Abp.Identity.IdentityUserDto',
+      'Volo.Abp.Core.Dummy',
+      'System.String',
+    ],
+  ],
+  [
+    'AuditedEntityWithUserDto',
+    ['AuditedEntityWithUserDto'],
+  ],
+];
+
+test.each(cases)('should parse %s', (inputStr, expected) => {
+    const parsed = parseBaseTypeWithGenericTypes(inputStr);
+    expect(parsed).toEqual(expected);
+})
+
+describe('parseGenerics', () => {
+
+  it('should work with simple type', function() {
+    const node = parseGenerics('System.String');
+    expect(node.data).toEqual('System.String');
+    expect(node.index).toBe(0);
+    expect(node.parent).toBe(null);
+  });
+  it('should work with simple  Array type', function() {
+    const node = parseGenerics('System.String[]');
+    expect(node.data).toEqual('System.String[]');
+    expect(node.index).toBe(0);
+    expect(node.parent).toBe(null);
+  });
+
+  it('should work with simple', function() {
+    const node = parseGenerics('Volo.Abp.Application.Dtos.AuditedEntityWithUserDto');
+    expect(node.data).toEqual('Volo.Abp.Application.Dtos.AuditedEntityWithUserDto');
+    expect(node.index).toBe(0);
+    expect(node.parent).toBe(null);
+  });
+
+  it('should work with `Volo.Abp.Application.Dtos.AuditedEntityWithUserDto<Volo.Abp.Identity.IdentityUserDto>`', function() {
+    const type = 'Volo.Abp.Application.Dtos.AuditedEntityWithUserDto<Volo.Abp.Identity.IdentityUserDto>';
+    const node = parseGenerics(type);
+
+    expect(node.data).toEqual('Volo.Abp.Application.Dtos.AuditedEntityWithUserDto');
+    expect(node.children.length).toBe(1);
+    const child = node.children[0];
+    expect(node.children[0].data).toEqual('Volo.Abp.Identity.IdentityUserDto');
+    expect(child.parent).toBe(node);
+  });
+
+
+  it('should work with `Volo.Abp.Application.Dtos.AuditedEntityWithUserDto<System.string,Volo.Abp.Identity.IdentityUserDto>`', function() {
+    const type = 'Volo.Abp.Application.Dtos.AuditedEntityWithUserDto<System.string,Volo.Abp.Identity.IdentityUserDto>';
+    const node = parseGenerics(type);
+
+    expect(node.data).toEqual('Volo.Abp.Application.Dtos.AuditedEntityWithUserDto');
+    expect(node.children.length).toBe(2);
+    expect(node.children[0].data).toEqual('System.string');
+    expect(node.children[0].index).toBe(0)
+    expect(node.children[1].data).toEqual('Volo.Abp.Identity.IdentityUserDto');
+    expect(node.children[1].index).toBe(1);
+
+  });
+  it('should Volo.Abp.Application.Dtos.AuditedEntityWithUserDto<System.string,Volo.Abp.Identity.IdentityUserDto<System.Int>>', function() {
+    const type = 'Volo.Abp.Application.Dtos.AuditedEntityWithUserDto<System.string,Volo.Abp.Identity.IdentityUserDto<System.Int>>';
+    const node = parseGenerics(type);
+    expect(node.data).toEqual('Volo.Abp.Application.Dtos.AuditedEntityWithUserDto');
+    expect(node.children.length).toBe(2);
+    expect(node.children[0].data).toEqual('System.string');
+    expect((node.children[0]).parent).toBe(node);
+
+    expect(node.children[1].data).toEqual('Volo.Abp.Identity.IdentityUserDto');
+    expect(node.children[1].children.length).toBe(1);
+    expect(node.children[1].children[0].data).toEqual('System.Int');
+    expect(node.children[1].children[0].parent).toBe(node.children[1])
+    expect(node.children[1].children[0].index).toBe(0)
+
+  });
+
+  it('should Volo.Abp.Application.Dtos.AuditedEntityWithUserDto<Volo.Abp.Identity.IdentityUserDto<System.Int>,System.string>', function() {
+    const type = 'Volo.Abp.Application.Dtos.AuditedEntityWithUserDto<Volo.Abp.Identity.IdentityUserDto<System.Int>,System.string>';
+    const node = parseGenerics(type);
+    expect(node.data).toEqual('Volo.Abp.Application.Dtos.AuditedEntityWithUserDto');
+    expect(node.children.length).toBe(2);
+    expect(node.children[0].data).toEqual('Volo.Abp.Identity.IdentityUserDto');
+    expect(node.children[0].children.length).toBe(1);
+    expect(node.children[0].children[0].data).toEqual('System.Int');
+    expect(node.children[1].data).toEqual('System.string');
+
+  });
+});
+
+
+


### PR DESCRIPTION
## Description

The order of generic properties of `AuditedEntityWithUserDto` must be `PrimaryKey` first the userType like c#

<img width="1118" alt="image" src="https://github.com/abpframework/abp/assets/2217899/89f9c5d9-d80c-4d2c-9ee8-60488c93b9da">

Due that, typescript version is changed

Resolves #17842 , #17142

After the changes, nothing broken in abp and volo

<img width="885" alt="image" src="https://github.com/abpframework/abp/assets/2217899/4b733248-4189-4bb8-9767-7db161d5814b"> 

Generic AuditedEntityDto has wrong order because of optional parameter must be last. So I changed order and all generic param has default value
 
### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

## How to test

**The test is a little bit hard, Steps:**

- Create an ABP App
- Add  AppService, for example: CategoryAppService
- Create dto in must inherited from `AuditedEntityWithUserDto<string, IdentityUserDto>`
- Add a method that return the dto. like 

```csharp
using System.Collections.Generic;
using MyCompanyName.MyProjectName;

namespace MyCompanyName.MyProjectName.Categories;

public class CategoryAppService : MyProjectNameAppService
{
    public List<CategoryDto> GetAll()
    {
        return new List<CategoryDto>();
    }
}

```
 
- go to  `npm/ng-packs` in ABP Repo and run `yarn dev:schematics` command in terminal and it must be stay opened
- go to  `npm/ng-packs/packages/schematics` run `npm link` in ABP repo
- go to created app's angular folder. run `npm link @abp/ng.schematics`
- Now developed version of AbpSchematic connected your app with symlink
- you need to execute schemetics, I would add the comment in my package.json. 

## The command

```json
{
  "name": "ExampleAppName",
  "version": "0.0.0",
  "scripts": {
    "g":"ng g ./node_modules/@abp/ng.schematics/src/collection.json:proxy-add app __default __default __default __default all __default ",
  }
}
```

## Expected behavior

It works with generic types like `AuditedEntityWithUserDto<string, IdentityUserDto>` and exited functionalty works.


