### PR TITLE
Introduce `ExposeKeyedServiceAttribute`.

### DIFF
--- a/docs/en/Dependency-Injection.md
+++ b/docs/en/Dependency-Injection.md
@@ -145,7 +145,7 @@ public class TaxCalculator : ITaxCalculator, ITransientDependency
 
 ### ExposeKeyedService Attribute 
 
-``ExposeKeyedServiceAttribute`` is used to control which keyed services are provided by the related class. Example:
+`ExposeKeyedServiceAttribute` is used to control which keyed services are provided by the related class. Example:
 
 ````C#
 [ExposeKeyedService<ITaxCalculator>("taxCalculator")]
@@ -155,14 +155,28 @@ public class TaxCalculator: ICalculator, ITaxCalculator, ICanCalculate, ITransie
 }
 ````
 
-``TaxCalculator`` class exposes ``ITaxCalculator`` interface with the key ``tax`` and ``ICalculator`` interface with the key ``calculator``. That means you can get keyed services from the ``IServiceProvider`` as shown below:
+In the example above, the `TaxCalculator` class exposes the `ITaxCalculator` interface with the key `taxCalculator` and the `ICalculator` interface with the key `calculator`. That means you can get keyed services from the `IServiceProvider` as shown below:
 
 ````C#
 var taxCalculator = ServiceProvider.GetRequiredKeyedService<ITaxCalculator>("taxCalculator");
 var calculator = ServiceProvider.GetRequiredKeyedService<ICalculator>("calculator");
 ````
 
-> Notice that the ``ExposeKeyedServiceAttribute`` is only expose keyed services. So, you can not inject ``ITaxCalculator`` or ``ICalculator`` in your application. If you want to expose both keyed and non-keyed services, you can use ``ExposeServicesAttribute`` and ``ExposeKeyedServiceAttribute`` together as shown below:
+Also, you can use the [`FromKeyedServicesAttribute`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.fromkeyedservicesattribute?view=dotnet-plat-ext-8.0) to resolve a certain keyed service in the constructor:
+
+```csharp
+public class MyClass
+{
+    //...
+
+    public MyClass([FromKeyedServices("taxCalculator")] ITaxCalculator taxCalculator)
+    {
+        TaxCalculator = taxCalculator;
+    }
+}
+```
+
+> Notice that the `ExposeKeyedServiceAttribute` only exposes the keyed services. So, you can not inject the `ITaxCalculator` or `ICalculator` interfaces in your application without using the `FromKeyedServicesAttribute` as shown in the example above. If you want to expose both keyed and non-keyed services, you can use the `ExposeServicesAttribute` and `ExposeKeyedServiceAttribute` attributes together as shown below:
 
 ````C#
 [ExposeKeyedService<ITaxCalculator>("taxCalculator")]

--- a/docs/en/Dependency-Injection.md
+++ b/docs/en/Dependency-Injection.md
@@ -143,6 +143,36 @@ public class TaxCalculator : ITaxCalculator, ITransientDependency
 }
 ````
 
+### ExposeKeyedService Attribute 
+
+``ExposeKeyedServiceAttribute`` is used to control which keyed services are provided by the related class. Example:
+
+````C#
+[ExposeKeyedService<ITaxCalculator>("taxCalculator")]
+[ExposeKeyedService<ICalculator>("calculator")]
+public class TaxCalculator: ICalculator, ITaxCalculator, ICanCalculate, ITransientDependency
+{
+}
+````
+
+``TaxCalculator`` class exposes ``ITaxCalculator`` interface with the key ``tax`` and ``ICalculator`` interface with the key ``calculator``. That means you can get keyed services from the ``IServiceProvider`` as shown below:
+
+````C#
+var taxCalculator = ServiceProvider.GetRequiredKeyedService<ITaxCalculator>("taxCalculator");
+var calculator = ServiceProvider.GetRequiredKeyedService<ICalculator>("calculator");
+````
+
+> Notice that the ``ExposeKeyedServiceAttribute`` is only expose keyed services. So, you can not inject ``ITaxCalculator`` or ``ICalculator`` in your application. If you want to expose both keyed and non-keyed services, you can use ``ExposeServicesAttribute`` and ``ExposeKeyedServiceAttribute`` together as shown below:
+
+````C#
+[ExposeKeyedService<ITaxCalculator>("taxCalculator")]
+[ExposeKeyedService<ICalculator>("calculator")]
+[ExposeServices(typeof(ITaxCalculator), typeof(ICalculator))]
+public class TaxCalculator: ICalculator, ITaxCalculator, ICanCalculate, ITransientDependency
+{
+}
+````
+
 ### Manually Registering
 
 In some cases, you may need to register a service to the `IServiceCollection` manually, especially if you need to use custom factory methods or singleton instances. In that case, you can directly add services just as [Microsoft documentation](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/dependency-injection) describes. Example:

