### PR TITLE
Async functions do not return a Task type. If the parameter is empty, an exception will be returned.

### DIFF
--- a/framework/test/Volo.Abp.Http.Client.Tests/Volo/Abp/Http/DynamicProxying/TestObjectToFormData.cs
+++ b/framework/test/Volo.Abp.Http.Client.Tests/Volo/Abp/Http/DynamicProxying/TestObjectToFormData.cs
@@ -15,7 +15,7 @@ public class TestObjectToFormData : IObjectToFormData<List<GetParamsNameValue>>,
     {
         if (values.IsNullOrEmpty())
         {
-            return null;
+            return Task.FromResult<List<KeyValuePair<string, HttpContent>>>(null);
         }
 
         var formDataContents = new List<KeyValuePair<string, HttpContent>>();

--- a/framework/test/Volo.Abp.Http.Client.Tests/Volo/Abp/Http/DynamicProxying/TestObjectToQueryString.cs
+++ b/framework/test/Volo.Abp.Http.Client.Tests/Volo/Abp/Http/DynamicProxying/TestObjectToQueryString.cs
@@ -14,7 +14,7 @@ public class TestObjectToQueryString : IObjectToQueryString<List<GetParamsNameVa
     {
         if (values.IsNullOrEmpty())
         {
-            return null;
+            return Task.FromResult<string>(null);
         }
 
         var sb = new StringBuilder();


### PR DESCRIPTION
### Description

Write my business code according to the test case. Discover that an exception is thrown when the parameter is empty. If the await keyword is not added to an asynchronous method, returning null will also throw an exception.

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [ ] I documented it (or no need to document or I will create a separate documentation issue)

