### PR TITLE
Angular - Proxy Generation Problem Specially for Enum Models (Revert Latest Changes)

### DIFF
--- a/npm/ng-packs/packages/schematics/src/utils/model.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/model.ts
@@ -91,16 +91,8 @@ export function createImportRefsToModelReducer(params: ModelGeneratorParams) {
 
             if (propType.isEnum) {
               toBeImported.push({ type: ref, isEnum: true });
-            }
-
-            if (parseNamespace(solution, ref) !== model.namespace) {
-              const isEnumImportAvailable = toBeImported.some(importValue => {
-                return importValue.isEnum && importValue.type === ref;
-              });
-
-              if (!isEnumImportAvailable) {
-                toBeImported.push({ type: ref, isEnum: false });
-              }
+            } else if (parseNamespace(solution, ref) !== model.namespace) {
+              toBeImported.push({ type: ref, isEnum: false });
             }
           });
         });


### PR DESCRIPTION
### Description

Resolves #20172
This PR covers a rollback and fixes the enum case related proxy generation problems. 

### Checklist

- [X] I fully tested it as developer / designer and created unit / integration tests
- [X] No need to make a change on the documentation

### How to test it?

- You should run `yarn copy-to:app` command to get the latest changes for schematics, so you can test it on the app template.
- You will need to add some configs to the backend side by following the instructions [here](https://drive.google.com/drive/folders/1FIATuU-_Sdkk9BEl_dJmF72k_LVNLmdJ?usp=drive_link).
- Then you will need to run the app template under `abp\templates\app`
- Lastly, you need to run abp `generate-proxy -t ng -a abp-ng-packs` under `abp\templates\app\angular`
- You should not see any import error in the generated model file (templates\app\angular\src\app\proxy\models\dtos\models.ts)
