### PR TITLE
Add self generic prop resolver for types from proxy config

### DIFF
--- a/npm/ng-packs/packages/schematics/src/commands/api/index.ts
+++ b/npm/ng-packs/packages/schematics/src/commands/api/index.ts
@@ -29,6 +29,7 @@ import {
   sanitizeTypeNames,
   sanitizeControllerTypeNames,
   serializeParameters,
+  resolveSelfGenericProps,
 } from '../../utils';
 import * as cases from '../../utils/text';
 
@@ -48,6 +49,8 @@ export default function (schema: GenerateProxySchema) {
       const createProxyConfigWriter = createProxyConfigWriterCreator(targetPath);
       const data = readProxyConfig(tree);
       data.types = sanitizeTypeNames(data.types);
+
+      resolveSelfGenericProps({ solution, types: data.types });
 
       const types = data.types;
       const modules = data.modules;

--- a/npm/ng-packs/packages/schematics/src/utils/generics.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/generics.ts
@@ -72,7 +72,7 @@ export function extractSimpleGenerics(sourceType: string) {
   return {
     identifier: getLastSegment(identifier),
     generics: generics.map(getLastSegment),
-    array
+    array,
   };
 }
 
@@ -80,10 +80,10 @@ export function extractGenerics(sourceType: string) {
   const isArray = /\[\]$/.test(sourceType);
   const regex = /(?<identifier>[^<]+)(<(?<generics>.+)>)?/g;
   const { identifier = '', generics = '' } = regex.exec(sourceType)?.groups ?? {};
-   return {
+  return {
     identifier,
     generics: generics.split(/,\s*/).filter(Boolean),
-    array: isArray ? '[]':'' 
+    array: isArray ? '[]' : '',
   };
 }
 

--- a/npm/ng-packs/packages/schematics/src/utils/model.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/model.ts
@@ -201,3 +201,27 @@ export function parseBaseTypeWithGenericTypes(type: string): string[] {
 
   return nodeToText(parsedTypeNode);
 }
+
+export function resolveSelfGenericProps(params: Partial<ModelGeneratorParams>) {
+  const { types, solution } = params;
+  if (!types || !solution) {
+    return;
+  }
+
+  Object.keys(types)
+    .filter(f => f.startsWith(solution))
+    .forEach(key => {
+      const type = types[key];
+      if (type.genericArguments?.length) {
+        type.properties?.map(prop => {
+          if (prop.type.includes('<>')) {
+            prop.type = prop.type.replace('<>', `<${type.genericArguments!.join(', ')}>`);
+            prop.typeSimple = prop.typeSimple.replace(
+              '<>',
+              `<${type.genericArguments!.join(', ')}>`,
+            );
+          }
+        });
+      }
+    });
+}


### PR DESCRIPTION
### Description

Resolves #18956 

![image](https://github.com/abpframework/abp/assets/49063256/3a5b762b-a07e-4246-81d9-769568fb1f95)

![image](https://github.com/abpframework/abp/assets/49063256/2d76e5a8-7486-4e99-a780-421011ea57e5)

![image](https://github.com/abpframework/abp/assets/49063256/bcabc273-bebf-4c20-8cb5-83f2e94adb0d)

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests

### How to test it?
- Add sample DTO and AppService to backend
- Run `abp generate-proxy -t ng` command in angular folder