### PR TITLE
Implement skipInitAuthService option in ng core package

### DIFF
--- a/npm/ng-packs/packages/core/src/lib/models/common.ts
+++ b/npm/ng-packs/packages/core/src/lib/models/common.ts
@@ -9,7 +9,7 @@ export namespace ABP {
     environment: Partial<Environment>;
     registerLocaleFn: (locale: string) => Promise<any>;
     skipGetAppConfiguration?: boolean;
-    skipiInitAuthService?: boolean;
+    skipInitAuthService?: boolean;
     sendNullsAsQueryParam?: boolean;
     tenantKey?: string;
     localizations?: Localization[];

--- a/npm/ng-packs/packages/core/src/lib/models/common.ts
+++ b/npm/ng-packs/packages/core/src/lib/models/common.ts
@@ -9,6 +9,7 @@ export namespace ABP {
     environment: Partial<Environment>;
     registerLocaleFn: (locale: string) => Promise<any>;
     skipGetAppConfiguration?: boolean;
+    skipiInitAuthService?: boolean;
     sendNullsAsQueryParam?: boolean;
     tenantKey?: string;
     localizations?: Localization[];

--- a/npm/ng-packs/packages/core/src/lib/utils/initial-utils.ts
+++ b/npm/ng-packs/packages/core/src/lib/utils/initial-utils.ts
@@ -29,7 +29,7 @@ export function getInitialData(injector: Injector) {
     const checkAuthenticationState = injector.get(CHECK_AUTHENTICATION_STATE_FN_KEY, noop, {
       optional: true,
     });
-    if (!options.skipiInitAuthService && authService) {
+    if (!options.skipInitAuthService && authService) {
       await authService.init();
     }
     if (options.skipGetAppConfiguration) return;

--- a/npm/ng-packs/packages/core/src/lib/utils/initial-utils.ts
+++ b/npm/ng-packs/packages/core/src/lib/utils/initial-utils.ts
@@ -29,7 +29,7 @@ export function getInitialData(injector: Injector) {
     const checkAuthenticationState = injector.get(CHECK_AUTHENTICATION_STATE_FN_KEY, noop, {
       optional: true,
     });
-    if (authService) {
+    if (!options.skipiInitAuthService && authService) {
       await authService.init();
     }
     if (options.skipGetAppConfiguration) return;


### PR DESCRIPTION
### Description

Resolves #19525 

This PR inroduce skipInitAuthService option to ABP.Root

It makes calling authService.init() optional in getInitialData function.
Currently, it's optional only if AuthService is injected so the new flag will make the initialization of authService optional even when AuthService is injected.
The new option skipInitAuthService will be similar to skipGetAppConfiguration option.

### Checklist

- [x] I fully tested it as developer 
- [x] I will create a separate documentation issue

### How to test it?

enable skipInitAuthService when calling 
`CoreModule.forRoot({
   skipiInitAuthService: true
})`

