### PR TITLE
Allow extending ConfigureConventions and OnModelCreating

### DIFF
--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/AbpDbContext.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/AbpDbContext.cs
@@ -116,7 +116,11 @@ public abstract class AbpDbContext<TDbContext> : DbContext, IAbpEfCoreDbContext,
                 .MakeGenericMethod(entityType.ClrType)
                 .Invoke(this, new object[] { modelBuilder, entityType });
         }
-        
+
+        if (LazyServiceProvider is null)
+        {
+            return;
+        }
         var abpDbContextOptions = LazyServiceProvider.LazyGetRequiredService<IOptions<AbpDbContextOptions>>().Value;
 
         var actions = abpDbContextOptions.ModelBuilderActions
@@ -144,6 +148,11 @@ public abstract class AbpDbContext<TDbContext> : DbContext, IAbpEfCoreDbContext,
     {
         base.ConfigureConventions(configurationBuilder);
 
+        if (LazyServiceProvider is null)
+        {
+            return;
+        }
+        
         var abpDbContextOptions = LazyServiceProvider.LazyGetRequiredService<IOptions<AbpDbContextOptions>>().Value;
 
         var actions = abpDbContextOptions.Conventions

--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/AbpDbContext.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/AbpDbContext.cs
@@ -14,6 +14,7 @@ using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Volo.Abp.Auditing;
 using Volo.Abp.Data;
 using Volo.Abp.DependencyInjection;
@@ -114,6 +115,48 @@ public abstract class AbpDbContext<TDbContext> : DbContext, IAbpEfCoreDbContext,
             ConfigureValueGeneratedMethodInfo
                 .MakeGenericMethod(entityType.ClrType)
                 .Invoke(this, new object[] { modelBuilder, entityType });
+        }
+        
+        var abpDbContextOptions = LazyServiceProvider.LazyGetRequiredService<IOptions<AbpDbContextOptions>>().Value;
+        
+        var modelBuilderActions = abpDbContextOptions.ModelBuilderActions.Where(x => x.Key == typeof(TDbContext) || x.Key == typeof(AbpDbContext<>)).SelectMany(x => x.Value).ToList();
+        
+        var actions = modelBuilderActions.OrderBy(a => a.Key).Select(a => a.Value).ToList();
+        foreach (var action in actions)
+        {
+            if(action is Action<ModelBuilder, DbContext> modelBuilderAction)
+            {
+                modelBuilderAction.Invoke(modelBuilder, this);
+            }
+            
+            if(this is TDbContext dbContext && action is Action<ModelBuilder, TDbContext> dbContextAction)
+            {
+                dbContextAction.Invoke(modelBuilder, dbContext);
+            }
+        }
+    }
+
+    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+    {
+        base.ConfigureConventions(configurationBuilder);
+
+        var abpDbContextOptions = LazyServiceProvider.LazyGetRequiredService<IOptions<AbpDbContextOptions>>().Value;
+        var conventions = abpDbContextOptions.Conventions.Where(x => x.Key == typeof(TDbContext) || x.Key == typeof(AbpDbContext<>)).SelectMany(x => x.Value).ToList();
+        
+        
+        var actions = conventions.OrderBy(a => a.Key).Select(a => a.Value).ToList();
+        
+        foreach (var action in actions)
+        {
+            if(action is Action<ModelConfigurationBuilder, DbContext> modelBuilderAction)
+            {
+                modelBuilderAction.Invoke(configurationBuilder, this);
+            }
+            
+            if(this is TDbContext dbContext && action is Action<ModelConfigurationBuilder, TDbContext> dbContextAction)
+            {
+                dbContextAction.Invoke(configurationBuilder, dbContext);
+            }
         }
     }
 

--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/AbpDbContext.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/AbpDbContext.cs
@@ -118,10 +118,14 @@ public abstract class AbpDbContext<TDbContext> : DbContext, IAbpEfCoreDbContext,
         }
         
         var abpDbContextOptions = LazyServiceProvider.LazyGetRequiredService<IOptions<AbpDbContextOptions>>().Value;
+
+        var actions = abpDbContextOptions.ModelBuilderActions
+            .Where(x => x.Key == typeof(TDbContext) || x.Key == typeof(AbpDbContext<>))
+            .SelectMany(x => x.Value)
+            .OrderBy(a => a.Key)
+            .Select(a => a.Value)
+            .ToList();
         
