### PR TITLE
Add disable filtering with id in AbstractTreeService, delete function

### DIFF
--- a/docs/en/UI/Angular/Modifying-the-Menu.md
+++ b/docs/en/UI/Angular/Modifying-the-Menu.md
@@ -152,8 +152,11 @@ import { APP_ROUTE_PROVIDER } from './route.provider';
 export class AppModule {}
 ```
 
-**Note:**
-Route items's `name` property is must be a unique key. If there are multiple items with the same name, the last one will be displayed in the menu. If you want to display multiple items with the same name, you can call the `setSingularizeStatus(false)` method of the `RoutesService` to disable the singularization of the names. This method should be called before adding the routes. If you want to enable the singularization of the names, you can call the `setSingularizeStatus(true)` method of the `RoutesService` to enable the singularization of the names. This method should be called before adding the routes. The default value of the singularization status is `true`. The default value of the singularization status is `true`.
+### Singularize Route Item
+- `name` property is must be a unique key. If there are multiple items with the same name, the last one will be displayed in the menu.
+- If you want to display multiple items in different parent with the same name, you can call the **setSingularizeStatus(false)** method of the `RoutesService` to disable the singularization.
+  - **This method should be called before adding the routes.**
+- To enable the singularization of the names, you can call the **setSingularizeStatus(true) `(default value: true)`** method of the `RoutesService`.
 
 ```typescript
 import { RoutesService } from '@abp/ng.core';

--- a/docs/en/UI/Angular/Modifying-the-Menu.md
+++ b/docs/en/UI/Angular/Modifying-the-Menu.md
@@ -153,7 +153,7 @@ export class AppModule {}
 ```
 
 **Note:**
-Route items's `name` property is must be a unique key. If there are multiple items with the same name, the last one will be displayed in the menu. If you want to display multiple items with the same name, you can call the `disableFiltering` method of the `RoutesService` to disable the filtering.
+Route items's `name` property is must be a unique key. If there are multiple items with the same name, the last one will be displayed in the menu. If you want to display multiple items with the same name, you can call the `setSingularizeStatus(false)` method of the `RoutesService` to disable the singularization of the names. This method should be called before adding the routes. If you want to enable the singularization of the names, you can call the `setSingularizeStatus(true)` method of the `RoutesService` to enable the singularization of the names. This method should be called before adding the routes. The default value of the singularization status is `true`. The default value of the singularization status is `true`.
 
 ```typescript
 import { RoutesService } from '@abp/ng.core';
@@ -162,7 +162,7 @@ import { Component } from '@angular/core';
 @Component(/* component metadata */)
 export class AppComponent {
   constructor(private routes: RoutesService) {
-    routes.disableFiltering();
+    routes.setSingularizeStatus(false);
   }
 }
 ```
@@ -241,7 +241,7 @@ After adding the `routes` property as described above, the navigation menu looks
 
 ## How to Patch or Remove a Navigation Element
 
-The `patch` method of `RoutesService` finds a route by its name and replaces its configuration with the new configuration passed as the second parameter. Similarly, `remove` method finds a route and removes it along with its children. Also you can use `delete` method to delete the routes with given properties.
+The `patch` method of `RoutesService` finds a route by its name and replaces its configuration with the new configuration passed as the second parameter. Similarly, `remove` method finds a route and removes it along with its children. Also you can use `removeByParams` method to delete the routes with given properties.
 
 ```js
 // this.routes is instance of RoutesService
@@ -266,7 +266,7 @@ this.routes.patch('::Menu:Home', newHomeRouteConfig);
 this.routes.remove(['Your navigation']);
 
 // or
-this.routes.delete({ name: 'Your navigation' });
+this.routes.removeByParams({ name: 'Your navigation' });
 ```
 
 - Moved the _Home_ navigation under the _Administration_ dropdown based on given `parentName`.

--- a/docs/en/UI/Angular/Modifying-the-Menu.md
+++ b/docs/en/UI/Angular/Modifying-the-Menu.md
@@ -241,7 +241,7 @@ After adding the `routes` property as described above, the navigation menu looks
 
 ## How to Patch or Remove a Navigation Element
 
-The `patch` method of `RoutesService` finds a route by its name and replaces its configuration with the new configuration passed as the second parameter. Similarly, `remove` method finds a route and removes it along with its children. Also you can use `removeByParams` method to delete the routes with given properties.
+The `patch` method of `RoutesService` finds a route by its name and replaces its configuration with the new configuration passed as the second parameter. Similarly, `remove` method finds a route and removes it along with its children. Also you can use `removeByParam` method to delete the routes with given properties.
 
 ```js
 // this.routes is instance of RoutesService
