### PR TITLE
Update angular-oauth2-oidc version to 17.x.x

### DIFF
--- a/npm/ng-packs/package.json
+++ b/npm/ng-packs/package.json
@@ -89,7 +89,7 @@
     "@types/node": "^20.0.0",
     "@typescript-eslint/eslint-plugin": "6.13.2",
     "@typescript-eslint/parser": "6.13.2",
-    "angular-oauth2-oidc": "^15.0.0",
+    "angular-oauth2-oidc": "^17.0.0",
     "autoprefixer": "^10.0.0",
     "bootstrap": "^5.0.0",
     "bootstrap-icons": "^1.0.0",

--- a/npm/ng-packs/packages/oauth/package.json
+++ b/npm/ng-packs/packages/oauth/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@abp/ng.core": "~8.1.0-rc.3",
     "@abp/utils": "~8.1.0-rc.3",
-    "angular-oauth2-oidc": "^15.0.0",
+    "angular-oauth2-oidc": "^17.0.0",
     "just-clone": "^6.0.0",
     "just-compare": "^2.0.0",
     "tslib": "^2.0.0"


### PR DESCRIPTION
Resolves #19438.

I am not sure you want the exact 17.0.2 version, so i keep the `^` symbol.

If you want exact version, i can remove it.