-        var modelBuilderActions = abpDbContextOptions.ModelBuilderActions.Where(x => x.Key == typeof(TDbContext) || x.Key == typeof(AbpDbContext<>)).SelectMany(x => x.Value).ToList();
-        
-        var actions = modelBuilderActions.OrderBy(a => a.Key).Select(a => a.Value).ToList();
         foreach (var action in actions)
         {
             if(action is Action<ModelBuilder, DbContext> modelBuilderAction)
@@ -142,9 +146,12 @@ public abstract class AbpDbContext<TDbContext> : DbContext, IAbpEfCoreDbContext,
 
         var abpDbContextOptions = LazyServiceProvider.LazyGetRequiredService<IOptions<AbpDbContextOptions>>().Value;
 
-        var conventions = abpDbContextOptions.Conventions.Where(x => x.Key == typeof(TDbContext) || x.Key == typeof(AbpDbContext<>)).SelectMany(x => x.Value).ToList();
-        
-        var actions = conventions.OrderBy(a => a.Key).Select(a => a.Value).ToList();
+        var actions = abpDbContextOptions.Conventions
+            .Where(x => x.Key == typeof(TDbContext) || x.Key == typeof(AbpDbContext<>))
+            .SelectMany(x => x.Value)
+            .OrderBy(a => a.Key)
+            .Select(a => a.Value)
+            .ToList();
         
         foreach (var action in actions)
         {

--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/AbpDbContextOptions.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/AbpDbContextOptions.cs
@@ -51,56 +51,24 @@ public class AbpDbContextOptions
     
     public void ConfigureConventions([NotNull] Action<ModelConfigurationBuilder, DbContext> action, Type? dbContextType = null, int? order = null)
     {
-        Check.NotNull(action, nameof(action));
-
-        var actions = Conventions.GetOrDefault(dbContextType ?? typeof(AbpDbContext<>));
-        if (actions == null)
-        {
-            Conventions[dbContextType ?? typeof(AbpDbContext<>)] = actions = new List<KeyValuePair<int?, object>>();
-        }
-        
-        actions.Add(new KeyValuePair<int?, object>(order, action));
+        InternalConfigureConventions(action, dbContextType, order);
     }
     
     public void ConfigureConventions<TDbContext>([NotNull] Action<ModelConfigurationBuilder, TDbContext> action, int? order = null)
         where TDbContext : AbpDbContext<TDbContext>
     {
-        Check.NotNull(action, nameof(action));
-
-        var actions = Conventions.GetOrDefault(typeof(TDbContext));
-        if (actions == null)
-        {
-            Conventions[typeof(TDbContext)] = actions = new List<KeyValuePair<int?, object>>();
-        }
-        
-        actions.Add(new KeyValuePair<int?, object>(order, action));
+        InternalConfigureConventions(action, typeof(TDbContext), order);
     }
 
     public void OnModelCreating([NotNull] Action<ModelBuilder, DbContext> action, Type? dbContextType = null, int? order = null)
     {
-        Check.NotNull(action, nameof(action));
-
-        var actions = ModelBuilderActions.GetOrDefault(dbContextType ?? typeof(AbpDbContext<>));
-        if (actions == null)
-        {
-            ModelBuilderActions[dbContextType ?? typeof(AbpDbContext<>)] = actions = new List<KeyValuePair<int?, object>>();
-        }
-        
-        actions.Add(new KeyValuePair<int?, object>(order, action));
+        InternalOnModelCreating(action, dbContextType, order);
     }
     
     public void OnModelCreating<TDbContext>([NotNull] Action<ModelBuilder, TDbContext> action, int? order = null)
         where TDbContext : AbpDbContext<TDbContext>
     {
-        Check.NotNull(action, nameof(action));
-
-        var actions = ModelBuilderActions.GetOrDefault(typeof(TDbContext));
-        if (actions == null)
-        {
-            ModelBuilderActions[typeof(TDbContext)] = actions = new List<KeyValuePair<int?, object>>();
-        }
-        
-        actions.Add(new KeyValuePair<int?, object>(order, action));
+        InternalOnModelCreating(action, typeof(TDbContext), order);
     }
 
     public bool IsConfiguredDefault()
@@ -162,5 +130,31 @@ public class AbpDbContextOptions
                 return replacementType;
             }
         }
+    }
+    
+    private void InternalConfigureConventions(object action, Type? dbContextType = null, int? order = null)
+    {
+        Check.NotNull(action, nameof(action));
+
+        var actions = Conventions.GetOrDefault(dbContextType ?? typeof(AbpDbContext<>));
+        if (actions == null)
+        {
+            Conventions[dbContextType ?? typeof(AbpDbContext<>)] = actions = new List<KeyValuePair<int?, object>>();
+        }
+        
+        actions.Add(new KeyValuePair<int?, object>(order, action));
+    }
+    
+    private void InternalOnModelCreating(object action, Type? dbContextType = null, int? order = null)
+    {
+        Check.NotNull(action, nameof(action));
+
+        var actions = ModelBuilderActions.GetOrDefault(dbContextType ?? typeof(AbpDbContext<>));
+        if (actions == null)
+        {
+            ModelBuilderActions[dbContextType ?? typeof(AbpDbContext<>)] = actions = new List<KeyValuePair<int?, object>>();
+        }
+        
+        actions.Add(new KeyValuePair<int?, object>(order, action));
     }
 }


### PR DESCRIPTION
### Description

Users will need to replace these methods on a per-DbContext basis when they require them. Instead of replacement, methods can be extended using options. In our case, we utilized citext to ensure case-insensitivity for strings in Postgres SQL. However, this change was effective only when applied to abp.io's own DbContext; even if other DbContexts used citext in the database, case sensitivity was not addressed. Subsequently, after replacing all DbContexts and configuring this change within each, our issue was resolved. Given the potential workload of replacing and maintaining all DbContexts, employing such a method would be more ideal.

Example usage:
```cs
Configure<AbpDbContextOptions>(options =>
{
    options.UseNpgsql();
    options.ConfigureConventions((builder, dbContext) =>
    {
        builder.Properties<string>().HaveColumnType("citext");
    });
});
```

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [ ] I documented it (or no need to document or I will create a separate documentation issue)
