### PR TITLE
CLI: Add angular implementation after new microservice added to project

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/NewCommand.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/NewCommand.cs
@@ -111,6 +111,8 @@ public class NewCommand : ProjectCreationCommandBase, IConsoleCommand, ITransien
         await RunGraphBuildForMicroserviceServiceTemplate(projectArgs);
         await CreateInitialMigrationsAsync(projectArgs);
 
+        await ConfigureAngularLibraryAfterMicroserviceServiceCreatedAsync(projectArgs, template);
+
         var skipInstallLibs = commandLineArgs.Options.ContainsKey(Options.SkipInstallingLibs.Long) || commandLineArgs.Options.ContainsKey(Options.SkipInstallingLibs.Short);
         if (!skipInstallLibs)
         {

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/NewCommand.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/NewCommand.cs
@@ -111,7 +111,7 @@ public class NewCommand : ProjectCreationCommandBase, IConsoleCommand, ITransien
         await RunGraphBuildForMicroserviceServiceTemplate(projectArgs);
         await CreateInitialMigrationsAsync(projectArgs);
 
-        await ConfigureAngularLibraryAfterMicroserviceServiceCreatedAsync(projectArgs, template);
+        await ConfigureAngularAfterMicroserviceServiceCreatedAsync(projectArgs, template);
 
         var skipInstallLibs = commandLineArgs.Options.ContainsKey(Options.SkipInstallingLibs.Long) || commandLineArgs.Options.ContainsKey(Options.SkipInstallingLibs.Short);
         if (!skipInstallLibs)

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/ProjectCreationCommandBase.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/ProjectCreationCommandBase.cs
@@ -756,10 +756,10 @@ public abstract class ProjectCreationCommandBase
             return;
         }
 
-        var projectRootpath = Directory.GetCurrentDirectory();
-        var projectUiFramework = FindMicroserviceSolutionUiFramework(projectRootpath);
+        var rootPath = Directory.GetCurrentDirectory();
+        var uiFramework = FindMicroserviceSolutionUiFramework(rootPath);
 
-        if (projectUiFramework != UiFramework.Angular)
+        if (uiFramework != UiFramework.Angular)
         {
             return;
         }
@@ -768,10 +768,10 @@ public abstract class ProjectCreationCommandBase
 
         var libraryName = projectArgs.SolutionName.ProjectName.ToKebabCase();
 
-        var hostAppPath = Path.Combine(projectRootpath, "apps", "angular");
-        var angularLibraryPath = Path.Combine(hostAppPath, "projects", libraryName);
+        var angularAppPath = Path.Combine(rootPath, "apps", "angular");
+        var angularLibraryPath = Path.Combine(angularAppPath, "projects", libraryName);
 
-        await GenerateAngularLibraryForNewMicroserviceAsync(libraryName, hostAppPath);
+        await GenerateAngularLibraryForNewMicroserviceAsync(libraryName, angularAppPath);
 
         try
         {

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/ProjectCreationCommandBase.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/ProjectCreationCommandBase.cs
@@ -793,9 +793,9 @@ public abstract class ProjectCreationCommandBase
 
         var commandBuilder = new StringBuilder($"npx ng g @abp/ng.schematics:create-lib --package-name {libraryName}");
 
-        commandBuilder.Append($" --is-secondary-entrypoint {(isSecondaryEndpoint ? "true" : "false")} ");
-        commandBuilder.Append($" --is-module-template {(isModuleTemplate ? "true" : "false")} ");
-        commandBuilder.Append($" --override {(isOverride ? "true" : "false")} ");
+        commandBuilder.Append($" --is-secondary-entrypoint {isSecondaryEndpoint.ToString().ToLower()}");
+        commandBuilder.Append($" --is-module-template {isModuleTemplate.ToString().ToLower()}");
+        commandBuilder.Append($" --override {isOverride.ToString().ToLower()}");
 
         var result = CmdHelper.RunCmdAndGetOutput(commandBuilder.ToString(), workingDirectory);
         return await Task.FromResult(result);

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package/__libraryName@kebab__/src/lib/__libraryName@kebab__-routing.module.ts.template
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package/__libraryName@kebab__/src/lib/__libraryName@kebab__-routing.module.ts.template
@@ -1,12 +1,12 @@
 import { NgModule } from '@angular/core';
-import { DynamicLayoutComponent } from '@abp/ng.core';
+import { RouterOutletComponent } from '@abp/ng.core';
 import { Routes, RouterModule } from '@angular/router';
 
 const routes: Routes = [
   {
     path: '',
     pathMatch: 'full',
-    component: DynamicLayoutComponent,
+    component: RouterOutletComponent,
     children: [],
   },
 ];


### PR DESCRIPTION
### Description

This PR provides to adding new angular library after new microservice-service-pro created to project and **if project uses angular ui**

### Angular output after run `abp new OrderService -t microservice-service-pro` command
--- 
![image](https://github.com/abpframework/abp/assets/49063256/c963da7f-3ca6-437f-84f9-7a3af851d77b)

![image](https://github.com/abpframework/abp/assets/49063256/ef8cc112-dd67-4b67-bfc5-affedbfaf9e3)

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests

### How to test
- Run command in abp > framework > Volo.Abp.Cli > bin > Debug > net8.0
  - `.\Volo.Abp.Cli.exe new OrderService -t microservice-service-pro -ms <project-root-path>`
