### PR TITLE
Checking dynamic claims at intervals rather than every time.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.SignalR/Volo/Abp/AspNetCore/SignalR/AbpSignalROptions.cs
+++ b/framework/src/Volo.Abp.AspNetCore.SignalR/Volo/Abp/AspNetCore/SignalR/AbpSignalROptions.cs
@@ -1,11 +1,19 @@
-﻿namespace Volo.Abp.AspNetCore.SignalR;
+﻿using System;
+
+namespace Volo.Abp.AspNetCore.SignalR;
 
 public class AbpSignalROptions
 {
     public HubConfigList Hubs { get; }
 
+    /// <summary>
+    /// Default: 5 seconds.
+    /// </summary>
+    public TimeSpan? CheckDynamicClaimsInterval { get; set; }
+
     public AbpSignalROptions()
     {
         Hubs = new HubConfigList();
+        CheckDynamicClaimsInterval = TimeSpan.FromSeconds(5);
     }
 }


### PR DESCRIPTION
If checked every time, there will be a performance impact.

Signalr triggers `InvokeMethodAsync` method even if the mouse is moved.

Related to https://github.com/abpframework/abp/pull/19579 and https://github.com/abpframework/abp/pull/19605
