### PR TITLE
ABP CLI - Throw exceptions instead swallowing

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/CliService.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/CliService.cs
@@ -84,6 +84,7 @@ public class CliService : ITransientDependency
         catch (Exception ex)
         {
             Logger.LogException(ex);
+            throw;
         }
     }
 

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/BundleCommand.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/BundleCommand.cs
@@ -49,6 +49,7 @@ public class BundleCommand : IConsoleCommand, ITransientDependency
         catch (BundlingException ex)
         {
             Logger.LogError(ex.Message);
+            throw;
         }
     }
 


### PR DESCRIPTION
### Description

ABP CLI exit code is always 0 even if there is an error. When it's used in pipeline (`abp install-libs`), or it's called by another program _(abpdev in my case)_, errors can't be recognized. 

> ![image](https://github.com/abpframework/abp/assets/23705418/581d565f-c4c7-402d-bb85-0e8766204fb2)
> Exit code 0 here 👆


So, I threw the exception instead of swallowing it. And now, when a command fails in ABP CLI, it can be handled programmatically. 

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

Please describe how this can be tested by the test engineers if it is not already explicit - or remove this section if no need to description.
