### PR TITLE
Disable `CheckLibs` if `DataMigrationEnvironment` or `IApplicationBulder` is not available.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/AbpAspNetCoreMvcUiBundlingModule.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Bundling/AbpAspNetCoreMvcUiBundlingModule.cs
@@ -1,5 +1,6 @@
 ﻿using Volo.Abp.AspNetCore.Mvc.Libs;
 using Volo.Abp.AspNetCore.Mvc.UI.Bootstrap;
+using Volo.Abp.Data;
 using Volo.Abp.Minify;
 using Volo.Abp.Modularity;
 
@@ -14,9 +15,12 @@ public class AbpAspNetCoreMvcUiBundlingModule : AbpModule
 {
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        Configure<AbpMvcLibsOptions>(options =>
+        if (!context.Services.IsDataMigrationEnvironment())
         {
-            options.CheckLibs = true;
-        });
+            Configure<AbpMvcLibsOptions>(options =>
+            {
+                options.CheckLibs = true;
+            });
+        }
     }
 }

--- a/framework/src/Volo.Abp.AspNetCore/Volo/Abp/ApplicationInitializationContextExtensions.cs
+++ b/framework/src/Volo.Abp.AspNetCore/Volo/Abp/ApplicationInitializationContextExtensions.cs
@@ -12,7 +12,14 @@ public static class ApplicationInitializationContextExtensions
 {
     public static IApplicationBuilder GetApplicationBuilder(this ApplicationInitializationContext context)
     {
-        return context.ServiceProvider.GetRequiredService<IObjectAccessor<IApplicationBuilder>>().Value!;
+        var applicationBuilder = context.ServiceProvider.GetRequiredService<IObjectAccessor<IApplicationBuilder>>().Value;
+        Check.NotNull(applicationBuilder, nameof(applicationBuilder));
+        return applicationBuilder;
+    }
+
+    public static IApplicationBuilder? GetApplicationBuilderOrNull(this ApplicationInitializationContext context)
+    {
+        return context.ServiceProvider.GetRequiredService<IObjectAccessor<IApplicationBuilder>>().Value;
     }
 
     public static IWebHostEnvironment GetEnvironment(this ApplicationInitializationContext context)


### PR DESCRIPTION
Continue https://github.com/abpframework/abp/pull/20565