### PR TITLE
Use `VersionOverride` when central package management is enabled..

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectBuilding/Building/Steps/ProjectReferenceReplaceStep.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectBuilding/Building/Steps/ProjectReferenceReplaceStep.cs
@@ -73,6 +73,7 @@ public class ProjectReferenceReplaceStep : ProjectBuildPipelineStep
         private readonly List<FileEntry> _entries;
         private readonly bool _isMicroserviceServiceTemplate;
         private readonly string _projectName;
+        protected bool CentralPackageManagement { get; }
 
         protected ProjectReferenceReplacer(
             ProjectBuildContext context,
@@ -81,6 +82,7 @@ public class ProjectReferenceReplaceStep : ProjectBuildPipelineStep
             _entries = context.Files;
             _isMicroserviceServiceTemplate = MicroserviceServiceTemplateBase.IsMicroserviceServiceTemplate(context.Template?.Name);
             _projectName = projectName;
+            CentralPackageManagement = context.Files.Any(x => x.Name.EndsWith("Directory.Packages.props"));
         }
 
         public void Run()
@@ -165,7 +167,7 @@ public class ProjectReferenceReplaceStep : ProjectBuildPipelineStep
                 includeAttr.Value = ConvertToNugetReference(oldNodeIncludeValue);
                 newNode.Attributes.Append(includeAttr);
 
-                var versionAttr = doc.CreateAttribute("Version");
+                var versionAttr = doc.CreateAttribute(CentralPackageManagement ? "VersionOverride" : "Version");
                 versionAttr.Value = _nugetPackageVersion;
                 newNode.Attributes.Append(versionAttr);
                 return newNode;


### PR DESCRIPTION
Resolve #18565


### How to test it?

```
abp new BookStore -t app        
abp add-module Volo.BasicTheme --with-source-code --add-to-solution-file
```