### PR TITLE
Prettify toaster message, and refresh token without asking for logout

### DIFF
--- a/npm/ng-packs/packages/theme-shared/src/lib/components/toast/toast.component.scss
+++ b/npm/ng-packs/packages/theme-shared/src/lib/components/toast/toast.component.scss
@@ -49,6 +49,7 @@ $toastClass: abp-toast;
     position: relative;
     display: flex;
     align-self: center;
+    flex-direction: column;
     word-break: break-word;
     .#{$toastClass}-close-button {
       position: absolute;


### PR DESCRIPTION
Resolves #18975

i have prettified the toast message content. and add auto-token refresh ability.

can you also test the name input. when the name input changes, it must be reflected to toolbar.

![image](https://github.com/abpframework/abp/assets/72804437/5eb720b0-541e-4860-b7dd-2ee25facafc5)
