### PR TITLE
Update AbpExtensibleDataGrid.razor

### DIFF
--- a/framework/src/Volo.Abp.BlazoriseUI/Components/AbpExtensibleDataGrid.razor
+++ b/framework/src/Volo.Abp.BlazoriseUI/Components/AbpExtensibleDataGrid.razor
@@ -23,7 +23,7 @@
     <EmptyTemplate>
         <Row Class="w-100 align-items-center" Style="height: 150px;">
             <Column>
-                <Heading Size="HeadingSize.Is4" Alignment="TextAlignment.Center">No data available</Heading>
+                <Heading Size="HeadingSize.Is4" TextAlignment="TextAlignment.Center">No data available</Heading>
             </Column>
         </Row>
     </EmptyTemplate>


### PR DESCRIPTION
The `Alignment` parameter was removed a long time ago and replaced with the `TextAlignment` parameter. 