### PR TITLE
Update and fixes es.json

### DIFF
--- a/framework/src/Volo.Abp.Validation/Volo/Abp/Validation/Localization/es.json
+++ b/framework/src/Volo.Abp.Validation/Volo/Abp/Validation/Localization/es.json
@@ -8,7 +8,7 @@
     "The {0} field only accepts files with the following extensions: {1}": "El campo {0} sólo acepta ficheros con la siguientes extensiones: {1}",
     "The field {0} must be a string or array type with a maximum length of '{1}'.": "El campo {0} debe ser de tipo cadena o lista con una longitud máxima de '{1}'.",
     "The field {0} must be a string or array type with a minimum length of '{1}'.": "El campo {0} debe ser de tipo cadena o lista con una longitud máxima de '{1}'.",
-    "The {0} field is not a valid phone number.": "El campo no tiene un número de teléfono valido.",
+    "The {0} field is not a valid phone number.": "El campo {0} no tiene un número de teléfono valido.",
     "The field {0} must be between {1} and {2}.": "El campo {0} debe estar entre {1} y {2}.",
     "The field {0} must match the regular expression '{1}'.": "El campo {0} no coincide con el formato solicitado.",
     "The {0} field is required.": "El campo {0} es requerido.",
@@ -23,17 +23,17 @@
     "ThisFieldIsNotValid.": "Este campo no es valido.",
     "ThisFieldIsNotAValidEmailAddress.": "Este campo no es una dirección de e-mail valida.",
     "ThisFieldOnlyAcceptsFilesWithTheFollowingExtensions:{0}": "Este campo sólo acepta ficheros con las siguientes extensiones: {0}",
-    "ThisFieldMustBeAStringOrArrayTypeWithAMaximumLengthOf{0}": "Este campo debe ser una cadena o lista con una longitud máxima de {1}.",
-    "ThisFieldMustBeAStringOrArrayTypeWithAMinimumLengthOf{0}": "Este campo debe ser una cadena o lista con una longitud mínima de {1}.",
+    "ThisFieldMustBeAStringOrArrayTypeWithAMaximumLengthOf{0}": "Este campo debe ser una cadena o lista con una longitud máxima de {0}.",
+    "ThisFieldMustBeAStringOrArrayTypeWithAMinimumLengthOf{0}": "Este campo debe ser una cadena o lista con una longitud mínima de {0}.",
     "ThisFieldIsNotAValidPhoneNumber.": "Este campo no es un número de teléfono valido.",
     "ThisFieldMustBeBetween{0}And{1}": "Este campo debe estar entre {0} y {1}.",
     "ThisFieldMustBeGreaterThanOrEqual{0}": "Este campo debe ser mayor o igual a {0}.",
     "ThisFieldMustBeLessOrEqual{0}": "Este campo debe ser menor o igual a {0}.",
     "ThisFieldMustMatchTheRegularExpression{0}": "Este campo debe coincidir con la expresión regular '{0}'.",
     "ThisFieldIsRequired.": "Este campo es requerido",
-    "ThisFieldMustBeAStringWithAMaximumLengthOf{0}": "Este campo debe ser una cadena con una longitud máxima de {1}.",
-    "ThisFieldMustBeAStringWithAMinimumLengthOf{1}AndAMaximumLengthOf{0}": "Este campo debe ser una cadena con una longitud mínima de {2} y máxima de {1}.",
-    "ThisFieldIsNotAValidFullyQualifiedHttpHttpsOrFtpUrl": "El campo {0} no es una URL (http, https o ftp) valida.",
-    "ThisFieldIsInvalid.": "Este en un campo no valido."
+    "ThisFieldMustBeAStringWithAMaximumLengthOf{0}": "Este campo debe ser una cadena con una longitud máxima de {0}.",
+    "ThisFieldMustBeAStringWithAMinimumLengthOf{1}AndAMaximumLengthOf{0}": "Este campo debe ser una cadena con una longitud mínima de {1} y máxima de {0}.",
+    "ThisFieldIsNotAValidFullyQualifiedHttpHttpsOrFtpUrl": "El campo no es una URL (http, https o ftp) valida.",
+    "ThisFieldIsInvalid.": "Este campo no es válido."
   }
 }


### PR DESCRIPTION
There are validation fields with incorrect messages and numbering for the interpolation of field names, for example the key shows "ThisFieldOnlyAcceptsFilesWithTheFollowingExtensions:{0}": "This field only accepts files with the following extensions: {1}", and it should be "ThisFieldOnlyAcceptsFilesWithTheFollowingExtensions:{0}": "This field only accepts files with the following extensions: {0}".

### Description

Spanish translation there are validation fields with incorrect messages and numbering for the interpolation of field names.

![image](https://github.com/user-attachments/assets/c8b53560-a0d2-403e-aff5-b9020ef177f0)


### How to test it?

Change localization of aplication angular to spanish lang and show this issue when field has max length validation or min length validation.