### PR TITLE
Use config provider function in templates

### DIFF
--- a/templates/app-nolayers/angular/src/app/app.module.ts
+++ b/templates/app-nolayers/angular/src/app/app.module.ts
@@ -1,12 +1,18 @@
-import { AccountConfigModule } from '@abp/ng.account/config';
-import { CoreModule } from '@abp/ng.core';
+import { provideAccountConfig } from '@abp/ng.account/config';
+import { CoreModule, provideAbpCore, withOptions } from '@abp/ng.core';
 import { registerLocale } from '@abp/ng.core/locale';
-import { IdentityConfigModule } from '@abp/ng.identity/config';
-import { SettingManagementConfigModule } from '@abp/ng.setting-management/config';
-import { TenantManagementConfigModule } from '@abp/ng.tenant-management/config';
+import { provideIdentityConfig } from '@abp/ng.identity/config';
+import { provideSettingManagementConfig } from '@abp/ng.setting-management/config';
+import { provideTenantManagementConfig } from '@abp/ng.tenant-management/config';
 import { ThemeLeptonXModule } from '@abp/ng.theme.lepton-x';
 import { SideMenuLayoutModule } from '@abp/ng.theme.lepton-x/layouts';
-import { InternetConnectionStatusComponent, ThemeSharedModule } from '@abp/ng.theme.shared';
+import {
+  InternetConnectionStatusComponent,
+  ThemeSharedModule,
+  provideAbpThemeShared,
+} from '@abp/ng.theme.shared';
+import { provideFeatureManagementConfig } from '@abp/ng.feature-management';
+import { provideAbpOAuth } from '@abp/ng.oauth';
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -14,31 +20,35 @@ import { environment } from '../environments/environment';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { APP_ROUTE_PROVIDER } from './route.provider';
-import { FeatureManagementModule } from '@abp/ng.feature-management';
-import { AbpOAuthModule } from '@abp/ng.oauth';
 
 @NgModule({
   imports: [
     BrowserModule,
     BrowserAnimationsModule,
     AppRoutingModule,
-    CoreModule.forRoot({
-      environment,
-      registerLocaleFn: registerLocale(),
-    }),
-    AbpOAuthModule.forRoot(),
-    ThemeSharedModule.forRoot(),
-    AccountConfigModule.forRoot(),
-    IdentityConfigModule.forRoot(),
-    TenantManagementConfigModule.forRoot(),
-    SettingManagementConfigModule.forRoot(),
+    CoreModule,
+    ThemeSharedModule,
     ThemeLeptonXModule.forRoot(),
     SideMenuLayoutModule.forRoot(),
-    FeatureManagementModule.forRoot(),
-    InternetConnectionStatusComponent
+    InternetConnectionStatusComponent,
   ],
   declarations: [AppComponent],
-  providers: [APP_ROUTE_PROVIDER],
+  providers: [
+    APP_ROUTE_PROVIDER,
+    provideAbpCore(
+      withOptions({
+        environment,
+        registerLocaleFn: registerLocale(),
+      })
+    ),
+    provideAbpOAuth(),
+    provideAbpThemeShared(),
+    provideSettingManagementConfig(),
+    provideAccountConfig(),
+    provideIdentityConfig(),
+    provideTenantManagementConfig(),
+    provideFeatureManagementConfig(),
+  ],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/templates/app/angular/src/app/app.module.ts
+++ b/templates/app/angular/src/app/app.module.ts
@@ -1,12 +1,19 @@
-import { AccountConfigModule } from '@abp/ng.account/config';
-import { CoreModule } from '@abp/ng.core';
+import { CoreModule, provideAbpCore, withOptions } from '@abp/ng.core';
 import { registerLocale } from '@abp/ng.core/locale';
-import { IdentityConfigModule } from '@abp/ng.identity/config';
-import { SettingManagementConfigModule } from '@abp/ng.setting-management/config';
-import { TenantManagementConfigModule } from '@abp/ng.tenant-management/config';
+import {
+  InternetConnectionStatusComponent,
+  ThemeSharedModule,
+  provideAbpThemeShared,
+} from '@abp/ng.theme.shared';
+import { provideFeatureManagementConfig } from '@abp/ng.feature-management';
+import { provideAbpOAuth } from '@abp/ng.oauth';
+import { provideIdentityConfig } from '@abp/ng.identity/config';
+import { provideSettingManagementConfig } from '@abp/ng.setting-management/config';
+import { provideTenantManagementConfig } from '@abp/ng.tenant-management/config';
+import { provideAccountConfig } from '@abp/ng.account/config';
 import { ThemeLeptonXModule } from '@abp/ng.theme.lepton-x';
 import { SideMenuLayoutModule } from '@abp/ng.theme.lepton-x/layouts';
-import { InternetConnectionStatusComponent, ThemeSharedModule } from '@abp/ng.theme.shared';
+import { AccountLayoutModule } from '@abp/ng.theme.lepton-x/account';
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -14,32 +21,36 @@ import { environment } from '../environments/environment';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { APP_ROUTE_PROVIDER } from './route.provider';
-import { FeatureManagementModule } from '@abp/ng.feature-management';
-import { AbpOAuthModule } from '@abp/ng.oauth';
-import { AccountLayoutModule } from '@abp/ng.theme.lepton-x/account';
+
 @NgModule({
   imports: [
     BrowserModule,
     BrowserAnimationsModule,
     AppRoutingModule,
-    CoreModule.forRoot({
-      environment,
-      registerLocaleFn: registerLocale(),
-    }),
-    AbpOAuthModule.forRoot(),
-    ThemeSharedModule.forRoot(),
-    AccountLayoutModule.forRoot(),
-    AccountConfigModule.forRoot(),
-    IdentityConfigModule.forRoot(),
-    TenantManagementConfigModule.forRoot(),
-    SettingManagementConfigModule.forRoot(),
+    CoreModule,
+    ThemeSharedModule,
     ThemeLeptonXModule.forRoot(),
     SideMenuLayoutModule.forRoot(),
-    FeatureManagementModule.forRoot(),
-    InternetConnectionStatusComponent
+    AccountLayoutModule.forRoot(),
+    InternetConnectionStatusComponent,
   ],
   declarations: [AppComponent],
-  providers: [APP_ROUTE_PROVIDER],
+  providers: [
+    APP_ROUTE_PROVIDER,
+    provideAbpCore(
+      withOptions({
+        environment,
+        registerLocaleFn: registerLocale(),
+      })
+    ),
+    provideAbpOAuth(),
+    provideAbpThemeShared(),
+    provideSettingManagementConfig(),
+    provideAccountConfig(),
+    provideIdentityConfig(),
+    provideTenantManagementConfig(),
+    provideFeatureManagementConfig(),
+  ],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/templates/module/angular/projects/dev-app/src/app/app.module.ts
+++ b/templates/module/angular/projects/dev-app/src/app/app.module.ts
@@ -1,11 +1,13 @@
-import { AccountConfigModule } from '@abp/ng.account/config';
-import { CoreModule } from '@abp/ng.core';
+import { provideAccountConfig } from '@abp/ng.account/config';
+import { CoreModule, provideAbpCore, withOptions } from '@abp/ng.core';
 import { registerLocale } from '@abp/ng.core/locale';
-import { IdentityConfigModule } from '@abp/ng.identity/config';
-import { SettingManagementConfigModule } from '@abp/ng.setting-management/config';
-import { TenantManagementConfigModule } from '@abp/ng.tenant-management/config';
-import { ThemeBasicModule } from '@abp/ng.theme.basic';
-import { ThemeSharedModule } from '@abp/ng.theme.shared';
+import { provideIdentityConfig } from '@abp/ng.identity/config';
+import { provideSettingManagementConfig } from '@abp/ng.setting-management/config';
+import { provideTenantManagementConfig } from '@abp/ng.tenant-management/config';
+import { ThemeBasicModule, provideThemeBasicConfig } from '@abp/ng.theme.basic';
+import { ThemeSharedModule, provideAbpThemeShared } from '@abp/ng.theme.shared';
+import { provideFeatureManagementConfig } from '@abp/ng.feature-management';
+import { provideAbpOAuth } from '@abp/ng.oauth';
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -14,31 +16,36 @@ import { environment } from '../environments/environment';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { APP_ROUTE_PROVIDER } from './route.provider';
-import { FeatureManagementModule } from '@abp/ng.feature-management';
-import { AbpOAuthModule } from '@abp/ng.oauth';
 
 @NgModule({
   imports: [
     BrowserModule,
     BrowserAnimationsModule,
     AppRoutingModule,
-    CoreModule.forRoot({
-      environment,
-      registerLocaleFn: registerLocale(),
-      sendNullsAsQueryParam: false,
-      skipGetAppConfiguration: false,
-    }),
-    AbpOAuthModule.forRoot(),
-    ThemeSharedModule.forRoot(),
-    AccountConfigModule.forRoot(),
-    IdentityConfigModule.forRoot(),
-    TenantManagementConfigModule.forRoot(),
-    SettingManagementConfigModule.forRoot(),
+    CoreModule,
+    ThemeSharedModule,
     MyProjectNameConfigModule.forRoot(),
-    ThemeBasicModule.forRoot(),
-    FeatureManagementModule.forRoot(),
+    ThemeBasicModule,
   ],
-  providers: [APP_ROUTE_PROVIDER],
+  providers: [
+    APP_ROUTE_PROVIDER,
+    provideAbpCore(
+      withOptions({
+        environment,
+        registerLocaleFn: registerLocale(),
+        sendNullsAsQueryParam: false,
+        skipGetAppConfiguration: false,
+      })
+    ),
+    provideAbpOAuth(),
+    provideAbpThemeShared(),
+    provideSettingManagementConfig(),
+    provideAccountConfig(),
+    provideIdentityConfig(),
+    provideTenantManagementConfig(),
+    provideFeatureManagementConfig(),
+    provideThemeBasicConfig(),
+  ],
   declarations: [AppComponent],
   bootstrap: [AppComponent],
 })


### PR DESCRIPTION
Resolves #19715
Depends on #19707 

Remove forRoot pattern in templates and use config provider functions.