### PR TITLE
CLI: Check `HttpApi.Host` project if exists for SignalR nuget package target to add the related package to the project

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/ProjectFinder.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/ProjectFinder.cs
@@ -46,8 +46,8 @@ public static class ProjectFinder
                 return FindProjectEndsWith(projectFiles, assemblyNames, ".HttpApi.Client");
             case NuGetPackageTarget.SignalR:
                 return FindProjectEndsWith(projectFiles, assemblyNames, ".SignalR") ??
-                       FindProjectEndsWith(projectFiles, assemblyNames, ".Web") ??
-                       FindProjectEndsWith(projectFiles, assemblyNames, ".HttpApi.Host");
+                       FindProjectEndsWith(projectFiles, assemblyNames, ".HttpApi.Host") ??
+                       FindProjectEndsWith(projectFiles, assemblyNames, ".Web");
             case NuGetPackageTarget.Blazor:
                 return FindProjectEndsWith(projectFiles, assemblyNames, ".Blazor")
                     ?? FindProjectEndsWith(projectFiles, assemblyNames, ".MauiBlazor");;

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/SolutionModuleAdder.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/SolutionModuleAdder.cs
@@ -625,7 +625,7 @@ public class SolutionModuleAdder : ITransientDependency
     private async Task AddNugetAndNpmReferences(ModuleWithMastersInfo module, string[] projectFiles,
         bool useDotnetCliToInstall)
     {
-        var webPackagesWillBeAddedToBlazorServerProject = SouldWebPackagesBeAddedToBlazorServerProject(module, projectFiles);
+        var webPackagesWillBeAddedToBlazorServerProject = ShouldWebPackagesBeAddedToBlazorServerProject(module, projectFiles);
 
         await PublishEventAsync(3, "Adding nuget package references");
         foreach (var nugetPackage in module.NugetPackages)
@@ -687,7 +687,7 @@ public class SolutionModuleAdder : ITransientDependency
         }
     }
 
-    private static bool SouldWebPackagesBeAddedToBlazorServerProject(ModuleWithMastersInfo module, string[] projectFiles)
+    private static bool ShouldWebPackagesBeAddedToBlazorServerProject(ModuleWithMastersInfo module, string[] projectFiles)
     {
         var blazorProject = projectFiles.FirstOrDefault(p => p.EndsWith(".Blazor.csproj"));
 


### PR DESCRIPTION
### Description

Related with https://github.com/volosoft/volo/issues/17053#issuecomment-1988337803

### Checklist

- [X] I fully tested it as developer / designer and created unit / integration tests
- [X] I documented it (or no need to document or I will create a separate documentation issue)
