### PR TITLE
Skip `PublishEntityDeletedEvent/PublishEntityUpdatedEvent` if only foreign keys have changed.

### DIFF
--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/AbpDbContext.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/AbpDbContext.cs
@@ -328,6 +328,12 @@ public abstract class AbpDbContext<TDbContext> : DbContext, IAbpEfCoreDbContext,
                 ApplyAbpConceptsForModifiedEntity(entry);
                 if (entry.Properties.Any(x => x.IsModified && (x.Metadata.ValueGenerated == ValueGenerated.Never || x.Metadata.ValueGenerated == ValueGenerated.OnAdd)))
                 {
+                    if (entry.Properties.Where(x => x.IsModified).All(x => x.Metadata.IsForeignKey()))
+                    {
+                        // Skip `PublishEntityDeletedEvent/PublishEntityUpdatedEvent` if only foreign keys have changed.
+                        break;
+                    }
+
                     if (entry.Entity is ISoftDelete && entry.Entity.As<ISoftDelete>().IsDeleted)
                     {
                         EntityChangeEventHelper.PublishEntityDeletedEvent(entry.Entity);

--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/ChangeTrackers/AbpEfCoreNavigationHelper.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/ChangeTrackers/AbpEfCoreNavigationHelper.cs
@@ -50,12 +50,6 @@ public class AbpEfCoreNavigationHelper : ITransientDependency
         var index = 0;
         foreach (var navigationEntry in entityEntry.Navigations.Where(navigation => !navigation.IsModified))
         {
-            if (!navigationEntry.IsLoaded)
-            {
-                index++;
-                continue;
-            }
-
             var currentValue = navigationEntry.CurrentValue;
             if (navigationEntry.CurrentValue is ICollection collection)
             {

--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/ChangeTrackers/AbpEfCoreNavigationHelper.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/ChangeTrackers/AbpEfCoreNavigationHelper.cs
@@ -50,6 +50,12 @@ public class AbpEfCoreNavigationHelper : ITransientDependency
         var index = 0;
         foreach (var navigationEntry in entityEntry.Navigations.Where(navigation => !navigation.IsModified))
         {
+            if (!navigationEntry.IsLoaded && navigationEntry.CurrentValue == null)
+            {
+                index++;
+                continue;
+            }
+
             var currentValue = navigationEntry.CurrentValue;
             if (navigationEntry.CurrentValue is ICollection collection)
             {

--- a/framework/test/Volo.Abp.EntityFrameworkCore.Tests/Volo/Abp/EntityFrameworkCore/DomainEvents/DomainEvents_Tests.cs
+++ b/framework/test/Volo.Abp.EntityFrameworkCore.Tests/Volo/Abp/EntityFrameworkCore/DomainEvents/DomainEvents_Tests.cs
@@ -1,4 +1,16 @@
-﻿using Volo.Abp.TestApp.Testing;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Volo.Abp.Domain.Entities.Events;
+using Volo.Abp.Domain.Repositories;
+using Volo.Abp.EntityFrameworkCore.DependencyInjection;
+using Volo.Abp.EventBus.Local;
+using Volo.Abp.TestApp.Domain;
+using Volo.Abp.TestApp.Testing;
+using Volo.Abp.Uow;
+using Xunit;
 
 namespace Volo.Abp.EntityFrameworkCore.DomainEvents;
 
@@ -8,4 +20,74 @@ public class DomainEvents_Tests : DomainEvents_Tests<AbpEntityFrameworkCoreTestM
 
 public class AbpEntityChangeOptions_DomainEvents_Tests : AbpEntityChangeOptions_DomainEvents_Tests<AbpEntityFrameworkCoreTestModule>
 {
+}
+
+public class AbpEfCoreDomainEvents_Tests : EntityFrameworkCoreTestBase
+{
+    protected readonly IRepository<AppEntityWithNavigations, Guid> AppEntityWithNavigationsRepository;
+    protected readonly ILocalEventBus LocalEventBus;
+
+    public AbpEfCoreDomainEvents_Tests()
+    {
+        AppEntityWithNavigationsRepository = GetRequiredService<IRepository<AppEntityWithNavigations, Guid>>();
+        LocalEventBus = GetRequiredService<ILocalEventBus>();
+    }
+
+    protected override void AfterAddApplication(IServiceCollection services)
+    {
+        services.Configure<AbpEntityOptions>(options =>
+        {
+            options.Entity<AppEntityWithNavigations>(opt =>
+            {
+                opt.DefaultWithDetailsFunc = q => q;
+            });
+        });
+
+        base.AfterAddApplication(services);
+    }
+
+    [Fact]
+    public async Task Should_Trigger_Domain_Events_For_Aggregate_Root_When_EnsureCollectionLoaded_Navigation_Changes_Tests()
+    {
+        var entityId = Guid.NewGuid();
+
+        await AppEntityWithNavigationsRepository.InsertAsync(new AppEntityWithNavigations(entityId, "TestEntity")
+        {
+            OneToMany = new List<AppEntityWithNavigationChildOneToMany>()
+            {
+                new AppEntityWithNavigationChildOneToMany
+                {
+                    ChildName = "ChildName1"
+                }
+            }
+        });
+
+        var entityUpdatedEventTriggered = false;
+
+        LocalEventBus.Subscribe<EntityUpdatedEventData<AppEntityWithNavigations>>(data =>
+        {
+            entityUpdatedEventTriggered = !entityUpdatedEventTriggered;
+            return Task.CompletedTask;
+        });
+
+        using (var scope = ServiceProvider.CreateScope())
+        {
+            var uowManager = scope.ServiceProvider.GetRequiredService<IUnitOfWorkManager>();
+            using (var uow = uowManager.Begin())
+            {
+                var entity = await AppEntityWithNavigationsRepository.GetAsync(entityId);
+                entity.OneToMany.ShouldBeNull();
+
+                await AppEntityWithNavigationsRepository.EnsureCollectionLoadedAsync(entity, x => x.OneToMany);
+                entity.OneToMany.ShouldNotBeNull();
+
+                entity.OneToMany.Clear();
+                await AppEntityWithNavigationsRepository.UpdateAsync(entity);
+
+                await uow.CompleteAsync();
+            }
+        }
+
+        entityUpdatedEventTriggered.ShouldBeTrue();
+    }
 }

--- a/framework/test/Volo.Abp.TestApp/Volo/Abp/TestApp/Testing/DomainEvents_Tests.cs
+++ b/framework/test/Volo.Abp.TestApp/Volo/Abp/TestApp/Testing/DomainEvents_Tests.cs
@@ -200,6 +200,11 @@ public abstract class DomainEvents_Tests<TStartupModule> : TestAppTestBase<TStar
         });
         entityUpdatedEventTriggered.ShouldBeTrue();
 
+        LocalEventBus.Subscribe<EntityUpdatedEventData<AppEntityWithValueObjectAddress>>(data =>
+        {
+            throw new Exception("Should not trigger this event");
+        });
+
         // Test with value object
         entityUpdatedEventTriggered = false;
         await WithUnitOfWorkAsync(async () =>
@@ -232,6 +237,11 @@ public abstract class DomainEvents_Tests<TStartupModule> : TestAppTestBase<TStar
         });
         entityUpdatedEventTriggered.ShouldBeTrue();
 
+        LocalEventBus.Subscribe<EntityUpdatedEventData<AppEntityWithNavigationChildOneToOne>>(data =>
+        {
+            throw new Exception("Should not trigger this event");
+        });
+
         entityUpdatedEventTriggered = false;
         await WithUnitOfWorkAsync(async () =>
         {
@@ -257,6 +267,11 @@ public abstract class DomainEvents_Tests<TStartupModule> : TestAppTestBase<TStar
             await AppEntityWithNavigationsRepository.UpdateAsync(entity);
         });
         entityUpdatedEventTriggered.ShouldBeTrue();
+
+        LocalEventBus.Subscribe<EntityUpdatedEventData<AppEntityWithNavigationChildOneToMany>>(data =>
+        {
+            throw new Exception("Should not trigger this event");
+        });
 
         entityUpdatedEventTriggered = false;
         await WithUnitOfWorkAsync(async () =>


### PR DESCRIPTION
Resolves https://support.abp.io/QA/Questions/7029/Deleting-a-entity-in-a-collection-from-an-aggregate-root-trigger-EntityUpdatedEventData-on-that-entity