### PR TITLE
Blazor Page Title

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Layout/PageHeader.razor
+++ b/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Layout/PageHeader.razor
@@ -1,11 +1,13 @@
 ﻿@using Blazorise
 @using Microsoft.Extensions.Options
+@using Microsoft.AspNetCore.Components.Web
 
 @inject IOptions<PageHeaderOptions> Options
 
 <Row Class="entry-row">
+    <PageTitle>@PageLayout.Title</PageTitle>
     @if(Options.Value.RenderPageTitle)
-    {   
+    {
         <Column ColumnSize="ColumnSize.IsAuto">
             <h1 class="content-header-title">@PageLayout.Title</h1>
         </Column>

--- a/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Layout/PageHeader.razor
+++ b/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Layout/PageHeader.razor
@@ -1,11 +1,22 @@
 ﻿@using Blazorise
 @using Microsoft.Extensions.Options
 @using Microsoft.AspNetCore.Components.Web
+@using Volo.Abp.Ui.Branding
 
 @inject IOptions<PageHeaderOptions> Options
+@inject IBrandingProvider BrandingProvider
 
 <Row Class="entry-row">
-    <PageTitle>@PageLayout.Title</PageTitle>
+
+    @if (PageLayout.Title.IsNullOrEmpty())
+    {
+        <PageTitle>@BrandingProvider.AppName</PageTitle>
+    }
+    else
+    {
+        <PageTitle>@PageLayout.Title | @BrandingProvider.AppName</PageTitle>
+    }
+
     @if(Options.Value.RenderPageTitle)
     {
         <Column ColumnSize="ColumnSize.IsAuto">

--- a/templates/app-nolayers/aspnet-core/MyCompanyName.MyProjectName.Blazor.Server.Mongo/Pages/_Host.cshtml
+++ b/templates/app-nolayers/aspnet-core/MyCompanyName.MyProjectName.Blazor.Server.Mongo/Pages/_Host.cshtml
@@ -18,6 +18,7 @@
     <base href="~/" />
 
     <abp-style-bundle name="@BlazorLeptonXLiteThemeBundles.Styles.Global"/>
+    <HeadOutlet />
 </head>
 <body class="abp-application-layout bg-light @rtl">
 

--- a/templates/app-nolayers/aspnet-core/MyCompanyName.MyProjectName.Blazor.Server/Pages/_Host.cshtml
+++ b/templates/app-nolayers/aspnet-core/MyCompanyName.MyProjectName.Blazor.Server/Pages/_Host.cshtml
@@ -18,6 +18,7 @@
     <base href="~/" />
 
     <abp-style-bundle name="@BlazorLeptonXLiteThemeBundles.Styles.Global"/>
+    <HeadOutlet />
 </head>
 <body class="abp-application-layout bg-light @rtl">
 

--- a/templates/app-nolayers/aspnet-core/MyCompanyName.MyProjectName.Blazor.WebAssembly/Client/MyProjectNameBlazorModule.cs
+++ b/templates/app-nolayers/aspnet-core/MyCompanyName.MyProjectName.Blazor.WebAssembly/Client/MyProjectNameBlazorModule.cs
@@ -1,5 +1,6 @@
 ﻿using Blazorise.Bootstrap5;
 using Blazorise.Icons.FontAwesome;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using MyCompanyName.MyProjectName.Menus;
 using MyCompanyName.MyProjectName;
@@ -121,7 +122,7 @@ public class MyProjectNameBlazorModule : AbpModule
     private static void ConfigureUI(WebAssemblyHostBuilder builder)
     {
         builder.RootComponents.Add<App>("#ApplicationContainer");
-
+        builder.RootComponents.Add<HeadOutlet>("head::after");
     }
 
     private static void ConfigureHttpClient(ServiceConfigurationContext context, IWebAssemblyHostEnvironment environment)

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.Server.Tiered/Pages/Index.razor
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.Server.Tiered/Pages/Index.razor
@@ -2,6 +2,9 @@
 @using Volo.Abp.MultiTenancy
 @inherits MyProjectNameComponentBase
 @inject AuthenticationStateProvider AuthenticationStateProvider
+
+<PageTitle>Index</PageTitle>
+
 <div class="container">
     <div class="p-5 text-center">
         <Badge Color="Color.Success" class="mb-4">

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.Server.Tiered/Pages/Index.razor
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.Server.Tiered/Pages/Index.razor
@@ -3,8 +3,6 @@
 @inherits MyProjectNameComponentBase
 @inject AuthenticationStateProvider AuthenticationStateProvider
 
-<PageTitle>Index</PageTitle>
-
 <div class="container">
     <div class="p-5 text-center">
         <Badge Color="Color.Success" class="mb-4">

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.Server.Tiered/Pages/_Host.cshtml
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.Server.Tiered/Pages/_Host.cshtml
@@ -18,6 +18,7 @@
     <base href="~/" />
     
     <abp-style-bundle name="@BlazorLeptonXLiteThemeBundles.Styles.Global"/>
+    <HeadOutlet />
 </head>
 <body class="abp-application-layout bg-light @rtl">
 

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.Server/Pages/Index.razor
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.Server/Pages/Index.razor
@@ -2,6 +2,9 @@
 @using Volo.Abp.MultiTenancy
 @inherits MyProjectNameComponentBase
 @inject AuthenticationStateProvider AuthenticationStateProvider
+
+<PageTitle>Index</PageTitle>
+
 <div class="container">
     <div class="p-5 text-center">
         <Badge Color="Color.Success" class="mb-4">

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.Server/Pages/_Host.cshtml
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.Server/Pages/_Host.cshtml
@@ -18,6 +18,7 @@
     <base href="~/" />
     
     <abp-style-bundle name="@BlazorLeptonXLiteThemeBundles.Styles.Global" />
+    <HeadOutlet />
 </head>
 <body class="abp-application-layout bg-light @rtl">
 

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor/MyProjectNameBlazorModule.cs
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor/MyProjectNameBlazorModule.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using Blazorise.Bootstrap5;
 using Blazorise.Icons.FontAwesome;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -86,7 +87,7 @@ public class MyProjectNameBlazorModule : AbpModule
     private static void ConfigureUI(WebAssemblyHostBuilder builder)
     {
         builder.RootComponents.Add<App>("#ApplicationContainer");
-
+        builder.RootComponents.Add<HeadOutlet>("head::after");
     }
 
     private static void ConfigureHttpClient(ServiceConfigurationContext context, IWebAssemblyHostEnvironment environment)

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor/Pages/Index.razor
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor/Pages/Index.razor
@@ -2,6 +2,9 @@
 @using Volo.Abp.MultiTenancy
 @inherits MyProjectNameComponentBase
 @inject AuthenticationStateProvider AuthenticationStateProvider
+
+<PageTitle>Index</PageTitle>
+
 <div class="container">
     <div class="p-5 text-center">
         <Badge Color="Color.Success" class="mb-4">

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor/Pages/Index.razor
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor/Pages/Index.razor
@@ -3,8 +3,6 @@
 @inherits MyProjectNameComponentBase
 @inject AuthenticationStateProvider AuthenticationStateProvider
 
-<PageTitle>Index</PageTitle>
-
 <div class="container">
     <div class="p-5 text-center">
         <Badge Color="Color.Success" class="mb-4">

--- a/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.Blazor.Host/MyProjectNameBlazorHostModule.cs
+++ b/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.Blazor.Host/MyProjectNameBlazorHostModule.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using Blazorise.Bootstrap5;
 using Blazorise.Icons.FontAwesome;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -80,6 +81,7 @@ public class MyProjectNameBlazorHostModule : AbpModule
     private static void ConfigureUI(WebAssemblyHostBuilder builder)
     {
         builder.RootComponents.Add<App>("#ApplicationContainer");
+        builder.RootComponents.Add<HeadOutlet>("head::after");
     }
 
     private static void ConfigureHttpClient(ServiceConfigurationContext context, IWebAssemblyHostEnvironment environment)

--- a/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.Blazor.Server.Host/Pages/_Host.cshtml
+++ b/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.Blazor.Server.Host/Pages/_Host.cshtml
@@ -18,6 +18,7 @@
     <base href="~/" />
 
     <abp-style-bundle name="@BlazorBasicThemeBundles.Styles.Global" />
+    <HeadOutlet />
 </head>
 <body class="abp-application-layout bg-light @rtl">
     <component type="typeof(App)" render-mode="Server" />


### PR DESCRIPTION
### Description

This PR enables controlling head section by using HeadOutlet of Blazor. 
(https://learn.microsoft.com/en-us/aspnet/core/blazor/components/control-head-content?view=aspnetcore-8.0)

**PageHeader** implements **PageTitle** by default. So no need further actions to show page titles. Existing modules and pages that use PageHeader will automatically update page title.

Resolves https://github.com/volosoft/volo/issues/16482#issuecomment-1963412039

![blazor-page-title](https://github.com/abpframework/abp/assets/23705418/804380df-6ceb-4d57-b14b-c70bb3688ca3)

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

Please describe how this can be tested by the test engineers if it is not already explicit - or remove this section if no need to description.
