### PR TITLE
Angular - Fixing Duplicate Import for Generating Proxy with Enum Model

### DIFF
--- a/npm/ng-packs/packages/schematics/src/utils/model.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/model.ts
@@ -94,7 +94,13 @@ export function createImportRefsToModelReducer(params: ModelGeneratorParams) {
             }
 
             if (parseNamespace(solution, ref) !== model.namespace) {
-              toBeImported.push({ type: ref, isEnum: false });
+              const isEnumImportAvailable = toBeImported.some(importValue => {
+                return importValue.isEnum && importValue.type === ref;
+              });
+
+              if (!isEnumImportAvailable) {
+                toBeImported.push({ type: ref, isEnum: false });
+              }
             }
           });
         });


### PR DESCRIPTION
### Description

Resolves #20172 

![image](https://github.com/abpframework/abp/assets/92928815/22fd9bc4-ac06-439d-9e9b-d998e9978197)


### Checklist

- [X] I fully tested it as developer / designer and created unit / integration tests
- [X] No need for documentation

### How to test it?

- You should run `yarn copy-to:app` command to get the latest changes for schematics, so you can test it on the app template.
- You will need to add some configs to the backend side by following the instructions [here](https://drive.google.com/drive/folders/1FIATuU-_Sdkk9BEl_dJmF72k_LVNLmdJ?usp=drive_link).
- Then you will need to run the app template under `abp\templates\app`
- Lastly, you need to run `abp generate-proxy -t ng -a abp-ng-packs` under `abp\templates\app\angular` 
- You should not see any import error in the generated model file (`templates\app\angular\src\app\proxy\models\dtos\models.ts`)