### PR TITLE
Add an empty view for blog posts

### DIFF
--- a/modules/cms-kit/src/Volo.CmsKit.Domain.Shared/Volo/CmsKit/Localization/Resources/en.json
+++ b/modules/cms-kit/src/Volo.CmsKit.Domain.Shared/Volo/CmsKit/Localization/Resources/en.json
@@ -1,5 +1,5 @@
 {
-  "culture": "en",
+    "culture": "en",
     "texts": {
         "AddSubMenuItem": "Add Sub Menu Item",
         "AreYouSure": "Are You Sure?",
@@ -227,6 +227,7 @@
         "CssClass": "CSS Class",
         "TagsHelpText": "Tags should be comma-separated (e.g.: tag1, tag2, tag3)",
         "ThisPartOfContentCouldntBeLoaded": "This part of content couldn't be loaded.",
-        "DuplicateCommentAttemptMessage": "Duplicate comment post attempt detected. Your comment has already been submitted."
+        "DuplicateCommentAttemptMessage": "Duplicate comment post attempt detected. Your comment has already been submitted.",
+        "NoBlogPostYet": "No blog post yet!"
     }
 }

--- a/modules/cms-kit/src/Volo.CmsKit.Public.Web/Pages/Public/CmsKit/Blogs/Index.cshtml
+++ b/modules/cms-kit/src/Volo.CmsKit.Public.Web/Pages/Public/CmsKit/Blogs/Index.cshtml
@@ -59,38 +59,48 @@
     <hr />
 }
 
-<abp-row id="blogs-container">
-    @foreach (var blog in Model.Blogs.Items)
-    {
-        <abp-column size="_12" size-md="_6" size-lg="_4">
-            <abp-card>
-                @if (blog.CoverImageMediaId != null)
-                {
-                    <img src="/api/cms-kit/media/@blog.CoverImageMediaId" class="card-img-top" onerror="this.src='@dummyImageSource'" />
-                }
-                else
-                {
-                    <img src="@(dummyImageSource)?text=@blog.Title" class="card-img-top" />
-                }
-                <abp-card-body class="p-4">
-                    <h5>@blog.Title</h5>
-                    <p class="mb-2">
-                        <span class="font-weight-bold author-name-span" data-author-id="@blog.Author.Id">@@@blog.Author?.UserName</span>
-                        <small style="opacity:.65;">@blog.CreationTime</small>
-                    </p>
-                    <p style="min-height: 60px;">@blog.ShortDescription</p>
-                    <div class="d-grid gap-2">
-                        <a href="/@CmsBlogsWebConsts.BlogsRoutePrefix/@Model.BlogSlug/@blog.Slug" class="btn btn-light">
-                            @L["Read"]
-                        </a>
-                    </div>
-                </abp-card-body>
-            </abp-card>
+@if (Model.Blogs.TotalCount > 0)
+{
+    <abp-row id="blogs-container">
+        @foreach (var blog in Model.Blogs.Items)
+        {
+            <abp-column size="_12" size-md="_6" size-lg="_4">
+                <abp-card>
+                    @if (blog.CoverImageMediaId != null)
+                    {
+                        <img src="/api/cms-kit/media/@blog.CoverImageMediaId" class="card-img-top" onerror="this.src='@dummyImageSource'" />
+                    }
+                    else
+                    {
+                        <img src="@(dummyImageSource)?text=@blog.Title" class="card-img-top" />
+                    }
+                    <abp-card-body class="p-4">
+                        <h5>@blog.Title</h5>
+                        <p class="mb-2">
+                            <span class="font-weight-bold author-name-span" data-author-id="@blog.Author.Id">@@@blog.Author?.UserName</span>
+                            <small style="opacity:.65;">@blog.CreationTime</small>
+                        </p>
+                        <p style="min-height: 60px;">@blog.ShortDescription</p>
+                        <div class="d-grid gap-2">
+                            <a href="/@CmsBlogsWebConsts.BlogsRoutePrefix/@Model.BlogSlug/@blog.Slug" class="btn btn-light">
+                                @L["Read"]
+                            </a>
+                        </div>
+                    </abp-card-body>
+                </abp-card>
+            </abp-column>
+        }
+    </abp-row>
+    <abp-row>
+        <abp-column>
+            <abp-paginator model="Model.PagerModel" />
         </abp-column>
-    }
-</abp-row>
-<abp-row>
-    <abp-column>
-        <abp-paginator model="Model.PagerModel" />
-    </abp-column>
-</abp-row>
+    </abp-row>
+}
+else
+{
+    <div class="w-100 h-100 d-flex flex-column align-items-center justify-content-center py-5">
+        <h1><i class="fa fa-ban"></i></h1>
+        <h3>@L["NoBlogPostYet"]</h3>
+    </div>
+}


### PR DESCRIPTION
### Description

Resolves https://github.com/abpframework/abp/issues/18765

Part of https://github.com/volosoft/vs-internal/issues/3588

When there is no blog post in the blog index, the following message will be rendered:
![image](https://github.com/abpframework/abp/assets/23705418/3692fae1-e072-4081-b317-48c8217c279e)

![image](https://github.com/abpframework/abp/assets/23705418/32534807-1180-4fc5-91c7-6567e63c4cf5)


### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

Please describe how this can be tested by the test engineers if it is not already explicit - or remove this section if no need to description.
