### PR TITLE
Audit log exception check added

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/Auditing/AbpAuditActionFilter.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/Auditing/AbpAuditActionFilter.cs
@@ -29,14 +29,17 @@ public class AbpAuditActionFilter : IAsyncActionFilter, IAbpFilter, ITransientDe
             {
                 var result = await next();
 
-                if (result.Exception != null && !result.ExceptionHandled)
+                if (result.Exception != null && !auditLog!.Exceptions.Contains(result.Exception))
                 {
                     auditLog!.Exceptions.Add(result.Exception);
                 }
             }
             catch (Exception ex)
             {
-                auditLog!.Exceptions.Add(ex);
+                if (!auditLog!.Exceptions.Contains(ex))
+                {
+                    auditLog!.Exceptions.Add(ex);
+                }
                 throw;
             }
             finally

--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/Auditing/AbpAuditPageFilter.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/Auditing/AbpAuditPageFilter.cs
@@ -34,14 +34,17 @@ public class AbpAuditPageFilter : IAsyncPageFilter, IAbpFilter, ITransientDepend
             {
                 var result = await next();
 
-                if (result.Exception != null && !result.ExceptionHandled)
+                if (result.Exception != null && !auditLog!.Exceptions.Contains(result.Exception))
                 {
                     auditLog!.Exceptions.Add(result.Exception);
                 }
             }
             catch (Exception ex)
             {
-                auditLog!.Exceptions.Add(ex);
+                if (!auditLog!.Exceptions.Contains(ex))
+                {
+                    auditLog!.Exceptions.Add(ex);
+                }
                 throw;
             }
             finally


### PR DESCRIPTION
We should check if the exception exists in the audit log. If it doesn't, we add the exception.

## Current Behaviour

![image](https://github.com/abpframework/abp/assets/35758317/4c2228ab-5b2f-416a-b46e-0cc3d0eca82e)

## Expected Behaviour

![image](https://github.com/abpframework/abp/assets/35758317/693c61e4-460e-4a67-b6bc-6df66312cf49)