@@ -266,7 +266,7 @@ this.routes.patch('::Menu:Home', newHomeRouteConfig);
 this.routes.remove(['Your navigation']);
 
 // or
-this.routes.removeByParams({ name: 'Your navigation' });
+this.routes.removeByParam({ name: 'Your navigation' });
 ```
 
 - Moved the _Home_ navigation under the _Administration_ dropdown based on given `parentName`.

--- a/docs/en/UI/Angular/Modifying-the-Menu.md
+++ b/docs/en/UI/Angular/Modifying-the-Menu.md
@@ -152,6 +152,21 @@ import { APP_ROUTE_PROVIDER } from './route.provider';
 export class AppModule {}
 ```
 
+**Note:**
+Route items's `name` property is must be a unique key. If there are multiple items with the same name, the last one will be displayed in the menu. If you want to display multiple items with the same name, you can call the `disableFiltering` method of the `RoutesService` to disable the filtering.
+
+```typescript
+import { RoutesService } from '@abp/ng.core';
+import { Component } from '@angular/core';
+
+@Component(/* component metadata */)
+export class AppComponent {
+  constructor(private routes: RoutesService) {
+    routes.disableFiltering();
+  }
+}
+```
+
 Here is what every property works as:
 
 - `path` is the absolute path of the navigation element.
@@ -226,7 +241,7 @@ After adding the `routes` property as described above, the navigation menu looks
 
 ## How to Patch or Remove a Navigation Element
 
-The `patch` method of `RoutesService` finds a route by its name and replaces its configuration with the new configuration passed as the second parameter. Similarly, `remove` method finds a route and removes it along with its children.
+The `patch` method of `RoutesService` finds a route by its name and replaces its configuration with the new configuration passed as the second parameter. Similarly, `remove` method finds a route and removes it along with its children. Also you can use `delete` method to delete the routes with given properties.
 
 ```js
 // this.routes is instance of RoutesService
@@ -249,6 +264,9 @@ const newHomeRouteConfig: Partial<ABP.Route> = {
 this.routes.add([dashboardRouteConfig]);
 this.routes.patch('::Menu:Home', newHomeRouteConfig);
 this.routes.remove(['Your navigation']);
+
+// or
+this.routes.delete({ name: 'Your navigation' });
 ```
 
 - Moved the _Home_ navigation under the _Administration_ dropdown based on given `parentName`.

