### PR TITLE
Update MAUI documentation images

### DIFF
--- a/docs/en/framework/ui/maui/index.md
+++ b/docs/en/framework/ui/maui/index.md
@@ -64,19 +64,19 @@ The MAUI template consists of four pages:
 
 ### Homepage
 
-![Maui Home Page](./images/maui-home-page.png)
+![Maui Home Page](../../../images/maui-home-page.png)
 
 ### Users Page
 
-![Maui Users Page](./images/maui-users-page.png)
+![Maui Users Page](../../../images/maui-users-page.png)
 
 ### Tenants Page
 
-![Maui Tenants Page](./images/maui-tenants-page.png)
+![Maui Tenants Page](../../../images/maui-tenants-page.png)
 
 ### Settings Page
 
-![Maui Settings Page](./images/maui-settings-page.png)
+![Maui Settings Page](../../../images/maui-settings-page.png)
 
 ## Run the Mobile Application
 


### PR DESCRIPTION
Currently they're broken

<img width="252" alt="image" src="https://github.com/user-attachments/assets/eee1af0e-ccfe-4876-b136-b67d1c104301">
