### PR TITLE
Clı: Added trustUserVersion option

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/ProjectCreationCommandBase.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/ProjectCreationCommandBase.cs
@@ -233,6 +233,8 @@ public abstract class ProjectCreationCommandBase
 
         var skipCache = commandLineArgs.Options.ContainsKey(Options.SkipCache.Long) || commandLineArgs.Options.ContainsKey(Options.SkipCache.Short);
 
+        var trustUserVersion = !version.IsNullOrEmpty() && commandLineArgs.Options.ContainsKey(Options.TrustUserVersion.Long) || commandLineArgs.Options.ContainsKey(Options.TrustUserVersion.Short);
+
         return new ProjectBuildArgs(
             solutionName,
             template,
@@ -251,7 +253,8 @@ public abstract class ProjectCreationCommandBase
             pwa,
             theme,
             themeStyle,
-            skipCache
+            skipCache,
+            trustUserVersion
         );
     }
 
@@ -902,6 +905,11 @@ public abstract class ProjectCreationCommandBase
             public const string Long = "skip-cache";
         }
 
+        public static class TrustUserVersion
+        {
+            public const string Short = "tv";
+            public const string Long = "trust-version";
+        }
 
         public static class Tiered
         {

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectBuilding/AbpIoSourceCodeStore.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectBuilding/AbpIoSourceCodeStore.cs
@@ -65,7 +65,8 @@ public class AbpIoSourceCodeStore : ISourceCodeStore, ITransientDependency
         string version = null,
         string templateSource = null,
         bool includePreReleases = false,
-        bool skipCache = false)
+        bool skipCache = false,
+        bool trustUserVersion = false)
     {
         DirectoryHelper.CreateIfNotExists(CliPaths.TemplateCache);
         var userSpecifiedVersion = version != null;
@@ -96,33 +97,36 @@ public class AbpIoSourceCodeStore : ISourceCodeStore, ITransientDependency
         var templateVersion = SemanticVersion.Parse(version);
 
         var outputWarning = false;
-        if (currentCliVersion.Major != templateVersion.Major || currentCliVersion.Minor != templateVersion.Minor)
+        if (!trustUserVersion)
         {
-            // major and minor version are different
-            outputWarning = true;
-        }
-        else if (currentCliVersion.Major == templateVersion.Major &&
-                 currentCliVersion.Minor == templateVersion.Minor &&
-                 currentCliVersion.Patch < templateVersion.Patch)
-        {
-            // major and minor version are same but patch version is lower
-            outputWarning = true;
-        }
-        else if(currentCliVersion.Major == templateVersion.Major &&
-                currentCliVersion.Minor == templateVersion.Minor &&
-                currentCliVersion.Patch == templateVersion.Patch &&
-                currentCliVersion.IsPrerelease && templateVersion.IsPrerelease)
-        {
-            // major and minor and patch version are same but prerelease version may be lower
-            var cliRcVersion = currentCliVersion.ReleaseLabels.LastOrDefault();
-            var templateRcVersion = templateVersion.ReleaseLabels.LastOrDefault();
-            if (cliRcVersion != null && templateRcVersion != null)
+            if (currentCliVersion.Major != templateVersion.Major || currentCliVersion.Minor != templateVersion.Minor)
             {
-                if (int.TryParse(cliRcVersion, out var cliRcVersionNumber) && int.TryParse(templateRcVersion, out var templateRcVersionNumber))
+                // major and minor version are different
+                outputWarning = true;
+            }
+            else if (currentCliVersion.Major == templateVersion.Major &&
+                     currentCliVersion.Minor == templateVersion.Minor &&
+                     currentCliVersion.Patch < templateVersion.Patch)
+            {
+                // major and minor version are same but patch version is lower
+                outputWarning = true;
+            }
+            else if(currentCliVersion.Major == templateVersion.Major &&
+                    currentCliVersion.Minor == templateVersion.Minor &&
+                    currentCliVersion.Patch == templateVersion.Patch &&
+                    currentCliVersion.IsPrerelease && templateVersion.IsPrerelease)
+            {
+                // major and minor and patch version are same but prerelease version may be lower
+                var cliRcVersion = currentCliVersion.ReleaseLabels.LastOrDefault();
+                var templateRcVersion = templateVersion.ReleaseLabels.LastOrDefault();
+                if (cliRcVersion != null && templateRcVersion != null)
                 {
-                    if (cliRcVersionNumber < templateRcVersionNumber)
+                    if (int.TryParse(cliRcVersion, out var cliRcVersionNumber) && int.TryParse(templateRcVersion, out var templateRcVersionNumber))
                     {
-                        outputWarning = true;
+                        if (cliRcVersionNumber < templateRcVersionNumber)
+                        {
+                            outputWarning = true;
+                        }
                     }
                 }
             }
@@ -147,12 +151,12 @@ public class AbpIoSourceCodeStore : ISourceCodeStore, ITransientDependency
             }
         }
 
