### PR TITLE
Backup `ExtraProperties` during `Reload` entry.

### DIFF
--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/AbpDbContext.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/AbpDbContext.cs
@@ -614,7 +614,19 @@ public abstract class AbpDbContext<TDbContext> : DbContext, IAbpEfCoreDbContext,
             return;
         }
 
+        ExtraPropertyDictionary? originalExtraProperties = null;
+        if (entry.Entity is IHasExtraProperties)
+        {
+            originalExtraProperties = entry.OriginalValues.GetValue<ExtraPropertyDictionary>(nameof(IHasExtraProperties.ExtraProperties));
+        }
+
         entry.Reload();
+
+        if (entry.Entity is IHasExtraProperties)
+        {
+            ObjectHelper.TrySetProperty(entry.Entity.As<IHasExtraProperties>(), x => x.ExtraProperties, () => originalExtraProperties);
+        }
+
         ObjectHelper.TrySetProperty(entry.Entity.As<ISoftDelete>(), x => x.IsDeleted, () => true);
         SetDeletionAuditProperties(entry);
     }

--- a/framework/test/Volo.Abp.TestApp/Volo/Abp/TestApp/Domain/City.cs
+++ b/framework/test/Volo.Abp.TestApp/Volo/Abp/TestApp/Domain/City.cs
@@ -5,11 +5,13 @@ using Volo.Abp.Domain.Entities;
 
 namespace Volo.Abp.TestApp.Domain;
 
-public class City : AggregateRoot<Guid>
+public class City : AggregateRoot<Guid>, ISoftDelete
 {
     public string Name { get; set; }
 
     public ICollection<District> Districts { get; set; }
+
+    public bool IsDeleted { get; set; }
 
     private City()
     {

--- a/framework/test/Volo.Abp.TestApp/Volo/Abp/TestApp/Testing/ConcurrencyStamp_Tests.cs
+++ b/framework/test/Volo.Abp.TestApp/Volo/Abp/TestApp/Testing/ConcurrencyStamp_Tests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Volo.Abp.Data;
+using Volo.Abp.Domain.Repositories;
 using Volo.Abp.Modularity;
 using Volo.Abp.TestApp.Domain;
 using Xunit;
@@ -49,7 +50,7 @@ public abstract class ConcurrencyStamp_Tests<TStartupModule> : TestAppTestBase<T
         //And deleting my old entity throws exception!
         await Assert.ThrowsAsync<AbpDbConcurrencyException>(async () =>
         {
-            await CityRepository.DeleteAsync(london1);
+            await CityRepository.HardDeleteAsync(london1);
         });
     }
 }


### PR DESCRIPTION
Resolve #20744 

Because `Reload` will not convert the `ExtraProperties` from the JSON string to the `Dictionary`.
