### PR TITLE
Add email/username changed event

### DIFF
--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/IdentityUserEmailChangedEto.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/IdentityUserEmailChangedEto.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Volo.Abp.MultiTenancy;
+
+namespace Volo.Abp.Identity;
+
+[Serializable]
+public class IdentityUserEmailChangedEto : IMultiTenant 
+{
+    public Guid Id { get; set; }
+
+    public Guid? TenantId { get; set; }
+
+    public string Email { get; set; }
+
+    public string OldEmail { get; set; }
+}

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/IdentityUserUserNameChangedEto.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/IdentityUserUserNameChangedEto.cs
@@ -7,7 +7,10 @@ namespace Volo.Abp.Identity;
 public class IdentityUserUserNameChangedEto : IMultiTenant
 {
     public Guid Id { get; set; }
+
     public Guid? TenantId { get; set; }
+
     public string UserName { get; set; }
+
     public string OldUserName { get; set; }
 }

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/IdentityUserUserNameChangedEto.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/IdentityUserUserNameChangedEto.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Volo.Abp.MultiTenancy;
+
+namespace Volo.Abp.Identity;
+
+[Serializable]
+public class IdentityUserUserNameChangedEto : IMultiTenant
+{
+    public Guid Id { get; set; }
+    public Guid? TenantId { get; set; }
+    public string UserName { get; set; }
+    public string OldUserName { get; set; }
+}

--- a/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/IdentityUserManager.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/IdentityUserManager.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Options;
 using Volo.Abp.Domain.Entities;
 using Volo.Abp.Domain.Repositories;
 using Volo.Abp.Domain.Services;
+using Volo.Abp.EventBus.Distributed;
 using Volo.Abp.Identity.Settings;
 using Volo.Abp.Settings;
 using Volo.Abp.Threading;
@@ -25,6 +26,7 @@ public class IdentityUserManager : UserManager<IdentityUser>, IDomainService
     protected IOrganizationUnitRepository OrganizationUnitRepository { get; }
     protected ISettingProvider SettingProvider { get; }
     protected ICancellationTokenProvider CancellationTokenProvider { get; }
+    protected IDistributedEventBus DistributedEventBus { get; }
 
     protected override CancellationToken CancellationToken => CancellationTokenProvider.Token;
 
@@ -42,7 +44,8 @@ public class IdentityUserManager : UserManager<IdentityUser>, IDomainService
         ILogger<IdentityUserManager> logger,
         ICancellationTokenProvider cancellationTokenProvider,
         IOrganizationUnitRepository organizationUnitRepository,
-        ISettingProvider settingProvider)
+        ISettingProvider settingProvider, 
+        IDistributedEventBus distributedEventBus)
         : base(
             store,
             optionsAccessor,
@@ -56,6 +59,7 @@ public class IdentityUserManager : UserManager<IdentityUser>, IDomainService
     {
         OrganizationUnitRepository = organizationUnitRepository;
         SettingProvider = settingProvider;
+        DistributedEventBus = distributedEventBus;
         RoleRepository = roleRepository;
         UserRepository = userRepository;
         CancellationTokenProvider = cancellationTokenProvider;
@@ -284,5 +288,44 @@ public class IdentityUserManager : UserManager<IdentityUser>, IDomainService
         }
 
         await identityUserStore.SetTokenAsync(user, await identityUserStore.GetInternalLoginProviderAsync(), await identityUserStore.GetRecoveryCodeTokenNameAsync(), string.Empty, CancellationToken);
+    }
+
+    public async override Task<IdentityResult> SetEmailAsync(IdentityUser user, string email)
+    {
+        var oldMail = user.Email;
+        
+        var result = await base.SetEmailAsync(user, email);
+        
+        result.CheckErrors();
+        
+        await DistributedEventBus.PublishAsync(
+            new IdentityUserEmailChangedEto 
+            {
+                Id = user.Id,
+                TenantId = user.TenantId,
+                Email = email,
+                OldEmail = oldMail
+            });
+
+        return result;
+    }
+
+    public async override Task<IdentityResult> SetUserNameAsync(IdentityUser user, string userName)
+    {
+        var oldUserName = user.UserName;
+        
+        var result = await base.SetUserNameAsync(user, userName);
+        
+        result.CheckErrors();
+
+        await DistributedEventBus.PublishAsync(
+            new IdentityUserUserNameChangedEto {
+                Id = user.Id,
+                TenantId = user.TenantId,
+                UserName = userName,
+                OldUserName = oldUserName
+            });
+        
+        return result;
     }
 }

--- a/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/IdentityUserManager.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/IdentityUserManager.cs
@@ -321,7 +321,7 @@ public class IdentityUserManager : UserManager<IdentityUser>, IDomainService
 
         result.CheckErrors();
 
-        if (!string.IsNullOrEmpty(oldUserName) && !oldUserName.Equals(userName, StringComparison.OrdinalIgnoreCase))
+        if (!string.IsNullOrEmpty(oldUserName) && oldUserName != userName)
         {
             await DistributedEventBus.PublishAsync(
                 new IdentityUserUserNameChangedEto

--- a/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/IdentityUserManager.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/IdentityUserManager.cs
@@ -297,15 +297,20 @@ public class IdentityUserManager : UserManager<IdentityUser>, IDomainService
         var result = await base.SetEmailAsync(user, email);
         
         result.CheckErrors();
-        
+
+        if (string.IsNullOrEmpty(oldMail) || oldMail.Equals(email, StringComparison.OrdinalIgnoreCase))
+        {
+            return result;
+        }
+
         await DistributedEventBus.PublishAsync(
-            new IdentityUserEmailChangedEto 
-            {
-                Id = user.Id,
-                TenantId = user.TenantId,
-                Email = email,
-                OldEmail = oldMail
-            });
+        new IdentityUserEmailChangedEto 
+        {
+            Id = user.Id,
+            TenantId = user.TenantId,
+            Email = email,
+            OldEmail = oldMail
+        });
 
         return result;
     }
@@ -317,6 +322,11 @@ public class IdentityUserManager : UserManager<IdentityUser>, IDomainService
         var result = await base.SetUserNameAsync(user, userName);
         
         result.CheckErrors();
+        
+        if (string.IsNullOrEmpty(oldUserName) || oldUserName == userName)
+        {
+            return result;
+        }
 
         await DistributedEventBus.PublishAsync(
             new IdentityUserUserNameChangedEto {


### PR DESCRIPTION
### Description

When changing email/username, there may be scenarios where the old email/username is needed. For this reason, when the email/username changes, publish a distributed event containing the old email/username.

#### Breaking Change
Added IDistributedEventBus to IdentityUserManager's constructor

### Checklist

- [x] I fully tested it as developer
- [ ] I documented it (or no need to document or I will create a separate documentation issue)
