### PR TITLE
export `PasswordComponent`

### DIFF
--- a/npm/ng-packs/packages/theme-shared/src/lib/theme-shared.module.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/theme-shared.module.ts
@@ -81,6 +81,7 @@ const declarationsWithExports = [
     AbpVisibleDirective,
     NgxDatatableListDirective,
     NgxDatatableDefaultDirective,
+    PasswordComponent,
     ...declarationsWithExports,
   ],
   providers: [DatePipe],


### PR DESCRIPTION
[Related Question](https://support.abp.io/QA/Questions/7012/abp-password-throwing-No-value-accessor-error-in-81)

This pr exports `PasswordComponent` to get rid of breaking changes.

Now on user's doesn't need to import `PasswordComponent` to related module or standalone component.

Importing ThemeSharedModule will be enough like before.

