### PR TITLE
Don't return child permission if parent is not enabled

### DIFF
--- a/modules/permission-management/src/Volo.Abp.PermissionManagement.Application/Volo/Abp/PermissionManagement/PermissionAppService.cs
+++ b/modules/permission-management/src/Volo.Abp.PermissionManagement.Application/Volo/Abp/PermissionManagement/PermissionAppService.cs
@@ -57,6 +57,11 @@ public class PermissionAppService : ApplicationService, IPermissionAppService
             
             foreach (var permission in permissions)
             {
+                if(permission.Parent != null && !neededCheckPermissions.Contains(permission.Parent))
+                {
+                    continue;
+                }
+                
                 if (await SimpleStateCheckerManager.IsEnabledAsync(permission))
                 {
                     neededCheckPermissions.Add(permission);

--- a/modules/permission-management/test/Volo.Abp.PermissionManagement.Application.Tests/Volo/Abp/PermissionManagement/PermissionAppService_Tests.cs
+++ b/modules/permission-management/test/Volo.Abp.PermissionManagement.Application.Tests/Volo/Abp/PermissionManagement/PermissionAppService_Tests.cs
@@ -42,12 +42,24 @@ public class PermissionAppService_Tests : AbpPermissionManagementApplicationTest
         permissionListResultDto.Groups.First().Permissions.ShouldContain(x => x.Name == "MyPermission4");
 
         permissionListResultDto.Groups.First().Permissions.ShouldNotContain(x => x.Name == "MyPermission5");
+        permissionListResultDto.Groups.First().Permissions.ShouldNotContain(x => x.Name == "MyPermission5.ChildPermission1");
 
         using (_currentPrincipalAccessor.Change(new Claim(AbpClaimTypes.Role, "super-admin")))
         {
-            (await _permissionAppService.GetAsync(UserPermissionValueProvider.ProviderName, PermissionTestDataBuilder.User1Id.ToString())).Groups.First().Permissions
-                .ShouldContain(x => x.Name == "MyPermission5");
+            var result = await _permissionAppService.GetAsync(UserPermissionValueProvider.ProviderName, PermissionTestDataBuilder.User1Id.ToString());
+            result.Groups.First().Permissions.ShouldContain(x => x.Name == "MyPermission5");
+            result.Groups.First().Permissions.ShouldContain(x => x.Name == "MyPermission5.ChildPermission1");
         }
+        
+        permissionListResultDto.Groups.First().Permissions.ShouldContain(x => x.Name == "MyPermission6");
+        permissionListResultDto.Groups.First().Permissions.ShouldNotContain(x => x.Name == "MyPermission6.ChildDisabledPermission1");
+        permissionListResultDto.Groups.First().Permissions.ShouldContain(x => x.Name == "MyPermission6.ChildPermission2");
+        
+        permissionListResultDto.Groups.First().Permissions.ShouldNotContain(x => x.Name == "MyDisabledPermission1");
+        permissionListResultDto.Groups.First().Permissions.ShouldNotContain(x => x.Name == "MyDisabledPermission2");
+        permissionListResultDto.Groups.First().Permissions.ShouldNotContain(x => x.Name == "MyDisabledPermission2.ChildPermission1");
+        permissionListResultDto.Groups.First().Permissions.ShouldNotContain(x => x.Name == "MyDisabledPermission2.ChildPermission2");
+        permissionListResultDto.Groups.First().Permissions.ShouldNotContain(x => x.Name == "MyDisabledPermission2.ChildPermission2.ChildPermission1");
     }
 
     [Fact]

--- a/modules/permission-management/test/Volo.Abp.PermissionManagement.TestBase/Volo/Abp/PermissionManagement/TestPermissionDefinitionProvider.cs
+++ b/modules/permission-management/test/Volo.Abp.PermissionManagement.TestBase/Volo/Abp/PermissionManagement/TestPermissionDefinitionProvider.cs
@@ -19,6 +19,17 @@ public class TestPermissionDefinitionProvider : PermissionDefinitionProvider
 
         testGroup.AddPermission("MyPermission4", multiTenancySide: MultiTenancySides.Host).WithProviders(UserPermissionValueProvider.ProviderName);
 
-        testGroup.AddPermission("MyPermission5").StateCheckers.Add(new TestRequireRolePermissionStateProvider("super-admin"));
+        var myPermission5 = testGroup.AddPermission("MyPermission5");
+        myPermission5.StateCheckers.Add(new TestRequireRolePermissionStateProvider("super-admin"));
+        myPermission5.AddChild("MyPermission5.ChildPermission1");
+        
+        var myPermission6 = testGroup.AddPermission("MyPermission6");
+        myPermission6.AddChild("MyPermission6.ChildDisabledPermission1", isEnabled: false);
+        myPermission6.AddChild("MyPermission6.ChildPermission2");
+        
+        var myDisabledPermission2 = testGroup.AddPermission("MyDisabledPermission2", isEnabled: false);
+        myDisabledPermission2.AddChild("MyDisabledPermission2.ChildPermission1");
+        var myDisabledPermission2Child2 = myDisabledPermission2.AddChild("MyDisabledPermission2.ChildPermission2");
+        myDisabledPermission2Child2.AddChild("MyDisabledPermission2.ChildPermission2.ChildPermission1");
     }
 }


### PR DESCRIPTION
### Description

Don't return child permission if parent is not enabled

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

```csharp
public class TestPermissionDefinitionProvider : PermissionDefinitionProvider
{
    public override void Define(IPermissionDefinitionContext context)
    {
        var myGroup = context.AddGroup("TestGroup");
       
       // These permissions will not be returned if Feature BookManagement is not enabled.
        var bookPermission =  myGroup.AddPermission("BookManagement").RequireFeatures("BookManagement");
        bookPermission.AddChild("Book_Create");
        
       // These permissions will not be returned because the parent permission is not enabled.
        var myDisabledPermission = myGroup.AddPermission("MyDisabledPermission", isEnabled: false);
        myDisabledPermission.AddChild("MyDisabledPermission.ChildPermission1");
        var myDisabledPermissionChild2 = myDisabledPermission.AddChild("MyDisabledPermission.ChildPermission2");
        myDisabledPermissionChild2.AddChild("MyDisabledPermission.ChildPermission2.ChildPermission1");
    }
}

```
