### PR TITLE
DistributedCacheEntryOptions configurable

### DIFF
--- a/modules/permission-management/src/Volo.Abp.PermissionManagement.Domain/Volo/Abp/PermissionManagement/AbpPermissionManagementDomainModule.cs
+++ b/modules/permission-management/src/Volo.Abp.PermissionManagement.Domain/Volo/Abp/PermissionManagement/AbpPermissionManagementDomainModule.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -37,6 +38,11 @@ public class AbpPermissionManagementDomainModule : AbpModule
                 options.IsDynamicPermissionStoreEnabled = false;
             });
         }
+
+        Configure<DistributedCacheEntryOptions>(options =>
+        {
+            options.SlidingExpiration = TimeSpan.FromDays(30);
+        });
     }
 
     public override void OnApplicationInitialization(ApplicationInitializationContext context)

--- a/modules/permission-management/src/Volo.Abp.PermissionManagement.Domain/Volo/Abp/PermissionManagement/DynamicPermissionDefinitionStore.cs
+++ b/modules/permission-management/src/Volo.Abp.PermissionManagement.Domain/Volo/Abp/PermissionManagement/DynamicPermissionDefinitionStore.cs
@@ -23,7 +23,8 @@ public class DynamicPermissionDefinitionStore : IDynamicPermissionDefinitionStor
     protected IAbpDistributedLock DistributedLock { get; }
     public PermissionManagementOptions PermissionManagementOptions { get; }
     protected AbpDistributedCacheOptions CacheOptions { get; }
-    
+    protected DistributedCacheEntryOptions DistributedCacheEntryOptions { get; }
+
     public DynamicPermissionDefinitionStore(
         IPermissionGroupDefinitionRecordRepository permissionGroupRepository,
         IPermissionDefinitionRecordRepository permissionRepository,
@@ -32,7 +33,8 @@ public class DynamicPermissionDefinitionStore : IDynamicPermissionDefinitionStor
         IDistributedCache distributedCache,
         IOptions<AbpDistributedCacheOptions> cacheOptions,
         IOptions<PermissionManagementOptions> permissionManagementOptions,
-        IAbpDistributedLock distributedLock)
+        IAbpDistributedLock distributedLock,
+        IOptions<DistributedCacheEntryOptions> distributedCacheEntryOptions)
     {
         PermissionGroupRepository = permissionGroupRepository;
         PermissionRepository = permissionRepository;
@@ -40,6 +42,7 @@ public class DynamicPermissionDefinitionStore : IDynamicPermissionDefinitionStor
         StoreCache = storeCache;
         DistributedCache = distributedCache;
         DistributedLock = distributedLock;
+        DistributedCacheEntryOptions = distributedCacheEntryOptions.Value;
         PermissionManagementOptions = permissionManagementOptions.Value;
         CacheOptions = cacheOptions.Value;
     }
@@ -149,10 +152,7 @@ public class DynamicPermissionDefinitionStore : IDynamicPermissionDefinitionStor
             await DistributedCache.SetStringAsync(
                 cacheKey,
                 stampInDistributedCache,
-                new DistributedCacheEntryOptions
-                {
-                    SlidingExpiration = TimeSpan.FromDays(30) //TODO: Make it configurable?
-                }
+                DistributedCacheEntryOptions
             );
         }
 

--- a/modules/permission-management/src/Volo.Abp.PermissionManagement.Domain/Volo/Abp/PermissionManagement/StaticPermissionSaver.cs
+++ b/modules/permission-management/src/Volo.Abp.PermissionManagement.Domain/Volo/Abp/PermissionManagement/StaticPermissionSaver.cs
@@ -31,6 +31,7 @@ public class StaticPermissionSaver : IStaticPermissionSaver, ITransientDependenc
     protected AbpDistributedCacheOptions CacheOptions { get; }
 
     protected IUnitOfWorkManager UnitOfWorkManager { get; }
+    protected DistributedCacheEntryOptions DistributedCacheEntryOptions { get; }
 
     public StaticPermissionSaver(
         IStaticPermissionDefinitionStore staticStore,
@@ -43,7 +44,8 @@ public class StaticPermissionSaver : IStaticPermissionSaver, ITransientDependenc
         IAbpDistributedLock distributedLock,
         IOptions<AbpPermissionOptions> permissionOptions,
         ICancellationTokenProvider cancellationTokenProvider,
-        IUnitOfWorkManager unitOfWorkManager)
+        IUnitOfWorkManager unitOfWorkManager,
+        IOptions<DistributedCacheEntryOptions> distributedCacheEntryOptions)
     {
         UnitOfWorkManager = unitOfWorkManager;
         StaticStore = staticStore;
@@ -56,6 +58,7 @@ public class StaticPermissionSaver : IStaticPermissionSaver, ITransientDependenc
         CancellationTokenProvider = cancellationTokenProvider;
         PermissionOptions = permissionOptions.Value;
         CacheOptions = cacheOptions.Value;
+        DistributedCacheEntryOptions = distributedCacheEntryOptions.Value;
     }
 
     public async Task SaveAsync()
@@ -116,9 +119,7 @@ public class StaticPermissionSaver : IStaticPermissionSaver, ITransientDependenc
                         await Cache.SetStringAsync(
                             GetCommonStampCacheKey(),
                             Guid.NewGuid().ToString(),
-                            new DistributedCacheEntryOptions {
-                                SlidingExpiration = TimeSpan.FromDays(30) //TODO: Make it configurable?
-                            },
+                            DistributedCacheEntryOptions,
                             CancellationTokenProvider.Token
                         );
                     }
@@ -143,10 +144,8 @@ public class StaticPermissionSaver : IStaticPermissionSaver, ITransientDependenc
 
         await Cache.SetStringAsync(
             cacheKey,
-            currentHash,
-            new DistributedCacheEntryOptions {
-                SlidingExpiration = TimeSpan.FromDays(30) //TODO: Make it configurable?
-            },
+            currentHash, 
+            DistributedCacheEntryOptions,
             CancellationTokenProvider.Token
         );
     }


### PR DESCRIPTION
DistributedCacheEntryOptions configurable

Change the DistributedCacheEntryOptions to can configure option Instead of directly instantiated

### Description

Resolves #xxxx (write the related issue number if available)

Change the DistributedCacheEntryOptions to can configure option Instead of directly instantiated
From 
`new DistributedCacheEntryOptions() 
{
    SlidingExpiration = TimeSpan.FromDays(30)
};`
To
` Configure<DistributedCacheEntryOptions>(options =>
 {
     options.SlidingExpiration = TimeSpan.FromDays(30);
 });`
### Checklist

- [ ] I fully tested it as developer  / integration tests

