### PR TITLE
CLI: Create `switch-to-prerc` command to only update npm packages to pre-rc versions.

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/AbpCliCoreModule.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/AbpCliCoreModule.cs
@@ -56,6 +56,7 @@ public class AbpCliCoreModule : AbpModule
             options.Commands[SwitchToPreviewCommand.Name] = typeof(SwitchToPreviewCommand);
             options.Commands[SwitchToStableCommand.Name] = typeof(SwitchToStableCommand);
             options.Commands[SwitchToNightlyCommand.Name] = typeof(SwitchToNightlyCommand);
+            options.Commands[SwitchToPreRcCommand.Name] = typeof(SwitchToPreRcCommand);
             options.Commands[SwitchToLocal.Name] = typeof(SwitchToLocal);
             options.Commands[TranslateCommand.Name] = typeof(TranslateCommand);
             options.Commands[BuildCommand.Name] = typeof(BuildCommand);

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/SwitchToPreRcCommand.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/SwitchToPreRcCommand.cs
@@ -1,0 +1,45 @@
+﻿using System.Text;
+using System.Threading.Tasks;
+using Volo.Abp.Cli.Args;
+using Volo.Abp.Cli.ProjectModification;
+using Volo.Abp.DependencyInjection;
+
+namespace Volo.Abp.Cli.Commands;
+
+public class SwitchToPreRcCommand : IConsoleCommand, ITransientDependency
+{
+    public const string Name = "switch-to-prerc";
+
+    private readonly PackagePreviewSwitcher _packagePreviewSwitcher;
+
+    public SwitchToPreRcCommand(PackagePreviewSwitcher packagePreviewSwitcher)
+    {
+        _packagePreviewSwitcher = packagePreviewSwitcher;
+    }
+
+    public async Task ExecuteAsync(CommandLineArgs commandLineArgs)
+    {
+        await _packagePreviewSwitcher.SwitchToPreRc(commandLineArgs);
+    }
+
+    public string GetUsageInfo()
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine("");
+        sb.AppendLine("Usage:");
+        sb.AppendLine("  abp switch-to-prerc [options]");
+        sb.AppendLine("");
+        sb.AppendLine("Options:");
+        sb.AppendLine("-d|--directory");
+        sb.AppendLine("");
+        sb.AppendLine("See the documentation for more info: https://docs.abp.io/en/abp/latest/CLI");
+
+        return sb.ToString();
+    }
+
+    public string GetShortDescription()
+    {
+        return "Switches npm packages to pre-rc preview ABP version.";
+    }
+}

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/SwitchToPreRcCommand.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/SwitchToPreRcCommand.cs
@@ -40,6 +40,6 @@ public class SwitchToPreRcCommand : IConsoleCommand, ITransientDependency
 
     public string GetShortDescription()
     {
-        return "Switches npm packages to pre-rc preview ABP version.";
+        return "Switches npm packages to pre-rc ABP version.";
     }
 }

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/PackagePreviewSwitcher.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/PackagePreviewSwitcher.cs
@@ -44,6 +44,52 @@ public class PackagePreviewSwitcher : ITransientDependency
             await SwitchProjectsToPreview(projectPaths);
         }
     }
+    
+    public async Task SwitchToStable(CommandLineArgs commandLineArgs)
+    {
+        var solutionPaths = GetSolutionPaths(commandLineArgs);
+
+        if (solutionPaths.Any())
+        {
+            await SwitchSolutionsToStable(solutionPaths);
+        }
+        else
+        {
+            var projectPaths = GetProjectPaths(commandLineArgs);
+            
+            await SwitchProjectsToStable(projectPaths);
+        }
+    }
+    
+    public async Task SwitchToNightlyPreview(CommandLineArgs commandLineArgs)
+    {
+        var solutionPaths = GetSolutionPaths(commandLineArgs);
+
+        if (solutionPaths.Any())
+        {
+            await SwitchSolutionsToNightlyPreview(solutionPaths);
+        }
+        else
+        {
+            var projectPaths = GetProjectPaths(commandLineArgs);
+            
+            await SwitchProjectsToNightlyPreview(projectPaths);
+        }
+    }
+
+    public async Task SwitchToPreRc(CommandLineArgs commandLineArgs)
+    {
+        var solutionPaths = GetSolutionPaths(commandLineArgs);
+
+        if (solutionPaths.Any())
+        {
+            await SwitchNpmPackageVersionsOfSolutionsToPreRc(solutionPaths);
+        }
+        else
+        {
+            await SwitchNpmPackageVersionsOfProjectsToPreRc(GetProjectPaths(commandLineArgs));
+        }
+    }
 
     private async Task SwitchProjectsToPreview(List<string> projects)
     {
@@ -85,22 +131,6 @@ public class PackagePreviewSwitcher : ITransientDependency
                     false,
                     true);
             }
-        }
-    }
-
-    public async Task SwitchToStable(CommandLineArgs commandLineArgs)
-    {
-        var solutionPaths = GetSolutionPaths(commandLineArgs);
-
-        if (solutionPaths.Any())
-        {
-            await SwitchSolutionsToStable(solutionPaths);
-        }
-        else
-        {
-            var projectPaths = GetProjectPaths(commandLineArgs);
-            
-            await SwitchProjectsToStable(projectPaths);
         }
     }
 
@@ -156,22 +186,6 @@ public class PackagePreviewSwitcher : ITransientDependency
         }
     }
 
-    public async Task SwitchToNightlyPreview(CommandLineArgs commandLineArgs)
-    {
-        var solutionPaths = GetSolutionPaths(commandLineArgs);
-
-        if (solutionPaths.Any())
-        {
-            await SwitchSolutionsToNightlyPreview(solutionPaths);
-        }
-        else
-        {
-            var projectPaths = GetProjectPaths(commandLineArgs);
-            
-            await SwitchProjectsToNightlyPreview(projectPaths);
-        }
-    }
-
     private async Task SwitchProjectsToNightlyPreview(List<string> projects)
     {
         foreach (var project in projects)
@@ -217,6 +231,38 @@ public class PackagePreviewSwitcher : ITransientDependency
                 await _npmPackagesUpdater.Update(
                     solutionAngularFolder,
                     true);
+            }
+        }
+    }
+    
+    private async Task SwitchNpmPackageVersionsOfProjectsToPreRc(List<string> projects)
+    {
+        foreach (var project in projects)
+        {
+            var folder = Path.GetDirectoryName(project);
+
+            await _npmPackagesUpdater.Update(
+                folder,
+                includePreRc: true);
+        }
+    }
+
+    private async Task SwitchNpmPackageVersionsOfSolutionsToPreRc(List<string> solutionPaths)
+    {
+        foreach (var solutionPath in solutionPaths)
+        {
+            var solutionFolder = Path.GetDirectoryName(solutionPath);
+            var solutionAngularFolder = GetSolutionAngularFolder(solutionFolder);
+
+            await _npmPackagesUpdater.Update(
+                solutionFolder,
+                includePreRc: true);
+
+            if (solutionAngularFolder != null)
+            {
+                await _npmPackagesUpdater.Update(
+                    solutionAngularFolder,
+                    includePreRc: true);
             }
         }
     }


### PR DESCRIPTION
Based on https://github.com/volosoft/vs-internal/issues/3391#issuecomment-1866111570

Resolves https://github.com/volosoft/vs-internal/issues/3422