### PR TITLE
Angular - Account Pages Sidebar Flicker on Reload

### DIFF
--- a/npm/ng-packs/apps/dev-app/src/app/home/home.component.ts
+++ b/npm/ng-packs/apps/dev-app/src/app/home/home.component.ts
@@ -1,17 +1,18 @@
 import { AuthService } from '@abp/ng.core';
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 
 @Component({
   selector: 'app-home',
   templateUrl: './home.component.html',
 })
 export class HomeComponent {
+  private authService = inject(AuthService);
+
   loading = false;
   get hasLoggedIn(): boolean {
     return this.authService.isAuthenticated;
   }
 
-  constructor(private authService: AuthService) {}
   login() {
     this.loading = true;
     this.authService.navigateToLogin();

--- a/npm/ng-packs/apps/dev-app/src/app/home/home.component.ts
+++ b/npm/ng-packs/apps/dev-app/src/app/home/home.component.ts
@@ -6,7 +6,7 @@ import { Component, inject } from '@angular/core';
   templateUrl: './home.component.html',
 })
 export class HomeComponent {
-  private authService = inject(AuthService);
+  protected readonly authService = inject(AuthService);
 
   loading = false;
   get hasLoggedIn(): boolean {

--- a/npm/ng-packs/packages/account/src/lib/components/login/login.component.ts
+++ b/npm/ng-packs/packages/account/src/lib/components/login/login.component.ts
@@ -1,6 +1,6 @@
 import { AuthService, ConfigStateService } from '@abp/ng.core';
 import { ToasterService } from '@abp/ng.theme.shared';
-import { Component, Injector, OnInit } from '@angular/core';
+import { Component, Injector, OnInit, inject } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
 import { throwError } from 'rxjs';
 import { catchError, finalize } from 'rxjs/operators';
@@ -14,6 +14,12 @@ const { maxLength, required } = Validators;
   templateUrl: './login.component.html',
 })
 export class LoginComponent implements OnInit {
+  protected injector = inject(Injector);
+  protected fb = inject(UntypedFormBuilder);
+  protected toasterService = inject(ToasterService);
+  protected authService = inject(AuthService);
+  protected configState = inject(ConfigStateService);
+
   form!: UntypedFormGroup;
 
   inProgress?: boolean;
@@ -21,14 +27,6 @@ export class LoginComponent implements OnInit {
   isSelfRegistrationEnabled = true;
 
   authWrapperKey = eAccountComponents.AuthWrapper;
-
-  constructor(
-    protected injector: Injector,
-    protected fb: UntypedFormBuilder,
-    protected toasterService: ToasterService,
-    protected authService: AuthService,
-    protected configState: ConfigStateService,
-  ) {}
 
   ngOnInit() {
     this.init();

--- a/npm/ng-packs/packages/core/src/lib/components/dynamic-layout.component.ts
+++ b/npm/ng-packs/packages/core/src/lib/components/dynamic-layout.component.ts
@@ -17,19 +17,19 @@ import { DYNAMIC_LAYOUTS_TOKEN } from '../tokens/dynamic-layout.token';
   template: ` <ng-container *ngIf="isLayoutVisible" [ngComponentOutlet]="layout"></ng-container> `,
   providers: [SubscriptionService],
 })
-export class DynamicLayoutComponent implements OnInit {
+export class DynamicLayoutComponent {
   layout?: Type<any>;
   layoutKey?: eLayoutType;
   readonly layouts = inject(DYNAMIC_LAYOUTS_TOKEN);
   isLayoutVisible = true;
 
-  private readonly router = inject(Router);
-  private readonly route = inject(ActivatedRoute);
-  private readonly routes = inject(RoutesService);
-  private localizationService = inject(LocalizationService);
-  private replaceableComponents = inject(ReplaceableComponentsService);
-  private subscription = inject(SubscriptionService);
-  private routerEvents = inject(RouterEvents);
+  protected readonly router = inject(Router);
+  protected readonly route = inject(ActivatedRoute);
+  protected readonly routes = inject(RoutesService);
+  protected readonly localizationService = inject(LocalizationService);
+  protected readonly replaceableComponents = inject(ReplaceableComponentsService);
+  protected readonly subscription = inject(SubscriptionService);
+  protected readonly routerEvents = inject(RouterEvents);
 
   constructor(@Optional() @SkipSelf() dynamicLayoutComponent: DynamicLayoutComponent) {
     if (dynamicLayoutComponent) {
@@ -38,13 +38,6 @@ export class DynamicLayoutComponent implements OnInit {
     }
     this.checkLayoutOnNavigationEnd();
     this.listenToLanguageChange();
-  }
-
-  ngOnInit(): void {
-    if (this.layout) {
-      return;
-    }
-    // this.getLayout();
   }
 
   private checkLayoutOnNavigationEnd() {

--- a/npm/ng-packs/packages/core/src/lib/components/dynamic-layout.component.ts
+++ b/npm/ng-packs/packages/core/src/lib/components/dynamic-layout.component.ts
@@ -38,8 +38,9 @@ export class DynamicLayoutComponent implements OnInit {
       return;
     }
 
-    const env = this.environment.getEnvironment();
-    if (env?.oAuthConfig?.responseType === 'code') {
+    const { oAuthConfig } = this.environment.getEnvironment() || {};
+
+    if (oAuthConfig.responseType && oAuthConfig.responseType === 'code') {
       this.getLayout();
     }
   }

--- a/npm/ng-packs/packages/core/src/lib/components/dynamic-layout.component.ts
+++ b/npm/ng-packs/packages/core/src/lib/components/dynamic-layout.component.ts
@@ -33,18 +33,6 @@ export class DynamicLayoutComponent implements OnInit {
   protected readonly routerEvents = inject(RouterEvents);
   protected readonly environment = inject(EnvironmentService);
 
-  ngOnInit(): void {
-    if (this.layout) {
-      return;
-    }
-
-    const { oAuthConfig } = this.environment.getEnvironment() || {};
-
-    if (oAuthConfig.responseType && oAuthConfig.responseType === 'code') {
-      this.getLayout();
-    }
-  }
-
   constructor(@Optional() @SkipSelf() dynamicLayoutComponent: DynamicLayoutComponent) {
     if (dynamicLayoutComponent) {
       if (isDevMode()) console.warn('DynamicLayoutComponent must be used only in AppComponent.');
@@ -52,6 +40,17 @@ export class DynamicLayoutComponent implements OnInit {
     }
     this.checkLayoutOnNavigationEnd();
     this.listenToLanguageChange();
+  }
+  
+  ngOnInit(): void {
+    if (this.layout) {
+      return;
+    }
+
+    const { oAuthConfig } = this.environment.getEnvironment();
+    if (oAuthConfig.responseType === 'code') {
+      this.getLayout();
+    }
   }
 
   private checkLayoutOnNavigationEnd() {

--- a/npm/ng-packs/packages/core/src/lib/components/dynamic-layout.component.ts
+++ b/npm/ng-packs/packages/core/src/lib/components/dynamic-layout.component.ts
@@ -11,13 +11,14 @@ import { SubscriptionService } from '../services/subscription.service';
 import { findRoute, getRoutePath } from '../utils/route-utils';
 import { TreeNode } from '../utils/tree-utils';
 import { DYNAMIC_LAYOUTS_TOKEN } from '../tokens/dynamic-layout.token';
+import { EnvironmentService } from '../services';
 
 @Component({
   selector: 'abp-dynamic-layout',
   template: ` <ng-container *ngIf="isLayoutVisible" [ngComponentOutlet]="layout"></ng-container> `,
   providers: [SubscriptionService],
 })
-export class DynamicLayoutComponent {
+export class DynamicLayoutComponent implements OnInit {
   layout?: Type<any>;
   layoutKey?: eLayoutType;
   readonly layouts = inject(DYNAMIC_LAYOUTS_TOKEN);
@@ -30,6 +31,18 @@ export class DynamicLayoutComponent {
   protected readonly replaceableComponents = inject(ReplaceableComponentsService);
   protected readonly subscription = inject(SubscriptionService);
   protected readonly routerEvents = inject(RouterEvents);
+  protected readonly environment = inject(EnvironmentService);
+
+  ngOnInit(): void {
+    if (this.layout) {
+      return;
+    }
+
+    const env = this.environment.getEnvironment();
+    if (env?.oAuthConfig?.responseType === 'code') {
+      this.getLayout();
+    }
+  }
 
   constructor(@Optional() @SkipSelf() dynamicLayoutComponent: DynamicLayoutComponent) {
     if (dynamicLayoutComponent) {

--- a/npm/ng-packs/packages/core/src/lib/components/dynamic-layout.component.ts
+++ b/npm/ng-packs/packages/core/src/lib/components/dynamic-layout.component.ts
@@ -1,49 +1,37 @@
-import {
-  Component,
-  inject,
-  isDevMode,
-  OnInit,
-  Optional,
-  SkipSelf,
-  Type
-} from '@angular/core';
-import {ActivatedRoute, Router} from '@angular/router';
-import {eLayoutType} from '../enums/common';
-import {ABP} from '../models';
-import {ReplaceableComponents} from '../models/replaceable-components';
-import {LocalizationService} from '../services/localization.service';
-import {ReplaceableComponentsService} from '../services/replaceable-components.service';
-import {RouterEvents} from '../services/router-events.service';
-import {RoutesService} from '../services/routes.service';
-import {SubscriptionService} from '../services/subscription.service';
-import {findRoute, getRoutePath} from '../utils/route-utils';
-import {TreeNode} from '../utils/tree-utils';
-import {DYNAMIC_LAYOUTS_TOKEN} from "../tokens/dynamic-layout.token";
+import { Component, inject, isDevMode, OnInit, Optional, SkipSelf, Type } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { eLayoutType } from '../enums/common';
+import { ABP } from '../models';
+import { ReplaceableComponents } from '../models/replaceable-components';
+import { LocalizationService } from '../services/localization.service';
+import { ReplaceableComponentsService } from '../services/replaceable-components.service';
+import { RouterEvents } from '../services/router-events.service';
+import { RoutesService } from '../services/routes.service';
+import { SubscriptionService } from '../services/subscription.service';
+import { findRoute, getRoutePath } from '../utils/route-utils';
+import { TreeNode } from '../utils/tree-utils';
+import { DYNAMIC_LAYOUTS_TOKEN } from '../tokens/dynamic-layout.token';
 
 @Component({
   selector: 'abp-dynamic-layout',
-  template: `
-    <ng-container *ngIf="isLayoutVisible" [ngComponentOutlet]="layout"></ng-container> `,
+  template: ` <ng-container *ngIf="isLayoutVisible" [ngComponentOutlet]="layout"></ng-container> `,
   providers: [SubscriptionService],
 })
 export class DynamicLayoutComponent implements OnInit {
   layout?: Type<any>;
   layoutKey?: eLayoutType;
-  readonly layouts = inject(DYNAMIC_LAYOUTS_TOKEN)
+  readonly layouts = inject(DYNAMIC_LAYOUTS_TOKEN);
   isLayoutVisible = true;
 
   private readonly router = inject(Router);
   private readonly route = inject(ActivatedRoute);
   private readonly routes = inject(RoutesService);
-  private localizationService = inject(LocalizationService)
-  private replaceableComponents = inject(ReplaceableComponentsService)
-  private subscription = inject(SubscriptionService)
-  private routerEvents = inject(RouterEvents)
+  private localizationService = inject(LocalizationService);
+  private replaceableComponents = inject(ReplaceableComponentsService);
+  private subscription = inject(SubscriptionService);
+  private routerEvents = inject(RouterEvents);
 
-
-  constructor(
-    @Optional() @SkipSelf() dynamicLayoutComponent: DynamicLayoutComponent,
-  ) {
+  constructor(@Optional() @SkipSelf() dynamicLayoutComponent: DynamicLayoutComponent) {
     if (dynamicLayoutComponent) {
       if (isDevMode()) console.warn('DynamicLayoutComponent must be used only in AppComponent.');
       return;
@@ -56,7 +44,7 @@ export class DynamicLayoutComponent implements OnInit {
     if (this.layout) {
       return;
     }
-    this.getLayout()
+    // this.getLayout();
   }
 
   private checkLayoutOnNavigationEnd() {
@@ -64,10 +52,8 @@ export class DynamicLayoutComponent implements OnInit {
     this.subscription.addOne(navigationEnd$, () => this.getLayout());
   }
 
-
   private getLayout() {
     let expectedLayout = this.getExtractedLayout();
-
 
     if (!expectedLayout) expectedLayout = eLayoutType.empty;
 
@@ -84,15 +70,11 @@ export class DynamicLayoutComponent implements OnInit {
   }
 
   private getExtractedLayout() {
-    const routeData = (this.route.snapshot.data || {});
+    const routeData = this.route.snapshot.data || {};
     let expectedLayout = routeData['layout'] as eLayoutType;
 
-    if (expectedLayout) {
-      return expectedLayout;
-    }
-
     let node = findRoute(this.routes, getRoutePath(this.router));
-    node = {parent: node} as TreeNode<ABP.Route>;
+    node = { parent: node } as TreeNode<ABP.Route>;
 
     while (node.parent) {
       node = node.parent;
@@ -108,11 +90,11 @@ export class DynamicLayoutComponent implements OnInit {
   showLayoutNotFoundError(layoutName: string) {
     let message = `Layout ${layoutName} not found.`;
     if (layoutName === 'account') {
-      message = 'Account layout not found. Please check your configuration. If you are using LeptonX, please make sure you have added "AccountLayoutModule.forRoot()" to your app.module configuration.';
+      message =
+        'Account layout not found. Please check your configuration. If you are using LeptonX, please make sure you have added "AccountLayoutModule.forRoot()" to your app.module configuration.';
     }
     console.warn(message);
   }
-
 
   private listenToLanguageChange() {
     this.subscription.addOne(this.localizationService.languageChange$, () => {

--- a/npm/ng-packs/packages/theme-basic/src/lib/components/application-layout/application-layout.component.ts
+++ b/npm/ng-packs/packages/theme-basic/src/lib/components/application-layout/application-layout.component.ts
@@ -1,8 +1,7 @@
-import {eLayoutType, SubscriptionService} from '@abp/ng.core';
+import { eLayoutType, SubscriptionService } from '@abp/ng.core';
 import { collapseWithMargin, slideFromBottom } from '@abp/ng.theme.shared';
-import {AfterViewInit, Component} from '@angular/core';
+import { AfterViewInit, Component, inject } from '@angular/core';
 import { LayoutService } from '../../services/layout.service';
-
 
 @Component({
   selector: 'abp-layout-application',
@@ -11,10 +10,9 @@ import { LayoutService } from '../../services/layout.service';
   providers: [LayoutService, SubscriptionService],
 })
 export class ApplicationLayoutComponent implements AfterViewInit {
+  public service = inject(LayoutService);
   // required for dynamic component
   static type = eLayoutType.application;
-
-  constructor(public service: LayoutService) {}
 
   ngAfterViewInit() {
     this.service.subscribeWindowSize();

--- a/npm/ng-packs/packages/theme-basic/src/lib/components/application-layout/application-layout.component.ts
+++ b/npm/ng-packs/packages/theme-basic/src/lib/components/application-layout/application-layout.component.ts
@@ -10,7 +10,7 @@ import { LayoutService } from '../../services/layout.service';
   providers: [LayoutService, SubscriptionService],
 })
 export class ApplicationLayoutComponent implements AfterViewInit {
-  public service = inject(LayoutService);
+  public readonly service = inject(LayoutService);
   // required for dynamic component
   static type = eLayoutType.application;
 


### PR DESCRIPTION
### Description

Resolves #19038 and relates #17061.
As another issue was fixed by #17061, the code piece added inside the `ngOnInit` lifecycle hook breaks the account pages and results in a flicker on reload. That is why, we have commented out the related part to propose a solution.

[SidebarFlickerResolved.webm](https://github.com/abpframework/abp/assets/92928815/59d95d8f-5c43-46b9-9b7d-683e78883c05)


### Checklist

- [X] I fully tested it as developer

### How to test it?

You can test it by following the instructions as declared in the issue.
