### PR TITLE
Remove obsolete codes for Exception

### DIFF
--- a/framework/src/Volo.Abp.BackgroundJobs.Abstractions/Volo/Abp/BackgroundJobs/BackgroundJobExecutionException.cs
+++ b/framework/src/Volo.Abp.BackgroundJobs.Abstractions/Volo/Abp/BackgroundJobs/BackgroundJobExecutionException.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Runtime.Serialization;
 
 namespace Volo.Abp.BackgroundJobs;
 
-[Serializable]
 public class BackgroundJobExecutionException : AbpException
 {
     public string JobType { get; set; } = default!;
@@ -11,15 +9,6 @@ public class BackgroundJobExecutionException : AbpException
     public object JobArgs { get; set; } = default!;
 
     public BackgroundJobExecutionException()
-    {
-
-    }
-
-    /// <summary>
-    /// Creates a new <see cref="BackgroundJobExecutionException"/> object.
-    /// </summary>
-    public BackgroundJobExecutionException(SerializationInfo serializationInfo, StreamingContext context)
-        : base(serializationInfo, context)
     {
 
     }

--- a/framework/src/Volo.Abp.BlobStoring/Volo/Abp/BlobStoring/BlobAlreadyExistsException.cs
+++ b/framework/src/Volo.Abp.BlobStoring/Volo/Abp/BlobStoring/BlobAlreadyExistsException.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.Serialization;
 
 namespace Volo.Abp.BlobStoring;
 
@@ -18,12 +17,6 @@ public class BlobAlreadyExistsException : AbpException
 
     public BlobAlreadyExistsException(string message, Exception innerException)
         : base(message, innerException)
-    {
-
-    }
-
-    public BlobAlreadyExistsException(SerializationInfo serializationInfo, StreamingContext context)
-        : base(serializationInfo, context)
     {
 
     }

--- a/framework/src/Volo.Abp.Core/System/Collections/Generic/AbpDictionaryExtensions.cs
+++ b/framework/src/Volo.Abp.Core/System/Collections/Generic/AbpDictionaryExtensions.cs
@@ -131,7 +131,7 @@ public static class AbpDictionaryExtensions
     }
 
     /// <summary>
-    /// Converts a <string,object> dictionary to dynamic object so added and removed at run
+    /// Converts a &lt;string,object&gt; dictionary to dynamic object so added and removed at run
     /// </summary>
     /// <param name="dictionary">The collection object</param>
     /// <returns>If value is correct, return ExpandoObject that represents an object</returns>

--- a/framework/src/Volo.Abp.Core/Volo/Abp/AbpException.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/AbpException.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.Serialization;
 
 namespace Volo.Abp;
 
@@ -21,12 +20,6 @@ public class AbpException : Exception
 
     public AbpException(string? message, Exception? innerException)
         : base(message, innerException)
-    {
-
-    }
-
-    public AbpException(SerializationInfo serializationInfo, StreamingContext context)
-        : base(serializationInfo, context)
     {
 
     }

--- a/framework/src/Volo.Abp.Core/Volo/Abp/AbpInitializationException.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/AbpInitializationException.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.Serialization;
 
 namespace Volo.Abp;
 
@@ -18,12 +17,6 @@ public class AbpInitializationException : AbpException
 
     public AbpInitializationException(string message, Exception innerException)
         : base(message, innerException)
-    {
-
-    }
-
-    public AbpInitializationException(SerializationInfo serializationInfo, StreamingContext context)
-        : base(serializationInfo, context)
     {
 
     }

--- a/framework/src/Volo.Abp.Core/Volo/Abp/AbpShutdownException.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/AbpShutdownException.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.Serialization;
 
 namespace Volo.Abp;
 
@@ -18,12 +17,6 @@ public class AbpShutdownException : AbpException
 
     public AbpShutdownException(string message, Exception innerException)
         : base(message, innerException)
-    {
-
-    }
-
-    public AbpShutdownException(SerializationInfo serializationInfo, StreamingContext context)
-        : base(serializationInfo, context)
     {
 
     }

--- a/framework/src/Volo.Abp.Core/Volo/Abp/BusinessException.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/BusinessException.cs
@@ -1,12 +1,10 @@
 ﻿using System;
-using System.Runtime.Serialization;
 using Microsoft.Extensions.Logging;
 using Volo.Abp.ExceptionHandling;
 using Volo.Abp.Logging;
 
 namespace Volo.Abp;
 
