### PR TITLE
Show error message when open modal fails in mvc.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/wwwroot/libs/abp/aspnetcore-mvc-ui-theme-shared/bootstrap/modal-manager.js
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/wwwroot/libs/abp/aspnetcore-mvc-ui-theme-shared/bootstrap/modal-manager.js
@@ -144,12 +144,9 @@ $.validator.defaults.ignore = ''; //TODO: Would be better if we can apply only f
                 _createContainer(_modalId)
                     .load(options.viewUrl, $.param(argsWithoutFunc), function (response, status, xhr) {
                         if (status === "error") {
-                            var error = JSON.parse(response)?.error;
-                            if (error.details) {
-                                return abp.message.error(error.details, error.message);
-                            } else {
-                                return abp.message.error(error.message || abp.ajax.defaultError.message);
-                            }
+                            var responseJSON = xhr.responseJSON ? xhr.responseJSON : JSON.parse(xhr.responseText);
+                            abp.ajax.showError(responseJSON.error ? responseJSON.error : abp.ajax.defaultError);
+                            return;
                         };
 
                         if (options.scriptUrl) {

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/wwwroot/libs/abp/aspnetcore-mvc-ui-theme-shared/bootstrap/modal-manager.js
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/wwwroot/libs/abp/aspnetcore-mvc-ui-theme-shared/bootstrap/modal-manager.js
@@ -135,7 +135,7 @@ $.validator.defaults.ignore = ''; //TODO: Would be better if we can apply only f
                 _args = args || {};
 
                 var argsWithoutFunc = {};
-                for (a in _args) {
+                for (var a in _args) {
                     if (_args.hasOwnProperty(a) && typeof _args[a] !== 'function') {
                         argsWithoutFunc[a] = _args[a];
                     }
@@ -144,8 +144,12 @@ $.validator.defaults.ignore = ''; //TODO: Would be better if we can apply only f
                 _createContainer(_modalId)
                     .load(options.viewUrl, $.param(argsWithoutFunc), function (response, status, xhr) {
                         if (status === "error") {
-                            //TODO: Handle!
-                            return;
+                            var error = JSON.parse(response)?.error;
+                            if (error.details) {
+                                return abp.message.error(error.details, error.message);
+                            } else {
+                                return abp.message.error(error.message || abp.ajax.defaultError.message);
+                            }
                         };
 
                         if (options.scriptUrl) {


### PR DESCRIPTION
### Description

When an error occurs when opening a modal, there is no record, unless you open the browser console.

I have modified the default behavior of the ModalManager class so that when it loads the information from a modal, if an error occurs, it displays an error message.

### Checklist

- [ ] I fully tested it as developer without creating unit testing

### How to test it?

To test it, the easiest thing is to throw an exception in the OnGetAsync method of a page that is used as a modal. EditModal.cshtml
