### PR TITLE
Show AppService endpoints in Swagger UI of module template

### DIFF
--- a/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.HttpApi.Host/MyProjectNameHttpApiHostModule.cs
+++ b/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.HttpApi.Host/MyProjectNameHttpApiHostModule.cs
@@ -15,6 +15,7 @@ using MyCompanyName.MyProjectName.MultiTenancy;
 using StackExchange.Redis;
 using Microsoft.OpenApi.Models;
 using Volo.Abp;
+using Volo.Abp.AspNetCore.Mvc;
 using Volo.Abp.AspNetCore.Mvc.UI.MultiTenancy;
 using Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared;
 using Volo.Abp.AspNetCore.Serilog;
@@ -154,6 +155,11 @@ public class MyProjectNameHttpApiHostModule : AbpModule
                     .AllowAnyMethod()
                     .AllowCredentials();
             });
+        });
+        
+        Configure<AbpAspNetCoreMvcOptions>(options =>
+        {
+            options.ConventionalControllers.Create(typeof(MyProjectNameApplicationModule).Assembly);
         });
     }
 


### PR DESCRIPTION
### Description

When creating a project using the module template, the `HttpApi.Host` module does not have configuration for creating Auto API Controllers. 

To fix that, I added this configuration in `MyProjectNameHttpApiHostModule.cs`:

``` csharp
Configure<AbpAspNetCoreMvcOptions>(options =>
{
    options.ConventionalControllers.Create(typeof(MyProjectNameApplicationModule).Assembly);
});
```
