### PR TITLE
Feat: provide filtering for OAuth error listener

### DIFF
--- a/docs/en/UI/Angular/Authorization.md
+++ b/docs/en/UI/Angular/Authorization.md
@@ -1,9 +1,9 @@
 ## Authorization in Angular UI
 
-OAuth is preconfigured in Angular application templates. So, when you start a project using the CLI (or Suite, for that matter), authorization already works. ABP Angular UI packages are using [angular-oauth2-oidc library](https://github.com/manfredsteyer/angular-oauth2-oidc#logging-in) for managing OAuth in the Angular client. 
+OAuth is preconfigured in Angular application templates. So, when you start a project using the CLI (or Suite, for that matter), authorization already works. ABP Angular UI packages are using [angular-oauth2-oidc library](https://github.com/manfredsteyer/angular-oauth2-oidc#logging-in) for managing OAuth in the Angular client.
 You can find **OAuth configuration** in the _environment.ts_ files.
 
-### Authorization Code Flow 
+### Authorization Code Flow
 
 ```js
 import { Config } from '@abp/ng.core';
@@ -29,7 +29,6 @@ export const environment = {
 This configuration results in an [OAuth authorization code flow with PKCE](https://tools.ietf.org/html/rfc7636).
 According to this flow, the user is redirected to an external login page which is built with MVC. So, if you need **to customize the login page**, please follow [this community article](https://community.abp.io/articles/how-to-customize-the-login-page-for-mvc-razor-page-applications-9a40f3cd).
 
-
 ### Resource Owner Password Flow
 
 If you have used the [Angular UI account module](./Account-Module) in your project, you can switch to the resource owner password flow by changing the OAuth configuration in the _environment.ts_ files as shown below:
@@ -52,3 +51,128 @@ export const environment = {
 ```
 
 According to this flow, the user is redirected to the login page in the account module.
+
+### Error Filtering
+
+In [AuthFlowStrategy](https://github.com/abpframework/abp/blob/21e70fd66154d4064d03b1a438f20a2e4318715e/npm/ng-packs/packages/oauth/src/lib/strategies/auth-flow-strategy.ts#L24) class, there is a method called `listenToOauthErrors` that listens to `OAuthErrorEvent` errors. This method clears the localStorage for OAuth keys. However, in certain cases, we might want to skip this process. To achieve this, we can use the `AuthErrorFilterService`.
+The `AuthErrorFilterService` is an abstract service that needs to be replaced with a custom implementation
+
+> By default, this service is replaced in the `@abp/ng.oauth` package
+
+**Usage**
+
+1.Create an auth-filter.provider
+
+```js
+import { APP_INITIALIZER, inject } from '@angular/core';
+import { AuthErrorFilter, AuthErrorEvent, AuthErrorFilterService } from '@abp/ng.core';
+import { eCustomersAuthFilterNames } from '../enums';
+
+export const CUSTOMERS_AUTH_FILTER_PROVIDER = [
+  { provide: APP_INITIALIZER, useFactory: configureAuthFilter, multi: true },
+];
+
+type Reason = object & { error: { grant_type: string | undefined } };
+
+function configureAuthFilter() {
+  const errorFilterService = inject(
+    AuthErrorFilterService<AuthErrorFilter<AuthErrorEvent>, AuthErrorEvent>,
+  );
+  const filter: AuthErrorFilter = {
+    id: eCustomersAuthFilterNames.LinkedUser,
+    executable: true,
+    execute: (event: AuthErrorEvent) => {
+      const { reason } = event;
+      const {
+        error: { grant_type },
+      } = <Reason>(reason || {});
+
+      return !!grant_type && grant_type === eCustomersAuthFilterNames.LinkedUser;
+    },
+  };
+
+  return () => errorFilterService.add(filter);
+}
+```
+
+- `AuthErrorFilter:` is a model for filter object and it have 3 properties
+
+  - `id:` a unique key in the list for the filter object
+  - `executable:` a status for the filter object. If it's false then it won't work, yet it'll stay in the list
+  - `execute:` a function that stores the skip logic
+
+    2.Add to the FeatureConfigModule
+
+```js
+import { ModuleWithProviders, NgModule } from "@angular/core";
+import { CUSTOMERS_AUTH_FILTER_PROVIDER } from "./providers/auth-filter.provider";
+
+@NgModule()
+export class CustomersConfigModule {
+  static forRoot(): ModuleWithProviders<CustomersConfigModule> {
+    return {
+      ngModule: CustomersConfigModule,
+      providers: [CUSTOMERS_AUTH_FILTER_PROVIDER],
+    };
+  }
+}
+```
+
+Now it'll skip the clearing of OAuth storage keys for `LinkedUser` grant_type if any `OAuthErrorEvent` occurs
+
+**Replace with custom implementation**
+
+- Use the `AbstractAuthErrorFilter<T,E>` class for signs of process.
+
+**Example**
+
+`my-auth-error-filter.service.ts`
+
+```js
+import { Injectable, signal } from '@angular/core';
+import { MyAuthErrorEvent } from 'angular-my-auth-oidc';
+import { AbstractAuthErrorFilter, AuthErrorFilter } from '@abp/ng.core';
+
+@Injectable({ providedIn: 'root' })
+export class OAuthErrorFilterService extends AbstractAuthErrorFilter<
+  AuthErrorFilter<MyAuthErrorEvent>,
+  MyAuthErrorEvent
+> {
+  protected readonly _filters = signal<Array<AuthErrorFilter<MyAuthErrorEvent>>>([]);
+  readonly filters = this._filters.asReadonly();
+
+  get(id: string): AuthErrorFilter<MyAuthErrorEvent> {
+    return this._filters().find(({ id: _id }) => _id === id);
+  }
+
+  add(filter: AuthErrorFilter<MyAuthErrorEvent>): void {
+    this._filters.update(items => [...items, filter]);
+  }
+
+  patch(item: Partial<AuthErrorFilter<MyAuthErrorEvent>>): void {
+    const _item = this.filters().find(({ id }) => id === item.id);
+    if (!_item) {
+      return;
+    }
+
+    Object.assign(_item, item);
+  }
+
+  remove(id: string): void {
+    const item = this.filters().find(({ id: _id }) => _id === id);
+    if (!item) {
+      return;
+    }
+
+    this._filters.update(items => items.filter(({ id: _id }) => _id !== id));
+  }
+
+  run(event: MyAuthErrorEvent): boolean {
+    return this.filters()
+      .filter(({ executable }) => !!executable)
+      .map(({ execute }) => execute(event))
+      .some(item => item);
+  }
+}
+
+```

--- a/npm/ng-packs/packages/core/package.json
+++ b/npm/ng-packs/packages/core/package.json
@@ -8,9 +8,8 @@
   },
   "dependencies": {
     "@abp/utils": "~7.4.4",
-    "angular-oauth2-oidc": "^15.0.1",
-    "just-clone": "^6.1.1",
-    "just-compare": "^2.3.0",
+    "just-clone": "^6.0.0",
+    "just-compare": "^2.0.0",
     "ts-toolbelt": "6.15.4",
     "tslib": "^2.0.0"
   },

--- a/npm/ng-packs/packages/core/src/lib/abstracts/auth-error-filter.ts
+++ b/npm/ng-packs/packages/core/src/lib/abstracts/auth-error-filter.ts
@@ -1,10 +1,6 @@
-import { signal } from '@angular/core';
 import { AuthErrorEvent, AuthErrorFilter } from '../models';
 
 export abstract class AbstractAuthErrorFilter<T, E> {
-  protected readonly _filters = signal<Array<T>>([]);
-  readonly filters = this._filters.asReadonly();
-
   abstract get(id: string): T;
   abstract add(filter: T): void;
   abstract patch(item: Partial<T>): void;
@@ -13,8 +9,8 @@ export abstract class AbstractAuthErrorFilter<T, E> {
 }
 
 export class AuthErrorFilterService<
-  T = AuthErrorEvent,
-  E = AuthErrorFilter,
+  T = AuthErrorFilter,
+  E = AuthErrorEvent,
 > extends AbstractAuthErrorFilter<T, E> {
   private warningMessage() {
     console.error('You should add @abp/ng-oauth packages or create your own auth packages.');
@@ -24,15 +20,19 @@ export class AuthErrorFilterService<
     this.warningMessage();
     throw new Error('not implemented');
   }
+
   add(filter: T): void {
     this.warningMessage();
   }
+
   patch(item: Partial<T>): void {
     this.warningMessage();
   }
+
   remove(id: string): void {
     this.warningMessage();
   }
+
   run(event: E): boolean {
     this.warningMessage();
     throw new Error('not implemented');

--- a/npm/ng-packs/packages/core/src/lib/abstracts/auth-error-filter.ts
+++ b/npm/ng-packs/packages/core/src/lib/abstracts/auth-error-filter.ts
@@ -1,0 +1,34 @@
+import { Signal, signal } from '@angular/core';
+import { AuthErrorEvent, AuthErrorFilter } from '../models';
+
+export abstract class AbstractAuthErrorFilter<T, E> {
+  readonly #filters = signal<Array<T>>([]);
+  filters = this.#filters.asReadonly();
+
+  abstract get(id: string): T;
+  abstract add(filter: T): void;
+  abstract patch(item: Partial<T>): void;
+  abstract remove(id: string): void;
+  abstract run(event: E): boolean;
+}
+
+export class AuthErrorFilterService<
+  T = AuthErrorEvent,
+  E = AuthErrorFilter,
+> extends AbstractAuthErrorFilter<T, E> {
+  get(id: string): T {
+    throw new Error('Import AbpOAuthModule from  @abp/ng.oauth or custom implementation');
+  }
+  add(filter: T): void {
+    throw new Error('Import AbpOAuthModule from  @abp/ng.oauth or custom implementation');
+  }
+  patch(item: Partial<T>): void {
+    throw new Error('Import AbpOAuthModule from  @abp/ng.oauth or custom implementation');
+  }
+  remove(id: string): void {
+    throw new Error('Import AbpOAuthModule from  @abp/ng.oauth or custom implementation');
+  }
+  run(event: E): boolean {
+    throw new Error('Import AbpOAuthModule from  @abp/ng.oauth or custom implementation');
+  }
+}

--- a/npm/ng-packs/packages/core/src/lib/abstracts/auth-error-filter.ts
+++ b/npm/ng-packs/packages/core/src/lib/abstracts/auth-error-filter.ts
@@ -1,4 +1,4 @@
-import { Signal, signal } from '@angular/core';
+import { signal } from '@angular/core';
 import { AuthErrorEvent, AuthErrorFilter } from '../models';
 
 export abstract class AbstractAuthErrorFilter<T, E> {

--- a/npm/ng-packs/packages/core/src/lib/abstracts/auth-error-filter.ts
+++ b/npm/ng-packs/packages/core/src/lib/abstracts/auth-error-filter.ts
@@ -2,8 +2,8 @@ import { signal } from '@angular/core';
 import { AuthErrorEvent, AuthErrorFilter } from '../models';
 
 export abstract class AbstractAuthErrorFilter<T, E> {
-  readonly #filters = signal<Array<T>>([]);
-  filters = this.#filters.asReadonly();
+  protected readonly _filters = signal<Array<T>>([]);
+  readonly filters = this._filters.asReadonly();
 
   abstract get(id: string): T;
   abstract add(filter: T): void;
@@ -16,19 +16,25 @@ export class AuthErrorFilterService<
   T = AuthErrorEvent,
   E = AuthErrorFilter,
 > extends AbstractAuthErrorFilter<T, E> {
+  private warningMessage() {
+    console.error('You should add @abp/ng-oauth packages or create your own auth packages.');
+  }
+
   get(id: string): T {
-    throw new Error('Import AbpOAuthModule from  @abp/ng.oauth or custom implementation');
+    this.warningMessage();
+    throw new Error('not implemented');
   }
   add(filter: T): void {
-    throw new Error('Import AbpOAuthModule from  @abp/ng.oauth or custom implementation');
+    this.warningMessage();
   }
   patch(item: Partial<T>): void {
-    throw new Error('Import AbpOAuthModule from  @abp/ng.oauth or custom implementation');
+    this.warningMessage();
   }
   remove(id: string): void {
-    throw new Error('Import AbpOAuthModule from  @abp/ng.oauth or custom implementation');
+    this.warningMessage();
   }
   run(event: E): boolean {
-    throw new Error('Import AbpOAuthModule from  @abp/ng.oauth or custom implementation');
+    this.warningMessage();
+    throw new Error('not implemented');
   }
 }

--- a/npm/ng-packs/packages/core/src/lib/abstracts/auth.service.ts
+++ b/npm/ng-packs/packages/core/src/lib/abstracts/auth.service.ts
@@ -33,9 +33,8 @@ export class AuthService implements IAuthService {
 
   navigateToLogin(queryParams?: Params): void {}
 
-  get isInternalAuth() {
+  get isInternalAuth(): boolean {
     throw new Error('not implemented');
-    return false;
   }
 
   get isAuthenticated(): boolean {

--- a/npm/ng-packs/packages/core/src/lib/abstracts/index.ts
+++ b/npm/ng-packs/packages/core/src/lib/abstracts/index.ts
@@ -3,3 +3,4 @@ export * from './ng-model.component';
 export * from './auth.guard';
 export * from './auth.service';
 export * from './auth-response.model';
+export * from './auth-error-filter';

--- a/npm/ng-packs/packages/core/src/lib/core.module.ts
+++ b/npm/ng-packs/packages/core/src/lib/core.module.ts
@@ -39,6 +39,7 @@ import { QUEUE_MANAGER } from './tokens/queue.token';
 import { DefaultQueueManager } from './utils/queue';
 import { IncludeLocalizationResourcesProvider } from './providers/include-localization-resources.provider';
 import { SORT_COMPARE_FUNC, compareFuncFactory } from './tokens/compare-func.token';
+import { AuthErrorFilterService } from './abstracts';
 
 /**
  * BaseCoreModule is the module that holds
@@ -179,7 +180,7 @@ export class CoreModule {
         },
         {
           provide: SORT_COMPARE_FUNC,
-          useFactory: compareFuncFactory
+          useFactory: compareFuncFactory,
         },
         {
           provide: QUEUE_MANAGER,
@@ -189,6 +190,7 @@ export class CoreModule {
           provide: OTHERS_GROUP,
           useValue: options.othersGroup || 'AbpUi::OthersGroup',
         },
+        AuthErrorFilterService,
         IncludeLocalizationResourcesProvider,
       ],
     };

--- a/npm/ng-packs/packages/core/src/lib/models/auth-events.ts
+++ b/npm/ng-packs/packages/core/src/lib/models/auth-events.ts
@@ -1,0 +1,60 @@
+export type EventType =
+  | 'discovery_document_loaded'
+  | 'jwks_load_error'
+  | 'invalid_nonce_in_state'
+  | 'discovery_document_load_error'
+  | 'discovery_document_validation_error'
+  | 'user_profile_loaded'
+  | 'user_profile_load_error'
+  | 'token_received'
+  | 'token_error'
+  | 'code_error'
+  | 'token_refreshed'
+  | 'token_refresh_error'
+  | 'silent_refresh_error'
+  | 'silently_refreshed'
+  | 'silent_refresh_timeout'
+  | 'token_validation_error'
+  | 'token_expires'
+  | 'session_changed'
+  | 'session_error'
+  | 'session_terminated'
+  | 'session_unchanged'
+  | 'logout'
+  | 'popup_closed'
+  | 'popup_blocked'
+  | 'token_revoke_error';
+
+export abstract class AuthEvent {
+  readonly type: EventType;
+  constructor(type: EventType) {
+    this.type = type;
+  }
+}
+
+export class AuthSuccessEvent extends AuthEvent {
+  readonly info: any;
+  constructor(type: EventType, info?: any) {
+    super(type);
+    this.info = info;
+  }
+}
+
+export class AuthInfoEvent extends AuthEvent {
+  readonly info: any;
+
+  constructor(type: EventType, info?: any) {
+    super(type);
+    this.info = info;
+  }
+}
+
+export class AuthErrorEvent extends AuthEvent {
+  readonly reason: object;
+  readonly params: object;
+  constructor(type: EventType, reason: object, params?: object) {
+    super(type);
+    this.reason = reason;
+    this.params = params;
+  }
+}

--- a/npm/ng-packs/packages/core/src/lib/models/auth-events.ts
+++ b/npm/ng-packs/packages/core/src/lib/models/auth-events.ts
@@ -26,35 +26,29 @@ export type EventType =
   | 'token_revoke_error';
 
 export abstract class AuthEvent {
-  readonly type: EventType;
-  constructor(type: EventType) {
+  constructor(public readonly type: EventType) {
     this.type = type;
   }
 }
 
 export class AuthSuccessEvent extends AuthEvent {
-  readonly info: any;
-  constructor(type: EventType, info?: any) {
+  constructor(public readonly type: EventType, public readonly info?: any) {
     super(type);
-    this.info = info;
   }
 }
 
 export class AuthInfoEvent extends AuthEvent {
-  readonly info: any;
-
-  constructor(type: EventType, info?: any) {
+  constructor(public readonly type: EventType, public readonly info?: any) {
     super(type);
-    this.info = info;
   }
 }
 
 export class AuthErrorEvent extends AuthEvent {
-  readonly reason: object;
-  readonly params: object;
-  constructor(type: EventType, reason: object, params?: object) {
+  constructor(
+    public readonly type: EventType,
+    public readonly reason: object,
+    public readonly params?: object,
+  ) {
     super(type);
-    this.reason = reason;
-    this.params = params;
   }
 }

--- a/npm/ng-packs/packages/core/src/lib/models/auth.ts
+++ b/npm/ng-packs/packages/core/src/lib/models/auth.ts
@@ -1,5 +1,6 @@
-import { UnaryFunction } from 'rxjs';
 import { Injector } from '@angular/core';
+import { UnaryFunction } from 'rxjs';
+import { AuthErrorEvent } from './auth-events';
 
 export interface LoginParams {
   username: string;
@@ -13,7 +14,13 @@ export type PipeToLoginFn = (
   injector: Injector,
 ) => UnaryFunction<any, any>;
 /**
- * @deprecated The interface should not be used anymore. 
+ * @deprecated The interface should not be used anymore.
  */
 export type SetTokenResponseToStorageFn<T = any> = (tokenRes: T) => void;
 export type CheckAuthenticationStateFn = (injector: Injector) => void;
+
+export interface AuthErrorFilter<T = AuthErrorEvent> {
+  id: string;
+  executable: boolean;
+  execute: (event: T) => boolean;
+}

--- a/npm/ng-packs/packages/core/src/lib/models/index.ts
+++ b/npm/ng-packs/packages/core/src/lib/models/index.ts
@@ -7,3 +7,4 @@ export * from './rest';
 export * from './session';
 export * from './utility';
 export * from './auth';
+export * from './auth-events';

--- a/npm/ng-packs/packages/oauth/package.json
+++ b/npm/ng-packs/packages/oauth/package.json
@@ -9,9 +9,9 @@
   "dependencies": {
     "@abp/ng.core": "~7.4.4",
     "@abp/utils": "~7.4.4",
-    "angular-oauth2-oidc": "^15.0.1",
-    "just-clone": "^6.1.1",
-    "just-compare": "^2.3.0",
+    "angular-oauth2-oidc": "^15.0.0",
+    "just-clone": "^6.0.0",
+    "just-compare": "^2.0.0",
     "tslib": "^2.0.0"
   },
   "publishConfig": {

--- a/npm/ng-packs/packages/oauth/src/lib/oauth.module.ts
+++ b/npm/ng-packs/packages/oauth/src/lib/oauth.module.ts
@@ -1,18 +1,19 @@
 import { APP_INITIALIZER, ModuleWithProviders, NgModule, Provider } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { HTTP_INTERCEPTORS } from '@angular/common/http';
 import { OAuthModule, OAuthStorage } from 'angular-oauth2-oidc';
 import {
   AbpLocalStorageService,
   ApiInterceptor,
+  AuthErrorFilterService,
   AuthGuard,
   AuthService,
   CHECK_AUTHENTICATION_STATE_FN_KEY,
   noop,
   PIPE_TO_LOGIN_FN_KEY,
 } from '@abp/ng.core';
-import { AbpOAuthService } from './services';
+import { AbpOAuthService, OAuthErrorFilterService } from './services';
 import { OAuthConfigurationHandler } from './handlers/oauth-configuration.handler';
-import { HTTP_INTERCEPTORS } from '@angular/common/http';
 import { OAuthApiInterceptor } from './interceptors/api.interceptor';
 import { AbpOAuthGuard } from './guards/oauth.guard';
 import { NavigateToManageProfileProvider } from './providers';
@@ -60,6 +61,7 @@ export class AbpOAuthModule {
         },
         OAuthModule.forRoot().providers as Provider[],
         { provide: OAuthStorage, useClass: AbpLocalStorageService },
+        { provide: AuthErrorFilterService, useExisting: OAuthErrorFilterService },
       ],
     };
   }

--- a/npm/ng-packs/packages/oauth/src/lib/services/index.ts
+++ b/npm/ng-packs/packages/oauth/src/lib/services/index.ts
@@ -1,1 +1,2 @@
 export * from './oauth.service';
+export * from './oauth-error-filter.service';

--- a/npm/ng-packs/packages/oauth/src/lib/services/oauth-error-filter.service.ts
+++ b/npm/ng-packs/packages/oauth/src/lib/services/oauth-error-filter.service.ts
@@ -1,0 +1,46 @@
+import { AbstractAuthErrorFilter, AuthErrorFilter } from '@abp/ng.core';
+import { Injectable, signal } from '@angular/core';
+import { OAuthErrorEvent } from 'angular-oauth2-oidc';
+
+@Injectable({ providedIn: 'root' })
+export class OAuthErrorFilterService extends AbstractAuthErrorFilter<
+  AuthErrorFilter<OAuthErrorEvent>,
+  OAuthErrorEvent
+> {
+  readonly #filters = signal<Array<AuthErrorFilter<OAuthErrorEvent>>>([]);
+
+  filters = this.#filters.asReadonly();
+
+  get(id: string): AuthErrorFilter<OAuthErrorEvent> {
+    return this.#filters().find(({ id: _id }) => _id === id);
+  }
+
+  add(filter: AuthErrorFilter<OAuthErrorEvent>): void {
+    this.#filters.update(items => [...items, filter]);
+  }
+
+  patch(item: Partial<AuthErrorFilter<OAuthErrorEvent>>): void {
+    const _item = this.filters().find(({ id }) => id === item.id);
+    if (!_item) {
+      return;
+    }
+
+    Object.assign(_item, item);
+  }
+
+  remove(id: string): void {
+    const item = this.filters().find(({ id: _id }) => _id === id);
+    if (!item) {
+      return;
+    }
+
+    this.#filters.update(items => items.filter(({ id: _id }) => _id !== id));
+  }
+
+  run(event: OAuthErrorEvent): boolean {
+    return this.filters()
+      .filter(({ executable }) => !!executable)
+      .map(({ execute }) => execute(event))
+      .some(item => item);
+  }
+}

--- a/npm/ng-packs/packages/oauth/src/lib/services/oauth-error-filter.service.ts
+++ b/npm/ng-packs/packages/oauth/src/lib/services/oauth-error-filter.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, signal } from '@angular/core';
 import { OAuthErrorEvent } from 'angular-oauth2-oidc';
 import { AbstractAuthErrorFilter, AuthErrorFilter } from '@abp/ng.core';
 
@@ -7,6 +7,9 @@ export class OAuthErrorFilterService extends AbstractAuthErrorFilter<
   AuthErrorFilter<OAuthErrorEvent>,
   OAuthErrorEvent
 > {
+  protected readonly _filters = signal<Array<AuthErrorFilter<OAuthErrorEvent>>>([]);
+  readonly filters = this._filters.asReadonly();
+
   get(id: string): AuthErrorFilter<OAuthErrorEvent> {
     return this._filters().find(({ id: _id }) => _id === id);
   }

--- a/npm/ng-packs/packages/oauth/src/lib/services/oauth-error-filter.service.ts
+++ b/npm/ng-packs/packages/oauth/src/lib/services/oauth-error-filter.service.ts
@@ -1,22 +1,18 @@
-import { AbstractAuthErrorFilter, AuthErrorFilter } from '@abp/ng.core';
-import { Injectable, signal } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { OAuthErrorEvent } from 'angular-oauth2-oidc';
+import { AbstractAuthErrorFilter, AuthErrorFilter } from '@abp/ng.core';
 
 @Injectable({ providedIn: 'root' })
 export class OAuthErrorFilterService extends AbstractAuthErrorFilter<
   AuthErrorFilter<OAuthErrorEvent>,
   OAuthErrorEvent
 > {
-  readonly #filters = signal<Array<AuthErrorFilter<OAuthErrorEvent>>>([]);
-
-  filters = this.#filters.asReadonly();
-
   get(id: string): AuthErrorFilter<OAuthErrorEvent> {
-    return this.#filters().find(({ id: _id }) => _id === id);
+    return this._filters().find(({ id: _id }) => _id === id);
   }
 
   add(filter: AuthErrorFilter<OAuthErrorEvent>): void {
-    this.#filters.update(items => [...items, filter]);
+    this._filters.update(items => [...items, filter]);
   }
 
   patch(item: Partial<AuthErrorFilter<OAuthErrorEvent>>): void {
@@ -34,7 +30,7 @@ export class OAuthErrorFilterService extends AbstractAuthErrorFilter<
       return;
     }
 
-    this.#filters.update(items => items.filter(({ id: _id }) => _id !== id));
+    this._filters.update(items => items.filter(({ id: _id }) => _id !== id));
   }
 
   run(event: OAuthErrorEvent): boolean {

--- a/npm/ng-packs/packages/oauth/src/lib/services/oauth.service.ts
+++ b/npm/ng-packs/packages/oauth/src/lib/services/oauth.service.ts
@@ -44,10 +44,10 @@ export class AbpOAuthService implements IAuthService {
   }
 
   logout(queryParams?: Params): Observable<any> {
-    
-    if(!this.strategy){
-      return EMPTY
+    if (!this.strategy) {
+      return EMPTY;
     }
+
     return this.strategy.logout(queryParams);
   }
 


### PR DESCRIPTION
Resolves #18575

### Description

- Create an abstraction for filtering oauth error listener
- Listener clear storage but for some case you may want to prevent this behavior

### Checklist

- [ ] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)
