### PR TITLE
Remove `IAbpClaimsPrincipalFactory` from `AbpComponentsClaimsCache`.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Components.Web/Volo/Abp/AspNetCore/Components/Web/Security/AbpComponentsClaimsCache.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Components.Web/Volo/Abp/AspNetCore/Components/Web/Security/AbpComponentsClaimsCache.cs
@@ -1,9 +1,9 @@
 ﻿using System.Security.Claims;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.Extensions.DependencyInjection;
 using Volo.Abp.DependencyInjection;
-using Volo.Abp.Security.Claims;
 
 namespace Volo.Abp.AspNetCore.Components.Web.Security;
 
@@ -12,18 +12,16 @@ public class AbpComponentsClaimsCache : IScopedDependency
     public ClaimsPrincipal Principal { get; private set; } = default!;
 
     private readonly AuthenticationStateProvider? _authenticationStateProvider;
-    private readonly IAbpClaimsPrincipalFactory _abpClaimsPrincipalFactory;
 
     public AbpComponentsClaimsCache(
         IClientScopeServiceProviderAccessor serviceProviderAccessor)
     {
         _authenticationStateProvider = serviceProviderAccessor.ServiceProvider.GetService<AuthenticationStateProvider>();
-        _abpClaimsPrincipalFactory = serviceProviderAccessor.ServiceProvider.GetRequiredService<IAbpClaimsPrincipalFactory>();
         if (_authenticationStateProvider != null)
         {
             _authenticationStateProvider.AuthenticationStateChanged += async (task) =>
             {
-                Principal = await _abpClaimsPrincipalFactory.CreateDynamicAsync((await task).User);
+                Principal = (await task).User;
             };
         }
     }
@@ -34,7 +32,6 @@ public class AbpComponentsClaimsCache : IScopedDependency
         {
             var authenticationState = await _authenticationStateProvider.GetAuthenticationStateAsync();
             Principal = authenticationState.User;
-            await _abpClaimsPrincipalFactory.CreateDynamicAsync(Principal);
         }
     }
 }

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor/MyProjectNameBlazorModule.cs
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor/MyProjectNameBlazorModule.cs
@@ -81,12 +81,6 @@ public class MyProjectNameBlazorModule : AbpModule
             options.ProviderOptions.DefaultScopes.Add("email");
             options.ProviderOptions.DefaultScopes.Add("phone");
         });
-
-        builder.Services.Configure<AbpClaimsPrincipalFactoryOptions>(options =>
-        {
-            options.IsDynamicClaimsEnabled = true;
-            options.RemoteRefreshUrl = builder.Configuration["AuthServer:Authority"] + options.RemoteRefreshUrl;
-        });
     }
 
     private static void ConfigureUI(WebAssemblyHostBuilder builder)


### PR DESCRIPTION
There is no redis cache in blazor wasm project, so we can remove/disable dynamic claims.