--- a/framework/src/Volo.Abp.Core/Volo/Abp/DependencyInjection/ExposeKeyedServiceAttribute.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/DependencyInjection/ExposeKeyedServiceAttribute.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Volo.Abp.DependencyInjection;
+
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+public class ExposeKeyedServiceAttribute<TServiceType> : Attribute, IExposedKeyedServiceTypesProvider
+    where TServiceType : class
+{
+    public ServiceIdentifier ServiceIdentifier { get; }
+
+    public ExposeKeyedServiceAttribute(object serviceKey)
+    {
+        if (serviceKey == null)
+        {
+            throw new AbpException($"{nameof(serviceKey)} can not be null! Use {nameof(ExposeServicesAttribute)} instead.");
+        }
+
+        ServiceIdentifier = new ServiceIdentifier(serviceKey, typeof(TServiceType));
+    }
+
+    public ServiceIdentifier[] GetExposedServiceTypes(Type targetType)
+    {
+        return new[] { ServiceIdentifier };
+    }
+}

--- a/framework/src/Volo.Abp.Core/Volo/Abp/DependencyInjection/ExposeServicesAttribute.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/DependencyInjection/ExposeServicesAttribute.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 
 namespace Volo.Abp.DependencyInjection;
 
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
 public class ExposeServicesAttribute : Attribute, IExposedServiceTypesProvider
 {
     public Type[] ServiceTypes { get; }

--- a/framework/src/Volo.Abp.Core/Volo/Abp/DependencyInjection/IExposedKeyedServiceTypesProvider.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/DependencyInjection/IExposedKeyedServiceTypesProvider.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace Volo.Abp.DependencyInjection;
+
+public interface IExposedKeyedServiceTypesProvider
+{
+    ServiceIdentifier[] GetExposedServiceTypes(Type targetType);
+}

--- a/framework/src/Volo.Abp.Core/Volo/Abp/DependencyInjection/IOnServiceExposingContext.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/DependencyInjection/IOnServiceExposingContext.cs
@@ -7,5 +7,5 @@ public interface IOnServiceExposingContext
 {
     Type ImplementationType { get; }
 
-    List<Type> ExposedTypes { get; }
+    List<ServiceIdentifier> ExposedTypes { get; }
 }

--- a/framework/src/Volo.Abp.Core/Volo/Abp/DependencyInjection/OnServiceExposingContext.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/DependencyInjection/OnServiceExposingContext.cs
@@ -8,9 +8,15 @@ public class OnServiceExposingContext : IOnServiceExposingContext
 {
     public Type ImplementationType { get; }
 
-    public List<Type> ExposedTypes { get; }
+    public List<ServiceIdentifier> ExposedTypes { get; }
 
     public OnServiceExposingContext([NotNull] Type implementationType, List<Type> exposedTypes)
+    {
+        ImplementationType = Check.NotNull(implementationType, nameof(implementationType));
+        ExposedTypes = Check.NotNull(exposedTypes, nameof(exposedTypes)).ConvertAll(t => new ServiceIdentifier(t));
+    }
+
+    public OnServiceExposingContext([NotNull] Type implementationType, List<ServiceIdentifier> exposedTypes)
     {
         ImplementationType = Check.NotNull(implementationType, nameof(implementationType));
         ExposedTypes = Check.NotNull(exposedTypes, nameof(exposedTypes));

--- a/framework/src/Volo.Abp.ObjectMapping/Volo/Abp/ObjectMapping/AbpObjectMappingModule.cs
+++ b/framework/src/Volo.Abp.ObjectMapping/Volo/Abp/ObjectMapping/AbpObjectMappingModule.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using Volo.Abp.DependencyInjection;
 using Volo.Abp.Modularity;
 using Volo.Abp.Reflection;
 
@@ -10,12 +11,12 @@ public class AbpObjectMappingModule : AbpModule
     {
         context.Services.OnExposing(onServiceExposingContext =>
         {
-                //Register types for IObjectMapper<TSource, TDestination> if implements
-                onServiceExposingContext.ExposedTypes.AddRange(
+            //Register types for IObjectMapper<TSource, TDestination> if implements
+            onServiceExposingContext.ExposedTypes.AddRange(
                 ReflectionHelper.GetImplementedGenericTypes(
                     onServiceExposingContext.ImplementationType,
                     typeof(IObjectMapper<,>)
-                )
+                ).ConvertAll(t => new ServiceIdentifier(t))
             );
         });
     }

--- a/framework/src/Volo.Abp.Serialization/Volo/Abp/Serialization/AbpSerializationModule.cs
+++ b/framework/src/Volo.Abp.Serialization/Volo/Abp/Serialization/AbpSerializationModule.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using Volo.Abp.DependencyInjection;
 using Volo.Abp.Modularity;
 using Volo.Abp.Reflection;
 
@@ -10,12 +11,12 @@ public class AbpSerializationModule : AbpModule
     {
         context.Services.OnExposing(onServiceExposingContext =>
         {
-                //Register types for IObjectSerializer<T> if implements
-                onServiceExposingContext.ExposedTypes.AddRange(
+            //Register types for IObjectSerializer<T> if implements
+            onServiceExposingContext.ExposedTypes.AddRange(
                 ReflectionHelper.GetImplementedGenericTypes(
                     onServiceExposingContext.ImplementationType,
                     typeof(IObjectSerializer<>)
-                )
+                ).ConvertAll(t => new ServiceIdentifier(t))
             );
         });
     }

--- a/framework/test/Volo.Abp.Core.Tests/Microsoft/Extensions/DependencyInjection/DependencyInjection_Tests.cs
+++ b/framework/test/Volo.Abp.Core.Tests/Microsoft/Extensions/DependencyInjection/DependencyInjection_Tests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Shouldly;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Modularity;
@@ -96,6 +97,10 @@ public abstract class DependencyInjection_Standard_Tests : AbpIntegratedTest<Dep
         GetService<MyExposingKeyedService3>().ShouldNotBeNull();
         GetRequiredKeyedService<IMyExposingKeyedServices>("k3").ShouldNotBeNull();
         GetRequiredKeyedService<MyExposingKeyedService3>("k3").ShouldNotBeNull();
+        
+        //resolving multiple keyed services
+        GetKeyedServices<IEnumerable<IMyExposingKeyedServices>>("k1").ShouldNotBeEmpty();
+        GetKeyedServices<IEnumerable<IMyExposingKeyedServices>>("k1").Count().ShouldBeGreaterThanOrEqualTo(2);
     }
 
     [Fact]
@@ -222,6 +227,12 @@ public abstract class DependencyInjection_Standard_Tests : AbpIntegratedTest<Dep
     public class MyExposingKeyedService3 : IMyExposingKeyedServices, ITransientDependency
     {
 
+    }
+    
+    [ExposeKeyedService<IMyExposingKeyedServices>("k1")]
+    public class MyExposingKeyedService4 : IMyExposingKeyedServices, ITransientDependency
+    {
+        
     }
 
     public class TestModule : AbpModule

--- a/framework/test/Volo.Abp.Core.Tests/Microsoft/Extensions/DependencyInjection/DependencyInjection_Tests.cs
+++ b/framework/test/Volo.Abp.Core.Tests/Microsoft/Extensions/DependencyInjection/DependencyInjection_Tests.cs
@@ -79,11 +79,35 @@ public abstract class DependencyInjection_Standard_Tests : AbpIntegratedTest<Dep
         GetRequiredService<GenericServiceWithDisablePropertyInjectionOnProperty<string>>().DisablePropertyInjectionService.ShouldBeNull();
     }
 
+
+    [Fact]
+    public void ExposeKeyedServices_Should_Expose_Correct_Services()
+    {
+        GetService<IMyExposingKeyedServices>().ShouldBeNull();
+        GetService<MyExposingKeyedService1>().ShouldBeNull();
+        GetService<MyExposingKeyedService2>().ShouldBeNull();
+
+        GetRequiredKeyedService<IMyExposingKeyedServices>("k1").ShouldNotBeNull();
+        GetRequiredKeyedService<MyExposingKeyedService1>("k1").ShouldNotBeNull();
+
+        GetRequiredKeyedService<IMyExposingKeyedServices>("k2").ShouldNotBeNull();
+        GetRequiredKeyedService<MyExposingKeyedService2>("k2").ShouldNotBeNull();
+
+        GetService<MyExposingKeyedService3>().ShouldNotBeNull();
+        GetRequiredKeyedService<IMyExposingKeyedServices>("k3").ShouldNotBeNull();
+        GetRequiredKeyedService<MyExposingKeyedService3>("k3").ShouldNotBeNull();
+    }
+
     [Fact]
     public void Singletons_Exposing_Multiple_Services_Should_Returns_The_Same_Instance()
     {
         var objectByInterfaceRef = GetRequiredService<IMySingletonExposingMultipleServices>();
         var objectByClassRef = GetRequiredService<MySingletonExposingMultipleServices>();
+
+        ReferenceEquals(objectByInterfaceRef, objectByClassRef).ShouldBeTrue();
+
+        objectByInterfaceRef = GetRequiredKeyedService<IMySingletonExposingMultipleServices>("k1");
+        objectByClassRef = GetRequiredKeyedService<MySingletonExposingMultipleServices>("k1");
 
         ReferenceEquals(objectByInterfaceRef, objectByClassRef).ShouldBeTrue();
     }
@@ -166,7 +190,36 @@ public abstract class DependencyInjection_Standard_Tests : AbpIntegratedTest<Dep
     }
 
     [ExposeServices(typeof(IMySingletonExposingMultipleServices), typeof(MySingletonExposingMultipleServices))]
