### PR TITLE
set default `className` if `group.name` doesn't defined in prop

### DIFF
--- a/npm/ng-packs/packages/components/extensible/src/lib/models/form-props.ts
+++ b/npm/ng-packs/packages/components/extensible/src/lib/models/form-props.ts
@@ -29,6 +29,7 @@ export interface FormPropGroup {
 
 export class GroupedFormPropList<R = any> {
   public readonly items: GroupedFormPropItem[] = [];
+  count = 1;
   addItem(item: FormProp<R>) {
     const groupName = item.group?.name;
     let group = this.items.find(i => i.group?.name === groupName);
@@ -37,7 +38,7 @@ export class GroupedFormPropList<R = any> {
     } else {
       group = {
         formPropList: new FormPropList(),
-        group: item.group,
+        group: item.group || { name: `default${this.count++}`, className: item.group?.className },
       };
       group.formPropList.addHead(item);
       this.items.push(group);


### PR DESCRIPTION
**`GroupedFormPropList`** class was grouping under the `undefined` object if `group.name` wasn't defined in prop.

This pr sets a default className for prop if `group.name` is undefined.

## Note

> Edited by @masumulu28 

We will try to manage input order (with and without group) `adding group property`, if it's not possible we'll accept this default behavior. 