### PR TITLE
SignInManager Checks IdentityOptions in AccountController Login

### DIFF
--- a/modules/account/src/Volo.Abp.Account.Web/Areas/Account/Controllers/AccountController.cs
+++ b/modules/account/src/Volo.Abp.Account.Web/Areas/Account/Controllers/AccountController.cs
@@ -59,6 +59,9 @@ public class AccountController : AbpControllerBase
         ValidateLoginInfo(login);
 
         await ReplaceEmailToUsernameOfInputIfNeeds(login);
+
+        await IdentityOptions.SetAsync();
+        
         var signInResult = await SignInManager.PasswordSignInAsync(
             login.UserNameOrEmailAddress,
             login.Password,


### PR DESCRIPTION
Hi,
we need to use settings to set "IdentitySettingNames.SignIn.RequireConfirmedEmail" to true. 
these are our settings:
```c#
context.Add(new SettingDefinition(
    name: IdentitySettingNames.SignIn.RequireConfirmedEmail,
    defaultValue: true.ToString(),
    isVisibleToClients: true
));
```
If the user tries to login and the email is not confirmed, the result should be failed.


- Everything is good in the admin (/Account/Login) view. If the user is not confirmed, give me the message "You are not allowed to login! Your account is inactive or needs to confirm your email/phone number."
![image](https://github.com/abpframework/abp/assets/97635301/cf21e49c-04f8-4101-a4d8-3ce8fda5f759)

- The issue is in Swagger (/api/account/login) endpoint. If the user is not confirmed, the login succeeds!
![image](https://github.com/abpframework/abp/assets/97635301/00096611-4eca-4370-a283-04e39993cbc3)


**What we found** is that the issue lies in the AccountController.Login where the SignInManager does not read the IdentityOptions. we should add code to read the IdentityOptions in SignInManager:

```c#
await IdentityOptions.SetAsync();
```

Please check the pull request to see if there is an issue or if we need to follow a step to bypass this issue.