### PR TITLE
CLI: CmdHelper should be working even the directory has 'space' characters

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Utils/CmdHelper.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Utils/CmdHelper.cs
@@ -20,10 +20,14 @@ public class CmdHelper : ICmdHelper, ITransientDependency
 
     public void Open(string pathOrUrl)
     {
+        //directory might contain 'space' character
+        pathOrUrl = pathOrUrl.EnsureStartsWith('"');
+        pathOrUrl = pathOrUrl.EnsureEndsWith('"');
+        
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             pathOrUrl = pathOrUrl.Replace("&", "^&");
-            Process.Start(new ProcessStartInfo("cmd", $"/c start {pathOrUrl}") { CreateNoWindow = true });
+            Process.Start(new ProcessStartInfo("cmd", $"/c start \"\" {pathOrUrl}") { CreateNoWindow = true });
         }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {


### PR DESCRIPTION
https://github.com/abpframework/abp/blob/736f0c0c2d0b7ca0f185c4d88e614b5578820be1/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Utils/CmdHelper.cs#L30

**Note:** `\"\"` is needed in the code above, it's a dummy title name and it should be provided to pass the full path within quotes (for cmd command). There is not such restriction in **xdg-open** (Linux) and **open** (OSX) commands.