### PR TITLE
Allow extending `ConfigureConventions` and `OnModelCreating`.

### DIFF
--- a/docs/en/Entity-Framework-Core.md
+++ b/docs/en/Entity-Framework-Core.md
@@ -139,6 +139,30 @@ Configure<AbpDbContextOptions>(options =>
 });
 ````
 
+Add actions for the `ConfigureConventions` and `OnModelCreating` methods of the `DbContext` as shown below:
+
+````csharp
+options.DefaultConventionAction = (dbContext, builder) =>
+{
+    // This action is called for ConfigureConventions method of all DbContexts.
+};
+
+options.ConfigureConventions<YourDbContext>((dbContext, builder) =>
+{
+    // This action is called for ConfigureConventions method of specific DbContext.
+});
+
+options.DefaultOnModelCreatingAction = (dbContext, builder) =>
+{
+    // This action is called for OnModelCreating method of all DbContexts.
+};
+
+options.ConfigureOnModelCreating<YourDbContext>((dbContext, builder) =>
+{
+    // This action is called for OnModelCreating method of specific DbContext.
+});
+````
+
 If you have a single `DbContext` or you have multiple `DbContext`s but want to use the same DBMS and configuration for all, you can leave it as is. However, if you need to configure a different DBMS or customize the configuration for a specific `DbContext`, you can specify it as shown below:
 
 ````csharp

--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/AbpDbContext.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/AbpDbContext.cs
@@ -116,7 +116,11 @@ public abstract class AbpDbContext<TDbContext> : DbContext, IAbpEfCoreDbContext,
                 .MakeGenericMethod(entityType.ClrType)
                 .Invoke(this, new object[] { modelBuilder, entityType });
         }
-        
+
+        if (LazyServiceProvider is null)
+        {
+            return;
+        }
         var abpDbContextOptions = LazyServiceProvider.LazyGetRequiredService<IOptions<AbpDbContextOptions>>().Value;
 
         var actions = abpDbContextOptions.ModelBuilderActions
@@ -144,6 +148,11 @@ public abstract class AbpDbContext<TDbContext> : DbContext, IAbpEfCoreDbContext,
     {
         base.ConfigureConventions(configurationBuilder);
 
+        if (LazyServiceProvider is null)
+        {
+            return;
+        }
+        
         var abpDbContextOptions = LazyServiceProvider.LazyGetRequiredService<IOptions<AbpDbContextOptions>>().Value;
 
         var actions = abpDbContextOptions.Conventions

--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/AbpDbContext.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/AbpDbContext.cs
@@ -14,6 +14,7 @@ using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Volo.Abp.Auditing;
 using Volo.Abp.Data;
 using Volo.Abp.DependencyInjection;
@@ -114,6 +115,48 @@ public abstract class AbpDbContext<TDbContext> : DbContext, IAbpEfCoreDbContext,
             ConfigureValueGeneratedMethodInfo
                 .MakeGenericMethod(entityType.ClrType)
                 .Invoke(this, new object[] { modelBuilder, entityType });
+        }
+        
+        var abpDbContextOptions = LazyServiceProvider.LazyGetRequiredService<IOptions<AbpDbContextOptions>>().Value;
+        
+        var modelBuilderActions = abpDbContextOptions.ModelBuilderActions.Where(x => x.Key == typeof(TDbContext) || x.Key == typeof(AbpDbContext<>)).SelectMany(x => x.Value).ToList();
+        
+        var actions = modelBuilderActions.OrderBy(a => a.Key).Select(a => a.Value).ToList();
+        foreach (var action in actions)
+        {
+            if(action is Action<ModelBuilder, DbContext> modelBuilderAction)
+            {
+                modelBuilderAction.Invoke(modelBuilder, this);
+            }
+            
+            if(this is TDbContext dbContext && action is Action<ModelBuilder, TDbContext> dbContextAction)
+            {
+                dbContextAction.Invoke(modelBuilder, dbContext);
+            }
+        }
+    }
+
+    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+    {
+        base.ConfigureConventions(configurationBuilder);
+
+        var abpDbContextOptions = LazyServiceProvider.LazyGetRequiredService<IOptions<AbpDbContextOptions>>().Value;
+        var conventions = abpDbContextOptions.Conventions.Where(x => x.Key == typeof(TDbContext) || x.Key == typeof(AbpDbContext<>)).SelectMany(x => x.Value).ToList();
+        
+        
+        var actions = conventions.OrderBy(a => a.Key).Select(a => a.Value).ToList();
+        
+        foreach (var action in actions)
+        {
+            if(action is Action<ModelConfigurationBuilder, DbContext> modelBuilderAction)
+            {
+                modelBuilderAction.Invoke(configurationBuilder, this);
+            }
+            
+            if(this is TDbContext dbContext && action is Action<ModelConfigurationBuilder, TDbContext> dbContextAction)
+            {
+                dbContextAction.Invoke(configurationBuilder, dbContext);
+            }
         }
     }
 

