### PR TITLE
Add `CachedBundleDynamicFileProvider` to sync bundle files using cache.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/CachedBundleDynamicFileProvider.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/CachedBundleDynamicFileProvider.cs
@@ -1,0 +1,57 @@
+using System;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Options;
+using Volo.Abp.Caching;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.VirtualFileSystem;
+
+namespace Volo.Abp.AspNetCore.Mvc.UI.Bundling;
+
+[Dependency(ReplaceServices = true)]
+public class CachedBundleDynamicFileProvider : DynamicFileProvider
+{
+    protected IDistributedCache<InMemoryFileInfoCacheItem> Cache { get; }
+    protected IOptions<AbpBundlingOptions> BundlingOptions { get; }
+
+    public CachedBundleDynamicFileProvider(
+        IDistributedCache<InMemoryFileInfoCacheItem> cache,
+        IOptions<AbpBundlingOptions> bundlingOptions)
+    {
+        Cache = cache;
+        BundlingOptions = bundlingOptions;
+    }
+
+    public override IFileInfo GetFileInfo(string? subpath)
+    {
+        var fileInfo = base.GetFileInfo(subpath);
+
+        if (!subpath.IsNullOrWhiteSpace() && fileInfo is NotFoundFileInfo &&
+            subpath.Contains(BundlingOptions.Value.BundleFolderName, StringComparison.OrdinalIgnoreCase))
+        {
+            var filePath = NormalizePath(subpath);
+            var cacheItem = Cache.Get(filePath);
+            if (cacheItem == null)
+            {
+                return fileInfo;
+            }
+
+            fileInfo = new InMemoryFileInfo(filePath, cacheItem.FileContent, cacheItem.Name);
+            DynamicFiles.AddOrUpdate(filePath, fileInfo, (key, value) => fileInfo);
+        }
+
+        return fileInfo;
+    }
+
+    public override void AddOrUpdate(IFileInfo fileInfo)
+    {
+        var filePath = fileInfo.GetVirtualOrPhysicalPathOrNull();
+        Cache.GetOrAdd(filePath!, () => new InMemoryFileInfoCacheItem(filePath!, fileInfo.ReadBytes(), fileInfo.Name));
+        base.AddOrUpdate(fileInfo);
+    }
+
+    public override bool Delete(string filePath)
+    {
+        Cache.Remove(filePath);
+        return base.Delete(filePath);
+    }
+}

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/InMemoryFileInfoCacheItem.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/InMemoryFileInfoCacheItem.cs
@@ -1,0 +1,22 @@
+using System;
+using Volo.Abp.MultiTenancy;
+
+namespace Volo.Abp.AspNetCore.Mvc.UI.Bundling;
+
+[Serializable]
+[IgnoreMultiTenancy]
+public class InMemoryFileInfoCacheItem
+{
+    public InMemoryFileInfoCacheItem(string dynamicPath, byte[] fileContent, string name)
+    {
+        DynamicPath = dynamicPath;
+        Name = name;
+        FileContent = fileContent;
+    }
+
+    public string DynamicPath { get; set; }
+
+    public string Name { get; set; }
+
+    public byte[] FileContent { get; set; }
+}

--- a/framework/src/Volo.Abp.VirtualFileSystem/Volo/Abp/VirtualFileSystem/DynamicFileProvider.cs
+++ b/framework/src/Volo.Abp.VirtualFileSystem/Volo/Abp/VirtualFileSystem/DynamicFileProvider.cs
@@ -29,14 +29,14 @@ public class DynamicFileProvider : DictionaryBasedFileProvider, IDynamicFileProv
         DynamicFiles = new ConcurrentDictionary<string, IFileInfo>();
     }
 
-    public void AddOrUpdate(IFileInfo fileInfo)
+    public virtual void AddOrUpdate(IFileInfo fileInfo)
     {
         var filePath = fileInfo.GetVirtualOrPhysicalPathOrNull();
         DynamicFiles.AddOrUpdate(filePath!, fileInfo, (key, value) => fileInfo);
         ReportChange(filePath!);
     }
 
-    public bool Delete(string filePath)
+    public virtual bool Delete(string filePath)
     {
         if (!DynamicFiles.TryRemove(filePath, out _))
         {
@@ -65,7 +65,7 @@ public class DynamicFileProvider : DictionaryBasedFileProvider, IDynamicFileProv
         return tokenInfo.ChangeToken;
     }
 
-    private void ReportChange(string filePath)
+    protected virtual void ReportChange(string filePath)
     {
         if (FilePathTokenLookup.TryRemove(filePath, out var tokenInfo))
         {


### PR DESCRIPTION
Resolve #19861

The situation:

Two servers (A and B) are on the backend to serve.

1. Browser request index page on Server A.
2. Server A index page renders the bundle tag helper, then adds bundle files to `DynamicFileProvider`.
3. Browser requests bundle file, but the request is forwarded to Server B.
4. Server B gets `404` because no bundle files are added to `DynamicFileProvider`.

**This PR adds the bundle files to Redis so other servers can get files correctly.**


### How to test it?

1. Enable Redis.
2. BundleAndMinify the js and css
```
Configure<AbpBundlingOptions>(options =>
{
    options.Mode = BundlingMode.BundleAndMinify;
}
```
3. Run the web app and navigate to the home page to ensure the bundle files are loaded once and cached.
5. Stop the web app and try to get a bundle file(`https://localhost:44303/__bundles/LeptonXLite.Global.C8BD9C08002E46065415D954057C9304.js`), **DO NOT open the home page this time.**
6. The bundle file should not be 404.