--- a/npm/ng-packs/packages/core/src/lib/services/routes.service.ts
+++ b/npm/ng-packs/packages/core/src/lib/services/routes.service.ts
@@ -152,7 +152,7 @@ export abstract class AbstractTreeService<T extends { [key: string | number | sy
     return this.publish(flatItems);
   }
 
-  removeByParams(params: Partial<T>): T[] | null {
+  removeByParam(params: Partial<T>): T[] | null {
     if (!params) {
       return null;
     }
@@ -168,7 +168,7 @@ export abstract class AbstractTreeService<T extends { [key: string | number | sy
     }
 
     for (const item of excludedList) {
-      this.removeByParams({ [this.parentId]: item[this.id] } as Partial<T>);
+      this.removeByParam({ [this.parentId]: item[this.id] } as Partial<T>);
     }
 
     const flatItems = this.flat.filter(item => !excludedList.includes(item));

--- a/npm/ng-packs/packages/core/src/lib/services/routes.service.ts
+++ b/npm/ng-packs/packages/core/src/lib/services/routes.service.ts
@@ -83,10 +83,10 @@ export abstract class AbstractTreeService<T extends { [key: string | number | sy
     }, set);
   }
 
-  private publish(flatItems: T[], visibleItems: T[]): T[] {
+  private publish(flatItems: T[]): T[] {
     this._flat$.next(flatItems);
     this._tree$.next(this.createTree(flatItems));
-    this._visible$.next(this.createTree(visibleItems));
+    this._visible$.next(this.createTree(flatItems.filter(item => !this.hide(item))));
     return flatItems;
   }
 
@@ -99,13 +99,11 @@ export abstract class AbstractTreeService<T extends { [key: string | number | sy
       map.forEach(pushValueTo(flatItems));
 
       flatItems.sort(this.sort);
-      const visibleItems = flatItems.filter(item => !this.hide(item));
-      return this.publish(flatItems, visibleItems);
+      return this.publish(flatItems);
     } else {
       const flatItems = this.flat.concat(items);
       flatItems.sort(this.sort);
-      const visibleItems = flatItems.filter(item => !this.hide(item));
-      return this.publish(flatItems, visibleItems);
+      return this.publish(flatItems);
     }
   }
 
@@ -125,9 +123,7 @@ export abstract class AbstractTreeService<T extends { [key: string | number | sy
       });
 
       const flatItems = this.flat.filter(item => !willRemoveItems.includes(item));
-      const visibleItems = flatItems.filter(item => !this.hide(item));
-
-      return this.publish(flatItems, visibleItems);
+      return this.publish(flatItems);
     }
 
     return this.flat;
@@ -156,9 +152,7 @@ export abstract class AbstractTreeService<T extends { [key: string | number | sy
     flatItems[index] = { ...flatItems[index], ...props };
 
     flatItems.sort(this.sort);
-    const visibleItems = flatItems.filter(item => !this.hide(item));
-
-    return this.publish(flatItems, visibleItems);
+    return this.publish(flatItems);
   }
 
   refresh(): T[] {
@@ -171,9 +165,7 @@ export abstract class AbstractTreeService<T extends { [key: string | number | sy
 
     const setToRemove = this.findItemsToRemove(set);
     const flatItems = this.filterWith(setToRemove);
-    const visibleItems = flatItems.filter(item => !this.hide(item));
-
-    return this.publish(flatItems, visibleItems);
+    return this.publish(flatItems);
   }
 
   search(params: Partial<T>, tree = this.tree): TreeNode<T> | null {

--- a/npm/ng-packs/packages/core/src/lib/tests/routes.service.spec.ts
+++ b/npm/ng-packs/packages/core/src/lib/tests/routes.service.spec.ts
@@ -172,9 +172,9 @@ describe('Routes Service', () => {
     });
   });
 
-  describe('#disableFiltering', () => {
-    it('should allow to duplicate routes', () => {
-      service.disableFiltering();
+  describe('#setSingularizeStatus', () => {
+    it('should allow to duplicate routes when called with false', () => {
+      service.setSingularizeStatus(false);
 
       service.add(routes);
 
@@ -183,8 +183,8 @@ describe('Routes Service', () => {
       expect(flat.length).toBe(routes.length);
     });
 
-    it('should allow to duplicate routes with the same name', () => {
-      service.disableFiltering();
+    it('should allow to duplicate routes with the same name when called with false', () => {
+      service.setSingularizeStatus(false);
 
       service.add([...routes, { path: '/foo/bar/test', name: 'bar', parentName: 'foo', order: 2 }]);
 
@@ -193,8 +193,8 @@ describe('Routes Service', () => {
       expect(flat.length).toBe(routes.length + 1);
     });
 
-    it('should allow to routes with the same name but different parentName', () => {
-      service.disableFiltering();
+    it('should allow to routes with the same name but different parentName when called with false', () => {
+      service.setSingularizeStatus(false);
 
       service.add([
         { path: '/foo/bar', name: 'bar', parentName: 'foo', order: 2 },
@@ -205,15 +205,13 @@ describe('Routes Service', () => {
 
       expect(flat.length).toBe(2);
     });
-  });
 
-  describe('#enableFiltering', () => {
-    it('should not allow to duplicate routes', () => {
-      service.disableFiltering();
+    it('should not allow to duplicate routes when called with true', () => {
+      service.setSingularizeStatus(false);
 
       service.add(routes);
 
-      service.enableFiltering();
+      service.setSingularizeStatus(true);
 
       service.add(routes);
 
@@ -222,8 +220,8 @@ describe('Routes Service', () => {
       expect(flat.length).toBe(5);
     });
 
-    it('should not allow to duplicate routes with the same name', () => {
-      service.enableFiltering();
+    it('should not allow to duplicate routes with the same name when called with true', () => {
+      service.setSingularizeStatus(true);
       service.add([...routes, { path: '/foo/bar/test', name: 'bar', parentName: 'any', order: 2 }]);
 
       const flat = service.flat;
@@ -302,11 +300,11 @@ describe('Routes Service', () => {
     });
   });
 
-  describe('#delete', () => {
+  describe('#removeByParams', () => {
     it('should remove route based on given route', () => {
       service.add(routes);
 
-      service.delete({
+      service.removeByParams({
         name: 'bar',
         parentName: 'foo',
       });
@@ -321,7 +319,7 @@ describe('Routes Service', () => {
     });
 
     it('should remove if more than one route has the same properties', () => {
-      service.disableFiltering();
+      service.setSingularizeStatus(false);
 
       service.add([
         ...routes,
@@ -335,7 +333,7 @@ describe('Routes Service', () => {
         },
       ]);
 
-      service.delete({
+      service.removeByParams({
         path: '/foo/bar',
         name: 'bar',
         parentName: 'foo',
@@ -345,7 +343,6 @@ describe('Routes Service', () => {
       });
 
       const flat = service.flat;
-      console.log(flat);
       expect(flat.length).toBe(5);
 
       const notFound = service.search({
@@ -363,7 +360,7 @@ describe('Routes Service', () => {
       service.add(routes);
       const flatLengthBeforeRemove = service.flat.length;
 
-      service.delete({
+      service.removeByParams({
         name: 'bar',
         parentName: 'baz',
       });

--- a/npm/ng-packs/packages/core/src/lib/tests/routes.service.spec.ts
+++ b/npm/ng-packs/packages/core/src/lib/tests/routes.service.spec.ts
@@ -300,11 +300,11 @@ describe('Routes Service', () => {
     });
   });
 
-  describe('#removeByParams', () => {
+  describe('#removeByParam', () => {
     it('should remove route based on given route', () => {
       service.add(routes);
 
-      service.removeByParams({
+      service.removeByParam({
         name: 'bar',
         parentName: 'foo',
       });
@@ -333,7 +333,7 @@ describe('Routes Service', () => {
         },
       ]);
 
-      service.removeByParams({
+      service.removeByParam({
         path: '/foo/bar',
         name: 'bar',
         parentName: 'foo',
@@ -360,7 +360,7 @@ describe('Routes Service', () => {
       service.add(routes);
       const flatLengthBeforeRemove = service.flat.length;
 
-      service.removeByParams({
+      service.removeByParam({
         name: 'bar',
         parentName: 'baz',
       });


### PR DESCRIPTION
### Description

Resolves #19359

I added three new functions and a new property:

- `private filterRoutesEnabled: boolean`
This property is added for managing the filtering.

- `disableFiltering(): void`
This method disables the filter by setting `filterRoutesEnabled` to `false`.

- `enableFiltering(): void`
This method enables the filter by setting `filterRoutesEnabled` to `true`.

- `delete(params: Partial<T>): T[]`
This method deletes the routes that match the given properties. It returns the current state of the `flat`.

I modified the `add` method:
- If the `filterRoutesEnabled` is `true`, the algorithm is exactly the same as before.
- If the `filterRoutesEnabled` is `false`, I add the all items without any filtering.

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?
Firstly you should check this PR does not affect the current functionality. Then you can test the new features by following the steps below:
- Add routes with same `name` properties.
- To test it with a more realistic scenario, add routes with the different `parentName` properties.
- If you called the `disableFiltering` method before adding the routes, you should see that the routes are added without any filtering.
- If you called the `enableFiltering` method before adding the routes or you have not called the `disableFiltering` method, you should see that the routes has the same `name` properties are filtered.
- To test the new `delete` method, you can delete the routes that match the given properties.
- It should delete the routes and its children.

Expected results:

![Screenshot 2024-03-20 at 15 04 38](https://github.com/abpframework/abp/assets/61491079/f7458d42-35f0-47b5-8a1a-6dc4ee891f9c)

