### PR TITLE
Set default port for expo

### DIFF
--- a/templates/app/react-native/package.json
+++ b/templates/app/react-native/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
-    "start": "expo start",
+    "start": "expo start --port 19000",
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",


### PR DESCRIPTION
I have realised that the expo port has been changed after the version update from `^47.0.0` to `^49.0.0`.

So this pr sets a default port for expo to prevent errors.

