### PR TITLE
Upgrade `System.Text.Json` and `MailKit` packages to the latest.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -48,7 +48,7 @@
     <PackageVersion Include="LdapForNet" Version="2.7.15" />
     <PackageVersion Include="LibGit2Sharp" Version="0.28.0" />
     <PackageVersion Include="Magick.NET-Q16-AnyCPU" Version="13.4.0" />
-    <PackageVersion Include="MailKit" Version="4.3.0" />
+    <PackageVersion Include="MailKit" Version="4.7.1.1" />
     <PackageVersion Include="Markdig.Signed" Version="0.37.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.4" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.4" />
@@ -163,7 +163,7 @@
     <PackageVersion Include="System.Security.Principal.Windows" Version="5.0.0" />
     <PackageVersion Include="System.Text.Encoding.CodePages" Version="8.0.0" />
     <PackageVersion Include="System.Text.Encodings.Web" Version="8.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.4" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="7.5.1" />
     <PackageVersion Include="TimeZoneConverter" Version="6.1.0" />
     <PackageVersion Include="Unidecode.NET" Version="2.1.0" />


### PR DESCRIPTION
Volo.Abp.Json.SystemTextJson depends on `System.Text.Json` 8.0.0 which is vulnerable.
https://github.com/advisories/GHSA-hh2w-p6rv-4g7w
![image](https://github.com/user-attachments/assets/c03b1ac6-fe01-4a63-9d23-477e3eb62ef5)

---

We're using `MailKit` 4.3.0 version in `Volo.Abp.MailKit` package. 
And `MailKit` 4.3.0 depends `MimeKit` 4.3.0.
`MimeKit` 4.3.0 has a security vulnerability.
https://github.com/advisories/GHSA-gmc6-fwg3-75m5
![image](https://github.com/user-attachments/assets/c7ccd368-a4b6-484c-8f17-f0a3276e3f23)
