### PR TITLE
Show Document navigation text for page title

### DIFF
--- a/modules/docs/src/Volo.Docs.Domain.Shared/Volo/Docs/Documents/NavigationNode.cs
+++ b/modules/docs/src/Volo.Docs.Domain.Shared/Volo/Docs/Documents/NavigationNode.cs
@@ -30,11 +30,16 @@ namespace Volo.Docs.Documents
 
         public bool IsSelected(string documentName)
         {
+            return FindNavigation(documentName) != null;
+        }
+
+        public NavigationNode FindNavigation(string documentName)
+        {
             if (documentName == null)
             {
-                return false;
+                return null;
             }
-
+            
             var path = Path ?? string.Empty;
             var pathHasExtension = System.IO.Path.HasExtension(path);
 
@@ -44,26 +49,26 @@ namespace Volo.Docs.Documents
                 path = path.EnsureEndsWith('/') + "index" + extension;
             }
             
-
             if (string.Equals(documentName, path, StringComparison.OrdinalIgnoreCase))
             {
-                return true;
+                return this;
             }
 
             if (Items == null)
             {
-                return false;
+                return null;
             }
 
             foreach (var childItem in Items)
             {
-                if (childItem.IsSelected(documentName))
+                var node = childItem.FindNavigation(documentName);
+                if (node != null)
                 {
-                    return true;
+                    return node;
                 }
             }
 
-            return false;
+            return null;
         }
     }
 

--- a/modules/docs/src/Volo.Docs.Web/Pages/Documents/Project/Index.cshtml
+++ b/modules/docs/src/Volo.Docs.Web/Pages/Documents/Project/Index.cshtml
@@ -28,7 +28,7 @@
 @{
     ViewBag.FluidLayout = true;
     Layout = ThemeManager.CurrentTheme.GetEmptyLayout();
-    PageLayout.Content.Title = Model.DocumentName?.Replace("-", " ");
+    PageLayout.Content.Title = Model.DocumentPageTitle;
     ViewBag.Description = Model.GetDescription();
     ViewBag.CanonicalUrl = Model.IsLatestVersion ? null : Model.GetFullUrlOfTheLatestDocument(); //issue #12355
 }

--- a/modules/docs/src/Volo.Docs.Web/Pages/Documents/Project/Index.cshtml.cs
+++ b/modules/docs/src/Volo.Docs.Web/Pages/Documents/Project/Index.cshtml.cs
@@ -55,6 +55,8 @@ namespace Volo.Docs.Pages.Documents.Project
         public List<SelectListItem> LanguageSelectListItems { get; set; }
 
         public string DocumentNameWithExtension { get; private set; }
+        
+        public string DocumentPageTitle { get; private set; }
 
         public DocumentWithDetailsDto Document { get; private set; }
 
@@ -191,6 +193,7 @@ namespace Volo.Docs.Pages.Documents.Project
 
             await SetNavigationAsync();
             SetLanguageSelectListItems();
+            SetDocumentPageTitle();
 
             return Page();
         }
@@ -455,11 +458,17 @@ namespace Volo.Docs.Pages.Documents.Project
                         Version = Version
                     }
                 );
+                
             }
             catch (DocumentNotFoundException) //TODO: What if called on a remote service which may return 404
             {
                 return;
             }
+        }
+        
+        private void SetDocumentPageTitle()
+        {
+            DocumentPageTitle = Navigation.FindNavigation(DocumentNameWithExtension)?.Text ?? DocumentName?.Replace("-", " ");
         }
 
         public string CreateVersionLink(VersionInfoViewModel latestVersion, string version, string documentName = null)


### PR DESCRIPTION
### Description

Resolves https://github.com/abpframework/abp/issues/19761

it's hard to use H1 text for a page title, so I use the navigation text as a page title.

<img width="1300" alt="image" src="https://github.com/user-attachments/assets/b1b9619d-190d-45eb-a141-50b8aed397c1">


### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

run the docs app
