### PR TITLE
Fix invalid lepton-x package version in all repository after deployment

### DIFF
--- a/npm/publish-ng.ps1
+++ b/npm/publish-ng.ps1
@@ -1,6 +1,7 @@
 param(
   [string]$Version,
-  [string]$Registry
+  [string]$Registry,
+  [string]$LeptonXVersion
 )
 
 yarn install
@@ -15,10 +16,11 @@ if (-Not $Version) {
 if (-Not $Registry) {
   $Registry = "https://registry.npmjs.org";
 }
+
 $UpdateNgPacksCommand = "yarn update-version $Version"
 $NgPacksPublishCommand = "npm run publish-packages -- --nextVersion $Version --skipGit --registry $Registry --skipVersionValidation"
 $UpdateGulpCommand = "yarn update-gulp --registry $Registry"
-
+$UpdateLeptonXCommand = "yarn update-lepton-x-versions -v $LeptonXVersion";
 
 $IsPrerelease = $(node publish-utils.js --prerelease --customVersion $Version) -eq "true";
 
@@ -38,7 +40,9 @@ $commands = (
   "cd scripts",
   "yarn remove-lock-files",
   "cd ..",
-  $UpdateGulpCommand
+  $UpdateGulpCommand,
+  "cd scripts",
+  $UpdateLeptonXCommand
 )
 
 foreach ($command in $commands) { 

--- a/npm/scripts/change-package-version.ts
+++ b/npm/scripts/change-package-version.ts
@@ -1,6 +1,90 @@
 import glob from "glob";
 import fse from "fs-extra";
-import {program} from "commander";
+import { program } from "commander";
+
+export const semverRegex =
+  /\d+\.\d+\.\d+(?:-[a-zA-Z0-9]+(?:\.[a-zA-Z0-9-]+)*)?(?:\+[a-zA-Z0-9]+(?:\.[a-zA-Z0-9-]+)*)?$/;
+
+function setupCommander() {
+  program
+    .option("-n, --packageName <packageName>", "Package name")
+    .option(
+      "-v, --targetVersion <targetVersion>",
+      "Version number of the package"
+    );
+
+  program.parse(process.argv);
+}
+
+function readPackageJsonFile(path, key, newVersion) {
+  const replace = (block, key, newVersion) => {
+    const founded = Object.keys(block).filter((x) => x === key);
+
+    if (founded.length > 0) {
+      let value = block[key];
+      value = value.replace(semverRegex, newVersion);
+
+      return [
+        true,
+        {
+          ...block,
+          [key]: value,
+        },
+      ];
+    }
+
+    return [false, block];
+  };
+
+  fse.readJson(path, (err, packageObj) => {
+    if (err) {
+      throw err;
+    }
+
+    const { dependencies, peerDependencies, devDependencies } = packageObj;
+    const results = [];
+
+    let result = { ...packageObj };
+    if (dependencies) {
+      const [founded, d] = replace(dependencies, key, newVersion);
+      results.push(founded);
+      result = {
+        ...result,
+        dependencies: d,
+      };
+    }
+
+    if (peerDependencies) {
+      const [founded, p] = replace(peerDependencies, key, newVersion);
+      results.push(founded);
+      result = {
+        ...result,
+        peerDependencies: p,
+      };
+    }
+
+    if (devDependencies) {
+      const [founded, d] = replace(devDependencies, key, newVersion);
+      results.push(founded);
+      result = {
+        ...result,
+        devDependencies: d,
+      };
+    }
+
+    const anyChanges = !results.some((x) => x);
+    if (anyChanges) {
+      return;
+    }
+
+    console.log("changed", path);
+    writeFile(path, result);
+  });
+}
+
+function writeFile(path, result) {
+  return fse.writeJson(path, result, { spaces: 2 });
+}
 
 (function findPackageJsonFiles() {
   setupCommander();
@@ -10,92 +94,21 @@ import {program} from "commander";
       "../../**/dist/**",
       "../../**/build/**",
       "../../**/scripts/**",
-      "../../**/wwwroot/**"
-    ]
+      "../../**/wwwroot/**",
+    ],
   };
 
   const workingDir = "../../";
   glob(`${workingDir}**/package.json`, options, (err, files) => {
-    if (err) throw err;
+    if (err) {
+      throw err;
+    }
 
     //Todo @masumulu28: check options value and throw error if not provided
-    const {packageName,targetVersion}= program.opts();
- 
-     for (const file of files) {
+    const { packageName, targetVersion } = program.opts();
+
+    for (const file of files) {
       readPackageJsonFile(file, packageName, targetVersion);
     }
   });
 })();
