### PR TITLE
Let the configuration form use the full width

### DIFF
--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Web/Pages/SettingManagement/Index.js
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Web/Pages/SettingManagement/Index.js
@@ -21,7 +21,7 @@
            }).done(function (response) {
                $('#tab-content').children('.tab-pane').removeClass('show').removeClass('active');
                _this.attr('data-bs-target', '#' + tabId);
-               $('#tab-content').append('<div id=' + tabId + ' class="tab-pane fade active show abp-md-form">' + response + '</div>');
+               $('#tab-content').append('<div id=' + tabId + ' class="tab-pane fade active show">' + response + '</div>');
            })
         });
     }).first().click();


### PR DESCRIPTION
### Description

Resolves #19196 

![image](https://github.com/abpframework/abp/assets/6320029/d6d7abe8-d4d7-42c0-9ac8-ca86dadefb90)

Remove limitations to use full width in configuration forms.


### Checklist

- [X] I fully tested it as developer / designer and created unit / integration tests
- [X] I documented it (or no need to document or I will create a separate documentation issue)


