### PR TITLE
Add default values to test email form in setting-management module

### DIFF
--- a/npm/ng-packs/packages/setting-management/config/src/lib/components/email-setting-group/email-setting-group.component.html
+++ b/npm/ng-packs/packages/setting-management/config/src/lib/components/email-setting-group/email-setting-group.component.html
@@ -2,7 +2,13 @@
 
 <hr class="my-3" />
 
-<form *ngIf="form" [formGroup]="form" class="abp-md-form"  (ngSubmit)="submit()" [validateOnSubmit]="true">
+<form
+  *ngIf="form"
+  [formGroup]="form"
+  class="abp-md-form"
+  (ngSubmit)="submit()"
+  [validateOnSubmit]="true"
+>
   <div class="mb-3 form-group">
     <label class="form-label"
       >{{ 'AbpSettingManagement::DefaultFromDisplayName' | abpLocalization
@@ -79,10 +85,10 @@
     {{ 'AbpSettingManagement::Save' | abpLocalization }}
   </button>
   <button
+    *abpPermission="emailingPolicy"
     type="button"
     (click)="openSendEmailModal()"
     class="btn btn-primary mx-2"
-    *abpPermission="emailingPolicy"
   >
     <i class="fa f-send" aria-hidden="true"></i>
     {{ 'AbpSettingManagement::SendTestEmail' | abpLocalization }}

--- a/npm/ng-packs/packages/setting-management/config/src/lib/enums/policy-names.ts
+++ b/npm/ng-packs/packages/setting-management/config/src/lib/enums/policy-names.ts
@@ -1,4 +1,3 @@
 export const enum SettingManagementPolicyNames {
   Emailing = 'SettingManagement.Emailing',
- }
-
+}


### PR DESCRIPTION
### Description

Resolves #18314 

![image](https://github.com/abpframework/abp/assets/49063256/dd492144-3630-4fbf-a2f1-b9627988916b)


### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests

### How to test it?
- Use `copy-to:app` script or run `ng-packs` project