### PR TITLE
Fix resize and compress problem

### DIFF
--- a/docs/en/Image-Manipulation.md
+++ b/docs/en/Image-Manipulation.md
@@ -76,8 +76,8 @@ public interface IImageResizer
 **Example usage:**
 
 ```csharp
-var result = await _imageResizer.ResizeAsync(
-    stream, /* A stream object that represents an image */
+var resizeResult = await _imageResizer.ResizeAsync(
+    imageStream, /* A stream object that represents an image */
     new ImageResizeArgs
     {
         Width = 100,
@@ -86,6 +86,16 @@ var result = await _imageResizer.ResizeAsync(
     },
     mimeType: "image/jpeg"
 );
+```
+
+> If `resizeResult.State` returns 'Done,' it means that the resize operation was successful. However, if it does not return 'Done,' the stream you're using might be corrupt. Therefore, you can perform a check like the one below and assign the correct stream to the main stream.
+
+```csharp
+if (resizeResult.Result is not null && imageStream != resizeResult.Result && resizeResult.Result.CanRead)
+{
+    await imageStream.DisposeAsync();
+    imageStream = resizeResult.Result;
+}
 ```
 
 > You can use `MimeTypes.Image.Jpeg` constant instead of the `image/jpeg` magic string used in that example.
@@ -170,10 +180,21 @@ public interface IImageCompressor
 **Example usage:**
 
 ```csharp
-var result = await _imageCompressor.CompressAsync(
-    stream, /* A stream object that represents an image */
+var compressResult = await _imageCompressor.CompressAsync(
+    imageStream, /* A stream object that represents an image */
     mimeType: "image/jpeg"
 );
+```
+
+> If `compressResult.State` returns 'Done,' it means that the compress operation was successful. However, if it does not return 'Done,' the stream you're using might be corrupt. Therefore, you can perform a check like the one below and assign the correct stream to the main stream.
+
+```csharp
+
+if (compressResult.Result is not null && imageStream != compressResult.Result && compressResult.Result.CanRead)
+{
+    await imageStream.DisposeAsync();
+    imageStream = compressResult.Result;
+}
 ```
 
 ### ImageCompressResult

--- a/docs/en/Image-Manipulation.md
+++ b/docs/en/Image-Manipulation.md
@@ -88,7 +88,7 @@ var resizeResult = await _imageResizer.ResizeAsync(
 );
 ```
 
-> If `resizeResult.State` returns 'Done,' it means that the resize operation was successful. However, if it does not return 'Done,' the stream you're using might be corrupt. Therefore, you can perform a check like the one below and assign the correct stream to the main stream.
+> **Note:** If `resizeResult.State` returns 'Done', then it means that the resize operation was successful. However, if it returns any other state than 'Done', the stream you're using might be corrupted. Therefore, you can perform a check like the one below and assign the correct stream to the main stream:
 
 ```csharp
 if (resizeResult.Result is not null && imageStream != resizeResult.Result && resizeResult.Result.CanRead)
@@ -186,7 +186,7 @@ var compressResult = await _imageCompressor.CompressAsync(
 );
 ```
 
-> If `compressResult.State` returns 'Done,' it means that the compress operation was successful. However, if it does not return 'Done,' the stream you're using might be corrupt. Therefore, you can perform a check like the one below and assign the correct stream to the main stream.
+> **Note:** If `compressResult.State` returns 'Done', then it means that the compression operation was successful. However, if it returns any other state than 'Done', the stream you're using might be corrupted. Therefore, you can perform a check like the one below and assign the correct stream to the main stream:
 
 ```csharp
 

--- a/framework/src/Volo.Abp.Imaging.Abstractions/Volo/Abp/Imaging/ImageResizer.cs
+++ b/framework/src/Volo.Abp.Imaging.Abstractions/Volo/Abp/Imaging/ImageResizer.cs
@@ -38,9 +38,24 @@ public class ImageResizer : IImageResizer, ITransientDependency
         
         ChangeDefaultResizeMode(resizeArgs);
         
+        if(!stream.CanRead)
+        {
+            return new ImageResizeResult<Stream>(stream, ImageProcessState.Unsupported);
+        }
+        
+        if(!stream.CanSeek)
+        {
+            var memoryStream = new MemoryStream();
+            await stream.CopyToAsync(memoryStream, CancellationTokenProvider.FallbackToProvider(cancellationToken));
+            SeekToBegin(memoryStream);
+            stream = memoryStream;
+        }
+        
         foreach (var imageResizerContributor in ImageResizerContributors)
         {
             var result = await imageResizerContributor.TryResizeAsync(stream, resizeArgs, mimeType, CancellationTokenProvider.FallbackToProvider(cancellationToken));
+
+            SeekToBegin(stream);
             
             if (result.State == ImageProcessState.Unsupported)
             {
@@ -83,6 +98,14 @@ public class ImageResizer : IImageResizer, ITransientDependency
         if (resizeArgs.Mode == ImageResizeMode.Default)
         {
             resizeArgs.Mode = ImageResizeOptions.DefaultResizeMode;
+        }
+    }
+    
+    protected virtual void SeekToBegin(Stream stream)
+    {
+        if (stream.CanSeek)
+        {
+            stream.Seek(0, SeekOrigin.Begin);
         }
     }
 }


### PR DESCRIPTION
### Description

Streams that cannot be rewound were causing unsuccessful processing since the original stream cannot be reused. Therefore, if a stream cannot be rewound, it is converted to a MemoryStream to continue processing.

### Checklist

- [ ] I fully tested it as developer
- [ ] I documented it
