### PR TITLE
Angular: Update `CoreTestingModule` for preventing dependency injection errors

### DIFF
--- a/npm/ng-packs/packages/core/testing/src/lib/core-testing.module.ts
+++ b/npm/ng-packs/packages/core/testing/src/lib/core-testing.module.ts
@@ -8,6 +8,9 @@ import {
   PermissionService,
   RestService,
   INCUDE_LOCALIZATION_RESOURCES_TOKEN,
+  OTHERS_GROUP,
+  compareFuncFactory,
+  SORT_COMPARE_FUNC,
 } from '@abp/ng.core';
 import { APP_BASE_HREF } from '@angular/common';
 import { ModuleWithProviders, NgModule } from '@angular/core';
@@ -64,6 +67,14 @@ export class CoreTestingModule {
         {
           provide: INCUDE_LOCALIZATION_RESOURCES_TOKEN,
           useValue: false,
+        },
+        {
+          provide: OTHERS_GROUP,
+          useValue: 'AbpUi::OthersGroup',
+        },
+        {
+          provide: SORT_COMPARE_FUNC,
+          useFactory: compareFuncFactory,
         },
         provideRoutes(routes),
       ],


### PR DESCRIPTION
### Description

Resolves #19570

Adding OTHERS_GROUP and SORT_COMPARE_FUNC injection tokens to CoreTestingModule to prevent injection errors

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests

### How to test it?

Run some tests with including CoreTestingModule.
