### PR TITLE
change dotnetRunMessages to bool for launchSettings.json

### DIFF
--- a/modules/setting-management/app/Volo.Abp.SettingManagement.DemoApp/Properties/launchSettings.json
+++ b/modules/setting-management/app/Volo.Abp.SettingManagement.DemoApp/Properties/launchSettings.json
@@ -17,7 +17,7 @@
     },
     "Volo.Abp.SettingManagement.DemoApp": {
       "commandName": "Project",
-      "dotnetRunMessages": "true",
+      "dotnetRunMessages": true,
       "launchBrowser": true,
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {

--- a/templates/app-nolayers/aspnet-core/MyCompanyName.MyProjectName.Blazor.Server.Mongo/Properties/launchSettings.json
+++ b/templates/app-nolayers/aspnet-core/MyCompanyName.MyProjectName.Blazor.Server.Mongo/Properties/launchSettings.json
@@ -17,7 +17,7 @@
     },
     "MyCompanyName.MyProjectName.Blazor.Server": {
       "commandName": "Project",
-      "dotnetRunMessages": "true",
+      "dotnetRunMessages": true,
       "launchBrowser": true,
       "applicationUrl": "https://localhost:44300/",
       "environmentVariables": {

--- a/templates/app-nolayers/aspnet-core/MyCompanyName.MyProjectName.Blazor.Server/Properties/launchSettings.json
+++ b/templates/app-nolayers/aspnet-core/MyCompanyName.MyProjectName.Blazor.Server/Properties/launchSettings.json
@@ -17,7 +17,7 @@
     },
     "MyCompanyName.MyProjectName.Blazor.Server": {
       "commandName": "Project",
-      "dotnetRunMessages": "true",
+      "dotnetRunMessages": true,
       "launchBrowser": true,
       "applicationUrl": "https://localhost:44300/",
       "environmentVariables": {

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.Server.Tiered/Properties/launchSettings.json
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.Server.Tiered/Properties/launchSettings.json
@@ -17,7 +17,7 @@
     },
     "MyCompanyName.MyProjectName.Blazor.Server.Tiered": {
       "commandName": "Project",
-      "dotnetRunMessages": "true",
+      "dotnetRunMessages": true,
       "launchBrowser": true,
       "applicationUrl": "https://localhost:44309/",
       "environmentVariables": {

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.Server/Properties/launchSettings.json
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.Server/Properties/launchSettings.json
@@ -17,7 +17,7 @@
     },
     "MyCompanyName.MyProjectName.Blazor.Server": {
       "commandName": "Project",
-      "dotnetRunMessages": "true",
+      "dotnetRunMessages": true,
       "launchBrowser": true,
       "applicationUrl": "https://localhost:44308/",
       "environmentVariables": {

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.WebApp.Tiered/Properties/launchSettings.json
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.WebApp.Tiered/Properties/launchSettings.json
@@ -17,7 +17,7 @@
     },
     "MyCompanyName.MyProjectName.Blazor.WebApp.Tiered": {
       "commandName": "Project",
-      "dotnetRunMessages": "true",
+      "dotnetRunMessages": true,
       "launchBrowser": true,
       "applicationUrl": "https://localhost:44309/",
       "environmentVariables": {

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.WebApp/Properties/launchSettings.json
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.WebApp/Properties/launchSettings.json
@@ -17,7 +17,7 @@
     },
     "MyCompanyName.MyProjectName.Blazor.WebApp": {
       "commandName": "Project",
-      "dotnetRunMessages": "true",
+      "dotnetRunMessages": true,
       "launchBrowser": true,
       "applicationUrl": "https://localhost:44308/",
       "environmentVariables": {

--- a/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.Blazor.Server.Host/Properties/launchSettings.json
+++ b/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.Blazor.Server.Host/Properties/launchSettings.json
@@ -17,7 +17,7 @@
     },
     "MyCompanyName.MyProjectName.Blazor.Server.Host": {
       "commandName": "Project",
-      "dotnetRunMessages": "true",
+      "dotnetRunMessages": true,
       "launchBrowser": true,
       "applicationUrl": "https://localhost:44304/",
       "environmentVariables": {

--- a/test/AbpPerfTest/AbpPerfTest.WithAbp/Properties/launchSettings.json
+++ b/test/AbpPerfTest/AbpPerfTest.WithAbp/Properties/launchSettings.json
@@ -17,7 +17,7 @@
     },
     "AbpPerfTest.WithAbp": {
       "commandName": "Project",
-      "dotnetRunMessages": "true",
+      "dotnetRunMessages": true,
       "launchBrowser": true,
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {

--- a/test/AbpPerfTest/AbpPerfTest.WithoutAbp/Properties/launchSettings.json
+++ b/test/AbpPerfTest/AbpPerfTest.WithoutAbp/Properties/launchSettings.json
@@ -17,7 +17,7 @@
     },
     "AbpPerfTest.WithoutAbp": {
       "commandName": "Project",
-      "dotnetRunMessages": "true",
+      "dotnetRunMessages": true,
       "launchBrowser": true,
       "applicationUrl": "https://localhost:5003;http://localhost:5002",
       "environmentVariables": {


### PR DESCRIPTION
### Description

change dotnetRunMessages to bool for launchSettings.json
some templates' launchSettings.json has a dotnetRunMessages field of string type,which may causes an error when using .NET Aspire.

### Checklist

- [ ] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)
![image](https://github.com/user-attachments/assets/d0d101e0-8765-485e-8d82-11794591e7e8)
![image](https://github.com/user-attachments/assets/65dbd918-da1b-4f6b-ba57-a01198b4bc84)
