### PR TITLE
Disable the `DynamicProxy` for `ConventionalControllers`.

### DIFF
--- a/docs/en/API/Auto-API-Controllers.md
+++ b/docs/en/API/Auto-API-Controllers.md
@@ -12,9 +12,9 @@ Basic configuration is simple. Just configure `AbpAspNetCoreMvcOptions` and use 
 [DependsOn(BookStoreApplicationModule)]
 public class BookStoreWebModule : AbpModule
 {
-    public override void ConfigureServices(ServiceConfigurationContext context)
+    public override void PreConfigureServices(ServiceConfigurationContext context)
     {
-        Configure<AbpAspNetCoreMvcOptions>(options =>
+        PreConfigure<AbpAspNetCoreMvcOptions>(options =>
         {
             options
                 .ConventionalControllers

--- a/docs/en/Integration-Services.md
+++ b/docs/en/Integration-Services.md
@@ -93,7 +93,7 @@ Configure<AbpAuditingOptions>(options =>
 You can filter integration services (or non-integration services) while creating [Auto API Controllers](API/Auto-API-Controllers.md), using the `ApplicationServiceTypes` option of the `ConventionalControllerSetting` by configuring the `AbpAspNetCoreMvcOptions` as shown below:
 
 ```csharp
-Configure<AbpAspNetCoreMvcOptions>(options =>
+PreConfigure<AbpAspNetCoreMvcOptions>(options =>
 {
     options.ConventionalControllers.Create(
         typeof(MyApplicationModule).Assembly,

--- a/docs/zh-Hans/API/Auto-API-Controllers.md
+++ b/docs/zh-Hans/API/Auto-API-Controllers.md
@@ -12,9 +12,9 @@ ABP可以按照惯例 **自动** 将你的应用程序服务配置为API控制�
 [DependsOn(BookStoreApplicationModule)]
 public class BookStoreWebModule : AbpModule
 {
-    public override void ConfigureServices(ServiceConfigurationContext context)
+    public override void PreConfigureServices(ServiceConfigurationContext context)
     {
-        Configure<AbpAspNetCoreMvcOptions>(options =>
+        PreConfigure<AbpAspNetCoreMvcOptions>(options =>
         {
             options
                 .ConventionalControllers

--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AbpAspNetCoreMvcModule.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/AbpAspNetCoreMvcModule.cs
@@ -212,6 +212,17 @@ public class AbpAspNetCoreMvcModule : AbpModule
             context.Services.GetSingletonInstance<ApplicationPartManager>(),
             context.Services.GetSingletonInstance<IModuleContainer>()
         );
+
+        var preConfigureActions = context.Services.GetPreConfigureActions<AbpAspNetCoreMvcOptions>();
+
+        DynamicProxyIgnoreTypes.Add(preConfigureActions.Configure()
+            .ConventionalControllers
+            .ConventionalControllerSettings.SelectMany(x => x.ControllerTypes).ToArray());
+
+        Configure<AbpAspNetCoreMvcOptions>(options =>
+        {
+            preConfigureActions.Configure(options);
+        });
     }
 
     public override void OnApplicationInitialization(ApplicationInitializationContext context)
@@ -247,7 +258,7 @@ public class AbpAspNetCoreMvcModule : AbpModule
             .Distinct();
 
         AddToApplicationParts(partManager, controllerAssemblies);
-        
+
         var additionalAssemblies = moduleContainer
             .Modules
             .SelectMany(m => m.GetAdditionalAssemblies())

--- a/framework/src/Volo.Abp.Core/Volo/Abp/DynamicProxy/DynamicProxyIgnoreTypes.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/DynamicProxy/DynamicProxyIgnoreTypes.cs
@@ -18,9 +18,22 @@ public static class DynamicProxyIgnoreTypes
 
     public static void Add<T>()
     {
+        Add(typeof(T));
+    }
+
+    public static void Add(Type type)
+    {
         lock (IgnoredTypes)
         {
-            IgnoredTypes.AddIfNotContains(typeof(T));
+            IgnoredTypes.AddIfNotContains(type);
+        }
+    }
+
+    public static void Add(params Type[] types)
+    {
+        lock (IgnoredTypes)
+        {
+            IgnoredTypes.AddIfNotContains(types);
         }
     }
 

--- a/framework/src/Volo.Abp.Core/Volo/Abp/DynamicProxy/ProxyHelper.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/DynamicProxy/ProxyHelper.cs
@@ -9,6 +9,14 @@ public static class ProxyHelper
     private const string ProxyNamespace = "Castle.Proxies";
 
     /// <summary>
+    /// Checks if given object is a dynamic proxy.
+    /// </summary>
+    public static bool IsProxy(object obj)
+    {
+        return obj.GetType().Namespace == ProxyNamespace;
+    }
+
+    /// <summary>
     /// Returns dynamic proxy target object if this is a proxied object, otherwise returns the given object.
     /// It supports Castle Dynamic Proxies.
     /// </summary>

--- a/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/AbpAspNetCoreMvcTestModule.cs
+++ b/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/AbpAspNetCoreMvcTestModule.cs
@@ -19,6 +19,7 @@ using Volo.Abp.Localization;
 using Volo.Abp.MemoryDb;
 using Volo.Abp.Modularity;
 using Volo.Abp.TestApp;
+using Volo.Abp.TestApp.Application;
 using Volo.Abp.Threading;
 using Volo.Abp.Validation.Localization;
 using Volo.Abp.VirtualFileSystem;
@@ -53,6 +54,8 @@ public class AbpAspNetCoreMvcTestModule : AbpModule
                     string.Equals(urlActionNameNormalizerContext.ActionNameInUrl, "phone", StringComparison.OrdinalIgnoreCase)
                         ? "phones"
                         : urlActionNameNormalizerContext.ActionNameInUrl;
+
+                opts.TypePredicate = type => type != typeof(ConventionalAppService);
             });
 
             options.ExposeIntegrationServices = true;

--- a/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/AbpAspNetCoreMvcTestModule.cs
+++ b/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/AbpAspNetCoreMvcTestModule.cs
@@ -44,6 +44,19 @@ public class AbpAspNetCoreMvcTestModule : AbpModule
                 typeof(AbpAspNetCoreMvcTestModule).Assembly
             );
         });
+
+        context.Services.PreConfigure<AbpAspNetCoreMvcOptions>(options =>
+        {
+            options.ConventionalControllers.Create(typeof(TestAppModule).Assembly, opts =>
+            {
+                opts.UrlActionNameNormalizer = urlActionNameNormalizerContext =>
+                    string.Equals(urlActionNameNormalizerContext.ActionNameInUrl, "phone", StringComparison.OrdinalIgnoreCase)
+                        ? "phones"
+                        : urlActionNameNormalizerContext.ActionNameInUrl;
+            });
+
+            options.ExposeIntegrationServices = true;
+        });
     }
 
     public override void ConfigureServices(ServiceConfigurationContext context)
@@ -77,19 +90,6 @@ public class AbpAspNetCoreMvcTestModule : AbpModule
             {
                 policy.Requirements.Add(new PermissionsRequirement(new []{"TestPermission1", "TestPermission2"}, requiresAll: false));
             });
-        });
-
-        Configure<AbpAspNetCoreMvcOptions>(options =>
-        {
-            options.ConventionalControllers.Create(typeof(TestAppModule).Assembly, opts =>
-            {
-                opts.UrlActionNameNormalizer = urlActionNameNormalizerContext =>
-                    string.Equals(urlActionNameNormalizerContext.ActionNameInUrl, "phone", StringComparison.OrdinalIgnoreCase)
-                        ? "phones"
-                        : urlActionNameNormalizerContext.ActionNameInUrl;
-            });
-
-            options.ExposeIntegrationServices = true;
         });
 
         Configure<AbpVirtualFileSystemOptions>(options =>

--- a/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/ConventionalController_Tests.cs
+++ b/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/ConventionalController_Tests.cs
@@ -1,0 +1,21 @@
+using Shouldly;
+using Volo.Abp.DynamicProxy;
+using Volo.Abp.TestApp.Application;
+using Xunit;
+
+namespace Volo.Abp.AspNetCore.Mvc;
+
+public class ConventionalController_Tests : AspNetCoreMvcTestBase
+{
+    [Fact]
+    public void Conventional_Controller_Should_Disable_DynamicProxy()
+    {
+        // PeopleAppService is a conventional controller
+        var peopleAppService = GetRequiredService<PeopleAppService>();
+        ProxyHelper.IsProxy(peopleAppService).ShouldBeFalse();
+
+        // ConventionalAppService is not a conventional controller
+        var conventionalAppService = GetRequiredService<ConventionalAppService>();
+        ProxyHelper.IsProxy(conventionalAppService).ShouldBeTrue();
+    }
+}

--- a/framework/test/Volo.Abp.TestApp/Volo/Abp/TestApp/Application/ConventionalAppService.cs
+++ b/framework/test/Volo.Abp.TestApp/Volo/Abp/TestApp/Application/ConventionalAppService.cs
@@ -1,0 +1,17 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Volo.Abp.Application.Services;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.Uow;
+
+namespace Volo.Abp.TestApp.Application;
+
+public class ConventionalAppService : IApplicationService, ITransientDependency
+{
+    [Authorize]
+    [UnitOfWork]
+    public virtual Task GetAsync()
+    {
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
From https://github.com/abpframework/abp/issues/18845#issuecomment-1909764887

Because it becomes an MVC controller, it has global filters. 

Resolve #18845
