### PR TITLE
Avoid classes if input is hidden

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpInputTagHelperService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpInputTagHelperService.cs
@@ -54,19 +54,22 @@ public class AbpInputTagHelperService : AbpTagHelperService<AbpInputTagHelper>
             output.TagMode = TagMode.StartTagAndEndTag;
             output.TagName = "div";
             LeaveOnlyGroupAttributes(context, output);
-            if (TagHelper.FloatingLabel && !isCheckBox)
+            if (!IsOutputHidden(output))
             {
-                output.Attributes.AddClass("form-floating");
-            }
-            if (TagHelper.AddMarginBottomClass)
-            {
-                output.Attributes.AddClass(isCheckBox ? "mb-2" : "mb-3");
-            }
-            if (isCheckBox)
-            {
-                output.Attributes.AddClass("custom-checkbox");
-                output.Attributes.AddClass("custom-control");
-                output.Attributes.AddClass("form-check");
+                if (TagHelper.FloatingLabel && !isCheckBox)
+                {
+                    output.Attributes.AddClass("form-floating");
+                }
+                if (TagHelper.AddMarginBottomClass)
+                {
+                    output.Attributes.AddClass(isCheckBox ? "mb-2" : "mb-3");
+                }
+                if (isCheckBox)
+                {
+                    output.Attributes.AddClass("custom-checkbox");
+                    output.Attributes.AddClass("custom-control");
+                    output.Attributes.AddClass("form-check");
+                }
             }
             output.Content.AppendHtml(innerHtml);
         }
@@ -263,7 +266,7 @@ public class AbpInputTagHelperService : AbpTagHelperService<AbpInputTagHelper>
     }
 
     protected virtual async Task<string> GetLabelAsHtmlAsync(TagHelperContext context, TagHelperOutput output, TagHelperOutput inputTag, bool isCheckbox)
-    {
+    {        
         if (IsOutputHidden(inputTag) || TagHelper.SuppressLabel)
         {
             return string.Empty;


### PR DESCRIPTION
### Description

Resolves [#19128](https://github.com/abpframework/abp/issues/19128)

This will avoid adding extra classes if the input generated by AbpTagHelper is hidden.

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

