### PR TITLE
Remove AccountLayoutModule import when change-theme to LeptonX

### DIFF
--- a/npm/ng-packs/packages/schematics/src/commands/change-theme/style-map.ts
+++ b/npm/ng-packs/packages/schematics/src/commands/change-theme/style-map.ts
@@ -287,8 +287,4 @@ importMap.set(ThemeOptionsEnum.LeptonX, [
     path: '@volosoft/abp.ng.theme.lepton-x/layouts',
     importName: 'SideMenuLayoutModule.forRoot()',
   },
-  {
-    path: '@volosoft/abp.ng.theme.lepton-x/account',
-    importName: 'AccountLayoutModule.forRoot()',
-  },
 ]);


### PR DESCRIPTION
Resolves #18530 

i have publish `@abp/ng.schematics` package to verdaccio and test it. 