### PR TITLE
Update Markdig to v0.37.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -49,7 +49,7 @@
     <PackageVersion Include="LibGit2Sharp" Version="0.28.0" />
     <PackageVersion Include="Magick.NET-Q16-AnyCPU" Version="13.4.0" />
     <PackageVersion Include="MailKit" Version="4.3.0" />
-    <PackageVersion Include="Markdig.Signed" Version="0.33.0" />
+    <PackageVersion Include="Markdig.Signed" Version="0.37.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.4" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.4" />
     <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="8.0.4" />


### PR DESCRIPTION
### Description

Updating Markdig library to support Github alerts in markdown content for docs module & Cms Kit.
https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts

Seems implemented in https://github.com/xoofx/markdig/issues/774

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)
