### PR TITLE
Update .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -135,3 +135,6 @@ dotnet_style_qualification_for_field = false:suggestion
 dotnet_style_qualification_for_method = false:suggestion
 #prefer properties not to be prefaced with this. or Me. in Visual Basic
 dotnet_style_qualification_for_property = false:suggestion
+
+dotnet_analyzer_diagnostic.category-performance.severity = warning
+dotnet_analyzer_diagnostic.category-security.severity = error


### PR DESCRIPTION
### Description

Changed `.editorconfig` file for #20516

**WARNING!** Will break the code, until security "error's" are suppressed.

### How to test it?

- Restart Visual Studio (this may be necessary to apply the changes).
- Rebuild the solution to view the warnings.
- To view all performance category warnings, temporarily remove `dotnet_analyzer_diagnostic.category-security.severity = error` from the `.editorconfig` file. Note that with the current settings, the build will break, preventing the display of these warnings.
