### PR TITLE
Exclude `function` parameters in querystrings.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/wwwroot/libs/abp/aspnetcore-mvc-ui-theme-shared/bootstrap/modal-manager.js
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/wwwroot/libs/abp/aspnetcore-mvc-ui-theme-shared/bootstrap/modal-manager.js
@@ -134,8 +134,15 @@ $.validator.defaults.ignore = ''; //TODO: Would be better if we can apply only f
 
                 _args = args || {};
 
+                var argsWithoutFunc = {};
+                for (a in _args) {
+                    if (_args.hasOwnProperty(a) && typeof _args[a] !== 'function') {
+                        argsWithoutFunc[a] = _args[a];
+                    }
+                }
+
                 _createContainer(_modalId)
-                    .load(options.viewUrl, $.param(_args), function (response, status, xhr) {
+                    .load(options.viewUrl, $.param(argsWithoutFunc), function (response, status, xhr) {
                         if (status === "error") {
                             //TODO: Handle!
                             return;


### PR DESCRIPTION

<img width="939" alt="image" src="https://github.com/abpframework/abp/assets/6908465/cb68a0f7-0285-42e7-900e-80a68da76446">

<img width="661" alt="image" src="https://github.com/abpframework/abp/assets/6908465/c3a2b8c9-73aa-412c-9515-6ec85909342f">
