### PR TITLE
pass `noRedirectToLogoutUrl` parameter to logout method 

### DIFF
--- a/npm/ng-packs/packages/oauth/src/lib/strategies/auth-code-flow-strategy.ts
+++ b/npm/ng-packs/packages/oauth/src/lib/strategies/auth-code-flow-strategy.ts
@@ -1,6 +1,6 @@
 import { noop } from '@abp/ng.core';
 import { Params } from '@angular/router';
-import { from, of } from 'rxjs';
+import { Observable, from, of } from 'rxjs';
 import { AuthFlowStrategy } from './auth-flow-strategy';
 import { isTokenExpired } from '../utils';
 
@@ -51,6 +51,10 @@ export class AuthCodeFlowStrategy extends AuthFlowStrategy {
 
   logout(queryParams?: Params) {
     this.rememberMeService.remove();
+    if (queryParams?.noRedirectToLogoutUrl) {
+      this.router.navigate(['/']);
+      return from(this.oAuthService.revokeTokenAndLogout(true));
+    }
     return from(this.oAuthService.revokeTokenAndLogout(this.getCultureParams(queryParams)));
   }
 

--- a/npm/ng-packs/packages/oauth/src/lib/strategies/auth-code-flow-strategy.ts
+++ b/npm/ng-packs/packages/oauth/src/lib/strategies/auth-code-flow-strategy.ts
@@ -1,6 +1,6 @@
 import { noop } from '@abp/ng.core';
 import { Params } from '@angular/router';
-import { Observable, from, of } from 'rxjs';
+import { from, of } from 'rxjs';
 import { AuthFlowStrategy } from './auth-flow-strategy';
 import { isTokenExpired } from '../utils';
 

--- a/npm/ng-packs/packages/theme-shared/src/lib/services/authentication-error-handler.service.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/services/authentication-error-handler.service.ts
@@ -3,13 +3,11 @@ import { AuthService, ConfigStateService } from '@abp/ng.core';
 import { HttpErrorResponse } from '@angular/common/http';
 import { CustomHttpErrorHandlerService } from '../models/common';
 import { CUSTOM_HTTP_ERROR_HANDLER_PRIORITY } from '../constants/default-errors';
-import { Router } from '@angular/router';
 
 @Injectable({ providedIn: 'root' })
 export class AbpAuthenticationErrorHandler implements CustomHttpErrorHandlerService {
   readonly priority = CUSTOM_HTTP_ERROR_HANDLER_PRIORITY.veryHigh;
   protected readonly authService = inject(AuthService);
-  protected readonly router = inject(Router);
   protected readonly configStateService = inject(ConfigStateService);
 
   canHandle(error: unknown): boolean {

--- a/npm/ng-packs/packages/theme-shared/src/lib/services/authentication-error-handler.service.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/services/authentication-error-handler.service.ts
@@ -3,11 +3,13 @@ import { AuthService, ConfigStateService } from '@abp/ng.core';
 import { HttpErrorResponse } from '@angular/common/http';
 import { CustomHttpErrorHandlerService } from '../models/common';
 import { CUSTOM_HTTP_ERROR_HANDLER_PRIORITY } from '../constants/default-errors';
+import { Router } from '@angular/router';
 
 @Injectable({ providedIn: 'root' })
 export class AbpAuthenticationErrorHandler implements CustomHttpErrorHandlerService {
   readonly priority = CUSTOM_HTTP_ERROR_HANDLER_PRIORITY.veryHigh;
   protected readonly authService = inject(AuthService);
+  protected readonly router = inject(Router);
   protected readonly configStateService = inject(ConfigStateService);
 
   canHandle(error: unknown): boolean {
@@ -17,7 +19,7 @@ export class AbpAuthenticationErrorHandler implements CustomHttpErrorHandlerServ
   execute() {
     this.configStateService.refreshAppState().subscribe(({ currentUser }) => {
       if (!currentUser.isAuthenticated) {
-        this.authService.logout();
+        this.authService.logout({ noRedirectToLogoutUrl: true });
       }
     });
   }


### PR DESCRIPTION
We don't want to remove auth server session when encounter with the 401 error.

With this way it only logs out from angular and revoke its token.

We can achieve this by passing true to logout method. 

[angular-oauth2-oidc > oauth.service.ts](https://github.com/manfredsteyer/angular-oauth2-oidc/blob/03357909ed3013623a1a69f9599f015d46aa4906/projects/lib/src/oauth-service.ts#L2529-L2531)