### PR TITLE
Fix typo in Spanish translation for "Loading..."

### DIFF
--- a/framework/src/Volo.Abp.UI/Localization/Resources/AbpUi/es.json
+++ b/framework/src/Volo.Abp.UI/Localization/Resources/AbpUi/es.json
@@ -21,7 +21,7 @@
     "Language": "Idioma",
     "LoadMore": "Cargar más",
     "ProcessingWithThreeDot": "Procesando...",
-    "LoadingWithThreeDot": "Cargardo...",
+    "LoadingWithThreeDot": "Cargando...",
     "Welcome": "Bienvenido",
     "Login": "Iniciar sesión",
     "Register": "Registrarse",


### PR DESCRIPTION
Corrected a typographical error in the Spanish localization file (`es.json`). The word "Cargardo..." was changed to "Cargando..." to accurately translate "Loading...".

