### PR TITLE
Remove RemoveUnnecessaryDbMigratorClients

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectBuilding/Templates/RemoveUnnecessaryPortsStep.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectBuilding/Templates/RemoveUnnecessaryPortsStep.cs
@@ -12,7 +12,6 @@ public class RemoveUnnecessaryPortsStep : ProjectBuildPipelineStep
 {
     public override void Execute(ProjectBuildContext context)
     {
-        RemoveUnnecessaryDbMigratorClients(context);
         RemoveUnnecessaryHttpApiHostPorts(context);
     }
 
@@ -65,37 +64,5 @@ public class RemoveUnnecessaryPortsStep : ProjectBuildPipelineStep
         }
 
         httpApiHostAppSettings.SetLines(newlines);
-    }
-
-    private static void RemoveUnnecessaryDbMigratorClients(ProjectBuildContext context)
-    {
-        var dbMigratorAppSettings = context.Files
-            .FirstOrDefault(f =>
-                f.Name.Contains("MyCompanyName.MyProjectName.DbMigrator") && f.Name.EndsWith("appsettings.json"));
-
-        if (dbMigratorAppSettings == null)
-        {
-            return;
-        }
-
-        var appSettingsJsonObject = JObject.Parse(dbMigratorAppSettings.Content);
-        var authServerJsonObject = (JObject)appSettingsJsonObject?["IdentityServer"] ?? (JObject)appSettingsJsonObject["OpenIddict"];
-        var clientsJsonObject = (JObject)authServerJsonObject?["Clients"] ?? (JObject)authServerJsonObject?["Applications"];
-
-        if (clientsJsonObject == null)
-        {
-            return;
-        }
-
-        if (context.BuildArgs.UiFramework != UiFramework.Blazor)
-        {
-            clientsJsonObject.Remove("MyProjectName_Blazor");
-        }
-        if (!context.BuildArgs.PublicWebSite)
-        {
-            clientsJsonObject.Remove("MyProjectName_Web_Public");
-        }
-
-        dbMigratorAppSettings.SetContent(appSettingsJsonObject.ToString(Formatting.Indented));
     }
 }


### PR DESCRIPTION
We don't need it, because CLI uses code markers to to remove them.

<img width="480" alt="image" src="https://github.com/abpframework/abp/assets/16813853/3ec420e3-ae3f-43ce-a352-609991c08227">


**Steps:**

`abp new Acme.BookStore`

Before

<img width="650" alt="image" src="https://github.com/abpframework/abp/assets/16813853/a69d699b-a365-4901-adb5-46b53958011d">

After 

<img width="608" alt="image" src="https://github.com/abpframework/abp/assets/16813853/786b9b74-007b-4da5-9f5b-efa6d6c71b0f">