-[Serializable]
 public class BusinessException : Exception,
     IBusinessException,
     IHasErrorCode,
@@ -30,15 +28,6 @@ public class BusinessException : Exception,
         Code = code;
         Details = details;
         LogLevel = logLevel;
-    }
-
-    /// <summary>
-    /// Constructor for serializing.
-    /// </summary>
-    public BusinessException(SerializationInfo serializationInfo, StreamingContext context)
-        : base(serializationInfo, context)
-    {
-
     }
 
     public BusinessException WithData(string name, object value)

--- a/framework/src/Volo.Abp.Core/Volo/Abp/IAbpApplicationWithExternalServiceProvider.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/IAbpApplicationWithExternalServiceProvider.cs
@@ -10,18 +10,18 @@ public interface IAbpApplicationWithExternalServiceProvider : IAbpApplication
     /// Sets the service provider, but not initializes the modules.
     /// </summary>
     void SetServiceProvider([NotNull] IServiceProvider serviceProvider);
-    
+
     /// <summary>
     /// Sets the service provider and initializes all the modules.
     /// If <see cref="SetServiceProvider"/> was called before, the same
-    /// <see cref="serviceProvider"/> instance should be passed to this method.
+    /// <paramref name="serviceProvider"/> instance should be passed to this method.
     /// </summary>
     Task InitializeAsync([NotNull] IServiceProvider serviceProvider);
 
     /// <summary>
     /// Sets the service provider and initializes all the modules.
     /// If <see cref="SetServiceProvider"/> was called before, the same
-    /// <see cref="serviceProvider"/> instance should be passed to this method.
+    /// <paramref name="serviceProvider"/> instance should be passed to this method.
     /// </summary>
     void Initialize([NotNull] IServiceProvider serviceProvider);
 }

--- a/framework/src/Volo.Abp.Core/Volo/Abp/UserFriendlyException.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/UserFriendlyException.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.Serialization;
 using Microsoft.Extensions.Logging;
 
 namespace Volo.Abp;
@@ -7,7 +6,6 @@ namespace Volo.Abp;
 /// <summary>
 /// This exception type is directly shown to the user.
 /// </summary>
-[Serializable]
 public class UserFriendlyException : BusinessException, IUserFriendlyException
 {
     public UserFriendlyException(
@@ -24,14 +22,5 @@ public class UserFriendlyException : BusinessException, IUserFriendlyException
               logLevel)
     {
         Details = details;
-    }
-
-    /// <summary>
-    /// Constructor for serializing.
-    /// </summary>
-    public UserFriendlyException(SerializationInfo serializationInfo, StreamingContext context)
-        : base(serializationInfo, context)
-    {
-
     }
 }

--- a/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/Http/Client/AbpRemoteCallException.cs
+++ b/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/Http/Client/AbpRemoteCallException.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.Runtime.Serialization;
 using Volo.Abp.ExceptionHandling;
 
 namespace Volo.Abp.Http.Client;
 
