### PR TITLE
CLI: Should skip bundling while creating a new custom module.

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/SolutionModuleAdder.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/SolutionModuleAdder.cs
@@ -594,10 +594,11 @@ public class SolutionModuleAdder : ITransientDependency
     {
         var args = new CommandLineArgs("new", module.Name);
 
-        args.Options.Add("t", newProTemplate ? ModuleProTemplate.TemplateName : ModuleTemplate.TemplateName);
-        args.Options.Add("v", version);
-        args.Options.Add("o", Path.Combine(modulesFolderInSolution, module.Name));
-        args.Options.Add("sib", true.ToString());
+        args.Options.Add(ProjectCreationCommandBase.Options.Template.Short, newProTemplate ? ModuleProTemplate.TemplateName : ModuleTemplate.TemplateName);
+        args.Options.Add(ProjectCreationCommandBase.Options.Version.Short, version);
+        args.Options.Add(ProjectCreationCommandBase.Options.OutputFolder.Short, Path.Combine(modulesFolderInSolution, module.Name));
+        args.Options.Add(ProjectCreationCommandBase.Options.SkipInstallingLibs.Short, true.ToString());
+        args.Options.Add(ProjectCreationCommandBase.Options.SkipBundling.Long, true.ToString());
 
         await NewCommand.ExecuteAsync(args);
     }


### PR DESCRIPTION
### Description

We should skip bundling in the custom module creation, because of https://github.com/abpframework/abp/pull/18659

Fixes the problem stated [here](https://support.abp.io/QA/Questions/6260/Bugs--Issues-v80x#answer-3a0fe96e-e115-d44d-b7d2-9ae9564587ff)

### Checklist

- [X] I fully tested it as developer / designer and created unit / integration tests
- [X] I documented it (or no need to document or I will create a separate documentation issue)
