### PR TITLE
Fix: Selects on docs shrinks to unusable sizes on mobile

### DIFF
--- a/modules/docs/src/Volo.Docs.Web/Pages/Documents/Project/Index.cshtml
+++ b/modules/docs/src/Volo.Docs.Web/Pages/Documents/Project/Index.cshtml
@@ -332,28 +332,45 @@
                                     </abp-column>
                                 </abp-row>
                                 <abp-row class="gx-2">
-                                    @foreach (var parameter in Model.DocumentPreferences.Parameters)
-                                    {
-                                        <div class="col">
-                                            <div class="custom-input-group">
-                                                <span class="input-group-text" id="@("Section" + parameter.Name + "ComboboxAddonId")">@(parameter.DisplayName)</span>
-                                                <select class="doc-section-combobox form-select"
-                                                        aria-describedby="@("Section" + parameter.Name + "ComboboxAddonId")"
-                                                        id="@("Section" + parameter.Name + "ComboboxId")" data-key="@parameter.Name">
-                                                    @foreach (var value in parameter.Values.OrderBy(p => p.Value))
-                                                    {
-                                                        @if (value.Key == (Model.UserPreferences.ContainsKey(parameter.Name) ? Model.UserPreferences[parameter.Name] : null))
+                                    @{
+                                        const int maxCellCount = 3;
+                                        var count = Model.DocumentPreferences.Parameters.Count;
+                                        var rowCount = count / maxCellCount + (count % maxCellCount > 0 ? 1 : 0);
+                                        var cellSize = 12 / (count > maxCellCount ? maxCellCount : count);
+                                        
+                                        string BuildParameterDivClass(int index)
+                                        {
+                                            var row = index / maxCellCount;
+                                            var isLastRow = row == rowCount - 1;
+                                            var currentCellSize = isLastRow ? 12 / (count % maxCellCount) : cellSize;
+                                            return $"col-12 col-lg-{currentCellSize} mb-lg-{(isLastRow ? "0" : "2")} {(index == count - 1 ? "" : "mb-2")}";
+                                        }
+                                        
+                                        for (var i = 0; i < count; ++i)
+                                        {
+                                            var parameter = Model.DocumentPreferences.Parameters[i];
+
+                                            <div class="@BuildParameterDivClass(i)">
+                                                <div class="custom-input-group">
+                                                    <span class="input-group-text" id="@("Section" + parameter.Name + "ComboboxAddonId")">@(parameter.DisplayName)</span>
+                                                    <select class="doc-section-combobox form-select"
+                                                            aria-describedby="@("Section" + parameter.Name + "ComboboxAddonId")"
+                                                            id="@("Section" + parameter.Name + "ComboboxId")" data-key="@parameter.Name">
+                                                        @foreach (var value in parameter.Values.OrderBy(p => p.Value))
                                                         {
-                                                            <option value="@value.Key" selected="selected">@value.Value</option>
+                                                            @if (value.Key == (Model.UserPreferences.ContainsKey(parameter.Name) ? Model.UserPreferences[parameter.Name] : null))
+                                                            {
+                                                                <option value="@value.Key" selected="selected">@value.Value</option>
+                                                            }
+                                                            else
+                                                            {
+                                                                <option value="@value.Key">@value.Value</option>
+                                                            }
                                                         }
-                                                        else
-                                                        {
-                                                            <option value="@value.Key">@value.Value</option>
-                                                        }
-                                                    }
-                                                </select>
+                                                    </select>
+                                                </div>
                                             </div>
-                                        </div>
+                                        }
                                     }
                                 </abp-row>
                             </div>

--- a/modules/docs/src/Volo.Docs.Web/Pages/Documents/Project/Index.cshtml
+++ b/modules/docs/src/Volo.Docs.Web/Pages/Documents/Project/Index.cshtml
@@ -337,12 +337,13 @@
                                         var count = Model.DocumentPreferences.Parameters.Count;
                                         var rowCount = count / maxCellCount + (count % maxCellCount > 0 ? 1 : 0);
                                         var cellSize = 12 / (count > maxCellCount ? maxCellCount : count);
+                                        var latestCellSize = 12 / count - (rowCount - 1) * maxCellCount;
                                         
                                         string BuildParameterDivClass(int index)
                                         {
                                             var row = index / maxCellCount;
                                             var isLastRow = row == rowCount - 1;
-                                            var currentCellSize = isLastRow ? 12 / (count % maxCellCount) : cellSize;
+                                            var currentCellSize = isLastRow ? latestCellSize : cellSize;
                                             return $"col-12 col-lg-{currentCellSize} mb-lg-{(isLastRow ? "0" : "2")} {(index == count - 1 ? "" : "mb-2")}";
                                         }
                                         


### PR DESCRIPTION
### Description

Related https://github.com/volosoft/vs-internal/issues/3658

Old UI:
![image](https://github.com/abpframework/abp/assets/58659931/3f3c686c-068c-4f5e-80e2-94fd352b891c)

New UI:
![image](https://github.com/abpframework/abp/assets/58659931/59e0018e-45bc-4308-be8c-78b67fed2658)


### Checklist

- [x] I fully tested it as developer