+    [ExposeKeyedService<IMySingletonExposingMultipleServices>("k1")]
+    [ExposeKeyedService<MySingletonExposingMultipleServices>("k1")]
     public class MySingletonExposingMultipleServices : IMySingletonExposingMultipleServices, ISingletonDependency
+    {
+
+    }
+
+    public interface IMyExposingKeyedServices
+    {
+
+    }
+
+    [ExposeKeyedService<IMyExposingKeyedServices>("k1")]
+    [ExposeKeyedService<MyExposingKeyedService1>("k1")]
+    public class MyExposingKeyedService1 : IMyExposingKeyedServices, ITransientDependency
+    {
+
+    }
+
+    [ExposeKeyedService<IMyExposingKeyedServices>("k2")]
+    [ExposeKeyedService<MyExposingKeyedService2>("k2")]
+    public class MyExposingKeyedService2 : IMyExposingKeyedServices, ITransientDependency
+    {
+
+    }
+
+    [ExposeServices(typeof(MyExposingKeyedService3))]
+    [ExposeKeyedService<IMyExposingKeyedServices>("k3")]
+    [ExposeKeyedService<MyExposingKeyedService3>("k3")]
+    public class MyExposingKeyedService3 : IMyExposingKeyedServices, ITransientDependency
     {
 
     }


