### PR TITLE
Replace `\n` with `<br>` in `abp-sweetalert2.js`

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/wwwroot/libs/abp/aspnetcore-mvc-ui-theme-shared/sweetalert2/abp-sweetalert2.js
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/wwwroot/libs/abp/aspnetcore-mvc-ui-theme-shared/sweetalert2/abp-sweetalert2.js
@@ -35,6 +35,8 @@ var abp = abp || {};
 
     /* MESSAGE **************************************************/
 
+    abp.utils = abp.utils || {};
+    abp.utils.htmlEscape = abp.utils.htmlEscape || function (str) { return str; };
     var showMessage = function (type, message, title) {
         var opts = $.extend(
             {},
@@ -42,7 +44,7 @@ var abp = abp || {};
             abp.libs.sweetAlert.config[type],
             {
                 title: title,
-                text: message
+                html: abp.utils.htmlEscape(message).replace(/\n/g, '<br>')
             }
         );
 


### PR DESCRIPTION
Based on https://github.com/sweetalert2/sweetalert2/issues/2368#issuecomment-1000873297
Resolve #19274


```
abp.message.success('123\n456\n789\n0000')
```

![image](https://github.com/abpframework/abp/assets/6908465/e2bef074-8cc7-4bf8-9876-fe405f06dbc2)

```
abp.message.error('123<br \>\n<script src="/123.js"></script>')
```

![image](https://github.com/abpframework/abp/assets/6908465/71286237-ca73-405a-8924-4036fc1c56c3)
