### PR TITLE
Add ObjectHelper support for property resolution for nullable value types

### DIFF
--- a/framework/src/Volo.Abp.Core/Volo/Abp/ObjectHelper.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/ObjectHelper.cs
@@ -57,12 +57,17 @@ public static class ObjectHelper
                 return null;
             }
 
-
             var propertyInfo = obj?.GetType()
                 .GetProperties()
-                .FirstOrDefault(x => x.Name == memberExpression.Member.Name && x.GetSetMethod(true) != null);
+                .FirstOrDefault(x => x.Name == memberExpression.Member.Name);
 
             if (propertyInfo == null)
+            {
+                return null;
+            }
+
+            var propPrivateSetMethod = propertyInfo.GetSetMethod(true);
+            if (propPrivateSetMethod == null)
             {
                 return null;
             }

--- a/framework/src/Volo.Abp.Core/Volo/Abp/ObjectHelper.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/ObjectHelper.cs
@@ -9,8 +9,7 @@ namespace Volo.Abp;
 
 public static class ObjectHelper
 {
-    private static readonly ConcurrentDictionary<string, PropertyInfo?> CachedObjectProperties =
-        new ConcurrentDictionary<string, PropertyInfo?>();
+    private static readonly ConcurrentDictionary<string, PropertyInfo?> _cachedObjectProperties = new();
 
     public static void TrySetProperty<TObject, TValue>(
         TObject obj,
@@ -27,37 +26,53 @@ public static class ObjectHelper
         Func<TObject, TValue> valueFactory,
         params Type[]? ignoreAttributeTypes)
     {
-        var cacheKey = $"{obj?.GetType().FullName}-" +
-                       $"{propertySelector}-" +
-                       $"{(ignoreAttributeTypes != null ? "-" + string.Join("-", ignoreAttributeTypes.Select(x => x.FullName)) : "")}";
+        var cacheKey =
+            $"{obj?.GetType().FullName}-{propertySelector}-{(ignoreAttributeTypes != null ? "-" + string.Join("-", ignoreAttributeTypes.Select(x => x.FullName)) : "")}";
 
-        var property = CachedObjectProperties.GetOrAdd(cacheKey, () =>
+        var property = _cachedObjectProperties.GetOrAdd(cacheKey, PropertyFactory);
+
+        property?.SetValue(obj, valueFactory(obj));
+        return;
+
+        PropertyInfo? PropertyFactory(string _)
         {
-            if (propertySelector.Body.NodeType != ExpressionType.MemberAccess)
+            MemberExpression? memberExpression;
+            switch (propertySelector.Body.NodeType)
+            {
+                case ExpressionType.Convert: {
+                    memberExpression = propertySelector.Body.As<UnaryExpression>().Operand as MemberExpression;
+                    break;
+                }
+                case ExpressionType.MemberAccess: {
+                    memberExpression = propertySelector.Body.As<MemberExpression>();
+                    break;
+                }
+                default: {
+                    return null;
+                }
+            }
+
+            if (memberExpression == null)
             {
                 return null;
             }
 
-            var memberExpression = propertySelector.Body.As<MemberExpression>();
 
-            var propertyInfo = obj?.GetType().GetProperties().FirstOrDefault(x =>
-                x.Name == memberExpression.Member.Name &&
-                x.GetSetMethod(true) != null);
+            var propertyInfo = obj?.GetType()
+                .GetProperties()
+                .FirstOrDefault(x => x.Name == memberExpression.Member.Name && x.GetSetMethod(true) != null);
 
             if (propertyInfo == null)
             {
                 return null;
             }
 
-            if (ignoreAttributeTypes != null &&
-                ignoreAttributeTypes.Any(ignoreAttribute => propertyInfo.IsDefined(ignoreAttribute, true)))
+            if (ignoreAttributeTypes != null && ignoreAttributeTypes.Any(ignoreAttribute => propertyInfo.IsDefined(ignoreAttribute, true)))
             {
                 return null;
             }
 
             return propertyInfo;
-        });
-
-        property?.SetValue(obj, valueFactory(obj));
+        }
     }
 }

--- a/framework/test/Volo.Abp.Core.Tests/Volo/Abp/ObjectHelper_Tests.cs
+++ b/framework/test/Volo.Abp.Core.Tests/Volo/Abp/ObjectHelper_Tests.cs
@@ -39,6 +39,30 @@ public class ObjectHelper_Tests
         testClass.ChildClass.Name.ShouldBe("NewChildName");
     }
 
+    [Fact]
+    public void TrySetPropertyWithValueType_SetsCorrectly()
+    {
+        // Arrange
+        var testClass = new MyClass();
+        const long newValue = 10;
+
+        // Act & Assert
+        ObjectHelper.TrySetProperty(testClass, x => x.Number, () => newValue);
+        testClass.Number.ShouldBe(newValue);
+
+        ObjectHelper.TrySetProperty(testClass, x => x.Number2, () => newValue);
+        testClass.Number2.ShouldBe(newValue);
+
+        ObjectHelper.TrySetProperty(testClass, x => x.Number3, () => newValue);
+        testClass.Number3.ShouldBe(newValue);
+
+        ObjectHelper.TrySetProperty(testClass, x => x.Number4, () => newValue);
+        testClass.Number4.ShouldBe(0); // readonly
+
+        ObjectHelper.TrySetProperty(testClass, x => x.Number5, () => newValue, ignoreAttributeTypes: typeof(IgnoreDataMemberAttribute));
+        testClass.Number5.ShouldNotBe(newValue); // ignore by attribute
+    }
+
     class MyClass
     {
         public string Name { get; set; }
@@ -51,6 +75,17 @@ public class ObjectHelper_Tests
 
         [IgnoreDataMember]
         public string Name5 { get; }
+
+        public long Number { get; set; }
+
+        public long Number2 { get; protected set; }
+
+        public long Number3 { get; private set; }
+
+        public long Number4 { get; }
+
+        [IgnoreDataMember]
+        public long Number5 { get; }
 
         public MyChildClass ChildClass { get; set; }
 


### PR DESCRIPTION
### Description

I'm using an overriding AuditPropertySetter, that sets a `long CreatorId` (defined on new entity interfaces, not _IMust/MayHaveCreator_).

With this setup, ObjectHelper.TrySetProperty did not set that property, due to the member selector expression pointing to a value type.

This PR adds retro-compatible support for such an expression, with no breaking changes.

### Checklist

- [ x] I fully tested it as developer / designer and created unit / integration tests
- [ ] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

Created specific unit test.