-
-function readPackageJsonFile(path, key, newVersion) {
-  const replace = (block, key, newVersion) => {
-    const founded = Object.keys(block).filter(x => x === key);
-    if (founded.length > 0) {
-      let value = block[key];
-      value = value.replace(semverRegex, newVersion);
-      return [true, {
-        ...block,
-        [key]:value
-      }];
-    }
-    return [false, block];
-  };
-  fse.readJson(path, (err, packageObj) => {
-      if (err) throw err;
-
-      const { dependencies, peerDependencies, devDependencies } = packageObj;
-      const results = [];
-
-      let result = { ...packageObj };
-      if (dependencies) {
-        const [founded, d] = replace(dependencies, key, newVersion);
-        results.push(founded);
-        result = {
-          ...result, dependencies: d
-        };
-      }
-      if (peerDependencies) {
-        const [founded, p] = replace(peerDependencies, key, newVersion);
-        results.push(founded);
-        result = {
-          ...result, peerDependencies: p
-        };
-      }
-      if (devDependencies) {
-        const [founded, d] = replace(devDependencies, key, newVersion);
-        results.push(founded);
-        result = {
-          ...result, devDependencies: d
-        };
-      }
-      const anyChanges = !results.some(x => x);
-      if (anyChanges) {
-        return;
-      }
-      console.log("changed", path);
-      writeFile(path, result);
-    }
-  )
-  ;
-}
-export const semverRegex =
-  /\d+\.\d+\.\d+(?:-[a-zA-Z0-9]+(?:\.[a-zA-Z0-9-]+)*)?(?:\+[a-zA-Z0-9]+(?:\.[a-zA-Z0-9-]+)*)?$/;
-
-function writeFile(path, result) {
-  return fse.writeJson(path, result, { spaces: 2 });
-}
-
-
-function setupCommander() {
-    program
-    .option(
-      "-n, --packageName <packageName>",
-      "Package name"
-    )
-    .option(
-      "-v, --targetVersion <targetVersion>",
-      "Version number of the package"
-    );
-
-  program.parse(process.argv);
-}

--- a/npm/scripts/package.json
+++ b/npm/scripts/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "remove-lock-files": "yarn && ts-node -r tsconfig-paths/register remove-lock-files.ts",
     "validate-versions": "yarn && ts-node -r tsconfig-paths/register validate-versions.ts",
