### PR TITLE
Add `OnActivated` event for `ServiceDescriptor`.

### DIFF
--- a/docs/en/Dependency-Injection.md
+++ b/docs/en/Dependency-Injection.md
@@ -480,6 +480,24 @@ This example simply checks if the service class has `MyLogAttribute` attribute a
 
 > Notice that `OnRegistered` callback might be called multiple times for the same service class if it exposes more than one service/interface. So, it's safe to use `Interceptors.TryAdd` method instead of `Interceptors.Add` method. See [the documentation](Dynamic-Proxying-Interceptors.md) of dynamic proxying / interceptors.
 
+### IServiceCollection.OnActivated Event
+
+The `OnActivated` event is raised once a service is fully constructed. Here you can perform application-level tasks that depend on the service being fully constructed - these should be rare.
+
+````csharp
+var serviceDescriptor = ServiceDescriptor.Transient<MyServer, MyServer>();
+services.Add(serviceDescriptor);
+if (setIsReadOnly)
+{
+    services.OnActivated(serviceDescriptor, x =>
+    {
+        x.Instance.As<MyServer>().IsReadOnly = true;
+    });
+}
+````
+
+> Notice that `OnActivated` event can be registered multiple times for the same `ServiceDescriptor`.
+
 ## 3rd-Party Providers
 
 While ABP has no core dependency to any 3rd-party DI provider, it's required to use a provider that supports dynamic proxying and some other advanced features to make some ABP features properly work. 

--- a/docs/zh-Hans/Dependency-Injection.md
+++ b/docs/zh-Hans/Dependency-Injection.md
@@ -310,6 +310,24 @@ public class AppModule : AbpModule
 
 > 注意, 如果服务类公开了多于一个服务或接口, `OnRegistered` 回调(callback)可能被同一服务类多次调用. 因此, 较安全的方法是使用 `Interceptors.TryAdd` 方法而不是 `Interceptors.Add` 方法. 请参阅动态代理(dynamic proxying)/拦截器 [文档](Dynamic-Proxying-Interceptors.md).
 
+### IServiceCollection.OnActivated 事件
+
+一旦服务完全构建完成`OnActivated`事件就会触发. 你可以执行依赖于服务已完全构建的的一些任务, 虽然这种情况可能很少见.
+
+````csharp
+var serviceDescriptor = ServiceDescriptor.Transient<MyServer, MyServer>();
+services.Add(serviceDescriptor);
+if (setIsReadOnly)
+{
+    services.OnActivated(serviceDescriptor, x =>
+    {
+        x.Instance.As<MyServer>().IsReadOnly = true;
+    });
+}
+````
+
+> 注意，`OnActivated`事件可以为一个`ServiceDescriptor`注册多次.
+
 ## 第三方提供程序
 
 虽然ABP框架没有对任何第三方DI提供程序的核心依赖, 但它必须使用一个提供程序来支持动态代理(dynamic proxying)和一些高级特性以便ABP特性能正常工作.

--- a/framework/src/Volo.Abp.Autofac/Autofac/Builder/AbpRegistrationBuilderExtensions.cs
+++ b/framework/src/Volo.Abp.Autofac/Autofac/Builder/AbpRegistrationBuilderExtensions.cs
@@ -18,10 +18,10 @@ public static class AbpRegistrationBuilderExtensions
             ServiceDescriptor serviceDescriptor,
             IModuleContainer moduleContainer,
             ServiceRegistrationActionList registrationActionList,
