### PR TITLE
Add registerLocale function that supported esbuild

### DIFF
--- a/npm/ng-packs/packages/core/locale/src/utils/register-locale.ts
+++ b/npm/ng-packs/packages/core/locale/src/utils/register-locale.ts
@@ -19,7 +19,7 @@ export interface RegisterLocaleData {
 function loadLocale(locale: string) {
   // hard coded list works with esbuild. Source https://github.com/angular/angular-cli/issues/26904#issuecomment-1903596563
 
-  var list = {
+  const list = {
       'ar': () => import('@angular/common/locales/ar'),
       'cs': () => import('@angular/common/locales/cs'),
       'en': () => import('@angular/common/locales/en'),
@@ -53,7 +53,7 @@ export function registerLocaleForEsBuild(
   return (locale: string): Promise<any> => {
       localeMap = { ...differentLocales, ...cultureNameLocaleFileMap };
       const l = localeMap[locale] || locale;
-      var localeSupportList = "ar|cs|en|en-GB|es|de|fi|fr|hi|hu|is|it|pt|tr|ru|ro|sk|sl|zh-Hans|zh-Hant".split("|");
+      const localeSupportList = "ar|cs|en|en-GB|es|de|fi|fr|hi|hu|is|it|pt|tr|ru|ro|sk|sl|zh-Hans|zh-Hant".split("|");
 
       if (localeSupportList.indexOf(locale) == -1) {
           return;

--- a/npm/ng-packs/packages/core/locale/src/utils/register-locale.ts
+++ b/npm/ng-packs/packages/core/locale/src/utils/register-locale.ts
@@ -15,6 +15,72 @@ export interface RegisterLocaleData {
   errorHandlerFn?: (data: LocaleErrorHandlerData) => any;
 }
 
+
+function loadLocale(locale: string) {
+  // hard coded list works with esbuild. Source https://github.com/angular/angular-cli/issues/26904#issuecomment-1903596563
+
+  var list = {
+      'ar': () => import('@angular/common/locales/ar'),
+      'cs': () => import('@angular/common/locales/cs'),
+      'en': () => import('@angular/common/locales/en'),
+      'en-GB': () => import('@angular/common/locales/en-GB'),
+      'es': () => import('@angular/common/locales/es'),
+      'de': () => import('@angular/common/locales/de'),
+      'fi': () => import('@angular/common/locales/fi'),
+      'fr': () => import('@angular/common/locales/fr'),
+      'hi': () => import('@angular/common/locales/hi'),
+      'hu': () => import('@angular/common/locales/hu'),
+      'is': () => import('@angular/common/locales/is'),
+      'it': () => import('@angular/common/locales/it'),
+      'pt': () => import('@angular/common/locales/pt'),
+      'tr': () => import('@angular/common/locales/tr'),
+      'ru': () => import('@angular/common/locales/ru'),
+      'ro': () => import('@angular/common/locales/ro'),
+      'sk': () => import('@angular/common/locales/sk'),
+      'sl': () => import('@angular/common/locales/sl'),
+      'zh-Hans': () => import('@angular/common/locales/zh-Hans'),
+      'zh-Hant': () => import('@angular/common/locales/zh-Hant')
+  }
+  return list[locale]();
+}
+
+export function registerLocaleForEsBuild(
+  {
+      cultureNameLocaleFileMap = {},
+      errorHandlerFn = defaultLocalErrorHandlerFn,
+  } = {} as RegisterLocaleData,
+) {
+  return (locale: string): Promise<any> => {
+      localeMap = { ...differentLocales, ...cultureNameLocaleFileMap };
+      const l = localeMap[locale] || locale;
+      var localeSupportList = "ar|cs|en|en-GB|es|de|fi|fr|hi|hu|is|it|pt|tr|ru|ro|sk|sl|zh-Hans|zh-Hant".split("|");
+
+      if (localeSupportList.indexOf(locale) == -1) {
+          return;
+      }
+      return new Promise((resolve, reject) => {
+          return loadLocale(l)
+              .then(val => {
+                  let module = val;
+                  while (module.default) {
+                      module = module.default;
+                  }
+                  resolve({ default: module });
+              })
+              .catch(error => {
+                  errorHandlerFn({
+                      resolve,
+                      reject,
+                      error,
+                      locale,
+                  });
+              });
+      });
+  };
+}
+
+
+
 export function registerLocale(
   {
     cultureNameLocaleFileMap = {},


### PR DESCRIPTION
### Description

Resolves #19607 

 
### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

I built my app with  esbuilder (  "builder": "@angular-devkit/build-angular:application" ) 
locale problem and warning gone.
 
![CleanShot 2024-06-24 at 19 24 19@2x](https://github.com/abpframework/abp/assets/2217899/8aedc88d-fc83-4121-9a68-f7f0cfb88d75)


After the changes, warning gone and locale loaded 


### How to use it?

![CleanShot 2024-06-24 at 19 22 51@2x](https://github.com/abpframework/abp/assets/2217899/c96a89a6-4647-46c5-b91b-d0dd34de1a20)

