### PR TITLE
Mark deprecated classed in Angular

### DIFF
--- a/npm/ng-packs/packages/core/src/lib/models/dtos.ts
+++ b/npm/ng-packs/packages/core/src/lib/models/dtos.ts
@@ -136,6 +136,7 @@ export class AuditedEntityDto<TPrimaryKey = string> extends CreationAuditedEntit
   }
 }
 
+/** @deprecated the class signature will change in v8.0 */ 
 export class AuditedEntityWithUserDto<
   TUserDto,
   TPrimaryKey = string,
@@ -157,7 +158,7 @@ export class FullAuditedEntityDto<TPrimaryKey = string> extends AuditedEntityDto
     super(initialValues);
   }
 }
-
+/** @deprecated the class signature will change in v8.0 */ 
 export class FullAuditedEntityWithUserDto<
   TUserDto,
   TPrimaryKey = string,

--- a/npm/ng-packs/packages/core/src/lib/tests/capsLock.directive.spec.ts
+++ b/npm/ng-packs/packages/core/src/lib/tests/capsLock.directive.spec.ts
@@ -11,7 +11,7 @@ import { By } from '@angular/platform-browser';
   imports:[TrackCapsLockDirective]
 })
 class TestComponent {
-  capsLock:boolean = false
+  capsLock = false
 }
 
 describe('TrackCapsLockDirective',()=>{

--- a/npm/ng-packs/packages/core/src/lib/tests/show-password-directive.spec.ts
+++ b/npm/ng-packs/packages/core/src/lib/tests/show-password-directive.spec.ts
@@ -13,7 +13,7 @@ import { By } from '@angular/platform-browser';
   imports:[ShowPasswordDirective]
 })
 class TestComponent {
-  showPassword:boolean = false
+  showPassword = false
 }
 
 describe('ShowPasswordDirective',()=>{
@@ -46,7 +46,7 @@ describe('ShowPasswordDirective',()=>{
     });
 
     it('should have three input has ShowPasswordDirective elements', () => {
-      let input = des[2].nativeElement
+      const input = des[2].nativeElement
       expect(input.type).toBe('password')
       fixture.componentInstance.showPassword = true
       fixture.detectChanges()

--- a/npm/ng-packs/packages/core/src/lib/utils/file-utils.ts
+++ b/npm/ng-packs/packages/core/src/lib/utils/file-utils.ts
@@ -1,3 +1,4 @@
+/** @deprecated the method will change in v8.0 */ 
 export function downloadBlob(blob: Blob, filename: string) {
   const blobUrl = URL.createObjectURL(blob);
 


### PR DESCRIPTION
### Description
The classes will cause breaking change or removed.  Due that it will marked as deprecated

Related https://github.com/abpframework/abp/issues/17854 and  https://github.com/abpframework/abp/issues/17142
 