### PR TITLE
Angular: extensible table action list dropdown problem

### DIFF
--- a/npm/ng-packs/packages/components/extensible/src/lib/components/extensible-table/extensible-table.component.html
+++ b/npm/ng-packs/packages/components/extensible/src/lib/components/extensible-table/extensible-table.component.html
@@ -6,62 +6,68 @@
   (activate)="tableActivate.emit($event)"
 >
   @if (actionsTemplate || (actionList.length && hasAtLeastOnePermittedAction)) {
-  <ngx-datatable-column
-    [name]="actionsText | abpLocalization"
-    [maxWidth]="columnWidths[0]"
-    [width]="columnWidths[0]"
-    [sortable]="false"
-  >
-    <ng-template let-row="row" let-i="rowIndex" ngx-datatable-cell-template>
-      <ng-container
-        *ngTemplateOutlet="actionsTemplate || gridActions; context: { $implicit: row, index: i }"
-      ></ng-container>
-      <ng-template #gridActions>
-        <abp-grid-actions [index]="i" [record]="row" text="AbpUi::Actions"></abp-grid-actions>
-      </ng-template>
-    </ng-template>
-  </ngx-datatable-column>
-  } @for (prop of propList; track prop.name; let i = $index) {
-  <ngx-datatable-column
-    *abpVisible="prop.columnVisible(getInjected)"
-    [width]="columnWidths[i + 1] || 200"
-    [name]="prop.displayName | abpLocalization"
-    [prop]="prop.name"
-    [sortable]="prop.sortable"
-  >
-    <ng-template ngx-datatable-header-template let-column="column">
-      @if (prop.tooltip) {
-      <span [ngbTooltip]="prop.tooltip.text | abpLocalization" [placement]="prop.tooltip.placement || 'auto'"
-      container="body">
-      {{ column.name }} <i class="fa fa-info-circle" aria-hidden="true"></i>
-    </span>
-      }@else{
-      {{ column.name }}
-      }
-    </ng-template>
-    <ng-template let-row="row" let-i="index" ngx-datatable-cell-template>
-      <ng-container *abpPermission="prop.permission; runChangeDetection: false">
-        <ng-container *abpVisible="row['_' + prop.name]?.visible">
-          @if (!row['_' + prop.name].component) {
-          <div
-            [innerHTML]="row['_' + prop.name]?.value | async"
-            (click)="
-              prop.action && prop.action({ getInjected: getInjected, record: row, index: i })
-            "
-            [ngClass]="entityPropTypeClasses[prop.type]"
-            [class.pointer]="prop.action"
-          ></div>
-          }@else{
-          <ng-container
-            *ngComponentOutlet="
-              row['_' + prop.name].component;
-              injector: row['_' + prop.name].injector
-            "
-          ></ng-container>
+    <ngx-datatable-column
+      [name]="actionsText | abpLocalization"
+      [maxWidth]="columnWidths[0]"
+      [width]="columnWidths[0]"
+      [sortable]="false"
+    >
+      <ng-template let-row="row" let-i="rowIndex" ngx-datatable-cell-template>
+        <ng-container
+          *ngTemplateOutlet="actionsTemplate || gridActions; context: { $implicit: row, index: i }"
+        ></ng-container>
+        <ng-template #gridActions>
+          @if (hasAvailableActions(i, row)) {
+            <abp-grid-actions [index]="i" [record]="row" text="AbpUi::Actions"></abp-grid-actions>
           }
+        </ng-template>
+      </ng-template>
+    </ngx-datatable-column>
+  }
+  @for (prop of propList; track prop.name; let i = $index) {
+    <ngx-datatable-column
+      *abpVisible="prop.columnVisible(getInjected)"
+      [width]="columnWidths[i + 1] || 200"
+      [name]="prop.displayName | abpLocalization"
+      [prop]="prop.name"
+      [sortable]="prop.sortable"
+    >
+      <ng-template ngx-datatable-header-template let-column="column">
+        @if (prop.tooltip) {
+          <span
+            [ngbTooltip]="prop.tooltip.text | abpLocalization"
+            [placement]="prop.tooltip.placement || 'auto'"
+            container="body"
+          >
+            {{ column.name }} <i class="fa fa-info-circle" aria-hidden="true"></i>
+          </span>
+        } @else {
+          {{ column.name }}
+        }
+      </ng-template>
+      <ng-template let-row="row" let-i="index" ngx-datatable-cell-template>
+        <ng-container *abpPermission="prop.permission; runChangeDetection: false">
+          <ng-container *abpVisible="row['_' + prop.name]?.visible">
+            @if (!row['_' + prop.name].component) {
+              <div
+                [innerHTML]="row['_' + prop.name]?.value | async"
+                (click)="
+                  prop.action && prop.action({ getInjected: getInjected, record: row, index: i })
+                "
+                [ngClass]="entityPropTypeClasses[prop.type]"
+                [class.pointer]="prop.action"
+              ></div>
+            } @else {
+              <ng-container
+                *ngComponentOutlet="
+                  row['_' + prop.name].component;
+                  injector: row['_' + prop.name].injector
+                "
+              ></ng-container>
+            }
+          </ng-container>
         </ng-container>
-      </ng-container>
-    </ng-template>
-  </ngx-datatable-column>
+      </ng-template>
+    </ngx-datatable-column>
   }
 </ngx-datatable>

--- a/npm/ng-packs/packages/components/extensible/src/lib/components/extensible-table/extensible-table.component.ts
+++ b/npm/ng-packs/packages/components/extensible/src/lib/components/extensible-table/extensible-table.component.ts
@@ -109,6 +109,7 @@ export class ExtensibleTableComponent<R = any> implements OnChanges {
   entityPropTypeClasses = inject(ENTITY_PROP_TYPE_CLASSES);
   #injector = inject(Injector);
   getInjected = this.#injector.get.bind(this.#injector);
+  permissionService = this.#injector.get(PermissionService);
 
   constructor() {
     const extensions = this.#injector.get(ExtensionsService);
@@ -117,9 +118,8 @@ export class ExtensibleTableComponent<R = any> implements OnChanges {
     this.actionList = extensions['entityActions'].get(name)
       .actions as unknown as EntityActionList<R>;
 
-    const permissionService = this.#injector.get(PermissionService);
     this.hasAtLeastOnePermittedAction =
-      permissionService.filterItemsByPolicy(
+      this.permissionService.filterItemsByPolicy(
         this.actionList.toArray().map(action => ({ requiredPolicy: action.permission })),
       ).length > 0;
     this.setColumnWidths(DEFAULT_ACTIONS_COLUMN_WIDTH);
@@ -204,5 +204,10 @@ export class ExtensibleTableComponent<R = any> implements OnChanges {
 
       return record;
     });
+  }
+
+  hasAvailableActions(index, row): boolean {
+    const { permission, visible } = this.actionList.get(index).value;
+    return this.permissionService.getGrantedPolicy(permission) && visible(row);
   }
 }

--- a/npm/ng-packs/packages/components/extensible/src/lib/components/grid-actions/grid-actions.component.html
+++ b/npm/ng-packs/packages/components/extensible/src/lib/components/grid-actions/grid-actions.component.html
@@ -1,32 +1,30 @@
-@if (hasAvailableActions()) {
-  @if (actionList.length > 1) {
-    <div ngbDropdown container="body" class="d-inline-block">
-      <button
-        class="btn btn-primary btn-sm dropdown-toggle"
-        data-toggle="dropdown"
-        aria-haspopup="true"
-        ngbDropdownToggle
-      >
-        <i [ngClass]="icon" [class.me-1]="icon"></i>{{ text | abpLocalization }}
-      </button>
-      <div ngbDropdownMenu>
-        @for (action of actionList; track action.text) {
-          <ng-container
-            [ngTemplateOutlet]="dropDownBtnItemTmp"
-            [ngTemplateOutletContext]="{ $implicit: action }"
-          >
-          </ng-container>
-        }
-      </div>
+@if (actionList.length > 1) {
+  <div ngbDropdown container="body" class="d-inline-block">
+    <button
+      class="btn btn-primary btn-sm dropdown-toggle"
+      data-toggle="dropdown"
+      aria-haspopup="true"
+      ngbDropdownToggle
+    >
+      <i [ngClass]="icon" [class.me-1]="icon"></i>{{ text | abpLocalization }}
+    </button>
+    <div ngbDropdownMenu>
+      @for (action of actionList; track action.text) {
+        <ng-container
+          [ngTemplateOutlet]="dropDownBtnItemTmp"
+          [ngTemplateOutletContext]="{ $implicit: action }"
+        >
+        </ng-container>
+      }
     </div>
-  }
+  </div>
+}
 
-  @if (actionList.length === 1) {
-    <ng-container
-      [ngTemplateOutlet]="btnTmp"
-      [ngTemplateOutletContext]="{ $implicit: actionList.get(0).value }"
-    ></ng-container>
-  }
+@if (actionList.length === 1) {
+  <ng-container
+    [ngTemplateOutlet]="btnTmp"
+    [ngTemplateOutletContext]="{ $implicit: actionList.get(0).value }"
+  ></ng-container>
 }
 
 <ng-template #dropDownBtnItemTmp let-action>

--- a/npm/ng-packs/packages/components/extensible/src/lib/components/grid-actions/grid-actions.component.html
+++ b/npm/ng-packs/packages/components/extensible/src/lib/components/grid-actions/grid-actions.component.html
@@ -1,42 +1,46 @@
-@if (actionList.length > 1) {
-<div ngbDropdown container="body" class="d-inline-block">
-  <button
-    class="btn btn-primary btn-sm dropdown-toggle"
-    data-toggle="dropdown"
-    aria-haspopup="true"
-    ngbDropdownToggle
-  >
-    <i [ngClass]="icon" [class.me-1]="icon"></i>{{ text | abpLocalization }}
-  </button>
-  <div ngbDropdownMenu>
-    @for (action of actionList; track action.text) {
-      <ng-container
-        [ngTemplateOutlet]="dropDownBtnItemTmp"
-        [ngTemplateOutletContext]="{ $implicit: action }"
+@if (hasAvailableActions()) {
+  @if (actionList.length > 1) {
+    <div ngbDropdown container="body" class="d-inline-block">
+      <button
+        class="btn btn-primary btn-sm dropdown-toggle"
+        data-toggle="dropdown"
+        aria-haspopup="true"
+        ngbDropdownToggle
       >
-      </ng-container>
-    }
-  </div>
-</div>
-} @if (actionList.length === 1) {
-<ng-container
-  [ngTemplateOutlet]="btnTmp"
-  [ngTemplateOutletContext]="{ $implicit: actionList.get(0).value }"
-></ng-container>
+        <i [ngClass]="icon" [class.me-1]="icon"></i>{{ text | abpLocalization }}
+      </button>
+      <div ngbDropdownMenu>
+        @for (action of actionList; track action.text) {
+          <ng-container
+            [ngTemplateOutlet]="dropDownBtnItemTmp"
+            [ngTemplateOutletContext]="{ $implicit: action }"
+          >
+          </ng-container>
+        }
+      </div>
+    </div>
+  }
+
+  @if (actionList.length === 1) {
+    <ng-container
+      [ngTemplateOutlet]="btnTmp"
+      [ngTemplateOutletContext]="{ $implicit: actionList.get(0).value }"
+    ></ng-container>
+  }
 }
 
 <ng-template #dropDownBtnItemTmp let-action>
   @if (action.visible(data)) {
-  <button
-    ngbDropdownItem
-    *abpPermission="action.permission; runChangeDetection: false"
-    (click)="action.action(data)"
-    type="button"
-  >
-    <ng-container
-      *ngTemplateOutlet="buttonContentTmp; context: { $implicit: action }"
-    ></ng-container>
-  </button>
+    <button
+      ngbDropdownItem
+      *abpPermission="action.permission; runChangeDetection: false"
+      (click)="action.action(data)"
+      type="button"
+    >
+      <ng-container
+        *ngTemplateOutlet="buttonContentTmp; context: { $implicit: action }"
+      ></ng-container>
+    </button>
   }
 </ng-template>
 
@@ -60,7 +64,9 @@
         type="button"
         [class]="action.btnClass"
         [style]="action.btnStyle"
-        [ngbTooltip]="action.tooltip.text | abpLocalization" [placement]="action.tooltip.placement || 'auto'"  container="body" 
+        [ngbTooltip]="action.tooltip.text | abpLocalization"
+        [placement]="action.tooltip.placement || 'auto'"
+        container="body"
       >
         <ng-container
           *ngTemplateOutlet="buttonContentTmp; context: { $implicit: action }"

--- a/npm/ng-packs/packages/components/extensible/src/lib/components/grid-actions/grid-actions.component.ts
+++ b/npm/ng-packs/packages/components/extensible/src/lib/components/grid-actions/grid-actions.component.ts
@@ -49,14 +49,4 @@ export class GridActionsComponent<R = any> extends AbstractActionsComponent<Enti
   constructor(injector: Injector) {
     super(injector);
   }
-
-  hasAvailableActions(): boolean {
-    return this.actionList.toArray().some(action => {
-      if (!action) return false;
-
-      const { permission, visible } = action;
-
-      return this.permissionService.getGrantedPolicy(permission) && visible(this.data);
-    });
-  }
 }

--- a/npm/ng-packs/packages/components/extensible/src/lib/components/grid-actions/grid-actions.component.ts
+++ b/npm/ng-packs/packages/components/extensible/src/lib/components/grid-actions/grid-actions.component.ts
@@ -4,12 +4,13 @@ import {
   Injector,
   Input,
   TrackByFunction,
+  inject,
 } from '@angular/core';
 import { EntityAction, EntityActionList } from '../../models/entity-actions';
 import { EXTENSIONS_ACTION_TYPE } from '../../tokens/extensions.token';
 import { AbstractActionsComponent } from '../abstract-actions/abstract-actions.component';
 import { NgbDropdownModule, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
-import { LocalizationModule, PermissionDirective } from '@abp/ng.core';
+import { LocalizationModule, PermissionDirective, PermissionService } from '@abp/ng.core';
 import { EllipsisDirective } from '@abp/ng.theme.shared';
 import { NgClass, NgTemplateOutlet } from '@angular/common';
 
@@ -23,7 +24,7 @@ import { NgClass, NgTemplateOutlet } from '@angular/common';
     NgClass,
     LocalizationModule,
     NgTemplateOutlet,
-    NgbTooltipModule
+    NgbTooltipModule,
   ],
   selector: 'abp-grid-actions',
   templateUrl: './grid-actions.component.html',
@@ -43,8 +44,19 @@ export class GridActionsComponent<R = any> extends AbstractActionsComponent<Enti
   @Input() text = '';
 
   readonly trackByFn: TrackByFunction<EntityAction<R>> = (_, item) => item.text;
+  public readonly permissionService = inject(PermissionService);
 
   constructor(injector: Injector) {
     super(injector);
+  }
+
+  hasAvailableActions(): boolean {
+    return this.actionList.toArray().some(action => {
+      if (!action) return false;
+
+      const { permission, visible } = action;
+
+      return this.permissionService.getGrantedPolicy(permission) && visible(this.data);
+    });
   }
 }

--- a/npm/ng-packs/packages/components/extensible/src/lib/components/grid-actions/grid-actions.component.ts
+++ b/npm/ng-packs/packages/components/extensible/src/lib/components/grid-actions/grid-actions.component.ts
@@ -4,13 +4,12 @@ import {
   Injector,
   Input,
   TrackByFunction,
-  inject,
 } from '@angular/core';
 import { EntityAction, EntityActionList } from '../../models/entity-actions';
 import { EXTENSIONS_ACTION_TYPE } from '../../tokens/extensions.token';
 import { AbstractActionsComponent } from '../abstract-actions/abstract-actions.component';
 import { NgbDropdownModule, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
-import { LocalizationModule, PermissionDirective, PermissionService } from '@abp/ng.core';
+import { LocalizationModule, PermissionDirective } from '@abp/ng.core';
 import { EllipsisDirective } from '@abp/ng.theme.shared';
 import { NgClass, NgTemplateOutlet } from '@angular/common';
 
@@ -44,7 +43,6 @@ export class GridActionsComponent<R = any> extends AbstractActionsComponent<Enti
   @Input() text = '';
 
   readonly trackByFn: TrackByFunction<EntityAction<R>> = (_, item) => item.text;
-  public readonly permissionService = inject(PermissionService);
 
   constructor(injector: Injector) {
     super(injector);


### PR DESCRIPTION
### Description

Resolves the action list dropdown problem as can be seen in the record:

[4_30_2024, 10_17_04 AM - Screen - Untitled video.webm](https://github.com/abpframework/abp/assets/92928815/fb297cc3-09af-4bb3-b968-1ef1c4f32144)



### Checklist

- [X] I fully tested it as developer 
- [X] No need to document

### How to test it?

Here is to steps to reproduce the related test case
1. Create a user under identity management
2. Then only give "Login With This User Permission" 
3. Once you login with its credentials, the actions button should not be visible since there will be no related action

We have previously discussed about the UI behavior with @masumulu28, and it is open to updates after further considerations.
