### PR TITLE
Fix ngx-datatable doesn't filtering the previous pages bug

### DIFF
--- a/npm/ng-packs/packages/core/src/lib/services/list.service.ts
+++ b/npm/ng-packs/packages/core/src/lib/services/list.service.ts
@@ -52,7 +52,7 @@ export class ListService<QueryParamsType = ABP.PageQueryParams | any> implements
     return this._page;
   }
 
-  private _totalCount = 0
+  private _totalCount = 0;
   set totalCount(value: number) {
     if (value === this._totalCount) return;
 
@@ -150,7 +150,7 @@ export class ListService<QueryParamsType = ABP.PageQueryParams | any> implements
     this._query$.next({
       filter: this._filter || undefined,
       maxResultCount: this._maxResultCount,
-      skipCount: this._page * this._maxResultCount,
+      skipCount: this._filter ? 0 : this._page * this._maxResultCount,
       sorting: this._sortOrder ? `${this._sortKey} ${this._sortOrder}` : undefined,
     } as any as QueryParamsType);
   }


### PR DESCRIPTION
Resolves https://github.com/abpframework/abp/issues/18834

This pr is resolves: https://support.abp.io/QA/Questions/6469
