### PR TITLE
Add kestrel https url to VoloDocs sample.

### DIFF
--- a/modules/docs/app/VoloDocs.Web/appsettings.json
+++ b/modules/docs/app/VoloDocs.Web/appsettings.json
@@ -1,4 +1,11 @@
 {
+  "Kestrel": {
+    "EndPoints": {
+      "Https": {
+        "Url": "https://localhost:5001"
+      }
+    }
+  },
   "ConnectionString": "Server=localhost;Database=VoloDocs;Trusted_Connection=True;TrustServerCertificate=True",
   "ElasticSearch": {
     "Url": "http://localhost:9200"


### PR DESCRIPTION
Since we are publishing the VoloDocs sample project as in [the production mode as self-contained](https://github.com/abpframework/abp/blob/dev/modules/docs/app/VoloDocs.Web/publish.bat), it should work on HTTPS and this kestrel configuration ensures that. Otherwise, some errors occur due to running on HTTP in the production mode, (such as bundles being processed as document names).

I have already updated VoloDocs download links according to this configuration, so we don't need to update them again.