### PR TITLE
Add default padding to `.tab-content` as LeptonX does

### DIFF
--- a/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.Web.BasicTheme/wwwroot/libs/abp/css/theme.css
+++ b/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.Web.BasicTheme/wwwroot/libs/abp/css/theme.css
@@ -173,5 +173,6 @@ form .table-responsive{
 }
 
 .tab-content {
-    padding: 1.5rem;
+    padding-top: 1.5rem;
+    padding-bottom: 1.5rem;
 }

--- a/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.Web.BasicTheme/wwwroot/libs/abp/css/theme.css
+++ b/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.Web.BasicTheme/wwwroot/libs/abp/css/theme.css
@@ -171,3 +171,7 @@ h1.content-header-title{
 form .table-responsive{
     min-height: 412px;
 }
+
+.tab-content {
+    padding: 1.5rem;
+}


### PR DESCRIPTION
### Description

Resolves https://github.com/volosoft/volo/issues/14922

**old**
![image](https://github.com/abpframework/abp/assets/23705418/175e9895-b516-4661-b7cc-9847763f01c8)

**new**
![image](https://github.com/abpframework/abp/assets/23705418/007ebc50-5ab3-4a5b-92ed-0283d3c14f21)


### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

Please describe how this can be tested by the test engineers if it is not already explicit - or remove this section if no need to description.


### Breaking-Change
It may cause existing designs which includes [Tabs](https://blazorise.com/docs/components/tab). All the `.tab-content` elements now have 1.5rem padding from up & down. It may cause unwanted spaces after update with the **Basic Theme**