### PR TITLE
Optimize the performance of `AbpEfCoreNavigationHelper`.

### DIFF
--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/ChangeTrackers/AbpEntityEntryNavigationProperty.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/ChangeTrackers/AbpEntityEntryNavigationProperty.cs
@@ -1,3 +1,5 @@
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+
 namespace Volo.Abp.EntityFrameworkCore.ChangeTrackers;
 
 public class AbpEntityEntryNavigationProperty
@@ -10,11 +12,17 @@ public class AbpEntityEntryNavigationProperty
 
     public bool IsChanged { get; set; }
 
-    public AbpEntityEntryNavigationProperty(int index, string name, object? value, bool isChanged)
+    public EntityEntry EntityEntry { get; set; }
+
+    public NavigationEntry NavigationEntry { get; set; }
+
+    public AbpEntityEntryNavigationProperty(int index, string name, object? value, bool isChanged, EntityEntry entityEntry, NavigationEntry navigationEntry)
     {
         Index = index;
         Name = name;
         Value = value;
         IsChanged = isChanged;
+        EntityEntry = entityEntry;
+        NavigationEntry = navigationEntry;
     }
 }

--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/EntityHistory/EntityHistoryHelper.cs
@@ -255,7 +255,10 @@ public class EntityHistoryHelper : IEntityHistoryHelper, ITransientDependency
 
     protected virtual bool HasNavigationPropertiesChanged(EntityEntry entityEntry)
     {
-        return entityEntry.State == EntityState.Unchanged && Options.SaveEntityHistoryWhenNavigationChanges && AbpEfCoreNavigationHelper != null && AbpEfCoreNavigationHelper.IsEntityEntryNavigationChanged(entityEntry);
+        return entityEntry.State == EntityState.Unchanged &&
+               Options.SaveEntityHistoryWhenNavigationChanges &&
+               AbpEfCoreNavigationHelper != null &&
+               AbpEfCoreNavigationHelper.IsEntityEntryNavigationChanged(entityEntry);
     }
 
     protected virtual bool ShouldSavePropertyHistory(PropertyEntry propertyEntry, bool defaultValue)


### PR DESCRIPTION
The `ChangeTracker.Entries` method may be performance issues with a large number of entities.