### PR TITLE
Angular - Add Missing `ng-zorro-antd-tree` Bundle for Lepton-X Theme Changes

### DIFF
--- a/npm/ng-packs/packages/schematics/src/commands/change-theme/style-map.ts
+++ b/npm/ng-packs/packages/schematics/src/commands/change-theme/style-map.ts
@@ -196,6 +196,11 @@ styleMap.set(ThemeOptionsEnum.LeptonX, [
     inject: true,
     bundleName: 'bootstrap-icons',
   },
+  {
+    input: 'node_modules/ng-zorro-antd/tree/style/index.min.css',
+    inject: false,
+    bundleName: 'ng-zorro-antd-tree',
+  },
 ]);
 styleMap.set(ThemeOptionsEnum.LeptonXLite, [
   {


### PR DESCRIPTION
### Description

Resolves [this issue.](https://github.com/volosoft/volo/issues/18427)

Here is a record showing the related fix:

<img width="452" alt="image" src="https://github.com/user-attachments/assets/c96bd5d1-83d8-41c8-a669-b89f3c6df78d">


### Checklist

- [X] I fully tested it as developer / designer and created unit / integration tests
- [X] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

- Create a new project that is open source by running this command `abp new OpenSourceTemp -u angular -uost -csf`
- Navigate to `npm > ng-packs` and build the packages to get the latest changes `yarn build:all`
- Navigate to `npm > ng-packs > dist > packages > schematics` and run `yarn link`, then copy the command that it gives you in the form of an output.
- Then, paste this command under the root angular folder of your project.
- Lastly, you can run `abp upgrade -t app` command to upgrade the free template app to pro template.
