### PR TITLE
Log out of blazor wasm when get a "401" response.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Components.WebAssembly/Volo/Abp/AspNetCore/Components/WebAssembly/ClientProxyExceptionEventHandler.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Components.WebAssembly/Volo/Abp/AspNetCore/Components/WebAssembly/ClientProxyExceptionEventHandler.cs
@@ -31,24 +31,11 @@ public class ClientProxyExceptionEventHandler : ILocalEventHandler<ClientProxyEx
                 case 401:
                 {
                     var options = scope.ServiceProvider.GetRequiredService<IOptions<AbpAspNetCoreComponentsWebOptions>>();
-
                     if (!options.Value.IsBlazorWebApp)
                     {
-                        var navigationManager = scope.ServiceProvider.GetRequiredService<NavigationManager>();
-                        var accessTokenProvider = scope.ServiceProvider.GetRequiredService<IAccessTokenProvider>();
                         var authenticationOptions = scope.ServiceProvider.GetRequiredService<IOptions<AbpAuthenticationOptions>>();
-                        var result = await accessTokenProvider.RequestAccessToken();
-                        if (result.Status != AccessTokenResultStatus.Success)
-                        {
-                            navigationManager.NavigateToLogout(authenticationOptions.Value.LogoutUrl);
-                            return;
-                        }
-
-                        result.TryGetToken(out var token);
-                        if (token != null && DateTimeOffset.Now >= token.Expires.AddMinutes(-5))
-                        {
-                            navigationManager.NavigateToLogout(authenticationOptions.Value.LogoutUrl);
-                        }
+                        var navigationManager = scope.ServiceProvider.GetRequiredService<NavigationManager>();
+                        navigationManager.NavigateToLogout(authenticationOptions.Value.LogoutUrl, "/");
                     }
                     else
                     {


### PR DESCRIPTION
@gizemmutukurt For your test: 

**Blazor wasm will also log out of the auth server. This is a limitation of Blazor wasm, We can't do anything.**

The Blazor server and Blazor web app don't have this behavior.