### PR TITLE
Specify `FileAccess` and `FileShare` in `Volo.Abp.IO.FileHelper.ReadAllBytesAsync` method

### DIFF
--- a/framework/src/Volo.Abp.Core/Volo/Abp/IO/FileHelper.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/IO/FileHelper.cs
@@ -69,7 +69,7 @@ public static class FileHelper
     /// <returns>A string containing all lines of the file.</returns>
     public static async Task<byte[]> ReadAllBytesAsync(string path)
     {
-        using (var stream = File.Open(path, FileMode.Open))
+        using (var stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read))
         {
             var result = new byte[stream.Length];
             await stream.ReadAsync(result, 0, (int)stream.Length);


### PR DESCRIPTION
### Description

Resolves #17904

This PR changes the [`ReadAllBytesAsync`](https://github.com/abpframework/abp/blob/dev/framework/src/Volo.Abp.Core/Volo/Abp/IO/FileHelper.cs#L70) method in [`Volo.Abp.IO.FileHelper`](https://github.com/abpframework/abp/blob/dev/framework/src/Volo.Abp.Core/Volo/Abp/IO/FileHelper.cs) to specify the `FileAccess` and `FileShare` properties when opening files to be able to read files from a read-only file system.