### PR TITLE
feat(blazor): html ui message alert

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Components/Volo/Abp/AspNetCore/Components/Messages/UiMessageOptions.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Components/Volo/Abp/AspNetCore/Components/Messages/UiMessageOptions.cs
@@ -49,4 +49,9 @@ public class UiMessageOptions
     /// Custom icon for the Cancel button.
     /// </summary>
     public object? CancelButtonIcon { get; set; }
+
+    /// <summary>
+    /// Whether the message is html (true) or plain text (false)
+    /// </summary>
+    public bool IsMessageHtmlMarkup { get; set; }
 }

--- a/framework/src/Volo.Abp.BlazoriseUI/Components/UiMessageAlert.razor
+++ b/framework/src/Volo.Abp.BlazoriseUI/Components/UiMessageAlert.razor
@@ -16,7 +16,14 @@
                 </DisplayHeading>
             }
             <Paragraph TextAlignment="TextAlignment.Center" Margin="Margin.Is0.FromBottom" Style="white-space: break-spaces;">
-                @Message
+                @if (!IsMessageHtmlMarkup)
+                {
+                    @Message
+                }
+                else
+                {
+                    @((MarkupString)Message)
+                }
             </Paragraph>
         </ModalBody>
         <ModalFooter class="d-flex justify-content-center">

--- a/framework/src/Volo.Abp.BlazoriseUI/Components/UiMessageAlert.razor.cs
+++ b/framework/src/Volo.Abp.BlazoriseUI/Components/UiMessageAlert.razor.cs
@@ -21,6 +21,9 @@ public partial class UiMessageAlert : ComponentBase, IDisposable
     protected virtual bool ShowMessageIcon
        => Options?.ShowMessageIcon ?? true;
 
+    protected virtual bool IsMessageHtmlMarkup
+        => Options?.IsMessageHtmlMarkup ?? false;
+
     protected virtual object? MessageIcon => Options?.MessageIcon ?? MessageType switch
     {
         UiMessageType.Info => IconName.Info,


### PR DESCRIPTION
added property to control whether the message is html or not

### Description

Resolves #19785

no breaking change, as default for bool is false.
implements feature described in the issue.

### unclarity

I am not sure if `UiMessageOptions` is used somewhere else. Couldn't find it anywhere else. But that's the only thing that bothers me here.