### PR TITLE
fix user role update

### DIFF
--- a/modules/identity/src/Volo.Abp.Identity.Application/Volo/Abp/Identity/IdentityUserAppService.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Application/Volo/Abp/Identity/IdentityUserAppService.cs
@@ -140,6 +140,8 @@ public class IdentityUserAppService : IdentityAppServiceBase, IIdentityUserAppSe
     [Authorize(IdentityPermissions.Users.Update)]
     public virtual async Task UpdateRolesAsync(Guid id, IdentityUserUpdateRolesDto input)
     {
+        await IdentityOptions.SetAsync();
+
         var user = await UserManager.GetByIdAsync(id);
         (await UserManager.SetRolesAsync(user, input.RoleNames)).CheckErrors();
         await UserRepository.UpdateAsync(user);


### PR DESCRIPTION
fix when user role update, the identity options without sync

### Description

when call `UserManager.UpdateUserAsync`, it will be call `ValidateUserAsync`, so if the identity options is not sync to correct value, it will be throw error. 

### Checklist

- [x] I fully tested it as developer
- [x] no need to document