### PR TITLE
Set a ratio to the CMS Kit blog post images

### DIFF
--- a/modules/cms-kit/src/Volo.CmsKit.Admin.Web/Pages/CmsKit/BlogPosts/Create.cshtml
+++ b/modules/cms-kit/src/Volo.CmsKit.Admin.Web/Pages/CmsKit/BlogPosts/Create.cshtml
@@ -60,7 +60,7 @@
     <abp-card-header title="@L["New"].Value"></abp-card-header>
     <abp-card-body>
         <div class="mb-3">
-            <label class="form-label">@L["CoverImage"]</label>
+            <label class="form-label">@L["CoverImage"] <span class="badge text-bg-light">16:9</span></label>
             <input type="file" id="BlogPostCoverImage" class="form-control" />
         </div>
 

--- a/modules/cms-kit/src/Volo.CmsKit.Admin.Web/Pages/CmsKit/BlogPosts/Create.cshtml
+++ b/modules/cms-kit/src/Volo.CmsKit.Admin.Web/Pages/CmsKit/BlogPosts/Create.cshtml
@@ -61,7 +61,7 @@
     <abp-card-body>
         <div class="mb-3">
             <label class="form-label">@L["CoverImage"] <span class="badge text-bg-light">16:9</span></label>
-            <input type="file" id="BlogPostCoverImage" class="form-control" />
+            <input type="file" id="BlogPostCoverImage" class="form-control" accept="image/*" />
         </div>
 
         <form asp-page="/CmsKit/BlogPosts/Create" id="form-blog-post-create">

--- a/modules/cms-kit/src/Volo.CmsKit.Admin.Web/Pages/CmsKit/BlogPosts/Update.cshtml
+++ b/modules/cms-kit/src/Volo.CmsKit.Admin.Web/Pages/CmsKit/BlogPosts/Update.cshtml
@@ -69,7 +69,7 @@
                 }
             </div>
             <label class="form-label">@L["CoverImage"]<span class="badge text-bg-light">16:9</span></label>
-            <input type="file" id="BlogPostCoverImage" class="form-control"/>
+            <input type="file" id="BlogPostCoverImage" class="form-control" accept="image/*" />
         </div>
 
         <form asp-page="/CmsKit/BlogPosts/Update" id="form-blog-post-update">

--- a/modules/cms-kit/src/Volo.CmsKit.Admin.Web/Pages/CmsKit/BlogPosts/Update.cshtml
+++ b/modules/cms-kit/src/Volo.CmsKit.Admin.Web/Pages/CmsKit/BlogPosts/Update.cshtml
@@ -68,7 +68,7 @@
                     <br/>
                 }
             </div>
-            <label class="form-label">@L["CoverImage"]</label>
+            <label class="form-label">@L["CoverImage"]<span class="badge text-bg-light">16:9</span></label>
             <input type="file" id="BlogPostCoverImage" class="form-control"/>
         </div>
 

--- a/modules/cms-kit/src/Volo.CmsKit.Public.Web/Pages/Public/CmsKit/Blogs/BlogPost.cshtml
+++ b/modules/cms-kit/src/Volo.CmsKit.Public.Web/Pages/Public/CmsKit/Blogs/BlogPost.cshtml
@@ -56,7 +56,7 @@
     <div class="row">
         <div @Html.Raw(isScrollIndexEnabled ? "class=\"col-md-10 col-sm-12\"" : "class=\"col-md-12\"")>
             <abp-card class="mb-4">
-                <img src="/api/cms-kit/media/@Model.ViewModel.CoverImageMediaId" class="card-img-top" onerror="this.src='@dummyImageSource'" />
+            <img src="/api/cms-kit/media/@Model.ViewModel.CoverImageMediaId" class="card-img-ratio" onerror="this.src='@dummyImageSource'" />
                 <input hidden id="BlogId" value="@Model.ViewModel.Id" />
                 <abp-card-body>
                     <abp-row>

--- a/modules/cms-kit/src/Volo.CmsKit.Public.Web/Pages/Public/CmsKit/Blogs/Index.cshtml
+++ b/modules/cms-kit/src/Volo.CmsKit.Public.Web/Pages/Public/CmsKit/Blogs/Index.cshtml
@@ -80,7 +80,7 @@
                             <span class="font-weight-bold author-name-span" data-author-id="@blog.Author.Id">@@@blog.Author?.UserName</span>
                             <small style="opacity:.65;">@blog.CreationTime</small>
                         </p>
-                        <p style="min-height: 60px;">@blog.ShortDescription</p>
+                        <p class="cms-blogpost-desc-preview">@blog.ShortDescription</p>
                         <div class="d-grid gap-2">
                             <a href="/@CmsBlogsWebConsts.BlogsRoutePrefix/@Model.BlogSlug/@blog.Slug" class="btn btn-light">
                                 @L["Read"]

--- a/modules/cms-kit/src/Volo.CmsKit.Public.Web/Pages/Public/CmsKit/Blogs/blogPost.css
+++ b/modules/cms-kit/src/Volo.CmsKit.Public.Web/Pages/Public/CmsKit/Blogs/blogPost.css
@@ -22,6 +22,11 @@ span.area-title {
     min-width: 276px;
 }
 
+.card-img-ratio {
+    aspect-ratio: 16 / 9;
+    object-fit: cover;
+}
+
 #scroll-index {
     position: sticky;
     top: 20px;

--- a/modules/cms-kit/src/Volo.CmsKit.Public.Web/Pages/Public/CmsKit/Blogs/index.css
+++ b/modules/cms-kit/src/Volo.CmsKit.Public.Web/Pages/Public/CmsKit/Blogs/index.css
@@ -1,4 +1,5 @@
 .card-img-top { 
+    aspect-ratio: 16 / 9;
 }
 
 .popover {
@@ -7,4 +8,12 @@
 
 .author-name-span{
     cursor: pointer;
+}
+
+.cms-blogpost-desc-preview {
+    min-height: 60px;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
 }

--- a/modules/cms-kit/src/Volo.CmsKit.Public.Web/Pages/Public/CmsKit/Blogs/index.css
+++ b/modules/cms-kit/src/Volo.CmsKit.Public.Web/Pages/Public/CmsKit/Blogs/index.css
@@ -1,5 +1,6 @@
-.card-img-top { 
+.card-img-top {
     aspect-ratio: 16 / 9;
+    object-fit: cover;
 }
 
 .popover {


### PR DESCRIPTION
### Description

Resolves https://github.com/volosoft/volo/issues/17748#issuecomment-2162209900

I go with 16:9 since our current placeholder image is 16:9
https://github.com/abpframework/abp/tree/dev/modules/cms-kit/src/Volo.CmsKit.Common.Web/wwwroot/cms-kit

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

Please describe how this can be tested by the test engineers if it is not already explicit - or remove this section if no need to description.