--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/AbpDbContext.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/AbpDbContext.cs
@@ -118,10 +118,14 @@ public abstract class AbpDbContext<TDbContext> : DbContext, IAbpEfCoreDbContext,
         }
         
         var abpDbContextOptions = LazyServiceProvider.LazyGetRequiredService<IOptions<AbpDbContextOptions>>().Value;
+
+        var actions = abpDbContextOptions.ModelBuilderActions
+            .Where(x => x.Key == typeof(TDbContext) || x.Key == typeof(AbpDbContext<>))
+            .SelectMany(x => x.Value)
+            .OrderBy(a => a.Key)
+            .Select(a => a.Value)
+            .ToList();
         
-        var modelBuilderActions = abpDbContextOptions.ModelBuilderActions.Where(x => x.Key == typeof(TDbContext) || x.Key == typeof(AbpDbContext<>)).SelectMany(x => x.Value).ToList();
-        
-        var actions = modelBuilderActions.OrderBy(a => a.Key).Select(a => a.Value).ToList();
         foreach (var action in actions)
         {
             if(action is Action<ModelBuilder, DbContext> modelBuilderAction)
@@ -142,9 +146,12 @@ public abstract class AbpDbContext<TDbContext> : DbContext, IAbpEfCoreDbContext,
 
         var abpDbContextOptions = LazyServiceProvider.LazyGetRequiredService<IOptions<AbpDbContextOptions>>().Value;
 
-        var conventions = abpDbContextOptions.Conventions.Where(x => x.Key == typeof(TDbContext) || x.Key == typeof(AbpDbContext<>)).SelectMany(x => x.Value).ToList();
-        
-        var actions = conventions.OrderBy(a => a.Key).Select(a => a.Value).ToList();
+        var actions = abpDbContextOptions.Conventions
+            .Where(x => x.Key == typeof(TDbContext) || x.Key == typeof(AbpDbContext<>))
+            .SelectMany(x => x.Value)
+            .OrderBy(a => a.Key)
+            .Select(a => a.Value)
+            .ToList();
         
         foreach (var action in actions)
         {

--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/AbpDbContextOptions.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/AbpDbContextOptions.cs
@@ -51,56 +51,24 @@ public class AbpDbContextOptions
     
     public void ConfigureConventions([NotNull] Action<ModelConfigurationBuilder, DbContext> action, Type? dbContextType = null, int? order = null)
     {
-        Check.NotNull(action, nameof(action));
-
-        var actions = Conventions.GetOrDefault(dbContextType ?? typeof(AbpDbContext<>));
-        if (actions == null)
-        {
-            Conventions[dbContextType ?? typeof(AbpDbContext<>)] = actions = new List<KeyValuePair<int?, object>>();
-        }
-        
-        actions.Add(new KeyValuePair<int?, object>(order, action));
+        InternalConfigureConventions(action, dbContextType, order);
     }
     
     public void ConfigureConventions<TDbContext>([NotNull] Action<ModelConfigurationBuilder, TDbContext> action, int? order = null)
         where TDbContext : AbpDbContext<TDbContext>
     {
-        Check.NotNull(action, nameof(action));
-
-        var actions = Conventions.GetOrDefault(typeof(TDbContext));
-        if (actions == null)
-        {
-            Conventions[typeof(TDbContext)] = actions = new List<KeyValuePair<int?, object>>();
-        }
-        
-        actions.Add(new KeyValuePair<int?, object>(order, action));
+        InternalConfigureConventions(action, typeof(TDbContext), order);
     }
 
     public void OnModelCreating([NotNull] Action<ModelBuilder, DbContext> action, Type? dbContextType = null, int? order = null)
     {
-        Check.NotNull(action, nameof(action));
-
-        var actions = ModelBuilderActions.GetOrDefault(dbContextType ?? typeof(AbpDbContext<>));
-        if (actions == null)
-        {
-            ModelBuilderActions[dbContextType ?? typeof(AbpDbContext<>)] = actions = new List<KeyValuePair<int?, object>>();
-        }
-        
-        actions.Add(new KeyValuePair<int?, object>(order, action));
+        InternalOnModelCreating(action, dbContextType, order);
     }
     
     public void OnModelCreating<TDbContext>([NotNull] Action<ModelBuilder, TDbContext> action, int? order = null)
         where TDbContext : AbpDbContext<TDbContext>
     {
-        Check.NotNull(action, nameof(action));
-
-        var actions = ModelBuilderActions.GetOrDefault(typeof(TDbContext));
-        if (actions == null)
-        {
-            ModelBuilderActions[typeof(TDbContext)] = actions = new List<KeyValuePair<int?, object>>();
-        }
-        
-        actions.Add(new KeyValuePair<int?, object>(order, action));
+        InternalOnModelCreating(action, typeof(TDbContext), order);
     }
 
     public bool IsConfiguredDefault()
@@ -162,5 +130,31 @@ public class AbpDbContextOptions
                 return replacementType;
             }
         }
