### PR TITLE
Angular - Fixing The Constants for Text Template Management in Proxy Generation

### DIFF
--- a/npm/ng-packs/packages/schematics/src/constants/volo.ts
+++ b/npm/ng-packs/packages/schematics/src/constants/volo.ts
@@ -26,10 +26,10 @@ export const VOLO_PACKAGE_PROXY_IMPORTS = new Map<string, string>([
   ['Volo.Saas.Editions.EditionDto', '@volo/abp.ng.saas/proxy'],
   [
     'Volo.Abp.TextTemplateManagement.TextTemplates.TextTemplateContentDto',
-    '@volo/abp.ng.saas/proxy',
+    '@volo/abp.ng.text-template-management/proxy',
   ],
   [
     'Volo.Abp.TextTemplateManagement.TextTemplates.TemplateDefinitionDto',
-    '@volo/abp.ng.saas/proxy',
+    '@volo/abp.ng.text-template-management/proxy',
   ],
 ]);


### PR DESCRIPTION
### Description

Resolves #20386

Here is the part that relates the changes

![image](https://github.com/user-attachments/assets/4286d54d-87da-49b2-9a08-06a73b19c88a)

### Checklist

- [X] I fully tested it as developer / designer and created unit / integration tests
- [X] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?
- You need to build the schematics package with this latest change and copy them to your project.
- You can create a service called `TestAppService` and modify it in this way.
```
using System.Collections.Generic;
using System.Threading.Tasks;
using Volo.Abp.TextTemplateManagement.TextTemplates;
using ProxyCheck.Models;

namespace ProxyCheck.Application.Services
{

  public class TestAppService : ProxyCheckAppService
  {
      public async Task<List<AppTextTemplateContentDto>> GetTextTemplateContentAsync(GetTemplateContentInput input)
      {
          return new List<AppTextTemplateContentDto>
          {
          
          };
      }
  }

}
```
- You need to add `AppTextTemplateContentDto` relatively
```
using System.Diagnostics.CodeAnalysis;
using Volo.Abp.TextTemplateManagement.TextTemplates;

namespace ProxyCheck.Models;
public class AppTextTemplateContentDto : TextTemplateContentDto
{
    public string DisplayName { get; set; }
    public string Subject { get; set; }

}
```
