### PR TITLE
Add information about Microsoft.Extensions.FileProviders.Embedded package

### DIFF
--- a/docs/en/Migration-Guides/Abp-7_0.md
+++ b/docs/en/Migration-Guides/Abp-7_0.md
@@ -135,6 +135,10 @@ await builder.AddApplicationAsync<MyMigratorModule>();
 
 See https://github.com/abpframework/abp/pull/13985 for more info.
 
+## Add Microsoft.Extensions.FileProviders.Embedded su support localization
+
+Virtual File System now relayes on the Microsoft.Extensions.FileProviders.Embedded 7.0.x package, so you must add this package to *.Domain.Shared project.
+
 ## Devart.Data.Oracle.EFCore
 
 The `Devart.Data.Oracle.EFCore` package do not yet support EF Core 7.0, If you use `AbpEntityFrameworkCoreOracleDevartModule(Volo.Abp.EntityFrameworkCore.Oracle.Devart)` may not work as expected, We will release new packages as soon as they are updated.


### PR DESCRIPTION
Related to #19804

The Microsoft.Extensions.FileProviders.Embedded must be added to v7 and above to support localization. v6 can work without it, so this info must be added to the migration guide.