### PR TITLE
Enable repository auto-save in `EntitySynchronizer`

### DIFF
--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Entities/Events/Distributed/EntitySynchronizer.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Entities/Events/Distributed/EntitySynchronizer.cs
@@ -103,7 +103,7 @@ public abstract class EntitySynchronizer<TEntity, TSourceEntityEto> :
                 );
             }
 
-            await Repository.InsertAsync(localEntity);
+            await Repository.InsertAsync(localEntity, true);
         }
         else
         {
@@ -122,7 +122,7 @@ public abstract class EntitySynchronizer<TEntity, TSourceEntityEto> :
                 );
             }
 
-            await Repository.UpdateAsync(localEntity);
+            await Repository.UpdateAsync(localEntity, true);
         }
 
         return true;


### PR DESCRIPTION
### Description

In this way, after synchronization, it is possible to get the inserted or updated entities before the transaction is committed.