### PR TITLE
Support `DateOnly` and `TimeOnly` in `AspNetCoreApiDescriptionModelProvider`.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AspNetCoreApiDescriptionModelProvider.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AspNetCoreApiDescriptionModelProvider.cs
@@ -214,6 +214,8 @@ public class AspNetCoreApiDescriptionModelProvider : IApiDescriptionModelProvide
             type == typeof(void) ||
             type == typeof(Enum) ||
             type == typeof(ValueType) ||
+            type == typeof(DateOnly) ||
+            type == typeof(TimeOnly) ||
             TypeHelper.IsPrimitiveExtended(type))
         {
             return;

--- a/framework/src/Volo.Abp.Core/Volo/Abp/Reflection/TypeHelper.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/Reflection/TypeHelper.cs
@@ -257,6 +257,14 @@ public static class TypeHelper
         {
             return "string";
         }
+        else if (type.FullName == "System.DateOnly")
+        {
+            return "string";
+        }
+        else if (type.FullName == "System.TimeOnly")
+        {
+            return "string";
+        }
         else if (type == typeof(TimeSpan))
         {
             return "string";

--- a/npm/ng-packs/packages/schematics/src/constants/system-types.ts
+++ b/npm/ng-packs/packages/schematics/src/constants/system-types.ts
@@ -5,6 +5,8 @@ export const SYSTEM_TYPES = new Map([
   ['Collections.Generic.Dictionary', 'Record'],
   ['DateTime', 'string'],
   ['DateTimeOffset', 'string'],
+  ['DateOnly', 'string'],
+  ['TimeOnly', 'string'],
   ['Decimal', 'number'],
   ['Double', 'number'],
   ['Guid', 'string'],


### PR DESCRIPTION
Resolves #17923

## Description 
When the create proxy if dto includes `DateOnly` or `TimeOnly` structs it should change to string property to

