### PR TITLE
Fix: navigate url with params after redirect from auth server

### DIFF
--- a/npm/ng-packs/packages/oauth/src/lib/strategies/auth-flow-strategy.ts
+++ b/npm/ng-packs/packages/oauth/src/lib/strategies/auth-flow-strategy.ts
@@ -99,10 +99,10 @@ export abstract class AuthFlowStrategy {
           filter(event => event.type === 'token_received' && !!this.oAuthService.state),
           take(1),
           map(() => {
-            const redirect_uri = decodeURIComponent(this.oAuthService.state);
+            const redirectUri = decodeURIComponent(this.oAuthService.state);
 
-            if (redirect_uri && redirect_uri !== '/') {
-              return redirect_uri;
+            if (redirectUri && redirectUri !== '/') {
+              return redirectUri;
             }
 
             return '/';
@@ -110,7 +110,7 @@ export abstract class AuthFlowStrategy {
           switchMap(redirectUri =>
             this.configState.getOne$('currentUser').pipe(
               filter(user => !!user?.isAuthenticated),
-              tap(() => this.router.navigate([redirectUri])),
+              tap(() => this.router.navigateByUrl(redirectUri)),
             ),
           ),
         )


### PR DESCRIPTION
### Description

Resolves #18804

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests

### How to test it?
- Create component and add to routes with path param
- Add `authGuard` to new route
- Try to go with params to new route

### Result
After redirect to angular app from auth server it must works fine