### PR TITLE
Use `sha256` to calculate the cache key.

### DIFF
--- a/framework/src/Volo.Abp.Core/System/AbpStringExtensions.cs
+++ b/framework/src/Volo.Abp.Core/System/AbpStringExtensions.cs
@@ -400,6 +400,36 @@ public static class AbpStringExtensions
         }
     }
 
+    public static string ToSha256(this string str)
+    {
+        using (var sha = SHA256.Create())
+        {
+            var data = sha.ComputeHash(Encoding.UTF8.GetBytes(str));
+
+            var sb = new StringBuilder();
+            foreach (var d in data)
+            {
+                sb.Append(d.ToString("x2"));
+            }
+            return sb.ToString();
+        }
+    }
+
+    public static string ToSha512(this string str)
+    {
+        using (var sha = SHA512.Create())
+        {
+            var data = sha.ComputeHash(Encoding.UTF8.GetBytes(str));
+
+            var sb = new StringBuilder();
+            foreach (var d in data)
+            {
+                sb.Append(d.ToString("x2"));
+            }
+            return sb.ToString();
+        }
+    }
+
     /// <summary>
     /// Converts camelCase string to PascalCase string.
     /// </summary>

--- a/framework/src/Volo.Abp.IdentityModel/Volo/Abp/IdentityModel/IdentityModelDiscoveryDocumentCacheItem.cs
+++ b/framework/src/Volo.Abp.IdentityModel/Volo/Abp/IdentityModel/IdentityModelDiscoveryDocumentCacheItem.cs
@@ -24,6 +24,6 @@ public class IdentityModelDiscoveryDocumentCacheItem
 
     public static string CalculateCacheKey(IdentityClientConfiguration configuration)
     {
-        return configuration.Authority.ToLower().ToMd5();
+        return configuration.Authority.ToLower().ToSha256();
     }
 }

--- a/framework/src/Volo.Abp.IdentityModel/Volo/Abp/IdentityModel/IdentityModelTokenCacheItem.cs
+++ b/framework/src/Volo.Abp.IdentityModel/Volo/Abp/IdentityModel/IdentityModelTokenCacheItem.cs
@@ -21,6 +21,6 @@ public class IdentityModelTokenCacheItem
 
     public static string CalculateCacheKey(IdentityClientConfiguration configuration)
     {
-        return string.Join(",", configuration.Select(x => x.Key + ":" + x.Value)).ToMd5();
+        return string.Join(",", configuration.Select(x => x.Key + ":" + x.Value)).ToSha256();
     }
 }


### PR DESCRIPTION
Resolve #20164

```cs
// Index component running under Blazor wasm mode.
public partial class Index
{
    protected override Task OnInitializedAsync()
    {
        Console.WriteLine("Hello from Index page!");
        Console.WriteLine("Hello from Index page!".ToSha256());
        Console.WriteLine("Hello from Index page!".ToSha512());
        Console.WriteLine("Hello from Index page!".ToMd5());

        return Task.CompletedTask;
    }
}
```

```cs
Hello from Index page!

//sha256
7c9a4c197b3589947bf7e97fd5fe16bb032ed226cc85d708f26398afd3c6e70c

//sha512
5a5684f229b3c52f34927d5e61ecbd6b2ef69b52fc5e5dbe71f6ee4671c6d00e5bcb855a2a073f171e0c7ef4d369be4384719358ce0a810d2cb70aa9af57bc7b

//md5
Microsoft.AspNetCore.Components.WebAssembly.Rendering.WebAssemblyRenderer[100]
      Unhandled exception rendering component: 'MD5' is not a known hash algorithm.
System.Security.Cryptography.CryptographicException: 'MD5' is not a known hash algorithm.
   at System.Security.Cryptography.HashProviderDispenser.CreateHashProvider(String hashAlgorithmId)
```