### PR TITLE
ImageSharp package has been updated due to vulnerabilities

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -144,7 +144,7 @@
     <PackageVersion Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
-    <PackageVersion Include="SixLabors.ImageSharp" Version="3.0.2" />
+    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.4" />
     <PackageVersion Include="SixLabors.ImageSharp.Drawing" Version="2.0.1" />
     <PackageVersion Include="SkiaSharp" Version="2.88.6" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="2.88.6" />


### PR DESCRIPTION
Resolves https://github.com/volosoft/volo/issues/17453

ImageSharp package has been updated due to vulnerabilities. 3.0.2 -> 3.1.4

I've tested uploading and getting images from the server, and it seems there is no breaking change.