### PR TITLE
Disable `DateTime` normalization for OpenIddict's `DateTime(UTC)`.

### DIFF
--- a/modules/openiddict/src/Volo.Abp.OpenIddict.Domain/Volo/Abp/OpenIddict/Authorizations/OpenIddictAuthorization.cs
+++ b/modules/openiddict/src/Volo.Abp.OpenIddict.Domain/Volo/Abp/OpenIddict/Authorizations/OpenIddictAuthorization.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Volo.Abp.Domain.Entities.Auditing;
+using Volo.Abp.Timing;
 
 namespace Volo.Abp.OpenIddict.Authorizations;
 
@@ -22,6 +23,7 @@ public class OpenIddictAuthorization : FullAuditedAggregateRoot<Guid>
     /// <summary>
     /// Gets or sets the UTC creation date of the current authorization.
     /// </summary>
+    [DisableDateTimeNormalization]
     public virtual DateTime? CreationDate { get; set; }
 
     /// <summary>

--- a/modules/openiddict/src/Volo.Abp.OpenIddict.Domain/Volo/Abp/OpenIddict/Tokens/OpenIddictToken.cs
+++ b/modules/openiddict/src/Volo.Abp.OpenIddict.Domain/Volo/Abp/OpenIddict/Tokens/OpenIddictToken.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Volo.Abp.Domain.Entities.Auditing;
+using Volo.Abp.Timing;
 
 namespace Volo.Abp.OpenIddict.Tokens;
 
@@ -27,11 +28,13 @@ public class OpenIddictToken : FullAuditedAggregateRoot<Guid>
     /// <summary>
     /// Gets or sets the UTC creation date of the current token.
     /// </summary>
+    [DisableDateTimeNormalization]
     public virtual DateTime? CreationDate { get; set; }
 
     /// <summary>
     /// Gets or sets the UTC expiration date of the current token.
     /// </summary>
+    [DisableDateTimeNormalization]
     public virtual DateTime? ExpirationDate { get; set; }
 
     /// <summary>
@@ -50,6 +53,7 @@ public class OpenIddictToken : FullAuditedAggregateRoot<Guid>
     /// <summary>
     /// Gets or sets the UTC redemption date of the current token.
     /// </summary>
+    [DisableDateTimeNormalization]
     public virtual DateTime? RedemptionDate { get; set; }
 
     /// <summary>


### PR DESCRIPTION
Resolves #20378

For version < 8.3, Please override the `ConfigureValueConverter` of `DbContext` to remove `AbpDateTimeValueConverter` from `DateTime` properties.

https://github.com/abpframework/abp/blob/dev/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/AbpDbContext.cs#L747-L774