### PR TITLE
Fix namespace in Getting started - Single Layer

### DIFF
--- a/docs/en/Tutorials/Todo/Single-Layer/Index.md
+++ b/docs/en/Tutorials/Todo/Single-Layer/Index.md
@@ -334,7 +334,7 @@ using TodoApp.Entities;
 using Volo.Abp.Application.Services;
 using Volo.Abp.Domain.Repositories;
 {{else}}
-using TodoApp.Entities;
+using TodoAppEntities;
 using Volo.Abp.Application.Services;
 using Volo.Abp.Domain.Repositories;
 {{end}}


### PR DESCRIPTION
### Description

dot(`.`) exists in only for Blazor condition
![image](https://github.com/abpframework/abp/assets/23705418/97bfa85d-0565-493c-9f80-419d4c9432fc)

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)
