### PR TITLE
Prevent a new user's email use another existing user's name

### DIFF
--- a/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/AbpIdentityUserValidator.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/AbpIdentityUserValidator.cs
@@ -41,6 +41,24 @@ namespace Volo.Abp.Identity
                     });
                 }
             }
+            
+            var email = await manager.GetEmailAsync(user);
+            if (email == null)
+            {
+                errors.Add(describer.InvalidEmail(null));
+            }
+            else
+            {
+                var owner = await manager.FindByNameAsync(email);
+                if (owner != null && !string.Equals(await manager.GetUserIdAsync(owner), await manager.GetUserIdAsync(user)))
+                {
+                    errors.Add(new IdentityError
+                    {
+                        Code = "InvalidEmail",
+                        Description = Localizer["Volo.Abp.Identity:InvalidEmail", email]
+                    });
+                }
+            }
 
             return errors.Count > 0 ? IdentityResult.Failed(errors.ToArray()) : IdentityResult.Success;
         }

--- a/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/AbpIdentityUserValidator_Tests.cs
+++ b/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/AbpIdentityUserValidator_Tests.cs
@@ -33,4 +33,19 @@ public class AbpIdentityUserValidator_Tests : AbpIdentityAspNetCoreTestBase
         identityResult.Errors.First().Code.ShouldBe("InvalidUserName");
         identityResult.Errors.First().Description.ShouldBe(Localizer["InvalidUserName", "user1@volosoft.com"]);
     }
+
+    [Fact]
+    public async Task Can_Not_Use_Another_Users_Name_As_Your_Email_Test()
+    {
+        var user1 = new IdentityUser(Guid.NewGuid(), "user1@volosoft.com", "user@volosoft.com");
+        var identityResult = await _identityUserManager.CreateAsync(user1);
+        identityResult.Succeeded.ShouldBeTrue();
+        
+        var user2 = new IdentityUser(Guid.NewGuid(), "user2", "user1@volosoft.com");
+        identityResult = await _identityUserManager.CreateAsync(user2);
+        identityResult.Succeeded.ShouldBeFalse();
+        identityResult.Errors.Count().ShouldBe(1);
+        identityResult.Errors.First().Code.ShouldBe("InvalidEmail");
+        identityResult.Errors.First().Description.ShouldBe(Localizer["Volo.Abp.Identity:InvalidEmail", "user1@volosoft.com"]);
+    }
 }


### PR DESCRIPTION
### Description

Resolves https://github.com/abpframework/abp/issues/20658

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

create a new user's email use another existing user's name
