### PR TITLE
feat: Add MultiQueue

### DIFF
--- a/framework/Volo.Abp.sln
+++ b/framework/Volo.Abp.sln
@@ -457,13 +457,19 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Volo.Abp.Imaging.MagickNet.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Volo.Abp.Imaging.AspNetCore.Tests", "test\Volo.Abp.Imaging.AspNetCore.Tests\Volo.Abp.Imaging.AspNetCore.Tests.csproj", "{983B0136-384B-4439-B374-31111FFAA286}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Volo.Abp.Maui.Client", "src\Volo.Abp.Maui.Client\Volo.Abp.Maui.Client.csproj", "{F19A6E0C-F719-4ED9-A024-14E4B8D40883}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Volo.Abp.Maui.Client", "src\Volo.Abp.Maui.Client\Volo.Abp.Maui.Client.csproj", "{F19A6E0C-F719-4ED9-A024-14E4B8D40883}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Volo.Abp.Imaging.SkiaSharp", "src\Volo.Abp.Imaging.SkiaSharp\Volo.Abp.Imaging.SkiaSharp.csproj", "{198683D0-7DC6-40F2-B81B-8E446E70A9DE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Volo.Abp.Imaging.SkiaSharp", "src\Volo.Abp.Imaging.SkiaSharp\Volo.Abp.Imaging.SkiaSharp.csproj", "{198683D0-7DC6-40F2-B81B-8E446E70A9DE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Volo.Abp.Imaging.SkiaSharp.Tests", "test\Volo.Abp.Imaging.SkiaSharp.Tests\Volo.Abp.Imaging.SkiaSharp.Tests.csproj", "{DFAF8763-D1D6-4EB4-B459-20E31007FE2F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Volo.Abp.Imaging.SkiaSharp.Tests", "test\Volo.Abp.Imaging.SkiaSharp.Tests\Volo.Abp.Imaging.SkiaSharp.Tests.csproj", "{DFAF8763-D1D6-4EB4-B459-20E31007FE2F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Volo.Abp.RemoteServices.Tests", "test\Volo.Abp.RemoteServices.Tests\Volo.Abp.RemoteServices.Tests.csproj", "{DACD4485-61BE-4DE5-ACAE-4FFABC122500}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Volo.Abp.RemoteServices.Tests", "test\Volo.Abp.RemoteServices.Tests\Volo.Abp.RemoteServices.Tests.csproj", "{DACD4485-61BE-4DE5-ACAE-4FFABC122500}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Volo.Abp.MultiQueue", "src\Volo.Abp.MultiQueue\Volo.Abp.MultiQueue.csproj", "{E61D87D0-2E95-4182-A2CF-34457873E7F6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Volo.Abp.MultiQueue.Kafka", "src\Volo.Abp.MultiQueue.Kafka\Volo.Abp.MultiQueue.Kafka.csproj", "{12E20B84-E2F3-48AD-8696-A3191ED1AD7E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Volo.Abp.MultiQueue.Tests", "test\Volo.Abp.MultiQueue.Tests\Volo.Abp.MultiQueue.Tests.csproj", "{46405A27-6C12-473D-ACA7-A7EC8D00CBAE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -1387,6 +1393,18 @@ Global
 		{DACD4485-61BE-4DE5-ACAE-4FFABC122500}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DACD4485-61BE-4DE5-ACAE-4FFABC122500}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DACD4485-61BE-4DE5-ACAE-4FFABC122500}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E61D87D0-2E95-4182-A2CF-34457873E7F6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E61D87D0-2E95-4182-A2CF-34457873E7F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E61D87D0-2E95-4182-A2CF-34457873E7F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E61D87D0-2E95-4182-A2CF-34457873E7F6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{12E20B84-E2F3-48AD-8696-A3191ED1AD7E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{12E20B84-E2F3-48AD-8696-A3191ED1AD7E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{12E20B84-E2F3-48AD-8696-A3191ED1AD7E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{12E20B84-E2F3-48AD-8696-A3191ED1AD7E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{46405A27-6C12-473D-ACA7-A7EC8D00CBAE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{46405A27-6C12-473D-ACA7-A7EC8D00CBAE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{46405A27-6C12-473D-ACA7-A7EC8D00CBAE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{46405A27-6C12-473D-ACA7-A7EC8D00CBAE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1621,6 +1639,9 @@ Global
 		{198683D0-7DC6-40F2-B81B-8E446E70A9DE} = {5DF0E140-0513-4D0D-BE2E-3D4D85CD70E6}
 		{DFAF8763-D1D6-4EB4-B459-20E31007FE2F} = {447C8A77-E5F0-4538-8687-7383196D04EA}
 		{DACD4485-61BE-4DE5-ACAE-4FFABC122500} = {447C8A77-E5F0-4538-8687-7383196D04EA}
+		{E61D87D0-2E95-4182-A2CF-34457873E7F6} = {5DF0E140-0513-4D0D-BE2E-3D4D85CD70E6}
+		{12E20B84-E2F3-48AD-8696-A3191ED1AD7E} = {5DF0E140-0513-4D0D-BE2E-3D4D85CD70E6}
+		{46405A27-6C12-473D-ACA7-A7EC8D00CBAE} = {447C8A77-E5F0-4538-8687-7383196D04EA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BB97ECF4-9A84-433F-A80B-2A3285BDD1D5}

--- a/framework/src/Volo.Abp.MultiQueue.Kafka/Volo.Abp.MultiQueue.Kafka.csproj
+++ b/framework/src/Volo.Abp.MultiQueue.Kafka/Volo.Abp.MultiQueue.Kafka.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<Import Project="..\..\..\configureawait.props" />
+	<Import Project="..\..\..\common.props" />
+
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
+		<!--<Nullable>enable</Nullable>-->
+		<!--<WarningsAsErrors>Nullable</WarningsAsErrors>-->
+		<AssemblyName>Volo.Abp.MultiQueue.Kafka</AssemblyName>
+		<PackageId>Volo.Abp.MultiQueue.Kafka</PackageId>
+		<AssetTargetFallback>$(AssetTargetFallback);portable-net45+win8+wp8+wpa81;</AssetTargetFallback>
+		<GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+		<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+		<GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+		<RootNamespace />
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Confluent.Kafka" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Volo.Abp.MultiQueue\Volo.Abp.MultiQueue.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/framework/src/Volo.Abp.MultiQueue.Kafka/Volo/Abp/MultiQueue/Kafka/AbpMultiQueueKafkaModule.cs
+++ b/framework/src/Volo.Abp.MultiQueue.Kafka/Volo/Abp/MultiQueue/Kafka/AbpMultiQueueKafkaModule.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Volo.Abp.Modularity;
+using Volo.Abp.MultiQueue.Publisher;
+using Volo.Abp.MultiQueue.Subscriber;
+
+namespace Volo.Abp.MultiQueue.Kafka;
+
+[DependsOn(typeof(AbpMultiQueueModule))]
+public class AbpMultiQueueKafkaModule : AbpMultiQueueModuleBase<KafkaQueueOptions>
+{
+    protected override (Type ServiceType, Type ImplementationType) GetQueuePublisherType(Type optionsType)
+    {
+        var implementationType = typeof(KafkaQueuePublisher<>).MakeGenericType(optionsType);
+        var serviceType = typeof(IQueuePublisher<>).MakeGenericType(optionsType);
+        return (serviceType, implementationType);
+    }
+
+    protected override (Type ServiceType, Type ImplementationType) GetQueueSubscriberType(Type optionType)
+    {
+        var implementationType = typeof(KafkaQueueSubscriber<>).MakeGenericType(optionType);
+        var serviceType = typeof(IQueueSubscriber<>).MakeGenericType(optionType);
+        return (serviceType, implementationType);
+    }
+}

--- a/framework/src/Volo.Abp.MultiQueue.Kafka/Volo/Abp/MultiQueue/Kafka/KafkaQueueOptions.cs
+++ b/framework/src/Volo.Abp.MultiQueue.Kafka/Volo/Abp/MultiQueue/Kafka/KafkaQueueOptions.cs
@@ -1,0 +1,22 @@
+﻿using Confluent.Kafka;
+using Volo.Abp.MultiQueue.Options;
+
+namespace Volo.Abp.MultiQueue.Kafka;
+
+[QueueOptionsType("Kafka")]
+public class KafkaQueueOptions : QueueOptions, IQueueOptions
+{
+    public virtual string Address { get; set; }
+
+    public virtual string GroupId { get; set; }
+
+    public virtual string UserName { get; set; }
+
+    public virtual string Password { get; set; }
+
+    public virtual int? MessageMaxBytes { get; set; }
+
+    public virtual SecurityProtocol? SecurityProtocol { get; set; }
+
+    public virtual SaslMechanism? SaslMechanism { get; set; }
+}

--- a/framework/src/Volo.Abp.MultiQueue.Kafka/Volo/Abp/MultiQueue/Kafka/KafkaQueuePublisher.cs
+++ b/framework/src/Volo.Abp.MultiQueue.Kafka/Volo/Abp/MultiQueue/Kafka/KafkaQueuePublisher.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Threading.Tasks;
+using Confluent.Kafka;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using Volo.Abp.MultiQueue.Publisher;
+
+namespace Volo.Abp.MultiQueue.Kafka;
+
+public class KafkaQueuePublisher<TOptions> : IQueuePublisher<TOptions> where TOptions : KafkaQueueOptions
+{
+    private readonly IOptions<TOptions> _options;
+    private readonly IProducer<Null, byte[]> _producer;
+
+    protected TOptions Options => _options.Value;
+    protected ILogger Logger { get; }
+
+    public KafkaQueuePublisher(ILogger<KafkaQueuePublisher<TOptions>> logger, IOptions<TOptions> options)
+    {
+        Logger = logger;
+        _options = options;
+        _producer = GetProducer();
+    }
+
+    public async Task PublishAsync(string topic, object data)
+    {
+        if (data == null) return;
+
+        try
+        {
+            byte[] pubData = ToByteData(data);
+            if (pubData == null) return;
+
+            await _producer.ProduceAsync(topic, new Message<Null, byte[]> { Value = pubData });
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Kafka PublishAsync Error");
+            throw;
+        }
+    }
+
+    public async Task BatchPublishAsync(string topic, object[] data)
+    {
+        try
+        {
+            foreach (var item in data)
+            {
+                byte[] pubData = ToByteData(item);
+                if (pubData == null) continue;
+
+                _producer.Produce(topic, new Message<Null, byte[]> { Value = pubData });
+            }
+            _producer.Flush(TimeSpan.FromSeconds(10));
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Kafka BatchPublishAsync Error");
+            throw;
+        }
+        await Task.CompletedTask;
+    }
+
+    protected virtual byte[] ToByteData(object data)
+    {
+        byte[] pubData = null;
+        if (data is byte[] byteData)
+        {
+            pubData = byteData;
+        }
+        else if (data is string strData)
+        {
+            pubData = System.Text.Encoding.UTF8.GetBytes(strData);
+        }
+        else
+        {
+            string jsonOrVal = null;
+            try
+            {
+                jsonOrVal = JsonConvert.SerializeObject(data);
+            }
+            catch
+            {
+                jsonOrVal = data.ToString();
+            }
+
+            if (jsonOrVal != null)
+                pubData = System.Text.Encoding.UTF8.GetBytes(jsonOrVal);
+        }
+
+        return pubData;
+    }
+
+    protected virtual ProducerConfig GetConfig()
+    {
+        var config = new ProducerConfig
+        {
+            BootstrapServers = Options.Address,
+            SaslUsername = Options.UserName,
+            SaslPassword = Options.Password,
+            MessageMaxBytes = Options.MessageMaxBytes,
+            SecurityProtocol = Options.SecurityProtocol,
+            SaslMechanism = Options.SaslMechanism
+        };
+        return config;
+    }
+
+    protected virtual IProducer<Null, byte[]> GetProducer()
+    {
+        var config = GetConfig();
+        return new ProducerBuilder<Null, byte[]>(config).Build();
+    }
+
+    public void Dispose()
+    {
+        if (_producer != null)
+            _producer.Dispose();
+    }
+}

--- a/framework/src/Volo.Abp.MultiQueue.Kafka/Volo/Abp/MultiQueue/Kafka/KafkaQueueSubscriber.cs
+++ b/framework/src/Volo.Abp.MultiQueue.Kafka/Volo/Abp/MultiQueue/Kafka/KafkaQueueSubscriber.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Confluent.Kafka;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Volo.Abp.EventBus.Local;
+using Volo.Abp.MultiQueue.Options;
+using Volo.Abp.MultiQueue.Subscriber;
+
+namespace Volo.Abp.MultiQueue.Kafka;
+
+public class KafkaQueueSubscriber<TQueueOptions> : QueueSubscriber<TQueueOptions> where TQueueOptions : class, IQueueOptions
+{
+    private readonly IOptions<TQueueOptions> _options;
+    private readonly ILocalEventBus _localEventBus;
+
+    protected TQueueOptions Options => _options.Value;
+
+    public KafkaQueueSubscriber(IServiceProvider serviceProvider, IOptions<TQueueOptions> options, ILocalEventBus localEventBus) : base(serviceProvider)
+    {
+        _options = options;
+        _localEventBus = localEventBus;
+    }
+    protected virtual IConsumer<Ignore, byte[]> GetConsumer(TQueueOptions options)
+    {
+        if (options is KafkaQueueOptions kafkaQueueOptions)
+        {
+            if (string.IsNullOrWhiteSpace(kafkaQueueOptions.GroupId))
+                throw new ArgumentNullException($"[GroupId] can`t  null or empty.");
+
+            if (string.IsNullOrWhiteSpace(kafkaQueueOptions.Address))
+                throw new ArgumentNullException($"[Address] can`t  null or empty.");
+
+            var consumer = new ConsumerBuilder<Ignore, byte[]>(new ConsumerConfig
+            {
+                BootstrapServers = kafkaQueueOptions.Address,
+                GroupId = kafkaQueueOptions.GroupId,
+                SaslUsername = kafkaQueueOptions.UserName,
+                SaslPassword = kafkaQueueOptions.Password
+
+            }).Build();
+            return consumer;
+        }
+        throw new ArgumentException("Options must be [KafkaQueueOptions]");
+    }
+
+    protected override async Task StartQueueAsync(CancellationToken cancellationToken = default)
+    {
+        var consumer = GetConsumer(Options);
+        consumer.Subscribe(EventMap.Keys);
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var consumeResult = consumer.Consume(cancellationToken);
+            if (consumeResult == null) continue;
+            if (consumeResult.IsPartitionEOF) continue;
+
+            if (EventMap.TryGetValue(consumeResult.Topic, out var eventType))
+            {
+                try
+                {
+                    var data = Activator.CreateInstance(eventType) as IQueueResult;
+                    data.Time = consumeResult.Message.Timestamp.UtcDateTime.ToLocalTime();
+                    data.Source = "Kafka";
+
+                    var setDataFunc = eventType.GetMethod("SetData", BindingFlags.Instance | BindingFlags.NonPublic);
+                    setDataFunc.Invoke(data, new object[] { consumeResult.Message.Value });
+
+                    await _localEventBus.PublishAsync(eventType, data);
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError(ex, "Kafka SubscribeAsync Error");
+                }
+            }
+        }
+    }
+}

--- a/framework/src/Volo.Abp.MultiQueue/Volo.Abp.MultiQueue.csproj
+++ b/framework/src/Volo.Abp.MultiQueue/Volo.Abp.MultiQueue.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<Import Project="..\..\..\configureawait.props" />
+	<Import Project="..\..\..\common.props" />
+
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
+		<!--<Nullable>enable</Nullable>-->
+		<!--<WarningsAsErrors>Nullable</WarningsAsErrors>-->
+		<AssemblyName>Volo.Abp.MultiQueue</AssemblyName>
+		<PackageId>Volo.Abp.MultiQueue</PackageId>
+		<AssetTargetFallback>$(AssetTargetFallback);portable-net45+win8+wp8+wpa81;</AssetTargetFallback>
+		<GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+		<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+		<GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+		<RootNamespace />
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Newtonsoft.Json" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Volo.Abp.Core\Volo.Abp.Core.csproj" />
+		<ProjectReference Include="..\Volo.Abp.EventBus\Volo.Abp.EventBus.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/framework/src/Volo.Abp.MultiQueue/Volo/Abp/MultiQueue/AbpMultiQueueConst.cs
+++ b/framework/src/Volo.Abp.MultiQueue/Volo/Abp/MultiQueue/AbpMultiQueueConst.cs
@@ -1,0 +1,5 @@
+﻿namespace Volo.Abp.MultiQueue;
+public static class AbpMultiQueueConst
+{
+    public const string ConfigurationKey = "MultiQueue";
+}

--- a/framework/src/Volo.Abp.MultiQueue/Volo/Abp/MultiQueue/AbpMultiQueueFactory.cs
+++ b/framework/src/Volo.Abp.MultiQueue/Volo/Abp/MultiQueue/AbpMultiQueueFactory.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.MultiQueue.Options;
+using Volo.Abp.MultiQueue.Publisher;
+using Volo.Abp.MultiQueue.Subscriber;
+
+namespace Volo.Abp.MultiQueue;
+
+public interface IAbpMultiQueueFactory : ISingletonDependency
+{
+    /// <summary>
+    /// 获取Queue发布者
+    /// </summary>
+    /// <param name="key"></param>
+    /// <returns></returns>
+    IQueuePublisher GetPublisher(string key);
+
+    /// <summary>
+    /// 获取Queue订阅者
+    /// </summary>
+    /// <param name="key"></param>
+    /// <returns></returns>
+    IQueueSubscriber GetSubscriber(string key);
+}
+
+public class AbpMultiQueueFactory : IAbpMultiQueueFactory
+{
+    protected IServiceProvider ServiceProvider { get; }
+
+    public AbpMultiQueueFactory(IServiceProvider serviceProvider)
+    {
+        ServiceProvider = serviceProvider;
+    }
+
+    public IQueuePublisher GetPublisher(string key)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+            throw new ArgumentNullException("Key is not null or empty.");
+
+        var optionType = QueueOptionsExtension.GetOptionType(key);
+        if (optionType == null) return null;
+
+        var type = typeof(IQueuePublisher<>).MakeGenericType(optionType);
+        var publisher = ServiceProvider.GetRequiredService(type) as IQueuePublisher;
+        return publisher;
+    }
+
+    public IQueueSubscriber GetSubscriber(string key)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+            throw new ArgumentNullException("Key is not null or empty.");
+
+        var optionType = QueueOptionsExtension.GetOptionType(key);
+        if (optionType == null) return null;
+
+        var type = typeof(IQueueSubscriber<>).MakeGenericType(optionType);
+        var subscriber = ServiceProvider.GetRequiredService(type) as IQueueSubscriber;
+        return subscriber;
+    }
+}

--- a/framework/src/Volo.Abp.MultiQueue/Volo/Abp/MultiQueue/AbpMultiQueueModule.cs
+++ b/framework/src/Volo.Abp.MultiQueue/Volo/Abp/MultiQueue/AbpMultiQueueModule.cs
@@ -1,0 +1,107 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Volo.Abp.EventBus;
+using Volo.Abp.Modularity;
+using Volo.Abp.MultiQueue.Options;
+using Volo.Abp.MultiQueue.Subscriber;
+using Volo.Abp.Threading;
+
+
+namespace Volo.Abp.MultiQueue;
+
+[DependsOn(typeof(AbpEventBusModule))]
+public class AbpMultiQueueModule : AbpModule
+{
+    private readonly List<QueueHandlerAttribute> _needSubTopic;
+    public AbpMultiQueueModule()
+    {
+        _needSubTopic = new List<QueueHandlerAttribute>();
+    }
+
+    public override void PostConfigureServices(ServiceConfigurationContext context)
+    {
+        context.Services.OnRegistered((c) =>
+        {
+            if (typeof(IEventHandler).IsAssignableFrom(c.ImplementationType))
+            {
+                var attr = c.ImplementationType.GetCustomAttribute<QueueHandlerAttribute>();
+                if (attr != null)
+                {
+                    _needSubTopic.Add(attr);
+                }
+            }
+        });
+    }
+
+
+    public override void OnApplicationInitialization(ApplicationInitializationContext context)
+    {
+        AsyncHelper.RunSync(() => OnApplicationInitializationAsync(context));
+    }
+
+    public override async Task OnApplicationInitializationAsync(ApplicationInitializationContext context)
+    {
+        var queueFactory = context.ServiceProvider.GetRequiredService<IAbpMultiQueueFactory>();
+        foreach (var item in _needSubTopic)
+        {
+            var subscriber = queueFactory.GetSubscriber(item.Key);
+            if (subscriber != null)
+            {
+                await subscriber.SubscribeAsync(item.Topic, item.EventType);
+            }
+            else
+            {
+                var logger = context.ServiceProvider.GetRequiredService<ILogger<AbpMultiQueueModule>>();
+                logger.LogWarning($"Subscriber is null or empty. Key->[{item.Key}]");
+            }
+        }
+    }
+
+    public override void OnPostApplicationInitialization(ApplicationInitializationContext context)
+    {
+        var optionKeys = QueueOptionsExtension.QueueOptionsTypeMap.Keys;
+        if (optionKeys != null && optionKeys.Count > 0)
+        {
+            foreach (var optionKey in optionKeys)
+            {
+                var optionType = QueueOptionsExtension.GetOptionType(optionKey);
+                if (optionType != null)
+                {
+                    var type = typeof(IQueueSubscriber<>).MakeGenericType(optionType);
+                    var sub = context.ServiceProvider.GetService(type) as IQueueSubscriber;
+
+                    if (sub != null)
+                    {
+                        sub.Start();
+                    }
+                }
+            }
+        }
+    }
+
+    public override void OnApplicationShutdown(ApplicationShutdownContext context)
+    {
+        var optionsContainer = context.ServiceProvider.GetRequiredService<IOptions<QueueOptionsContainer>>();
+        if (optionsContainer.Value.Options != null && optionsContainer.Value.Options.Count > 0)
+        {
+            foreach (var item in optionsContainer.Value.Options)
+            {
+                var optionType = QueueOptionsExtension.GetOptionType(item.Key);
+                if (optionType != null)
+                {
+                    var type = typeof(IQueueSubscriber<>).MakeGenericType(optionType);
+                    var sub = context.ServiceProvider.GetService(type) as IQueueSubscriber;
+
+                    if (sub != null)
+                    {
+                        sub.Stop();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/framework/src/Volo.Abp.MultiQueue/Volo/Abp/MultiQueue/AbpMultiQueueModuleBase.cs
+++ b/framework/src/Volo.Abp.MultiQueue/Volo/Abp/MultiQueue/AbpMultiQueueModuleBase.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json.Linq;
+using Volo.Abp.Modularity;
+using Volo.Abp.MultiQueue.Options;
+
+namespace Volo.Abp.MultiQueue;
+
+[DependsOn(typeof(AbpMultiQueueModule))]
+public abstract class AbpMultiQueueModuleBase<TOptionsType> : AbpModule where TOptionsType : class, IQueueOptions
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        var attr = typeof(TOptionsType).GetCustomAttribute<QueueOptionsTypeAttribute>();
+        if (attr != null && !string.IsNullOrWhiteSpace(attr.Type))
+        {
+            var options = context.Services.ExecutePreConfiguredActions<QueueOptionsContainer>();
+            var useOptions = options.Options.Where(p => p.Value.QueueType.ToLower() == attr.Type.ToLower()).ToArray();
+            if (useOptions.Length > 0)
+            {
+                MethodInfo configureOptionsMethod = GetType().GetMethod(nameof(ConfigureOptions), BindingFlags.Instance | BindingFlags.NonPublic);
+                foreach (var item in useOptions)
+                {
+                    // 注册Options
+                    var optionType = QueueOptionsExtension.GetOrCreateOptionType<TOptionsType>(item.Key);
+                    object optionsVal = null;
+                    if (item.Value.Options is IQueueOptions)
+                    {
+                        optionsVal = item.Value.Options;
+                    }
+                    else if (item.Value.Options is JToken jToken)
+                    {
+                        optionsVal = jToken.ToObject(optionType);
+                    }
+
+                    if (optionsVal != null)
+                    {
+                        configureOptionsMethod.MakeGenericMethod(optionType).Invoke(this, new object[] { optionsVal });
+                    }
+
+                    var publisherType = GetQueuePublisherType(optionType);
+                    var subscriberType = GetQueueSubscriberType(optionType);
+
+                    RegisterPublisher(context, publisherType.ServiceType, publisherType.ImplementationType);
+                    RegisterSubscriber(context, subscriberType.ServiceType, subscriberType.ImplementationType);
+                }
+            }
+        }
+    }
+
+    protected void ConfigureOptions<T>(IQueueOptions options) where T : class, TOptionsType
+    {
+        Configure<T>((opt) =>
+        {
+            SetOptionsVal(options, opt);
+        });
+    }
+
+    protected void SetOptionsVal(object source, object target)
+    {
+        var sourceType = source.GetType();
+        var targetType = target.GetType();
+
+
+        if (sourceType.IsAssignableFrom(targetType))
+        {
+            var props = source.GetType().GetProperties();
+            foreach (var prop in props)
+            {
+                if (prop.CanWrite)
+                    prop.SetValue(target, prop.GetValue(source));
+            }
+        }
+    }
+
+    protected abstract (Type ServiceType, Type ImplementationType) GetQueuePublisherType(Type optionsType);
+
+    protected abstract (Type ServiceType, Type ImplementationType) GetQueueSubscriberType(Type optionType);
+
+    protected virtual void RegisterPublisher(ServiceConfigurationContext context, Type serviceType, Type implType)
+    {
+        context.Services.AddSingleton(serviceType, implType);
+    }
+
+    protected virtual void RegisterSubscriber(ServiceConfigurationContext context, Type serviceType, Type implType)
+    {
+        context.Services.AddSingleton(serviceType, implType);
+    }
+}

--- a/framework/src/Volo.Abp.MultiQueue/Volo/Abp/MultiQueue/Options/QueueOptions.cs
+++ b/framework/src/Volo.Abp.MultiQueue/Volo/Abp/MultiQueue/Options/QueueOptions.cs
@@ -1,0 +1,5 @@
+﻿namespace Volo.Abp.MultiQueue.Options;
+
+public interface IQueueOptions { }
+
+public class QueueOptions : IQueueOptions { }

--- a/framework/src/Volo.Abp.MultiQueue/Volo/Abp/MultiQueue/Options/QueueOptionsContainer.cs
+++ b/framework/src/Volo.Abp.MultiQueue/Volo/Abp/MultiQueue/Options/QueueOptionsContainer.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+
+namespace Volo.Abp.MultiQueue.Options;
+public class QueueOptionsContainer
+{
+    public QueueOptionsContainer()
+    {
+        Options = new Dictionary<string, QueueOptionsWarp>();
+    }
+
+    public Dictionary<string, QueueOptionsWarp> Options { get; set; }
+
+    public void AddOptions(QueueOptionsWarp options)
+    {
+        if (!Options.ContainsKey(options.Key))
+        {
+            Options.Add(options.Key, options);
+        }
+    }
+}

--- a/framework/src/Volo.Abp.MultiQueue/Volo/Abp/MultiQueue/Options/QueueOptionsExtension.cs
+++ b/framework/src/Volo.Abp.MultiQueue/Volo/Abp/MultiQueue/Options/QueueOptionsExtension.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json.Linq;
+
+namespace Volo.Abp.MultiQueue.Options;
+public static class QueueOptionsExtension
+{
+    internal readonly static Dictionary<string, Type> QueueOptionsTypeMap = new Dictionary<string, Type>();
+
+    public static Type GetOptionType(string key)
+    {
+        QueueOptionsTypeMap.TryGetValue(key, out var type);
+        return type;
+    }
+
+    public static Type GetOrCreateOptionType<TQueueOptions>(string key) where TQueueOptions : class, IQueueOptions
+    {
+        var type = GetOptionType(key);
+        if (type == null)
+        {
+            AssemblyName assemblyName = new AssemblyName("Volo.Abp.MultiQueue.Options");
+            AssemblyBuilder dyAssembly = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.RunAndCollect);
+
+            ModuleBuilder dyModule = dyAssembly.DefineDynamicModule("DynamicOptions");
+
+            TypeBuilder dyClass = dyModule.DefineType($"{key}QueueOptions", TypeAttributes.Public | TypeAttributes.Serializable | TypeAttributes.Class | TypeAttributes.AutoClass, typeof(TQueueOptions), new Type[] { typeof(IQueueOptions) });
+
+            type = dyClass.CreateTypeInfo();
+            QueueOptionsTypeMap.Add(key, type);
+        };
+        return type;
+    }
+
+    public static JToken GetOptions(IConfigurationSection config)
+    {
+        JObject obj = new JObject();
+        var children = config.GetChildren();
+        foreach (var child in children)
+        {
+            obj.Add(child.Key, GetOptions(child));
+        }
+
+        if (!obj.HasValues && config is IConfigurationSection section)
+            return new JValue(section.Value);
+
+        return obj;
+    }
+
+    public static List<QueueOptionsWarp> GetQueueOptions(IConfigurationSection config)
+    {
+        var jToken = GetOptions(config);
+        var options = jToken.ToObject<Dictionary<string, QueueOptionsWarp>>();
+
+        if (options == null)
+            options = new Dictionary<string, QueueOptionsWarp>();
+
+        if (options != null && options.Count > 0)
+        {
+            foreach (var item in options)
+            {
+                item.Value.Key = item.Key;
+            }
+        }
+        return options.Select(p => p.Value).ToList();
+    }
+}

--- a/framework/src/Volo.Abp.MultiQueue/Volo/Abp/MultiQueue/Options/QueueOptionsTypeAttribute.cs
+++ b/framework/src/Volo.Abp.MultiQueue/Volo/Abp/MultiQueue/Options/QueueOptionsTypeAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Volo.Abp.MultiQueue.Options;
+
+public class QueueOptionsTypeAttribute : Attribute
+{
+    public QueueOptionsTypeAttribute(string type)
+    {
+        Type = type;
+    }
+    public string Type { get; set; }
+}

--- a/framework/src/Volo.Abp.MultiQueue/Volo/Abp/MultiQueue/Options/QueueOptionsWarp.cs
+++ b/framework/src/Volo.Abp.MultiQueue/Volo/Abp/MultiQueue/Options/QueueOptionsWarp.cs
@@ -1,0 +1,19 @@
+﻿namespace Volo.Abp.MultiQueue.Options;
+
+public class QueueOptionsWarp
+{
+    /// <summary>
+    /// 唯一键
+    /// </summary>
+    public string Key { get; set; }
+
+    /// <summary>
+    /// 管道类型
+    /// </summary>
+    public string QueueType { get; set; }
+
+    /// <summary>
+    /// 配置
+    /// </summary>
+    public object Options { get; set; }
+}

--- a/framework/src/Volo.Abp.MultiQueue/Volo/Abp/MultiQueue/Publisher/IQueuePublisher.cs
+++ b/framework/src/Volo.Abp.MultiQueue/Volo/Abp/MultiQueue/Publisher/IQueuePublisher.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Threading.Tasks;
+using Volo.Abp.MultiQueue.Options;
+
+namespace Volo.Abp.MultiQueue.Publisher;
+
+
+public interface IQueuePublisher : IDisposable
+{
+    /// <summary>
+    /// 发布
+    /// </summary>
+    /// <param name="topic"></param>
+    /// <param name="data"></param>
+    /// <returns></returns>
+    Task PublishAsync(string topic, object data);
+
+    /// <summary>
+    /// 批量发布
+    /// </summary>
+    /// <param name="topic"></param>
+    /// <param name="data"></param>
+    /// <returns></returns>
+    Task BatchPublishAsync(string topic, object[] data);
+}
+
+public interface IQueuePublisher<TQueueOptions> : IQueuePublisher where TQueueOptions : IQueueOptions
+{
+
+}

--- a/framework/src/Volo.Abp.MultiQueue/Volo/Abp/MultiQueue/Subscriber/IQueueSubscriber.cs
+++ b/framework/src/Volo.Abp.MultiQueue/Volo/Abp/MultiQueue/Subscriber/IQueueSubscriber.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Threading.Tasks;
+using Volo.Abp.MultiQueue.Options;
+
+namespace Volo.Abp.MultiQueue.Subscriber;
+
+public interface IQueueSubscriber
+{
+    /// <summary>
+    /// 启动管道
+    /// </summary>
+    /// <returns></returns>
+    void Start();
+
+    /// <summary>
+    /// 停止管道
+    /// </summary>
+    /// <returns></returns>
+    void Stop();
+
+    /// <summary>
+    /// 订阅
+    /// </summary>
+    /// <param name="topic"></param>
+    /// <param name="type"></param>
+    /// <returns></returns>
+    Task SubscribeAsync(string topic, Type type);
+
+    /// <summary>
+    /// 订阅
+    /// </summary>
+    /// <typeparam name="TQueueResult"></typeparam>
+    /// <param name="topic"></param>
+    /// <returns></returns>
+    Task SubscribeAsync<TQueueResult>(string topic) where TQueueResult : class, IQueueResult;
+
+    /// <summary>
+    /// 取消订阅
+    /// </summary>
+    /// <param name="topic">Topic</param>
+    /// <returns></returns>
+    Task UnSubscribeAsync(string topic);
+}
+
+public interface IQueueSubscriber<TQueueOptions> : IQueueSubscriber where TQueueOptions : IQueueOptions
+{
+
+}

--- a/framework/src/Volo.Abp.MultiQueue/Volo/Abp/MultiQueue/Subscriber/QueueHandlerAttribute.cs
+++ b/framework/src/Volo.Abp.MultiQueue/Volo/Abp/MultiQueue/Subscriber/QueueHandlerAttribute.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Volo.Abp.MultiQueue.Subscriber;
+
+public class QueueHandlerAttribute : Attribute
+{
+    public string Key { get; }
+
+    public string Topic { get; }
+
+    public Type EventType { get; }
+
+    public QueueHandlerAttribute(string key, string topic, Type eventType)
+    {
+        Key = key;
+        Topic = topic;
+        EventType = eventType;
+    }
+}

--- a/framework/src/Volo.Abp.MultiQueue/Volo/Abp/MultiQueue/Subscriber/QueueResult.cs
+++ b/framework/src/Volo.Abp.MultiQueue/Volo/Abp/MultiQueue/Subscriber/QueueResult.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using Newtonsoft.Json;
+using System.Text;
+
+namespace Volo.Abp.MultiQueue.Subscriber;
+
+public interface IQueueResult
+{
+    public string Source { get; set; }
+
+    public DateTime Time { get; set; }
+}
+
+public abstract class QueueResult : IQueueResult
+{
+    public string Source { get; set; }
+    public DateTime Time { get; set; }
+}
+
+public abstract class QueueResult<TObj> : QueueResult
+{
+    public TObj Data { get; private set; }
+
+    protected void SetData(byte[] data)
+    {
+        Data = DeData(data);
+    }
+
+    protected abstract TObj DeData(byte[] data);
+}
+
+/// <summary>
+/// 原始返回值
+/// </summary>
+public class OriginalEventData : QueueResult<byte[]>
+{
+    protected override byte[] DeData(byte[] data)
+    {
+        return data;
+    }
+}
+
+/// <summary>
+/// JSON返回值
+/// </summary>
+/// <typeparam name="TObj"></typeparam>
+public class JsonQueueResult<TObj> : QueueResult<TObj>
+{
+    protected override TObj DeData(byte[] data)
+    {
+        return JsonConvert.DeserializeObject<TObj>(Encoding.UTF8.GetString(data));
+    }
+}

--- a/framework/src/Volo.Abp.MultiQueue/Volo/Abp/MultiQueue/Subscriber/QueueSubscriber.cs
+++ b/framework/src/Volo.Abp.MultiQueue/Volo/Abp/MultiQueue/Subscriber/QueueSubscriber.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Volo.Abp.MultiQueue.Options;
+
+namespace Volo.Abp.MultiQueue.Subscriber;
+
+public abstract class QueueSubscriber<TQueueOptions> : IQueueSubscriber<TQueueOptions> where TQueueOptions : class, IQueueOptions
+{
+    protected ConcurrentDictionary<string, Type> EventMap { get; set; }
+    protected IServiceProvider ServiceProvider { get; set; }
+    protected ILogger Logger { get; set; }
+
+    private readonly CancellationTokenSource _cancellationTokenSource;
+
+
+    public QueueSubscriber(IServiceProvider serviceProvider)
+    {
+        ServiceProvider = serviceProvider;
+        Logger = serviceProvider.GetRequiredService<ILogger<QueueSubscriber<TQueueOptions>>>();
+        EventMap = new ConcurrentDictionary<string, Type>();
+        _cancellationTokenSource = new CancellationTokenSource();
+    }
+
+    public virtual void Start()
+    {
+        Task.Factory.StartNew(() =>
+        {
+            try
+            {
+                StartQueueAsync(_cancellationTokenSource.Token);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Pipeline startup failed");
+                throw;
+            }
+
+        }, _cancellationTokenSource.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+    }
+
+    public virtual void Stop()
+    {
+        _cancellationTokenSource.Cancel();
+    }
+
+    protected abstract Task StartQueueAsync(CancellationToken cancellationToken = default);
+
+    public virtual Task SubscribeAsync(string topic, Type type)
+    {
+        if (!type.IsAbstract && typeof(IQueueResult).IsAssignableFrom(type))
+        {
+            EventMap.TryAdd(topic, type);
+        }
+        return Task.CompletedTask;
+    }
+
+    public virtual Task SubscribeAsync<TQueueResult>(string topic) where TQueueResult : class, IQueueResult
+    {
+        return SubscribeAsync(topic, typeof(TQueueResult));
+    }
+
+    public virtual Task UnSubscribeAsync(string topic)
+    {
+        EventMap.TryRemove(topic, out _);
+        return Task.CompletedTask;
+    }
+}

--- a/framework/test/Volo.Abp.MultiQueue.Tests/Volo.Abp.MultiQueue.Tests.abppkg
+++ b/framework/test/Volo.Abp.MultiQueue.Tests/Volo.Abp.MultiQueue.Tests.abppkg
@@ -1,0 +1,3 @@
+{
+  "role": "lib.test"
+}

--- a/framework/test/Volo.Abp.MultiQueue.Tests/Volo.Abp.MultiQueue.Tests.csproj
+++ b/framework/test/Volo.Abp.MultiQueue.Tests/Volo.Abp.MultiQueue.Tests.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<Import Project="..\..\..\common.test.props" />
+
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<RootNamespace />
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Volo.Abp.Autofac\Volo.Abp.Autofac.csproj" />
+		<ProjectReference Include="..\..\src\Volo.Abp.MultiQueue\Volo.Abp.MultiQueue.csproj" />
+		<ProjectReference Include="..\..\src\Volo.Abp.MultiQueue.Kafka\Volo.Abp.MultiQueue.Kafka.csproj" />
+		<ProjectReference Include="..\AbpTestBase\AbpTestBase.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/framework/test/Volo.Abp.MultiQueue.Tests/Volo/Abp/MultiQueue/JsonReceiveHandler.cs
+++ b/framework/test/Volo.Abp.MultiQueue.Tests/Volo/Abp/MultiQueue/JsonReceiveHandler.cs
@@ -1,0 +1,21 @@
+﻿using System.Threading.Tasks;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.EventBus;
+using Volo.Abp.MultiQueue.Subscriber;
+
+namespace Volo.Abp.MultiQueue;
+
+[QueueHandler(MultiQueueTestConst.ConfigKey, MultiQueueTestConst.Topic, typeof(JsonQueueResult<ReceiveEventData>))]
+public class JsonReceiveHandler : ILocalEventHandler<JsonQueueResult<ReceiveEventData>>, ISingletonDependency
+{
+
+    public static ReceiveEventData Result;
+    public static int ReceiveCount;
+
+    public async Task HandleEventAsync(JsonQueueResult<ReceiveEventData> eventData)
+    {
+        ReceiveCount++;
+        Result = eventData.Data;
+        await Task.CompletedTask;
+    }
+}

--- a/framework/test/Volo.Abp.MultiQueue.Tests/Volo/Abp/MultiQueue/MultiQueueKafka_Tests.cs
+++ b/framework/test/Volo.Abp.MultiQueue.Tests/Volo/Abp/MultiQueue/MultiQueueKafka_Tests.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Threading.Tasks;
+using Volo.Abp.MultiQueue.Subscriber;
+using Xunit;
+
+namespace Volo.Abp.MultiQueue;
+public class MultiQueueKafka_Tests : MultiQueueTestBase
+{
+    [Fact]
+    public async Task Should_Pub_And_Receive()
+    {
+        var publisher = MultiQueueFactory.GetPublisher(MultiQueueTestConst.ConfigKey);
+        var subscriber = MultiQueueFactory.GetSubscriber(MultiQueueTestConst.ConfigKey);
+
+        await Task.Delay(10000); // 等待启动
+
+        Assert.NotNull(publisher);
+        Assert.NotNull(subscriber);
+
+        var id = Guid.NewGuid();
+        await publisher.PublishAsync(MultiQueueTestConst.Topic, new ReceiveEventData
+        {
+            Name = "Test",
+            Id = id
+        });
+
+        await Task.Delay(8000);
+
+        Assert.NotNull(JsonReceiveHandler.Result);
+
+        Assert.Equal(1, JsonReceiveHandler.ReceiveCount);
+        Assert.Equal(id, JsonReceiveHandler.Result.Id);
+        Assert.Equal("Test", JsonReceiveHandler.Result.Name);
+
+        var id2 = Guid.NewGuid();
+        await publisher.PublishAsync(MultiQueueTestConst.Topic, new ReceiveEventData
+        {
+            Name = "Test2",
+            Id = id2
+        });
+
+        await Task.Delay(8000);
+
+        Assert.NotNull(JsonReceiveHandler.Result);
+        Assert.Equal(2, JsonReceiveHandler.ReceiveCount);
+        Assert.Equal(id2, JsonReceiveHandler.Result.Id);
+        Assert.Equal("Test2", JsonReceiveHandler.Result.Name);
+
+        await publisher.PublishAsync(MultiQueueTestConst.Topic, new ReceiveEventData
+        {
+            Name = "Test",
+            Id = Guid.NewGuid()
+        });
+        await publisher.PublishAsync(MultiQueueTestConst.Topic, new ReceiveEventData
+        {
+            Name = "Test",
+            Id = Guid.NewGuid()
+        });
+        await publisher.PublishAsync(MultiQueueTestConst.Topic, new ReceiveEventData
+        {
+            Name = "Test",
+            Id = Guid.NewGuid()
+        });
+
+        await Task.Delay(8000);
+
+        Assert.Equal(5, JsonReceiveHandler.ReceiveCount);
+    }
+
+}

--- a/framework/test/Volo.Abp.MultiQueue.Tests/Volo/Abp/MultiQueue/MultiQueueTestBase.cs
+++ b/framework/test/Volo.Abp.MultiQueue.Tests/Volo/Abp/MultiQueue/MultiQueueTestBase.cs
@@ -1,0 +1,16 @@
+﻿using Volo.Abp.Testing;
+
+namespace Volo.Abp.MultiQueue;
+public class MultiQueueTestBase : AbpIntegratedTest<MultiQueueTestModule>
+{
+    protected IAbpMultiQueueFactory MultiQueueFactory { get; }
+    public MultiQueueTestBase()
+    {
+        MultiQueueFactory = GetRequiredService<IAbpMultiQueueFactory>();
+    }
+
+    protected override void SetAbpApplicationCreationOptions(AbpApplicationCreationOptions options)
+    {
+        options.UseAutofac();
+    }
+}

--- a/framework/test/Volo.Abp.MultiQueue.Tests/Volo/Abp/MultiQueue/MultiQueueTestConst.cs
+++ b/framework/test/Volo.Abp.MultiQueue.Tests/Volo/Abp/MultiQueue/MultiQueueTestConst.cs
@@ -1,0 +1,7 @@
+﻿namespace Volo.Abp.MultiQueue;
+public static class MultiQueueTestConst
+{
+    public const string ConfigKey = "Test";
+
+    public const string Topic = "MultiQueueTest";
+}

--- a/framework/test/Volo.Abp.MultiQueue.Tests/Volo/Abp/MultiQueue/MultiQueueTestModule.cs
+++ b/framework/test/Volo.Abp.MultiQueue.Tests/Volo/Abp/MultiQueue/MultiQueueTestModule.cs
@@ -1,0 +1,26 @@
+﻿using Volo.Abp.Modularity;
+using Volo.Abp.MultiQueue.Kafka;
+using Volo.Abp.MultiQueue.Options;
+
+namespace Volo.Abp.MultiQueue;
+
+[DependsOn(typeof(AbpTestBaseModule), typeof(AbpMultiQueueModule), typeof(AbpMultiQueueKafkaModule))]
+public class MultiQueueTestModule : AbpModule
+{
+    public override void PreConfigureServices(ServiceConfigurationContext context)
+    {
+        PreConfigure<QueueOptionsContainer>(options =>
+        {
+            options.AddOptions(new QueueOptionsWarp
+            {
+                Key = MultiQueueTestConst.ConfigKey,
+                QueueType = "Kafka",
+                Options = new KafkaQueueOptions
+                {
+                    Address = "server.dev.ai-care.top",
+                    GroupId = "abp-test",
+                }
+            });
+        });
+    }
+}

--- a/framework/test/Volo.Abp.MultiQueue.Tests/Volo/Abp/MultiQueue/ReceiveEventData.cs
+++ b/framework/test/Volo.Abp.MultiQueue.Tests/Volo/Abp/MultiQueue/ReceiveEventData.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Volo.Abp.MultiQueue;
+
+public class ReceiveEventData
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; }
+}


### PR DESCRIPTION
### Description

Added the MultiQueue functionality, allowing simultaneous connections to multiple Queue pipelines and using a Key to differentiate between different Queues. Also included a Kafka implementation for MultiQueue, enabling access to multiple Kafka pipelines, sending data to multiple Kafka instances, and listening to different topics across multiple Kafka streams.

### Checklist

- [x] Verified that sending and subscribing work correctly and created unit tests.

### How to test it?

```
public override void PreConfigureServices(ServiceConfigurationContext context)
{
    PreConfigure<QueueOptionsContainer>(options =>
    {
        options.AddOptions(new QueueOptionsWarp
        {
            Key = MultiQueueTestConst.ConfigKey,
            QueueType = "Kafka",
            Options = new KafkaQueueOptions
            {
                Address = "server.dev.ai-care.top",
                GroupId = "abp-test",
            }
        });
    });
}

```
You can add any pipeline here and configure it. The following example demonstrates how to use it:
```
var publisher = MultiQueueFactory.GetPublisher(MultiQueueTestConst.ConfigKey);
var subscriber = MultiQueueFactory.GetSubscriber(MultiQueueTestConst.ConfigKey);
```