### PR TITLE
fix(angular/components): Fix extensible table component to display rows when totalCount is 0 but items.length is greater than 0

### DIFF
--- a/npm/ng-packs/packages/components/extensible/src/lib/components/extensible-table/extensible-table.component.ts
+++ b/npm/ng-packs/packages/components/extensible/src/lib/components/extensible-table/extensible-table.component.ts
@@ -1,6 +1,6 @@
 import {
   ABP,
-  ConfigStateService, 
+  ConfigStateService,
   getShortDateFormat,
   getShortDateShortTimeFormat,
   getShortTimeFormat,
@@ -9,12 +9,7 @@ import {
   PermissionDirective,
   PermissionService,
 } from '@abp/ng.core';
-import {
-  AsyncPipe,
-  formatDate,
-  NgComponentOutlet, 
-  NgTemplateOutlet,
-} from '@angular/common';
+import { AsyncPipe, formatDate, NgComponentOutlet, NgTemplateOutlet } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -179,8 +174,8 @@ export class ExtensibleTableComponent<R = any> implements OnChanges {
   ngOnChanges({ data, recordsTotal }: SimpleChanges) {
     if (data?.currentValue.length < 1 && recordsTotal?.currentValue > 0) {
       let maxPage = Math.floor(Number(recordsTotal?.currentValue / this.list.maxResultCount));
-      
-      if(recordsTotal?.currentValue < this.list.maxResultCount) {
+
+      if (recordsTotal?.currentValue < this.list.maxResultCount) {
         this.list.page = 0;
         return;
       }
@@ -202,6 +197,10 @@ export class ExtensibleTableComponent<R = any> implements OnChanges {
 
     if (data.currentValue.length < 1) {
       this.list.totalCount = this.recordsTotal;
+    }
+
+    if (data.currentValue.length !== this.recordsTotal) {
+      this.recordsTotal = data.currentValue.length;
     }
 
     this.data = data.currentValue.map((record: any, index: number) => {


### PR DESCRIPTION
### Description

Resolves #19370

- This pull request implements a workaround for a backend issue. Specifically, when the response payload returns a `totalCount` of 0, despite there being more than 0 `items` present.

### Checklist

- [x] I fully tested it as developer
