### PR TITLE
Add network status component to template

### DIFF
--- a/npm/ng-packs/apps/dev-app/src/app/app.module.ts
+++ b/npm/ng-packs/apps/dev-app/src/app/app.module.ts
@@ -39,7 +39,7 @@ import { APP_ROUTE_PROVIDER } from './route.provider';
     ThemeLeptonXModule.forRoot(),
     SideMenuLayoutModule.forRoot(),
     AccountLayoutModule.forRoot(),
-    InternetConnectionStatusComponent
+    InternetConnectionStatusComponent,
   ],
   providers: [APP_ROUTE_PROVIDER],
   declarations: [AppComponent],

--- a/npm/ng-packs/packages/core/src/lib/services/internet-connection-service.ts
+++ b/npm/ng-packs/packages/core/src/lib/services/internet-connection-service.ts
@@ -5,28 +5,28 @@ import { BehaviorSubject } from 'rxjs';
 @Injectable({
   providedIn: 'root',
 })
-export class InternetConnectionService{
-  readonly document = inject(DOCUMENT)
+export class InternetConnectionService {
+  readonly document = inject(DOCUMENT);
   readonly window = this.document.defaultView;
   readonly navigator = this.window.navigator;
 
-  private status$ = new BehaviorSubject<boolean>(this.navigator.onLine)
+  private status$ = new BehaviorSubject<boolean>(this.navigator.onLine);
 
   private status = signal(this.navigator.onLine);
 
-  networkStatus = computed(() => this.status())
-  
-  constructor(){
+  networkStatus = computed(() => this.status());
+
+  constructor() {
     this.window.addEventListener('offline', () => this.setStatus(false));
     this.window.addEventListener('online', () => this.setStatus(true));
   }
 
-  setStatus(val:boolean){
-    this.status.set(val)
-    this.status$.next(val)
+  setStatus(val: boolean) {
+    this.status.set(val);
+    this.status$.next(val);
   }
 
-  get networkStatus$(){
-    return this.status$.asObservable()
+  get networkStatus$() {
+    return this.status$.asObservable();
   }
 }

--- a/npm/ng-packs/packages/theme-shared/src/lib/components/internet-connection-status/internet-connection-status.component.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/components/internet-connection-status/internet-connection-status.component.ts
@@ -1,47 +1,62 @@
-import { Component, computed, inject  } from '@angular/core';
-import { NgIf } from '@angular/common'
-import { InternetConnectionService , LocalizationModule } from '@abp/ng.core';
+import { Component, inject } from '@angular/core';
+import { InternetConnectionService, LocalizationModule } from '@abp/ng.core';
+import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
   selector: 'abp-internet-status',
   standalone: true,
-  imports:[NgIf, LocalizationModule],
+  imports: [LocalizationModule, NgbTooltip],
   template: `
-    <div class="status-icon" *ngIf="!isOnline()">
-      <i data-toggle="tooltip" title="{{ 'AbpUi::InternetConnectionInfo' | abpLocalization }}" data-placement="left" class="fa fa-circle text-blinking blink">
-      </i>
-    </div>
+    @if (!isOnline()) {
+      <div class="status-icon">
+        <i
+          ngbTooltip="{{ 'AbpUi::InternetConnectionInfo' | abpLocalization }}"
+          container="body"
+          placement="left-top" 
+          class="fa fa-circle text-blinking blink"
+        >
+        </i>
+      </div>
+    }
   `,
-  styles: [`
-    .blink {
-      animation: blinker 0.9s cubic-bezier(.5, 0, 1, 1) infinite alternate;  
-    }
-    @keyframes blinker {  
-      0% { color:#c1c1c1 }
-      70% { color: #DC3545 }
-      100% { color: #DC3545 }
-    }
-
-    .text-blinking{
-      font-size:1.2rem;
-    }
-
-    .status-icon{
-      position: fixed;
-      z-index: 999999;
-      top: 10px;
-      right: 10px;
-    }
-
-    @media (width < 768px){
-      .status-icon{
-        top: 26px;
-        right: 134px;
+  styles: [
+    `
+      .blink {
+        animation: blinker 0.9s cubic-bezier(0.5, 0, 1, 1) infinite alternate;
       }
-    }
-  `]
+      @keyframes blinker {
+        0% {
+          color: #c1c1c1;
+        }
+        70% {
+          color: #dc3545;
+        }
+        100% {
+          color: #dc3545;
+        }
+      }
+
+      .text-blinking {
+        font-size: 1.2rem;
+      }
+
+      .status-icon {
+        position: fixed;
+        z-index: 999999;
+        top: 10px;
+        right: 10px;
+      }
+
+      @media (width < 768px) {
+        .status-icon {
+          top: 26px;
+          right: 134px;
+        }
+      }
+    `,
+  ],
 })
-export class InternetConnectionStatusComponent{
+export class InternetConnectionStatusComponent {
   internetConnectionService = inject(InternetConnectionService);
-  isOnline = this.internetConnectionService.networkStatus
+  isOnline = this.internetConnectionService.networkStatus;
 }

--- a/npm/ng-packs/packages/theme-shared/src/lib/components/internet-connection-status/internet-connection-status.component.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/components/internet-connection-status/internet-connection-status.component.ts
@@ -13,7 +13,7 @@ import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
           ngbTooltip="{{ 'AbpUi::InternetConnectionInfo' | abpLocalization }}"
           container="body"
           placement="left-top" 
-          class="fa fa-circle text-blinking blink"
+          class="fa fa-wifi text-blinking blink"
         >
         </i>
       </div>
@@ -29,29 +29,27 @@ import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
           color: #c1c1c1;
         }
         70% {
-          color: #dc3545;
+          color: #fa2379;
         }
         100% {
-          color: #dc3545;
+          color: #fa2379;
         }
       }
 
       .text-blinking {
-        font-size: 1.2rem;
+        font-size: 30px;
       }
 
       .status-icon {
         position: fixed;
         z-index: 999999;
-        top: 10px;
-        right: 10px;
-      }
-
-      @media (width < 768px) {
-        .status-icon {
-          top: 26px;
-          right: 134px;
-        }
+        top: 50%;
+        left: 50%;
+        width: 30px;
+        text-align: center;
+        margin-left: -15px;
+        margin-top: -15px;
+        translate: transform(-50%, -50%);
       }
     `,
   ],

--- a/templates/app/angular/src/app/app.component.ts
+++ b/templates/app/angular/src/app/app.component.ts
@@ -5,6 +5,7 @@ import { Component } from '@angular/core';
   template: `
     <abp-loader-bar></abp-loader-bar>
     <abp-dynamic-layout></abp-dynamic-layout>