+    }
+    
+    private void InternalConfigureConventions(object action, Type? dbContextType = null, int? order = null)
+    {
+        Check.NotNull(action, nameof(action));
+
+        var actions = Conventions.GetOrDefault(dbContextType ?? typeof(AbpDbContext<>));
+        if (actions == null)
+        {
+            Conventions[dbContextType ?? typeof(AbpDbContext<>)] = actions = new List<KeyValuePair<int?, object>>();
+        }
+        
+        actions.Add(new KeyValuePair<int?, object>(order, action));
+    }
+    
+    private void InternalOnModelCreating(object action, Type? dbContextType = null, int? order = null)
+    {
+        Check.NotNull(action, nameof(action));
+
+        var actions = ModelBuilderActions.GetOrDefault(dbContextType ?? typeof(AbpDbContext<>));
+        if (actions == null)
+        {
+            ModelBuilderActions[dbContextType ?? typeof(AbpDbContext<>)] = actions = new List<KeyValuePair<int?, object>>();
+        }
+        
+        actions.Add(new KeyValuePair<int?, object>(order, action));
     }
 }


### PR DESCRIPTION
Add actions for the `ConfigureConventions` and `OnModelCreating` methods of the `DbContext` as shown below:

````csharp
Configure<AbpDbContextOptions>(options =>
{
    options.ConfigureDefaultConvention((dbContext, builder) =>
    {
        // This action is called for ConfigureConventions method of all DbContexts.
    });

    options.ConfigureConventions<YourDbContext>((dbContext, builder) =>
    {
        // This action is called for ConfigureConventions method of specific DbContext.
    });

    options.ConfigureDefaultOnModelCreating((dbContext, builder) =>
    {
        // This action is called for OnModelCreating method of all DbContexts.
    });

    options.ConfigureOnModelCreating<YourDbContext>((dbContext, builder) =>
    {
        // This action is called for OnModelCreating method of specific DbContext.
    });
});
````