-        if (!await IsVersionExists(name, version))
+        if (!trustUserVersion && !await IsVersionExists(name, version))
         {
             throw new Exception("There is no version found with given version: " + version);
         }
 
-        var nugetVersion = (await GetTemplateNugetVersionAsync(name, type, version)) ?? version;
+        var nugetVersion = await GetTemplateNugetVersionAsync(name, type, version) ?? version;
 
         if (!string.IsNullOrWhiteSpace(templateSource) && !IsNetworkSource(templateSource))
         {

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectBuilding/ISourceCodeStore.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectBuilding/ISourceCodeStore.cs
@@ -11,6 +11,7 @@ public interface ISourceCodeStore
         [CanBeNull] string version = null,
         [CanBeNull] string templateSource = null,
         bool includePreReleases = false,
-        bool skipCache = false
+        bool skipCache = false,
+        bool trustUserVersion = false
     );
 }

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectBuilding/ProjectBuildArgs.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectBuilding/ProjectBuildArgs.cs
@@ -15,6 +15,8 @@ public class ProjectBuildArgs
     [CanBeNull]
     public string Version { get; set; }
 
+    public bool TrustUserVersion { get; set; }
+
     public DatabaseProvider DatabaseProvider { get; set; }
 
     public DatabaseManagementSystem DatabaseManagementSystem { get; set; }
@@ -69,7 +71,8 @@ public class ProjectBuildArgs
         bool pwa = false,
         Theme? theme = null,
         ThemeStyle? themeStyle = null,
-        bool skipCache = false)
+        bool skipCache = false,
+        bool trustUserVersion = false)
     {
         SolutionName = Check.NotNull(solutionName, nameof(solutionName));
         TemplateName = templateName;
@@ -89,5 +92,6 @@ public class ProjectBuildArgs
         Theme = theme;
         ThemeStyle = themeStyle;
         SkipCache = skipCache;
+        TrustUserVersion = trustUserVersion;
     }
 }

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectBuilding/TemplateProjectBuilder.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectBuilding/TemplateProjectBuilder.cs
@@ -68,7 +68,8 @@ public class TemplateProjectBuilder : IProjectBuilder, ITransientDependency
             SourceCodeTypes.Template,
             args.Version,
             args.TemplateSource,
-            args.ExtraProperties.ContainsKey(NewCommand.Options.Preview.Long)
+            args.ExtraProperties.ContainsKey(NewCommand.Options.Preview.Long),
+            trustUserVersion: args.TrustUserVersion
         );
 
         ConfigureThemeOptions(args, templateFile.Version);


### PR DESCRIPTION
resolves https://github.com/abpframework/abp/issues/18902

new option: `-tv` or `--trust-version`

Description: When set, cli doesn't check if this version really exist. If the template with the given version is found in the cache, it will be used. (If not found and it doesn't exist on server too, it will throw exception.)
This will make easier to create spesific versions for personal testing or usage.

usage:

`abp new Acme.BookStore -v 8.1.0-preview20243101 -tv`

It can be combined with `--local-framework-ref`, of course.