### PR TITLE
Add `lastNavigation` prop to `RouterEvents` service for track last successful navigation event

### DIFF
--- a/npm/ng-packs/packages/core/src/lib/services/router-events.service.ts
+++ b/npm/ng-packs/packages/core/src/lib/services/router-events.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Type } from '@angular/core';
+import { Injectable, Type, inject, signal } from '@angular/core';
 import {
   NavigationCancel,
   NavigationEnd,
@@ -6,7 +6,8 @@ import {
   NavigationStart,
   Router,
   RouterEvent,
-  Event
+  Event,
+  RouterState,
 } from '@angular/router';
 import { filter } from 'rxjs/operators';
 
@@ -19,12 +20,32 @@ export const NavigationEvent = {
 
 @Injectable({ providedIn: 'root' })
 export class RouterEvents {
-  constructor(private router: Router) {}
+  protected readonly router = inject(Router);
+
+  readonly #lastNavigation = signal<string | undefined>(undefined);
+  lastNavigation = this.#lastNavigation.asReadonly();
+
+  constructor() {
+    this.listenToNavigation();
+  }
+
+  protected listenToNavigation(): void {
+    this.router.events.pipe(filter(e => e instanceof NavigationEvent.End)).subscribe(() => {
+      // It must be "NavigationTransition" but it is not exported in Angular
+      //https://github.com/angular/angular/blob/9c486c96827a9282cbdbff176761bc95554a260b/packages/router/src/navigation_transition.ts#L282
+      const lastNavigation = this.router.lastSuccessfulNavigation as unknown as any;
+      const curr = lastNavigation.targetRouterState as RouterState;
+      const currUrl = curr.snapshot.url;
+
+      //Todo: improve this logic. Maybe we can handle error status in a better way ?
+      if (!currUrl.includes('error')) {
+        this.#lastNavigation.set(currUrl);
+      }
+    });
+  }
 
   getEvents<T extends RouterEventConstructors>(...eventTypes: T) {
-
-    const filterRouterEvents = (event: Event) =>
-      eventTypes.some(type => event instanceof type);
+    const filterRouterEvents = (event: Event) => eventTypes.some(type => event instanceof type);
 
     return this.router.events.pipe(filter(filterRouterEvents));
   }

--- a/npm/ng-packs/packages/theme-shared/src/lib/components/http-error-wrapper/http-error-wrapper.component.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/components/http-error-wrapper/http-error-wrapper.component.ts
@@ -72,6 +72,15 @@ export class HttpErrorWrapperComponent implements OnInit, AfterViewInit, OnDestr
       });
 
       customComponentRef.instance.errorStatus = this.status;
+      
+      //In our custom "HttpErrorComponent", we have a "status" property.
+      //We used to have "errorStatus", but it wasn't signal type. "status" variable is signal type.
+      //I've checked because of backward compatibility. Developers might have their own custom HttpErrorComponent.
+      //We need to deprecated and remove "errorStatus" in the future.
+      if (customComponentRef.instance.status) {
+        customComponentRef.instance.status.set(this.status);
+      }
+      
       customComponentRef.instance.destroy$ = this.destroy$;
 
       this.appRef.attachView(customComponentRef.hostView);


### PR DESCRIPTION
We can use the `RouterEventsService` for the handle routing events