### PR TITLE
BackgroundWorkers should be restartable to permit changes in Timer interval

### DIFF
--- a/framework/src/Volo.Abp.BackgroundWorkers/Volo/Abp/BackgroundWorkers/BackgroundWorkerBase.cs
+++ b/framework/src/Volo.Abp.BackgroundWorkers/Volo/Abp/BackgroundWorkers/BackgroundWorkerBase.cs
@@ -22,10 +22,16 @@ public abstract class BackgroundWorkerBase : IBackgroundWorker
 
     protected ILogger Logger => LazyServiceProvider.LazyGetService<ILogger>(provider => LoggerFactory?.CreateLogger(GetType().FullName!) ?? NullLogger.Instance);
 
-    protected CancellationTokenSource StoppingTokenSource { get; }
-    protected CancellationToken StoppingToken { get; }
+    protected CancellationTokenSource StoppingTokenSource { get; private set; }
+	
+    protected CancellationToken StoppingToken { get; private set; }
 
     public BackgroundWorkerBase()
+    {
+        ResetStoppingCancellationTokenSource();
+    }
+
+    private void ResetStoppingCancellationTokenSource()
     {
         StoppingTokenSource = new CancellationTokenSource();
         StoppingToken = StoppingTokenSource.Token;
@@ -42,6 +48,9 @@ public abstract class BackgroundWorkerBase : IBackgroundWorker
         Logger.LogDebug("Stopped background worker: " + ToString());
         StoppingTokenSource.Cancel();
         StoppingTokenSource.Dispose();
+
+        ResetStoppingCancellationTokenSource();
+        
         return Task.CompletedTask;
     }
 

--- a/framework/src/Volo.Abp.BackgroundWorkers/Volo/Abp/BackgroundWorkers/BackgroundWorkerBase.cs
+++ b/framework/src/Volo.Abp.BackgroundWorkers/Volo/Abp/BackgroundWorkers/BackgroundWorkerBase.cs
@@ -42,7 +42,7 @@ public abstract class BackgroundWorkerBase : IBackgroundWorker
     {
         Logger.LogDebug("Stopped background worker: " + ToString());
         StoppingTokenSource.Cancel();
-        StoppingTokenSource.Dispose();        
+        StoppingTokenSource.Dispose();
         return Task.CompletedTask;
     }
 

--- a/framework/src/Volo.Abp.BackgroundWorkers/Volo/Abp/BackgroundWorkers/BackgroundWorkerBase.cs
+++ b/framework/src/Volo.Abp.BackgroundWorkers/Volo/Abp/BackgroundWorkers/BackgroundWorkerBase.cs
@@ -22,16 +22,11 @@ public abstract class BackgroundWorkerBase : IBackgroundWorker
 
     protected ILogger Logger => LazyServiceProvider.LazyGetService<ILogger>(provider => LoggerFactory?.CreateLogger(GetType().FullName!) ?? NullLogger.Instance);
 
-    protected CancellationTokenSource StoppingTokenSource { get; private set; }
+    protected CancellationTokenSource StoppingTokenSource { get; set; }
 	
-    protected CancellationToken StoppingToken { get; private set; }
+    protected CancellationToken StoppingToken { get; set; }
 
     public BackgroundWorkerBase()
-    {
-        ResetStoppingCancellationTokenSource();
-    }
-
-    private void ResetStoppingCancellationTokenSource()
     {
         StoppingTokenSource = new CancellationTokenSource();
         StoppingToken = StoppingTokenSource.Token;
@@ -47,10 +42,7 @@ public abstract class BackgroundWorkerBase : IBackgroundWorker
     {
         Logger.LogDebug("Stopped background worker: " + ToString());
         StoppingTokenSource.Cancel();
-        StoppingTokenSource.Dispose();
-
-        ResetStoppingCancellationTokenSource();
-        
+        StoppingTokenSource.Dispose();        
         return Task.CompletedTask;
     }
 


### PR DESCRIPTION
As BackgroundWorkers are a Singleton, they should be restartable to permit changes in Timer interval without an application restart.

### Description

When StopAsync is invoked followed by a StartAsync on a BackgroundWorker the StoppingTokenSource is not renewed and will throw if the BackgroundWorker is stopped a second time.

The change assigns a new CancellationTokenSource to the StoppingTokenSource property and assigns a new token from the new source.

### Checklist

- [ ] I fully tested it as developer / designer and created unit / integration tests
- [ ] I documented it (or no need to document or I will create a separate documentation issue)