-            ServiceActivatedActionList serviceActivatedActionList)
+            ServiceActivatedActionList activatedActionList)
         where TActivatorData : ReflectionActivatorData
     {
-        registrationBuilder = registrationBuilder.InvokeActivatedActions(serviceActivatedActionList, serviceDescriptor);
+        registrationBuilder = registrationBuilder.InvokeActivatedActions(activatedActionList, serviceDescriptor);
 
         var serviceType = registrationBuilder.RegistrationData.Services.OfType<IServiceWithType>().FirstOrDefault()?.ServiceType;
         if (serviceType == null)
@@ -43,14 +43,14 @@ public static class AbpRegistrationBuilderExtensions
 
     private static IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> InvokeActivatedActions<TLimit, TActivatorData, TRegistrationStyle>(
         this IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> registrationBuilder,
-        ServiceActivatedActionList serviceActivatedActionList,
+        ServiceActivatedActionList activatedActionList,
         ServiceDescriptor serviceDescriptor)
         where TActivatorData : ReflectionActivatorData
     {
         registrationBuilder.OnActivated(context =>
         {
             var serviceActivatedContext = new OnServiceActivatedContext(context.Instance!);
-            foreach (var action in serviceActivatedActionList.GetActions(serviceDescriptor))
+            foreach (var action in activatedActionList.GetActions(serviceDescriptor))
             {
                 action.Invoke(serviceActivatedContext);
             }

--- a/framework/src/Volo.Abp.Autofac/Autofac/Builder/AbpRegistrationBuilderExtensions.cs
+++ b/framework/src/Volo.Abp.Autofac/Autofac/Builder/AbpRegistrationBuilderExtensions.cs
@@ -15,7 +15,8 @@ public static class AbpRegistrationBuilderExtensions
     public static IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> ConfigureAbpConventions<TLimit, TActivatorData, TRegistrationStyle>(
             this IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> registrationBuilder,
             IModuleContainer moduleContainer,
-            ServiceRegistrationActionList registrationActionList)
+            ServiceRegistrationActionList registrationActionList,
+            List<Action<IOnServiceActivatedContext>> serviceActivatedActions)
         where TActivatorData : ReflectionActivatorData
     {
         var serviceType = registrationBuilder.RegistrationData.Services.OfType<IServiceWithType>().FirstOrDefault()?.ServiceType;
@@ -23,6 +24,15 @@ public static class AbpRegistrationBuilderExtensions
         {
             return registrationBuilder;
         }
+
+        registrationBuilder.OnActivated(context =>
+        {
+            var serviceActivatedContext = new OnServiceActivatedContext(context.Instance!);
+            foreach (var action in serviceActivatedActions)
+            {
+                action.Invoke(serviceActivatedContext);
+            }
+        });
 
         var implementationType = registrationBuilder.ActivatorData.ImplementationType;
         if (implementationType == null)

--- a/framework/src/Volo.Abp.Autofac/Autofac/Builder/AbpRegistrationBuilderExtensions.cs
+++ b/framework/src/Volo.Abp.Autofac/Autofac/Builder/AbpRegistrationBuilderExtensions.cs
@@ -18,10 +18,10 @@ public static class AbpRegistrationBuilderExtensions
             ServiceDescriptor serviceDescriptor,
             IModuleContainer moduleContainer,
             ServiceRegistrationActionList registrationActionList,
-            ServiceActivatedActionList serviceActivatedActions)
+            ServiceActivatedActionList serviceActivatedActionList)
         where TActivatorData : ReflectionActivatorData
     {
-        registrationBuilder = registrationBuilder.InvokeActivatedActions(serviceActivatedActions, serviceDescriptor);
+        registrationBuilder = registrationBuilder.InvokeActivatedActions(serviceActivatedActionList, serviceDescriptor);
 
         var serviceType = registrationBuilder.RegistrationData.Services.OfType<IServiceWithType>().FirstOrDefault()?.ServiceType;
         if (serviceType == null)
@@ -43,14 +43,14 @@ public static class AbpRegistrationBuilderExtensions
 
     private static IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> InvokeActivatedActions<TLimit, TActivatorData, TRegistrationStyle>(
         this IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> registrationBuilder,
-        ServiceActivatedActionList serviceActivatedActions,
+        ServiceActivatedActionList serviceActivatedActionList,
         ServiceDescriptor serviceDescriptor)
         where TActivatorData : ReflectionActivatorData
     {
         registrationBuilder.OnActivated(context =>
         {
             var serviceActivatedContext = new OnServiceActivatedContext(context.Instance!);
-            foreach (var action in serviceActivatedActions.GetActions(serviceDescriptor))
+            foreach (var action in serviceActivatedActionList.GetActions(serviceDescriptor))
             {
                 action.Invoke(serviceActivatedContext);
             }

--- a/framework/src/Volo.Abp.Autofac/Autofac/Extensions/DependencyInjection/AutofacRegistration.cs
+++ b/framework/src/Volo.Abp.Autofac/Autofac/Extensions/DependencyInjection/AutofacRegistration.cs
@@ -189,8 +189,6 @@ public static class AutofacRegistration
         {
             if (descriptor.ImplementationType != null)
             {
-                var activatedActions = activatedActionList.GetActions(descriptor);
-
                 // Test if the an open generic type is being registered
                 var serviceTypeInfo = descriptor.ServiceType.GetTypeInfo();
                 if (serviceTypeInfo.IsGenericTypeDefinition)
@@ -199,7 +197,7 @@ public static class AutofacRegistration
                         .RegisterGeneric(descriptor.ImplementationType)
                         .As(descriptor.ServiceType)
                         .ConfigureLifecycle(descriptor.Lifetime, lifetimeScopeTagForSingletons)
-                        .ConfigureAbpConventions(moduleContainer, registrationActionList, activatedActions);
+                        .ConfigureAbpConventions(descriptor, moduleContainer, registrationActionList, activatedActionList);
                 }
                 else
                 {
@@ -207,7 +205,7 @@ public static class AutofacRegistration
                         .RegisterType(descriptor.ImplementationType)
                         .As(descriptor.ServiceType)
                         .ConfigureLifecycle(descriptor.Lifetime, lifetimeScopeTagForSingletons)
-                        .ConfigureAbpConventions(moduleContainer, registrationActionList, activatedActions);
+                        .ConfigureAbpConventions(descriptor, moduleContainer, registrationActionList, activatedActionList);
                 }
             }
             else if (descriptor.ImplementationFactory != null)

--- a/framework/src/Volo.Abp.Autofac/Autofac/Extensions/DependencyInjection/AutofacRegistration.cs
+++ b/framework/src/Volo.Abp.Autofac/Autofac/Extensions/DependencyInjection/AutofacRegistration.cs
@@ -183,11 +183,14 @@ public static class AutofacRegistration
     {
         var moduleContainer = services.GetSingletonInstance<IModuleContainer>();
         var registrationActionList = services.GetRegistrationActionList();
+        var activatedActionList = services.GetServiceActivatedActionList();
 
         foreach (var descriptor in services)
         {
             if (descriptor.ImplementationType != null)
             {
+                var activatedActions = activatedActionList.GetActions(descriptor);
+
                 // Test if the an open generic type is being registered
                 var serviceTypeInfo = descriptor.ServiceType.GetTypeInfo();
                 if (serviceTypeInfo.IsGenericTypeDefinition)
@@ -196,7 +199,7 @@ public static class AutofacRegistration
                         .RegisterGeneric(descriptor.ImplementationType)
                         .As(descriptor.ServiceType)
                         .ConfigureLifecycle(descriptor.Lifetime, lifetimeScopeTagForSingletons)
-                        .ConfigureAbpConventions(moduleContainer, registrationActionList);
+                        .ConfigureAbpConventions(moduleContainer, registrationActionList, activatedActions);
                 }
                 else
                 {
@@ -204,7 +207,7 @@ public static class AutofacRegistration
                         .RegisterType(descriptor.ImplementationType)
                         .As(descriptor.ServiceType)
                         .ConfigureLifecycle(descriptor.Lifetime, lifetimeScopeTagForSingletons)
-                        .ConfigureAbpConventions(moduleContainer, registrationActionList);
+                        .ConfigureAbpConventions(moduleContainer, registrationActionList, activatedActions);
                 }
             }
             else if (descriptor.ImplementationFactory != null)

--- a/framework/src/Volo.Abp.Core/Microsoft/Extensions/DependencyInjection/ServiceCollectionLifetimeEventExtensions.cs
+++ b/framework/src/Volo.Abp.Core/Microsoft/Extensions/DependencyInjection/ServiceCollectionLifetimeEventExtensions.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using Volo.Abp.DependencyInjection;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+public static class ServiceCollectionLifetimeEventExtensions
+{
+    // OnActivated
+    public static void OnActivated(this IServiceCollection services, ServiceDescriptor descriptor, Action<IOnServiceActivatedContext> onActivatedAction)
+    {
+        GetOrCreateOnActivatedActionList(services).Add(new KeyValuePair<ServiceDescriptor, Action<IOnServiceActivatedContext>>(descriptor, onActivatedAction));
+    }
+
+    public static ServiceActivatedActionList GetServiceActivatedActionList(this IServiceCollection services)
+    {
+        return GetOrCreateOnActivatedActionList(services);
+    }
+
+    private static ServiceActivatedActionList GetOrCreateOnActivatedActionList(IServiceCollection services)
+    {
+        var actionList = services.GetSingletonInstanceOrNull<IObjectAccessor<ServiceActivatedActionList>>()?.Value;
+        if (actionList == null)
+        {
+            actionList = new ServiceActivatedActionList();
+            services.AddObjectAccessor(actionList);
+        }
+
+        return actionList;
+    }
+}

--- a/framework/src/Volo.Abp.Core/Volo/Abp/DependencyInjection/IOnServiceActivatedContext.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/DependencyInjection/IOnServiceActivatedContext.cs
@@ -1,0 +1,6 @@
+namespace Volo.Abp.DependencyInjection;
+
+public interface IOnServiceActivatedContext
+{
+    public object Instance { get; }
+}

--- a/framework/src/Volo.Abp.Core/Volo/Abp/DependencyInjection/OnServiceActivatedContext.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/DependencyInjection/OnServiceActivatedContext.cs
@@ -1,0 +1,11 @@
+namespace Volo.Abp.DependencyInjection;
+
+public class OnServiceActivatedContext : IOnServiceActivatedContext
+{
+    public object Instance { get; set; }
+
+    public OnServiceActivatedContext(object instance)
+    {
+        Instance = instance;
+    }
+}

--- a/framework/src/Volo.Abp.Core/Volo/Abp/DependencyInjection/ServiceActivatedActionList.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/DependencyInjection/ServiceActivatedActionList.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Volo.Abp.DependencyInjection;
+
+public class ServiceActivatedActionList : List<KeyValuePair<ServiceDescriptor, Action<IOnServiceActivatedContext>>>
+{
+    public List<Action<IOnServiceActivatedContext>> GetActions(ServiceDescriptor descriptor)
+    {
+        return this.Where(x => x.Key == descriptor).Select(x => x.Value).ToList();
+    }
+}

--- a/framework/src/Volo.Abp.Ddd.Domain/Microsoft/Extensions/DependencyInjection/ServiceCollectionRepositoryExtensions.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Microsoft/Extensions/DependencyInjection/ServiceCollectionRepositoryExtensions.cs
@@ -84,21 +84,15 @@ public static class ServiceCollectionRepositoryExtensions
         bool replaceExisting,
         bool isReadOnlyRepository = false)
     {
-        ServiceDescriptor descriptor;
+        var descriptor = ServiceDescriptor.Transient(serviceType, implementationType);
 
         if (isReadOnlyRepository)
         {
-            services.TryAddTransient(implementationType);
-            descriptor = ServiceDescriptor.Transient(serviceType, provider =>
+            services.OnActivated(descriptor, context =>
             {
-                var repository = provider.GetRequiredService(implementationType);
+                var repository = context.Instance.As<IRepository>();
                 ObjectHelper.TrySetProperty(repository.As<IRepository>(), x => x.IsChangeTrackingEnabled, _ => false);
-                return repository;
             });
-        }
-        else
-        {
-            descriptor = ServiceDescriptor.Transient(serviceType, implementationType);
         }
 
         if (replaceExisting)

--- a/framework/test/Volo.Abp.Autofac.Tests/Volo/Abp/Autofac/AutoFac_OnActivated_Tests.cs
+++ b/framework/test/Volo.Abp.Autofac.Tests/Volo/Abp/Autofac/AutoFac_OnActivated_Tests.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Volo.Abp.Autofac.Interception;
+using Xunit;
+
+namespace Volo.Abp.Autofac;
+
+public class AutoFac_OnActivated_Tests : Autofac_Interception_Test
+{
+    protected override Task AfterAddApplicationAsync(IServiceCollection services)
+    {
+        var serviceDescriptor = ServiceDescriptor.Transient<MyServer, MyServer>();
+        services.Add(serviceDescriptor);
+        services.OnActivated(serviceDescriptor, x =>
+        {
+            x.Instance.As<MyServer>().Name += "1";
+        });
+        services.OnActivated(serviceDescriptor, x =>
+        {
+            x.Instance.As<MyServer>().Name += "2";
+        });
+
+        return base.AfterAddApplicationAsync(services);
+    }
+
+    [Fact]
+    public void Should_Call_OnActivated()
+    {
+        var server = ServiceProvider.GetRequiredService<MyServer>();
+        server.Name.ShouldBe("MyServer12");
+    }
+}
+
+class MyServer
+{
+    public string Name { get; set; } = "MyServer";
+}

--- a/framework/test/Volo.Abp.Ddd.Tests/Volo/Abp/Domain/Repositories/RepositoryRegistration_Tests.cs
+++ b/framework/test/Volo.Abp.Ddd.Tests/Volo/Abp/Domain/Repositories/RepositoryRegistration_Tests.cs
@@ -31,15 +31,15 @@ public class RepositoryRegistration_Tests
         //Assert
 
         //MyTestAggregateRootWithoutPk
-        services.ShouldContainTransientImplementationFactory(typeof(IReadOnlyRepository<MyTestAggregateRootWithoutPk>));
+        services.ShouldContainTransient(typeof(IReadOnlyRepository<MyTestAggregateRootWithoutPk>), typeof(MyTestDefaultRepository<MyTestAggregateRootWithoutPk>));
         services.ShouldContainTransient(typeof(IBasicRepository<MyTestAggregateRootWithoutPk>), typeof(MyTestDefaultRepository<MyTestAggregateRootWithoutPk>));
         services.ShouldContainTransient(typeof(IRepository<MyTestAggregateRootWithoutPk>), typeof(MyTestDefaultRepository<MyTestAggregateRootWithoutPk>));
 
         //MyTestAggregateRootWithGuidPk
-        services.ShouldContainTransientImplementationFactory(typeof(IReadOnlyRepository<MyTestAggregateRootWithGuidPk>));
+        services.ShouldContainTransient(typeof(IReadOnlyRepository<MyTestAggregateRootWithGuidPk>), typeof(MyTestDefaultRepository<MyTestAggregateRootWithGuidPk, Guid>));
         services.ShouldContainTransient(typeof(IBasicRepository<MyTestAggregateRootWithGuidPk>), typeof(MyTestDefaultRepository<MyTestAggregateRootWithGuidPk, Guid>));
         services.ShouldContainTransient(typeof(IRepository<MyTestAggregateRootWithGuidPk>), typeof(MyTestDefaultRepository<MyTestAggregateRootWithGuidPk, Guid>));
-        services.ShouldContainTransientImplementationFactory(typeof(IReadOnlyRepository<MyTestAggregateRootWithGuidPk, Guid>));
+        services.ShouldContainTransient(typeof(IReadOnlyRepository<MyTestAggregateRootWithGuidPk, Guid>), typeof(MyTestDefaultRepository<MyTestAggregateRootWithGuidPk, Guid>));
         services.ShouldContainTransient(typeof(IBasicRepository<MyTestAggregateRootWithGuidPk, Guid>), typeof(MyTestDefaultRepository<MyTestAggregateRootWithGuidPk, Guid>));
         services.ShouldContainTransient(typeof(IRepository<MyTestAggregateRootWithGuidPk, Guid>), typeof(MyTestDefaultRepository<MyTestAggregateRootWithGuidPk, Guid>));
 
@@ -69,24 +69,24 @@ public class RepositoryRegistration_Tests
         //Assert
 
         //MyTestAggregateRootWithoutPk
-        services.ShouldContainTransientImplementationFactory(typeof(IReadOnlyRepository<MyTestAggregateRootWithoutPk>));
+        services.ShouldContainTransient(typeof(IReadOnlyRepository<MyTestAggregateRootWithoutPk>), typeof(MyTestDefaultRepository<MyTestAggregateRootWithoutPk>));
         services.ShouldContainTransient(typeof(IBasicRepository<MyTestAggregateRootWithoutPk>), typeof(MyTestDefaultRepository<MyTestAggregateRootWithoutPk>));
         services.ShouldContainTransient(typeof(IRepository<MyTestAggregateRootWithoutPk>), typeof(MyTestDefaultRepository<MyTestAggregateRootWithoutPk>));
 
         //MyTestAggregateRootWithGuidPk
-        services.ShouldContainTransientImplementationFactory(typeof(IReadOnlyRepository<MyTestAggregateRootWithGuidPk>));
+        services.ShouldContainTransient(typeof(IReadOnlyRepository<MyTestAggregateRootWithGuidPk>), typeof(MyTestDefaultRepository<MyTestAggregateRootWithGuidPk, Guid>));
         services.ShouldContainTransient(typeof(IBasicRepository<MyTestAggregateRootWithGuidPk>), typeof(MyTestDefaultRepository<MyTestAggregateRootWithGuidPk, Guid>));
         services.ShouldContainTransient(typeof(IRepository<MyTestAggregateRootWithGuidPk>), typeof(MyTestDefaultRepository<MyTestAggregateRootWithGuidPk, Guid>));
-        services.ShouldContainTransientImplementationFactory(typeof(IReadOnlyRepository<MyTestAggregateRootWithGuidPk, Guid>));
+        services.ShouldContainTransient(typeof(IReadOnlyRepository<MyTestAggregateRootWithGuidPk, Guid>), typeof(MyTestDefaultRepository<MyTestAggregateRootWithGuidPk, Guid>));
         services.ShouldContainTransient(typeof(IBasicRepository<MyTestAggregateRootWithGuidPk, Guid>), typeof(MyTestDefaultRepository<MyTestAggregateRootWithGuidPk, Guid>));
         services.ShouldContainTransient(typeof(IRepository<MyTestAggregateRootWithGuidPk, Guid>), typeof(MyTestDefaultRepository<MyTestAggregateRootWithGuidPk, Guid>));
 
         //MyTestEntityWithInt32Pk
-        services.ShouldContainTransientImplementationFactory(typeof(IReadOnlyRepository<MyTestEntityWithInt32Pk>));
+        services.ShouldContainTransient(typeof(IReadOnlyRepository<MyTestEntityWithInt32Pk>), typeof(MyTestDefaultRepository<MyTestEntityWithInt32Pk, int>));
         services.ShouldContainTransient(typeof(IBasicRepository<MyTestEntityWithInt32Pk>), typeof(MyTestDefaultRepository<MyTestEntityWithInt32Pk, int>));
         services.ShouldContainTransient(typeof(IRepository<MyTestEntityWithInt32Pk>), typeof(MyTestDefaultRepository<MyTestEntityWithInt32Pk, int>));
-        services.ShouldContainTransientImplementationFactory(typeof(IReadOnlyRepository<MyTestEntityWithInt32Pk, int>));
-        services.ShouldContainTransientImplementationFactory(typeof(IReadOnlyBasicRepository<MyTestEntityWithInt32Pk, int>));
+        services.ShouldContainTransient(typeof(IReadOnlyRepository<MyTestEntityWithInt32Pk, int>), typeof(MyTestDefaultRepository<MyTestEntityWithInt32Pk, int>));
+        services.ShouldContainTransient(typeof(IReadOnlyBasicRepository<MyTestEntityWithInt32Pk, int>), typeof(MyTestDefaultRepository<MyTestEntityWithInt32Pk, int>));
         services.ShouldContainTransient(typeof(IBasicRepository<MyTestEntityWithInt32Pk, int>), typeof(MyTestDefaultRepository<MyTestEntityWithInt32Pk, int>));
         services.ShouldContainTransient(typeof(IRepository<MyTestEntityWithInt32Pk, int>), typeof(MyTestDefaultRepository<MyTestEntityWithInt32Pk, int>));
     }
@@ -114,20 +114,20 @@ public class RepositoryRegistration_Tests
         services.ShouldContainTransient(typeof(IRepository<MyTestAggregateRootWithoutPk>), typeof(MyTestDefaultRepository<MyTestAggregateRootWithoutPk>));
 
         //MyTestAggregateRootWithGuidPk
-        services.ShouldContainTransientImplementationFactory(typeof(IReadOnlyRepository<MyTestAggregateRootWithGuidPk>));
+        services.ShouldContainTransient(typeof(IReadOnlyRepository<MyTestAggregateRootWithGuidPk>), typeof(MyTestAggregateRootWithDefaultPkCustomRepository));
         services.ShouldContainTransient(typeof(IBasicRepository<MyTestAggregateRootWithGuidPk>), typeof(MyTestAggregateRootWithDefaultPkCustomRepository));
         services.ShouldContainTransient(typeof(IRepository<MyTestAggregateRootWithGuidPk>), typeof(MyTestAggregateRootWithDefaultPkCustomRepository));
-        services.ShouldContainTransientImplementationFactory(typeof(IReadOnlyRepository<MyTestAggregateRootWithGuidPk, Guid>));
-        services.ShouldContainTransientImplementationFactory(typeof(IReadOnlyBasicRepository<MyTestAggregateRootWithGuidPk, Guid>));
+        services.ShouldContainTransient(typeof(IReadOnlyRepository<MyTestAggregateRootWithGuidPk, Guid>), typeof(MyTestAggregateRootWithDefaultPkCustomRepository));
+        services.ShouldContainTransient(typeof(IReadOnlyBasicRepository<MyTestAggregateRootWithGuidPk, Guid>), typeof(MyTestAggregateRootWithDefaultPkCustomRepository));
         services.ShouldContainTransient(typeof(IBasicRepository<MyTestAggregateRootWithGuidPk, Guid>), typeof(MyTestAggregateRootWithDefaultPkCustomRepository));
         services.ShouldContainTransient(typeof(IRepository<MyTestAggregateRootWithGuidPk, Guid>), typeof(MyTestAggregateRootWithDefaultPkCustomRepository));
 
         //MyTestEntityWithInt32Pk
-        services.ShouldContainTransientImplementationFactory(typeof(IReadOnlyRepository<MyTestEntityWithInt32Pk>));
+        services.ShouldContainTransient(typeof(IReadOnlyRepository<MyTestEntityWithInt32Pk>), typeof(MyTestDefaultRepository<MyTestEntityWithInt32Pk, int>));
         services.ShouldContainTransient(typeof(IBasicRepository<MyTestEntityWithInt32Pk>), typeof(MyTestDefaultRepository<MyTestEntityWithInt32Pk, int>));
         services.ShouldContainTransient(typeof(IRepository<MyTestEntityWithInt32Pk>), typeof(MyTestDefaultRepository<MyTestEntityWithInt32Pk, int>));
-        services.ShouldContainTransientImplementationFactory(typeof(IReadOnlyRepository<MyTestEntityWithInt32Pk, int>));
-        services.ShouldContainTransientImplementationFactory(typeof(IReadOnlyBasicRepository<MyTestEntityWithInt32Pk, int>));
+        services.ShouldContainTransient(typeof(IReadOnlyRepository<MyTestEntityWithInt32Pk, int>), typeof(MyTestDefaultRepository<MyTestEntityWithInt32Pk, int>));
+        services.ShouldContainTransient(typeof(IReadOnlyBasicRepository<MyTestEntityWithInt32Pk, int>), typeof(MyTestDefaultRepository<MyTestEntityWithInt32Pk, int>));
         services.ShouldContainTransient(typeof(IBasicRepository<MyTestEntityWithInt32Pk, int>), typeof(MyTestDefaultRepository<MyTestEntityWithInt32Pk, int>));
         services.ShouldContainTransient(typeof(IRepository<MyTestEntityWithInt32Pk, int>), typeof(MyTestDefaultRepository<MyTestEntityWithInt32Pk, int>));
     }
@@ -209,10 +209,10 @@ public class RepositoryRegistration_Tests
         services.ShouldNotContainService(typeof(IRepository<MyTestAggregateRootWithoutPk>));
 
         //MyTestAggregateRootWithGuidPk
-        services.ShouldContainTransientImplementationFactory(typeof(IReadOnlyRepository<MyTestAggregateRootWithGuidPk>));
+        services.ShouldContainTransient(typeof(IReadOnlyRepository<MyTestAggregateRootWithGuidPk>), typeof(MyTestDefaultRepository<MyTestAggregateRootWithGuidPk, Guid>));
         services.ShouldContainTransient(typeof(IBasicRepository<MyTestAggregateRootWithGuidPk>), typeof(MyTestDefaultRepository<MyTestAggregateRootWithGuidPk, Guid>));
         services.ShouldContainTransient(typeof(IRepository<MyTestAggregateRootWithGuidPk>), typeof(MyTestDefaultRepository<MyTestAggregateRootWithGuidPk, Guid>));
-        services.ShouldContainTransientImplementationFactory(typeof(IReadOnlyRepository<MyTestAggregateRootWithGuidPk, Guid>));
+        services.ShouldContainTransient(typeof(IReadOnlyRepository<MyTestAggregateRootWithGuidPk, Guid>), typeof(MyTestDefaultRepository<MyTestAggregateRootWithGuidPk, Guid>));
         services.ShouldContainTransient(typeof(IBasicRepository<MyTestAggregateRootWithGuidPk, Guid>), typeof(MyTestDefaultRepository<MyTestAggregateRootWithGuidPk, Guid>));
         services.ShouldContainTransient(typeof(IRepository<MyTestAggregateRootWithGuidPk, Guid>), typeof(MyTestDefaultRepository<MyTestAggregateRootWithGuidPk, Guid>));
     }
@@ -234,11 +234,11 @@ public class RepositoryRegistration_Tests
         new MyTestRepositoryRegistrar(options).AddRepositories();
 
         //MyTestAggregateRootWithGuidPk
-        services.ShouldContainTransientImplementationFactory(typeof(IReadOnlyRepository<MyTestAggregateRootWithGuidPk>));
+        services.ShouldContainTransient(typeof(IReadOnlyRepository<MyTestAggregateRootWithGuidPk>), typeof(MyTestAggregateRootWithDefaultPkCustomRepository));
         services.ShouldContainTransient(typeof(IBasicRepository<MyTestAggregateRootWithGuidPk>), typeof(MyTestAggregateRootWithDefaultPkCustomRepository));
         services.ShouldContainTransient(typeof(IRepository<MyTestAggregateRootWithGuidPk>), typeof(MyTestAggregateRootWithDefaultPkCustomRepository));
-        services.ShouldContainTransientImplementationFactory(typeof(IReadOnlyRepository<MyTestAggregateRootWithGuidPk, Guid>));
-        services.ShouldContainTransientImplementationFactory(typeof(IReadOnlyBasicRepository<MyTestAggregateRootWithGuidPk, Guid>));
+        services.ShouldContainTransient(typeof(IReadOnlyRepository<MyTestAggregateRootWithGuidPk, Guid>), typeof(MyTestAggregateRootWithDefaultPkCustomRepository));
+        services.ShouldContainTransient(typeof(IReadOnlyBasicRepository<MyTestAggregateRootWithGuidPk, Guid>), typeof(MyTestAggregateRootWithDefaultPkCustomRepository));
         services.ShouldContainTransient(typeof(IBasicRepository<MyTestAggregateRootWithGuidPk, Guid>), typeof(MyTestAggregateRootWithDefaultPkCustomRepository));
         services.ShouldContainTransient(typeof(IRepository<MyTestAggregateRootWithGuidPk, Guid>), typeof(MyTestAggregateRootWithDefaultPkCustomRepository));
     }


### PR DESCRIPTION
Resolves #18241

We added `Repository Implementation Type` to DI and set the `IsChangeTrackingEnabled` in the factory method.  Intercepting classes will have performance problems.

Now we will use the `OnActivated` event to set the `IsChangeTrackingEnabled` and remove the 
 `Repository Implementation Type` from DI.

https://github.com/abpframework/abp/pull/18259/files#diff-14b31eb692e682b42405475f5c13d448b8bc2a7cc532b0b943dda6a5bc77444e

```cs
[00:00:22 INF] Starting web host.
[00:00:23 INF] Loaded ABP modules:
[00:00:23 INF] ........
[00:00:24 INF] Initialized all ABP modules.
[00:00:24 INF] Now listening on: https://localhost:44303
[00:00:24 INF] Application started. Press Ctrl+C to shut down.
[00:00:24 INF] Hosting environment: Development
```
