### PR TITLE
Add more Arguments to AbpRabbitMqEventBusOptions

### DIFF
--- a/docs/en/Distributed-Event-Bus-RabbitMQ-Integration.md
+++ b/docs/en/Distributed-Event-Bus-RabbitMQ-Integration.md
@@ -152,4 +152,14 @@ Configure<AbpRabbitMqEventBusOptions>(options =>
 });
 ````
 
+**Example: Configure the queue and exchange optional arguments**
+
+```csharp
+Configure<AbpRabbitMqEventBusOptions>(options =>
+{
+    options.ExchangeArguments["x-delayed-type"] = "direct";
+    options.QueueArguments["x-message-ttl"] = 60000;
+});
+```
+
 Using these options classes can be combined with the `appsettings.json` way. Configuring an option property in the code overrides the value in the configuration file.

--- a/docs/zh-Hans/Distributed-Event-Bus-RabbitMQ-Integration.md
+++ b/docs/zh-Hans/Distributed-Event-Bus-RabbitMQ-Integration.md
@@ -152,4 +152,14 @@ Configure<AbpRabbitMqEventBusOptions>(options =>
 });
 ````
 
+**示例：配置队列和交换机的额外参数**
+
+```csharp
+Configure<AbpRabbitMqEventBusOptions>(options =>
+{
+    options.ExchangeArguments["x-delayed-type"] = "direct";
+    options.QueueArguments["x-message-ttl"] = 60000;
+});
+```
+
 使用这些选项类可以与 `appsettings.json` 组合在一起. 在代码中配置选项属性会覆盖配置文件中的值.

--- a/framework/src/Volo.Abp.EventBus.RabbitMQ/Volo/Abp/EventBus/RabbitMq/AbpRabbitMqEventBusOptions.cs
+++ b/framework/src/Volo.Abp.EventBus.RabbitMQ/Volo/Abp/EventBus/RabbitMq/AbpRabbitMqEventBusOptions.cs
@@ -1,4 +1,5 @@
-﻿using Volo.Abp.RabbitMQ;
+﻿using System.Collections.Generic;
+using Volo.Abp.RabbitMQ;
 
 namespace Volo.Abp.EventBus.RabbitMq;
 
@@ -13,9 +14,13 @@ public class AbpRabbitMqEventBusOptions
     public string ExchangeName { get; set; } = default!;
 
     public string? ExchangeType { get; set; }
-    
+
     public ushort? PrefetchCount { get; set; }
 
+    public IDictionary<string, object> QueueArguments { get; set; } = new Dictionary<string, object>();
+
+    public IDictionary<string, object> ExchangeArguments { get; set; } = new Dictionary<string, object>();
+    
     public string GetExchangeTypeOrDefault()
     {
         return string.IsNullOrEmpty(ExchangeType)

--- a/framework/src/Volo.Abp.EventBus.RabbitMQ/Volo/Abp/EventBus/RabbitMq/RabbitMqDistributedEventBus.cs
+++ b/framework/src/Volo.Abp.EventBus.RabbitMQ/Volo/Abp/EventBus/RabbitMq/RabbitMqDistributedEventBus.cs
@@ -79,14 +79,16 @@ public class RabbitMqDistributedEventBus : DistributedEventBusBase, ISingletonDe
             new ExchangeDeclareConfiguration(
                 AbpRabbitMqEventBusOptions.ExchangeName,
                 type: AbpRabbitMqEventBusOptions.GetExchangeTypeOrDefault(),
-                durable: true
+                durable: true,
+                arguments: AbpRabbitMqEventBusOptions.ExchangeArguments
             ),
             new QueueDeclareConfiguration(
                 AbpRabbitMqEventBusOptions.ClientName,
                 durable: true,
                 exclusive: false,
                 autoDelete: false,
-                prefetchCount: AbpRabbitMqEventBusOptions.PrefetchCount
+                prefetchCount: AbpRabbitMqEventBusOptions.PrefetchCount,
+                arguments: AbpRabbitMqEventBusOptions.QueueArguments
             ),
             AbpRabbitMqEventBusOptions.ConnectionName
         );

--- a/framework/src/Volo.Abp.RabbitMQ/Volo/Abp/RabbitMQ/ExchangeDeclareConfiguration.cs
+++ b/framework/src/Volo.Abp.RabbitMQ/Volo/Abp/RabbitMQ/ExchangeDeclareConfiguration.cs
@@ -18,12 +18,13 @@ public class ExchangeDeclareConfiguration
         string exchangeName,
         string type,
         bool durable = false,
-        bool autoDelete = false)
+        bool autoDelete = false,
+        IDictionary<string, object>? arguments = null)
     {
         ExchangeName = exchangeName;
         Type = type;
         Durable = durable;
         AutoDelete = autoDelete;
-        Arguments = new Dictionary<string, object>();
+        Arguments = arguments?? new Dictionary<string, object>();
     }
 }

--- a/framework/src/Volo.Abp.RabbitMQ/Volo/Abp/RabbitMQ/QueueDeclareConfiguration.cs
+++ b/framework/src/Volo.Abp.RabbitMQ/Volo/Abp/RabbitMQ/QueueDeclareConfiguration.cs
@@ -23,13 +23,14 @@ public class QueueDeclareConfiguration
         bool durable = true,
         bool exclusive = false,
         bool autoDelete = false,
-        ushort? prefetchCount = null)
+        ushort? prefetchCount = null,
+        IDictionary<string, object>? arguments = null)
     {
         QueueName = queueName;
         Durable = durable;
         Exclusive = exclusive;
         AutoDelete = autoDelete;
-        Arguments = new Dictionary<string, object>();
+        Arguments = arguments?? new Dictionary<string, object>();
         PrefetchCount = prefetchCount;
     }
 


### PR DESCRIPTION
### Description

Resolves https://github.com/abpframework/abp/issues/17401

Thanks @htve, After rethinking, I didn't add parameters like `QueueAutoDelete`, because it may break the work of the event bus system.

```csharp
Configure<AbpRabbitMqEventBusOptions>(options =>
{
    options.ExchangeArguments["x-delayed-type"] = "direct";
    options.QueueArguments["x-message-ttl"] = 60000;
});
```

```json
"RabbitMQ": {
  "EventBus": {
    "QueueArguments": {
      "x-message-ttl": 60000
    }
  }
}
```

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

