### PR TITLE
abp.js - Fix Event Trigger Callback Execution

### DIFF
--- a/npm/packs/core/src/abp.js
+++ b/npm/packs/core/src/abp.js
@@ -480,7 +480,11 @@ var abp = abp || {};
 
             var args = Array.prototype.slice.call(arguments, 1);
             for (var i = 0; i < callbacks.length; i++) {
-                callbacks[i].apply(this, args);
+                try {
+                    callbacks[i].apply(this, args);
+                } catch(e) {
+                    console.error(e);
+                }
             }
         };
 


### PR DESCRIPTION
Allow subsequent callbacks executed when error occurred in one

### Description

When an error thrown during event callback execution, blocks subsequent callbacks which leads unexpected behaviours in the application. 

Example

```ts
abp.event.on('notification', e => {
  console.log(1);
});
abp.event.on('notification', e => {
  throw Error('Example error');
});
abp.event.on('notification', e => {
  console.log(2);
});
```
When `abp.event.trigger('notification')` called, first 2 callbacks will be executed, subsequent callbacks will be blocked due to error.

Console output

```
1
```

Note: No error info will be logged in the console also. Which makes it harder to recognize the issue.

### Checklist

- [+] I fully tested it as developer / designer and created unit / integration tests
- [+] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

Please describe how this can be tested by the test engineers if it is not already explicit - or remove this section if no need to description.

Example case shared in the description section
