### PR TITLE
Angular - Actions button visibility problem on the extensible table component

### DIFF
--- a/npm/ng-packs/packages/components/extensible/src/lib/components/extensible-table/extensible-table.component.html
+++ b/npm/ng-packs/packages/components/extensible/src/lib/components/extensible-table/extensible-table.component.html
@@ -17,7 +17,7 @@
           *ngTemplateOutlet="actionsTemplate || gridActions; context: { $implicit: row, index: i }"
         ></ng-container>
         <ng-template #gridActions>
-          @if (hasAvailableActions(i, row)) {
+          @if (hasAvailableActions(row)) {
             <abp-grid-actions [index]="i" [record]="row" text="AbpUi::Actions"></abp-grid-actions>
           }
         </ng-template>

--- a/npm/ng-packs/packages/components/extensible/src/lib/components/extensible-table/extensible-table.component.ts
+++ b/npm/ng-packs/packages/components/extensible/src/lib/components/extensible-table/extensible-table.component.ts
@@ -206,12 +206,20 @@ export class ExtensibleTableComponent<R = any> implements OnChanges {
     });
   }
 
-  hasAvailableActions(index, data): boolean {
-    const { permission, visible } = this.actionList.get(index)?.value || {};
-    let isActionAvailable = this.permissionService.getGrantedPolicy(permission);
-    if (data && data.record) {
-      isActionAvailable &&= visible(data);
-    }
+  hasAvailableActions(data): boolean {
+    let isActionAvailable = true;
+    this.actionList.toArray().map(action => {
+      const { visible, permission } = action;
+      if (data && action) {
+        const visibilityCheck = visible({
+          record: data,
+          getInjected: this.getInjected,
+        });
+        const permissionCheck = this.permissionService.getGrantedPolicy(permission);
+
+        isActionAvailable = visibilityCheck && permissionCheck;
+      }
+    });
     return isActionAvailable;
   }
 }

--- a/npm/ng-packs/packages/components/extensible/src/lib/components/extensible-table/extensible-table.component.ts
+++ b/npm/ng-packs/packages/components/extensible/src/lib/components/extensible-table/extensible-table.component.ts
@@ -206,13 +206,13 @@ export class ExtensibleTableComponent<R = any> implements OnChanges {
     });
   }
 
-  hasAvailableActions(data): boolean {
+  hasAvailableActions(rowData): boolean {
     let isActionAvailable = true;
     this.actionList.toArray().map(action => {
       const { visible, permission } = action;
-      if (data && action) {
+      if (rowData && action) {
         const visibilityCheck = visible({
-          record: data,
+          record: rowData,
           getInjected: this.getInjected,
         });
         const permissionCheck = this.permissionService.getGrantedPolicy(permission);


### PR DESCRIPTION
### Description

Resolves the actions button dropdown issue that normally should check the action items in the whole list whether each has both the necessary permission(s) and visibility requirements. Here is a record to demonstrate the related parts

https://github.com/abpframework/abp/assets/92928815/922ca631-6417-4e28-83d8-ac0f1dece8eb

### Checklist

- [X] I fully tested it as developer
- [X] No need for documentation

### How to test it?

Here are the steps to reproduce the related test case

1. Create a user under identity management
2. Then only give "Login With This User Permission"
3. Once you login with its credentials, the actions button should not be visible since there will be no related action
4. Also, when you check the other actions button that should have items inside, the button visibility can be confirmed as it should be.