+    <abp-internet-status></abp-internet-status>
   `,
 })
 export class AppComponent {}

--- a/templates/app/angular/src/app/app.module.ts
+++ b/templates/app/angular/src/app/app.module.ts
@@ -6,7 +6,7 @@ import { SettingManagementConfigModule } from '@abp/ng.setting-management/config
 import { TenantManagementConfigModule } from '@abp/ng.tenant-management/config';
 import { ThemeLeptonXModule } from '@abp/ng.theme.lepton-x';
 import { SideMenuLayoutModule } from '@abp/ng.theme.lepton-x/layouts';
-import { ThemeSharedModule } from '@abp/ng.theme.shared';
+import { InternetConnectionStatusComponent, ThemeSharedModule } from '@abp/ng.theme.shared';
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -36,6 +36,7 @@ import { AccountLayoutModule } from '@abp/ng.theme.lepton-x/account';
     ThemeLeptonXModule.forRoot(),
     SideMenuLayoutModule.forRoot(),
     FeatureManagementModule.forRoot(),
+    InternetConnectionStatusComponent
   ],
   declarations: [AppComponent],
   providers: [APP_ROUTE_PROVIDER],


### PR DESCRIPTION
### Description

Resolves #19423 

Network status component added to the template.

![image](https://github.com/abpframework/abp/assets/72804437/3e445b97-04e2-4cad-a9af-d37dfe2c6d00)



### How to test it?
- run `yarn copy-to:app`
- go `http://localhost:4200` 
- open `developer tools` -> `network`
- set `No throttling` to `offline`