-    "change-package-version": "ts-node -r tsconfig-paths/register change-package-version.ts"
+    "change-package-version": "ts-node -r tsconfig-paths/register change-package-version.ts",
+    "update-lepton-x-versions": "ts-node -r  tsconfig-paths/register update-lepton-x-versions.ts"
   },
   "dependencies": {
     "axios": "^0.24.0",

--- a/npm/scripts/update-lepton-x-versions.ts
+++ b/npm/scripts/update-lepton-x-versions.ts
@@ -1,0 +1,55 @@
+import { program } from "commander";
+import childProcess from "child_process";
+
+/**
+ * This script is used to update the version of the LeptonX (angular |mvc | blazor) npm packages.
+ * Depending to **change-package-version.ts** file. (Should we move this to a single script?)
+ *
+ * I'm not sure about depending "commander" package. We might need to get options from process.env directly ?
+ *
+ * Example
+ * -Set env
+ *   $env:targetVersion = "1.0.0"
+ * -Read from nodejs
+ *   process.env.targetVersion
+ * -Use as argument in commands
+ *   const command = `yarn change-package-version -n ${packageName} -v ${process.env.targetVersion}`;
+ */
+
+//All lepton-x-lite packages for open source (angular | mvc | blazor) UI frameworks
+const LEPTON_X_PACKAGE_NAMES = [
+  "@abp/ng.theme.lepton-x",
+  "@abp/aspnetcore.mvc.ui.theme.leptonxlite",
+  "@abp/aspnetcore.components.server.leptonxlitetheme",
+];
+
+function validteVersion(targetVersion) {
+  if (!targetVersion) {
+    console.log("\x1b[31m", "Error: lepton-x targetVersion is not defined");
+    process.exit(1);
+  }
+}
+
+function initCommander() {
+  program.option(
+    "-v, --targetVersion <targetVersion>",
+    "Version number of the package"
+  );
+
+  program.parse(process.argv);
+}
+
+(() => {
+  initCommander();
+
+  const { targetVersion } = program.opts();
+
+  validteVersion(targetVersion);
+
+  LEPTON_X_PACKAGE_NAMES.forEach((packageName) => {
+    const command = `yarn change-package-version -n ${packageName} -v ${targetVersion}`;
+    const result = childProcess.execSync(command).toString();
+
+    console.log(result);
+  });
+})();

--- a/npm/scripts/update-lepton-x-versions.ts
+++ b/npm/scripts/update-lepton-x-versions.ts
@@ -23,7 +23,7 @@ const LEPTON_X_PACKAGE_NAMES = [
   "@abp/aspnetcore.components.server.leptonxlitetheme",
 ];
 
-function validteVersion(targetVersion) {
+function validateVersion(targetVersion) {
   if (!targetVersion) {
     console.log("\x1b[31m", "Error: lepton-x targetVersion is not defined");
     process.exit(1);
@@ -44,7 +44,7 @@ function initCommander() {
 
   const { targetVersion } = program.opts();
 
-  validteVersion(targetVersion);
+  validateVersion(targetVersion);
 
   LEPTON_X_PACKAGE_NAMES.forEach((packageName) => {
     const command = `yarn change-package-version -n ${packageName} -v ${targetVersion}`;

--- a/npm/scripts/validate-versions.ts
+++ b/npm/scripts/validate-versions.ts
@@ -1,7 +1,7 @@
-import { program } from 'commander';
-import fse from 'fs-extra';
-import * as path from 'path';
-import { log } from './utils/log';
+import { program } from "commander";
+import fse from "fs-extra";
+import * as path from "path";
+import { log } from "./utils/log";
 
 let excludedPackages = [];
 
@@ -12,29 +12,31 @@ let excludedPackages = [];
 
 function initCommander() {
   program.requiredOption(
-    '-v, --compareVersion <version>',
-    'version to compare'
+    "-v, --compareVersion <version>",
+    "version to compare"
   );
-  program.requiredOption('-p, --path <path>', 'NPM packages folder path');
+  program.requiredOption("-p, --path <path>", "NPM packages folder path");
   program.option(
-    '-ep, --excludedPackages <excludedpackages>',
-    'Packages that will not be checked. Can be passed with separeted comma (like @abp/utils,@abp/core)',
-    ''
+    "-ep, --excludedPackages <excludedpackages>",
+    "Packages that will not be checked. Can be passed with separeted comma (like @abp/utils,@abp/core)",
+    ""
   );
   program.parse(process.argv);
 
-  excludedPackages = program.opts().excludedPackages.split(',');
+  excludedPackages = program.opts().excludedPackages.split(",");
 }
 
 async function compare() {
   let { compareVersion, path: packagesPath } = program.opts();
   packagesPath = path.resolve(packagesPath);
+
   const packageFolders = await fse.readdir(packagesPath);
 
   for (let i = 0; i < packageFolders.length; i++) {
     const folder = packageFolders[i];
     const pkgJsonPath = `${packagesPath}/${folder}/package.json`;
     let pkgJson;
+
     try {
       pkgJson = await fse.readJSON(pkgJsonPath);
     } catch (error) {}
@@ -46,11 +48,10 @@ async function compare() {
       throwError(pkgJsonPath, pkgJson.name, pkgJson.version);
     }
 
-    const { dependencies, peerDependencies } = pkgJson;
-    if (dependencies) await compareDependencies(dependencies, pkgJsonPath);
-    // if (peerDependencies) { // TODO: update peerDependencies while updating version
-    //   await compareDependencies(peerDependencies, pkgJsonPath);
-    // }
+    const { dependencies } = pkgJson;
+    if (dependencies) {
+      await compareDependencies(dependencies, pkgJsonPath);
+    }
   }
 }
 
@@ -66,6 +67,7 @@ async function compareDependencies(
     const packageName = entry[0];
     const version = getCleanVersionName(entry[1]);
     const cleanCompareVersion = getCleanVersionName(compareVersion);
+
     if (
       !excludedPackages.includes(entry[0]) &&
       packageName.match(/@(abp|volo)/)?.length &&
@@ -79,11 +81,13 @@ async function compareDependencies(
 function throwError(filePath: string, pkg: string, version?: string) {
   const { compareVersion } = program.opts();
 
-  log.error(`${filePath}: ${pkg} version is not ${compareVersion}. it is ${version}`);
+  log.error(
+    `${filePath}: ${pkg} version is not ${compareVersion}. it is ${version}`
+  );
   process.exit(1);
 }
 
 function getCleanVersionName(version) {
   // Remove caret (^) or tilde (~) from the beginning of the version number
-  return version.replace(/^[\^~]+/, '');
+  return version.replace(/^[\^~]+/, "");
 }


### PR DESCRIPTION
### Description

Resolves #19275 

- This PR will solve lepton-x package's invalid version after deployment
- We need to pass lepton-x version as argument to `publish-ng.ps1` file 

I've create a TS file for update lepton-x packages version, It depends on the [change-package-version.ts](https://github.com/abpframework/abp/blob/rel-8.0/npm/scripts/change-package-version.ts)

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests

### How to test it?
- I've run `verdaccio` at my local
- Updated `.npmrc` file in `ng-packs` folder and copy this file under to `modules` folder
- Run `publish-mvc.ps1` with args: `.\publish-mvc.ps1 8.1.0-rc.3 http://localhost:4873`
- Run `publish-ng.ps1` with args: `.\publish-mvc.ps1 8.1.0-rc.3 http://localhost:4873 3.1.0-rc.3`
  - The third argument `3.1.0-rc.3` will be lepton-x version for npm packages in repository