### PR TITLE
Fix reindex problem

### DIFF
--- a/modules/docs/src/Volo.Docs.Admin.Application/Volo/Docs/Admin/Projects/ProjectAdminAppService.cs
+++ b/modules/docs/src/Volo.Docs.Admin.Application/Volo/Docs/Admin/Projects/ProjectAdminAppService.cs
@@ -137,7 +137,7 @@ namespace Volo.Docs.Admin.Projects
             
             await _elasticSearchService.DeleteAllByProjectIdAsync(project.Id);
             
-            var docsCount = await _documentRepository.GetCountByProjectId(projectId);
+            var docsCount = await _documentRepository.GetUniqueDocumentCountByProjectIdAsync(projectId);
             
             if (docsCount == 0)
             {
@@ -149,7 +149,7 @@ namespace Volo.Docs.Admin.Projects
             var skipCount = 0;
             while(skipCount < docsCount)
             {
-                var docs = await _documentRepository.GetListByProjectId(projectId, skipCount, maxResultCount);
+                var docs = await _documentRepository.GetUniqueDocumentsByProjectIdPagedAsync(projectId, skipCount, maxResultCount);
                 docs = docs.Where(doc => doc.FileName != project.NavigationDocumentName && doc.FileName != project.ParametersDocumentName).ToList();
                 if (!docs.Any())
                 {

--- a/modules/docs/src/Volo.Docs.Admin.Application/Volo/Docs/Admin/Projects/ProjectAdminAppService.cs
+++ b/modules/docs/src/Volo.Docs.Admin.Application/Volo/Docs/Admin/Projects/ProjectAdminAppService.cs
@@ -134,15 +134,29 @@ namespace Volo.Docs.Admin.Projects
             {
                 throw new Exception("Cannot find the project with the Id " + projectId);
             }
-
-            var docs = (await _documentRepository.GetListByProjectId(project.Id))
-                .Where(doc => doc.FileName != project.NavigationDocumentName && doc.FileName != project.ParametersDocumentName)
-                .ToList();
+            
             await _elasticSearchService.DeleteAllByProjectIdAsync(project.Id);
-
-            if(docs.Any())
+            
+            var docsCount = await _documentRepository.GetCountByProjectId(projectId);
+            
+            if (docsCount == 0)
             {
-                await _elasticSearchService.AddOrUpdateManyAsync(docs);    
+                return;
+            }
+            
+            const int maxResultCount = 1000;
+            
+            var skipCount = 0;
+            while(skipCount < docsCount)
+            {
+                var docs = await _documentRepository.GetListByProjectId(projectId, skipCount, maxResultCount);
+                docs = docs.Where(doc => doc.FileName != project.NavigationDocumentName && doc.FileName != project.ParametersDocumentName).ToList();
+                if (!docs.Any())
+                {
+                    return;
+                }
+                await _elasticSearchService.AddOrUpdateManyAsync(docs);
+                skipCount += maxResultCount;
             }
         }
 

--- a/modules/docs/src/Volo.Docs.Domain/Volo/Docs/Documents/FullSearch/Elastic/ElasticDocumentFullSearch.cs
+++ b/modules/docs/src/Volo.Docs.Domain/Volo/Docs/Documents/FullSearch/Elastic/ElasticDocumentFullSearch.cs
@@ -58,6 +58,12 @@ namespace Volo.Docs.Documents.FullSearch.Elastic
         public virtual async Task AddOrUpdateAsync(Document document, CancellationToken cancellationToken = default)
         {
             var client = _clientProvider.GetClient();
+            
+            var existsResponse = await client.DocumentExistsAsync(DocumentPath<Document>.Id(NormalizeField(document.Id)), x => x.Index(_options.IndexName), cancellationToken);
+            if (existsResponse.Exists)
+            {
+                await DeleteAsync(document.Id, cancellationToken);
+            }
 
             var esDocument = new EsDocument
             {

--- a/modules/docs/src/Volo.Docs.Domain/Volo/Docs/Documents/FullSearch/Elastic/ElasticDocumentFullSearch.cs
+++ b/modules/docs/src/Volo.Docs.Domain/Volo/Docs/Documents/FullSearch/Elastic/ElasticDocumentFullSearch.cs
@@ -76,9 +76,7 @@ namespace Volo.Docs.Documents.FullSearch.Elastic
             
             if (existResponse.Documents.Count != 0)
             {
-                // delete many
-                var ids = existResponse.Documents.Select(x => x.Id).ToList();
-                HandleError(await client.DeleteManyAsync(ids, _options.IndexName, cancellationToken));
+                HandleError(await client.DeleteManyAsync(existResponse.Documents, _options.IndexName, cancellationToken));
             }
 
             var esDocument = new EsDocument

--- a/modules/docs/src/Volo.Docs.Domain/Volo/Docs/Documents/IDocumentRepository.cs
+++ b/modules/docs/src/Volo.Docs.Domain/Volo/Docs/Documents/IDocumentRepository.cs
@@ -13,9 +13,9 @@ namespace Volo.Docs.Documents
 
         Task<List<Document>> GetListByProjectId(Guid projectId, CancellationToken cancellationToken = default);
         
-        Task<List<Document>> GetListByProjectId(Guid projectId, int skipCount, int maxResultCount, CancellationToken cancellationToken = default);
+        Task<List<Document>> GetUniqueDocumentsByProjectIdPagedAsync(Guid projectId, int skipCount, int maxResultCount, CancellationToken cancellationToken = default);
         
-        Task<long> GetCountByProjectId(Guid projectId, CancellationToken cancellationToken = default);
+        Task<long> GetUniqueDocumentCountByProjectIdAsync(Guid projectId, CancellationToken cancellationToken = default);
         
         Task UpdateProjectLastCachedTimeAsync(Guid projectId, DateTime cachedTime,
             CancellationToken cancellationToken = default);

--- a/modules/docs/src/Volo.Docs.Domain/Volo/Docs/Documents/IDocumentRepository.cs
+++ b/modules/docs/src/Volo.Docs.Domain/Volo/Docs/Documents/IDocumentRepository.cs
@@ -13,6 +13,10 @@ namespace Volo.Docs.Documents
 
         Task<List<Document>> GetListByProjectId(Guid projectId, CancellationToken cancellationToken = default);
         
+        Task<List<Document>> GetListByProjectId(Guid projectId, int skipCount, int maxResultCount, CancellationToken cancellationToken = default);
+        
+        Task<long> GetCountByProjectId(Guid projectId, CancellationToken cancellationToken = default);
+        
         Task UpdateProjectLastCachedTimeAsync(Guid projectId, DateTime cachedTime,
             CancellationToken cancellationToken = default);
 

--- a/modules/docs/src/Volo.Docs.EntityFrameworkCore/Volo/Docs/Documents/EFCoreDocumentRepository.cs
+++ b/modules/docs/src/Volo.Docs.EntityFrameworkCore/Volo/Docs/Documents/EFCoreDocumentRepository.cs
@@ -56,6 +56,17 @@ namespace Volo.Docs.Documents
             return await (await GetDbSetAsync()).Where(d => d.ProjectId == projectId).ToListAsync(GetCancellationToken(cancellationToken));
         }
 
+        public virtual async Task<List<Document>> GetListByProjectId(Guid projectId, int skipCount, int maxResultCount,
+            CancellationToken cancellationToken = default)
+        {
+            return await (await GetDbSetAsync()).Where(d => d.ProjectId == projectId).PageBy(skipCount, maxResultCount).ToListAsync(GetCancellationToken(cancellationToken));
+        }
+
+        public virtual async Task<long> GetCountByProjectId(Guid projectId, CancellationToken cancellationToken = default)
+        {
+            return await (await GetDbSetAsync()).Where(d => d.ProjectId == projectId).LongCountAsync(GetCancellationToken(cancellationToken));
+        }
+
         public async Task UpdateProjectLastCachedTimeAsync(Guid projectId, DateTime cachedTime,
             CancellationToken cancellationToken = default)
         {

--- a/modules/docs/src/Volo.Docs.EntityFrameworkCore/Volo/Docs/Documents/EFCoreDocumentRepository.cs
+++ b/modules/docs/src/Volo.Docs.EntityFrameworkCore/Volo/Docs/Documents/EFCoreDocumentRepository.cs
@@ -56,15 +56,25 @@ namespace Volo.Docs.Documents
             return await (await GetDbSetAsync()).Where(d => d.ProjectId == projectId).ToListAsync(GetCancellationToken(cancellationToken));
         }
 
-        public virtual async Task<List<Document>> GetListByProjectId(Guid projectId, int skipCount, int maxResultCount,
+        public virtual async Task<List<Document>> GetUniqueDocumentsByProjectIdPagedAsync(Guid projectId, int skipCount, int maxResultCount,
             CancellationToken cancellationToken = default)
         {
-            return await (await GetDbSetAsync()).Where(d => d.ProjectId == projectId).PageBy(skipCount, maxResultCount).ToListAsync(GetCancellationToken(cancellationToken));
+            return await (await GetDbSetAsync())
+                .Where(d => d.ProjectId == projectId)
+                .OrderBy(x => x.LastCachedTime)
+                .GroupBy(x => new { x.Name, x.LanguageCode, x.Version })
+                .Select(group => group.First())
+                .Skip(skipCount)
+                .Take(maxResultCount)
+                .ToListAsync(cancellationToken);
         }
 
-        public virtual async Task<long> GetCountByProjectId(Guid projectId, CancellationToken cancellationToken = default)
+        public virtual async Task<long> GetUniqueDocumentCountByProjectIdAsync(Guid projectId, CancellationToken cancellationToken = default)
         {
-            return await (await GetDbSetAsync()).Where(d => d.ProjectId == projectId).LongCountAsync(GetCancellationToken(cancellationToken));
+            return await (await GetDbSetAsync())
+                .Where(d => d.ProjectId == projectId)
+                .GroupBy(x => new {x.FileName, x.Version, x.LanguageCode})
+                .LongCountAsync(GetCancellationToken(cancellationToken));
         }
 
         public async Task UpdateProjectLastCachedTimeAsync(Guid projectId, DateTime cachedTime,

--- a/modules/docs/src/Volo.Docs.MongoDB/Volo/Docs/Documents/MongoDocumentRepository.cs
+++ b/modules/docs/src/Volo.Docs.MongoDB/Volo/Docs/Documents/MongoDocumentRepository.cs
@@ -54,6 +54,21 @@ namespace Volo.Docs.Documents
             return await (await GetMongoQueryableAsync(cancellationToken)).Where(d => d.ProjectId == projectId).ToListAsync(GetCancellationToken(cancellationToken));
         }
 
+        public virtual async Task<List<Document>> GetListByProjectId(Guid projectId, int skipCount, int maxResultCount,
+            CancellationToken cancellationToken = default)
+        {
+            return await (await GetMongoQueryableAsync(cancellationToken)).Where(d => d.ProjectId == projectId)
+                .OrderBy(x => x.Name)
+                .Skip(skipCount)
+                .Take(maxResultCount)
+                .ToListAsync(GetCancellationToken(cancellationToken));
+        }
+
+        public virtual async Task<long> GetCountByProjectId(Guid projectId, CancellationToken cancellationToken = default)
+        {
+            return await (await GetMongoQueryableAsync(cancellationToken)).LongCountAsync(x => x.ProjectId == projectId, GetCancellationToken(cancellationToken));
+        }
+
         public async Task UpdateProjectLastCachedTimeAsync(Guid projectId, DateTime cachedTime,
             CancellationToken cancellationToken = default)
         {

--- a/modules/docs/test/Volo.Docs.TestBase/Volo/Docs/DocumentRepository_Tests.cs
+++ b/modules/docs/test/Volo.Docs.TestBase/Volo/Docs/DocumentRepository_Tests.cs
@@ -43,5 +43,19 @@ namespace Volo.Docs
             var documentsAfterClear = await DocumentRepository.GetListByProjectId(DocsTestData.ProjectId);
             documentsAfterClear.ForEach(d => d.LastCachedTime.ShouldBe(DateTime.MinValue));
         }
+        
+        [Fact] 
+        public async Task GetUniqueDocumentsByProjectIdPagedAsync()
+        {
+            var documents = await DocumentRepository.GetUniqueDocumentsByProjectIdPagedAsync(DocsTestData.ProjectId, 0, 10);
+            documents.Count.ShouldBe(1);
+        }
+        
+        [Fact]
+        public async Task GetUniqueDocumentCountByProjectIdAsync()
+        {
+            var count = await DocumentRepository.GetUniqueDocumentCountByProjectIdAsync(DocsTestData.ProjectId);
+            count.ShouldBe(1);
+        }
     }
 }


### PR DESCRIPTION
### Description
Resolves https://github.com/volosoft/vs-internal/issues/4175

- As the count of documents increases, the problems with memory increase. Pagination has been added to prevent this.
- When indexing, the last cached document should be indexed as unique