### PR DESCRIPTION
Resolves https://github.com/abpframework/abp/issues/18794

---

### ExposeKeyedService Attribute 

``ExposeKeyedServiceAttribute`` is used to control which keyed services are provided by the related class. Example:

````C#
[ExposeKeyedService<ITaxCalculator>("taxCalculator")]
[ExposeKeyedService<ICalculator>("calculator")]
public class TaxCalculator: ICalculator, ITaxCalculator, ICanCalculate, ITransientDependency
{
}
````

``TaxCalculator`` class exposes ``ITaxCalculator`` interface with the key ``tax`` and ``ICalculator`` interface with the key ``calculator``. That means you can get keyed services from the ``IServiceProvider`` as shown below:

````C#
var taxCalculator = ServiceProvider.GetRequiredKeyedService<ITaxCalculator>("taxCalculator");
var calculator = ServiceProvider.GetRequiredKeyedService<ICalculator>("calculator");
````

> Notice that the ``ExposeKeyedServiceAttribute`` is only expose keyed services. So, you can not inject ``ITaxCalculator`` or ``ICalculator`` in your application. If you want to expose both keyed and non-keyed services, you can use ``ExposeServicesAttribute`` and ``ExposeKeyedServiceAttribute`` together as shown below:
````C#
[ExposeKeyedService<ITaxCalculator>("taxCalculator")]
[ExposeKeyedService<ICalculator>("calculator")]
[ExposeServices(typeof(ITaxCalculator), typeof(ICalculator))]
public class TaxCalculator: ICalculator, ITaxCalculator, ICanCalculate, ITransientDependency
{
}
````



This is a small **breaking change** because `IOnServiceExposingContext` has changed.

<img width="1211" alt="image" src="https://github.com/abpframework/abp/assets/6908465/c6eb8aec-7638-4487-baed-c2f4075e10d3">
