### PR TITLE
Angular: Sort user menu items by base sorting function at `AbstractMenuService<T>`

### DIFF
--- a/npm/ng-packs/packages/core/src/lib/models/index.ts
+++ b/npm/ng-packs/packages/core/src/lib/models/index.ts
@@ -8,3 +8,4 @@ export * from './session';
 export * from './utility';
 export * from './auth';
 export * from './auth-events';
+export * from './sort';

--- a/npm/ng-packs/packages/core/src/lib/models/sort.ts
+++ b/npm/ng-packs/packages/core/src/lib/models/sort.ts
@@ -1,0 +1,5 @@
+export interface SortableItem {
+  id?: string | number;
+  name?: string;
+  order?: number;
+}

--- a/npm/ng-packs/packages/core/src/lib/tokens/compare-func.token.ts
+++ b/npm/ng-packs/packages/core/src/lib/tokens/compare-func.token.ts
@@ -1,27 +1,33 @@
 import { InjectionToken, inject } from '@angular/core';
+import { SortableItem } from '../models';
 import { LocalizationService } from '../services';
 
-export const SORT_COMPARE_FUNC = new InjectionToken< 0 | 1 | -1 >('SORT_COMPARE_FUNC');
+export const SORT_COMPARE_FUNC = new InjectionToken<(a: SortableItem, b: SortableItem) => number>(
+  'SORT_COMPARE_FUNC',
+);
 
 export function compareFuncFactory() {
-  const localizationService = inject(LocalizationService)
-  const fn = (a,b) => {
+  const localizationService = inject(LocalizationService);
+  const fn = (a: SortableItem, b: SortableItem) => {
     const aName = localizationService.instant(a.name);
     const bName = localizationService.instant(b.name);
     const aNumber = a.order;
     const bNumber = b.order;
-    
+
     if (!Number.isInteger(aNumber)) return 1;
     if (!Number.isInteger(bNumber)) return -1;
-  
-    if (aNumber > bNumber) return 1
-    if (aNumber < bNumber) return -1
-    
-    if ( aName > bName ) return 1;
-    if ( aName < bName ) return -1;
-  
-    return 0
-  }
 
-  return fn
+    if (aNumber > bNumber) return 1;
+    if (aNumber < bNumber) return -1;
+
+    if (aName > bName) return 1;
+    if (aName < bName) return -1;
+
+    if (a.id > b.id) return 1;
+    if (a.id < b.id) return -1;
+
+    return 0;
+  };
+
+  return fn;
 }

--- a/npm/ng-packs/packages/theme-shared/src/lib/services/abstract-menu.service.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/services/abstract-menu.service.ts
@@ -1,9 +1,12 @@
 import { BehaviorSubject, Observable } from 'rxjs';
 import { NavItem } from '../models/nav-item';
-import { Type } from '@angular/core';
+import { inject, Type } from '@angular/core';
+import { SORT_COMPARE_FUNC } from '@abp/ng.core';
 
 export abstract class AbstractMenuService<T extends NavItem> {
   protected abstract baseClass: Type<any>;
+
+  protected readonly sortFn = inject(SORT_COMPARE_FUNC);
 
   protected _items$ = new BehaviorSubject<T[]>([]);
 
@@ -52,10 +55,7 @@ export abstract class AbstractMenuService<T extends NavItem> {
     this._items$.next(items);
   }
 
-  private sortItems(a: T, b: T) {
-    if (!a.order) return 1;
-    if (!b.order) return -1;
-
-    return a.order - b.order;
-  }
+  sortItems = (a: T, b: T) => {
+    return this.sortFn(a, b);
+  };
 }


### PR DESCRIPTION
### Description

Resolves #19562

- Injecting `SORT_COMPARE_FUNC` from the core library in AbstractMenuService and replacing sortItems function.
- Removing private access modifier from `sortItems` function and making it arrow function.
- Adding id based sorting to compareFuncFactory.

### Checklist

- [x] I fully tested it as developer

### How to test it?
I tested this issue in lepton.
<details><summary>This is an example menu item objects to use.</summary>

```ts
      {
        id: 'DifferentName3',
        order: 103,
        textTemplate: {
          text: 'DifferentName3',
        },
        action: () => {},
        visible: () => true,
      },
      {
        id: 'DifferentName1',
        order: 103,
        textTemplate: {
          text: 'DifferentName1',
        },
        action: () => {},
        visible: () => true,
      },
      {
        id: 'DifferentName2',
        order: 103,
        textTemplate: {
          text: 'DifferentName2',
        },
        action: () => {},
        visible: () => true,
      },
```
</details> 

<details><summary>You can also view this images to see sorting is working correctly, based with id fields.</summary>

![image](https://github.com/abpframework/abp/assets/81169996/9e6a8df3-d4ff-4e22-acaf-2db7d5f4f7b7)
![image](https://github.com/abpframework/abp/assets/81169996/b1185509-3382-4d2d-8256-19ab313522c1)

</details> 