-[Serializable]
 public class AbpRemoteCallException : AbpException, IHasErrorCode, IHasErrorDetails, IHasHttpStatusCode
 {
     public int HttpStatusCode { get; set; }
@@ -22,12 +20,6 @@ public class AbpRemoteCallException : AbpException, IHasErrorCode, IHasErrorDeta
 
     public AbpRemoteCallException(string message, Exception? innerException = null)
         : base(message, innerException)
-    {
-
-    }
-
-    public AbpRemoteCallException(SerializationInfo serializationInfo, StreamingContext context)
-        : base(serializationInfo, context)
     {
 
     }

--- a/framework/src/Volo.Abp.Minify/Volo/Abp/Minify/NUglify/NUglifyException.cs
+++ b/framework/src/Volo.Abp.Minify/Volo/Abp/Minify/NUglify/NUglifyException.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.Serialization;
 using NUglify;
 
 namespace Volo.Abp.Minify.NUglify;
@@ -17,15 +16,6 @@ public class NUglifyException : AbpException
 
     public NUglifyException(string message, Exception innerException)
         : base(message, innerException)
-    {
-
-    }
-
-    /// <summary>
-    /// Constructor for serializing.
-    /// </summary>
-    public NUglifyException(SerializationInfo serializationInfo, StreamingContext context)
-        : base(serializationInfo, context)
     {
 
     }

--- a/framework/src/Volo.Abp.Security/Volo/Abp/Authorization/AbpAuthorizationException.cs
+++ b/framework/src/Volo.Abp.Security/Volo/Abp/Authorization/AbpAuthorizationException.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.Serialization;
 using Microsoft.Extensions.Logging;
 using Volo.Abp.ExceptionHandling;
 using Volo.Abp.Logging;
@@ -9,7 +8,6 @@ namespace Volo.Abp.Authorization;
 /// <summary>
 /// This exception is thrown on an unauthorized request.
 /// </summary>
-[Serializable]
 public class AbpAuthorizationException : AbpException, IHasLogLevel, IHasErrorCode
 {
     /// <summary>
@@ -29,15 +27,6 @@ public class AbpAuthorizationException : AbpException, IHasLogLevel, IHasErrorCo
     public AbpAuthorizationException()
     {
         LogLevel = LogLevel.Warning;
-    }
-
-    /// <summary>
-    /// Creates a new <see cref="AbpAuthorizationException"/> object.
-    /// </summary>
-    public AbpAuthorizationException(SerializationInfo serializationInfo, StreamingContext context)
-        : base(serializationInfo, context)
-    {
-
     }
 
     /// <summary>

--- a/framework/src/Volo.Abp.Validation.Abstractions/Volo/Abp/Validation/AbpValidationException.cs
+++ b/framework/src/Volo.Abp.Validation.Abstractions/Volo/Abp/Validation/AbpValidationException.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
-using System.Runtime.Serialization;
 using System.Text;
 using Microsoft.Extensions.Logging;
 using Volo.Abp.Logging;
@@ -12,7 +11,6 @@ namespace Volo.Abp.Validation;
 /// <summary>
 /// This exception type is used to throws validation exceptions.
 /// </summary>
-[Serializable]
 public class AbpValidationException : AbpException,
     IHasLogLevel,
     IHasValidationErrors,
@@ -33,16 +31,6 @@ public class AbpValidationException : AbpException,
     /// Constructor.
     /// </summary>
     public AbpValidationException()
-    {
-        ValidationErrors = new List<ValidationResult>();
-        LogLevel = LogLevel.Warning;
-    }
-
-    /// <summary>
-    /// Constructor for serializing.
-    /// </summary>
-    public AbpValidationException(SerializationInfo serializationInfo, StreamingContext context)
-        : base(serializationInfo, context)
     {
         ValidationErrors = new List<ValidationResult>();
         LogLevel = LogLevel.Warning;

--- a/modules/cms-kit/src/Volo.CmsKit.Domain/Volo/CmsKit/Blogs/BlogPostSlugAlreadyExistException.cs
+++ b/modules/cms-kit/src/Volo.CmsKit.Domain/Volo/CmsKit/Blogs/BlogPostSlugAlreadyExistException.cs
@@ -1,16 +1,10 @@
 ﻿using System;
-using System.Runtime.Serialization;
 using Volo.Abp;
 
 namespace Volo.CmsKit.Blogs;
 
 public class BlogPostSlugAlreadyExistException : BusinessException
 {
-    public BlogPostSlugAlreadyExistException(SerializationInfo serializationInfo, StreamingContext context)
-        : base(serializationInfo, context)
-    {
-    }
-
     public BlogPostSlugAlreadyExistException(Guid blogId, string slug)
     {
         Slug = slug;

--- a/modules/cms-kit/src/Volo.CmsKit.Domain/Volo/CmsKit/Blogs/BlogSlugAlreadyExistException.cs
+++ b/modules/cms-kit/src/Volo.CmsKit.Domain/Volo/CmsKit/Blogs/BlogSlugAlreadyExistException.cs
@@ -1,20 +1,12 @@
-﻿using System;
-using System.Runtime.Serialization;
-using Volo.Abp;
+﻿using Volo.Abp;
 
 namespace Volo.CmsKit.Blogs;
 
-[Serializable]
 public class BlogSlugAlreadyExistException : BusinessException
 {
     public BlogSlugAlreadyExistException(string slug)
         : base(code: CmsKitErrorCodes.Blogs.SlugAlreadyExists)
     {
         WithData(nameof(Blog.Slug), slug);
-    }
-
-    public BlogSlugAlreadyExistException(SerializationInfo serializationInfo, StreamingContext context)
-        : base(serializationInfo, context)
-    {
     }
 }

--- a/modules/cms-kit/src/Volo.CmsKit.Domain/Volo/CmsKit/Comments/EntityNotCommentableException.cs
+++ b/modules/cms-kit/src/Volo.CmsKit.Domain/Volo/CmsKit/Comments/EntityNotCommentableException.cs
@@ -1,20 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Text;
-using System.Threading.Tasks;
-using Volo.Abp;
+﻿using Volo.Abp;
 
 namespace Volo.CmsKit.Comments;
 
-[Serializable]
 public class EntityNotCommentableException : BusinessException
 {
-    public EntityNotCommentableException(SerializationInfo serializationInfo, StreamingContext context) : base(serializationInfo, context)
-    {
-    }
-
     public EntityNotCommentableException(string entityType)
     {
         Code = CmsKitErrorCodes.Comments.EntityNotCommentable;

--- a/modules/cms-kit/src/Volo.CmsKit.Domain/Volo/CmsKit/MediaDescriptors/EntityCantHaveMediaException.cs
+++ b/modules/cms-kit/src/Volo.CmsKit.Domain/Volo/CmsKit/MediaDescriptors/EntityCantHaveMediaException.cs
@@ -1,14 +1,9 @@
-﻿using System.Runtime.Serialization;
-using Volo.Abp;
+﻿using Volo.Abp;
 
 namespace Volo.CmsKit.MediaDescriptors;
 
 public class EntityCantHaveMediaException : BusinessException
 {
-    public EntityCantHaveMediaException(SerializationInfo serializationInfo, StreamingContext context) : base(serializationInfo, context)
-    {
-    }
-
     public EntityCantHaveMediaException(string entityType)
       : base(code: CmsKitErrorCodes.MediaDescriptors.EntityTypeDoesntExist)
     {

--- a/modules/cms-kit/src/Volo.CmsKit.Domain/Volo/CmsKit/MediaDescriptors/InvalidMediaDescriptorNameException.cs
+++ b/modules/cms-kit/src/Volo.CmsKit.Domain/Volo/CmsKit/MediaDescriptors/InvalidMediaDescriptorNameException.cs
@@ -1,22 +1,13 @@
-﻿using System;
-using System.Runtime.Serialization;
-using JetBrains.Annotations;
+﻿using JetBrains.Annotations;
 using Volo.Abp;
 
 namespace Volo.CmsKit.MediaDescriptors;
 
-[Serializable]
 public class InvalidMediaDescriptorNameException : BusinessException
 {
     public InvalidMediaDescriptorNameException([NotNull] string name)
     {
         Code = CmsKitErrorCodes.MediaDescriptors.InvalidName;
         WithData(nameof(MediaDescriptor.Name), name);
-    }
-
-    public InvalidMediaDescriptorNameException(SerializationInfo serializationInfo, StreamingContext context)
-        : base(serializationInfo, context)
-    {
-
     }
 }

--- a/modules/cms-kit/src/Volo.CmsKit.Domain/Volo/CmsKit/Pages/MultipleHomePageException.cs
+++ b/modules/cms-kit/src/Volo.CmsKit.Domain/Volo/CmsKit/Pages/MultipleHomePageException.cs
@@ -1,23 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Text;
-using System.Threading.Tasks;
-using Volo.Abp;
+﻿using Volo.Abp;
 
 namespace Volo.CmsKit.Domain.Volo.CmsKit.Pages;
 
-[Serializable]
 public class MultipleHomePageException : BusinessException
 {
-	public MultipleHomePageException()
-	{
-		Code = CmsKitErrorCodes.Pages.MultipleHomePage;
-	}
-	
-	public MultipleHomePageException(SerializationInfo serializationInfo, StreamingContext context)
-		: base(serializationInfo, context)
-	{
-	}
+    public MultipleHomePageException()
+    {
+        Code = CmsKitErrorCodes.Pages.MultipleHomePage;
+    }
 }

--- a/modules/cms-kit/src/Volo.CmsKit.Domain/Volo/CmsKit/Pages/PageSlugAlreadyExistsException.cs
+++ b/modules/cms-kit/src/Volo.CmsKit.Domain/Volo/CmsKit/Pages/PageSlugAlreadyExistsException.cs
@@ -1,22 +1,13 @@
-﻿using System;
-using System.Runtime.Serialization;
-using JetBrains.Annotations;
+﻿using JetBrains.Annotations;
 using Volo.Abp;
 
 namespace Volo.CmsKit.Pages;
 
-[Serializable]
 public class PageSlugAlreadyExistsException : BusinessException
 {
     public PageSlugAlreadyExistsException([NotNull] string slug)
     {
         Code = CmsKitErrorCodes.Pages.SlugAlreadyExist;
         WithData(nameof(Page.Slug), slug);
-    }
-
-    public PageSlugAlreadyExistsException(SerializationInfo serializationInfo, StreamingContext context)
-        : base(serializationInfo, context)
-    {
-
     }
 }

--- a/modules/cms-kit/src/Volo.CmsKit.Domain/Volo/CmsKit/Ratings/EntityCantHaveRatingException.cs
+++ b/modules/cms-kit/src/Volo.CmsKit.Domain/Volo/CmsKit/Ratings/EntityCantHaveRatingException.cs
@@ -1,15 +1,10 @@
 ﻿using JetBrains.Annotations;
-using System.Runtime.Serialization;
 using Volo.Abp;
 
 namespace Volo.CmsKit.Ratings;
 
 public class EntityCantHaveRatingException : BusinessException
 {
-    public EntityCantHaveRatingException(SerializationInfo serializationInfo, StreamingContext context) : base(serializationInfo, context)
-    {
-    }
-
     public EntityCantHaveRatingException([NotNull] string entityType)
     {
         Code = CmsKitErrorCodes.Ratings.EntityCantHaveRating;

--- a/modules/cms-kit/src/Volo.CmsKit.Domain/Volo/CmsKit/Reactions/EntityCantHaveReactionException.cs
+++ b/modules/cms-kit/src/Volo.CmsKit.Domain/Volo/CmsKit/Reactions/EntityCantHaveReactionException.cs
@@ -1,16 +1,10 @@
-﻿
-using JetBrains.Annotations;
-using System.Runtime.Serialization;
+﻿using JetBrains.Annotations;
 using Volo.Abp;
 
 namespace Volo.CmsKit.Reactions;
 
 public class EntityCantHaveReactionException : BusinessException
 {
-    public EntityCantHaveReactionException(SerializationInfo serializationInfo, StreamingContext context) : base(serializationInfo, context)
-    {
-    }
-
     public EntityCantHaveReactionException([NotNull] string entityType)
     {
         EntityType = Check.NotNullOrEmpty(entityType, nameof(entityType));

--- a/modules/cms-kit/src/Volo.CmsKit.Domain/Volo/CmsKit/Tags/EntityNotTaggableException.cs
+++ b/modules/cms-kit/src/Volo.CmsKit.Domain/Volo/CmsKit/Tags/EntityNotTaggableException.cs
@@ -1,16 +1,9 @@
-﻿using System;
-using System.Runtime.Serialization;
-using Volo.Abp;
+﻿using Volo.Abp;
 
 namespace Volo.CmsKit.Tags;
 
-[Serializable]
 public class EntityNotTaggableException : BusinessException
 {
-    public EntityNotTaggableException(SerializationInfo serializationInfo, StreamingContext context) : base(serializationInfo, context)
-    {
-    }
-
     public EntityNotTaggableException(string entityType)
     {
         Code = CmsKitErrorCodes.Tags.EntityNotTaggable;

--- a/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/AbpIdentityResultException.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/AbpIdentityResultException.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.Serialization;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Localization;
@@ -11,7 +9,6 @@ using Volo.Abp.Localization;
 
 namespace Volo.Abp.Identity;
 
-[Serializable]
 public class AbpIdentityResultException : BusinessException, ILocalizeErrorMessage
 {
     public IdentityResult IdentityResult { get; }
@@ -22,12 +19,6 @@ public class AbpIdentityResultException : BusinessException, ILocalizeErrorMessa
             message: identityResult.Errors.Select(err => err.Description).JoinAsString(", "))
     {
         IdentityResult = Check.NotNull(identityResult, nameof(identityResult));
-    }
-
-    public AbpIdentityResultException(SerializationInfo serializationInfo, StreamingContext context)
-        : base(serializationInfo, context)
-    {
-
     }
 
     public virtual string LocalizeMessage(LocalizationContext context)


### PR DESCRIPTION
### Description

Resolves #19189

Applies the best practices for removing  legacy serialization infrastructure (the infrastructure which supports SerializableAttribute and ISerializable, along with infrastructure which supports BinaryFormatter) which [has been obsoleted by the .netcore team](https://github.com/dotnet/docs/issues/34893#issue-1656250649) for .net 8+.

### Breaking changes
Any existing applications which uses the base exception class (i.e. Volo.Abp.BusinessExpception) will need to remove the ctor implementation of `Exception(SerializationInfo info, StreamingContext context)`.

### Checklist

- [X] I fully tested it as developer / designer and created unit / integration tests
- [X ] I documented it (I will create a separate documentation issue)

