### PR TITLE
Adding PackageSourceMapping while adding new sources

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/PackagePreviewSwitcher.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/PackagePreviewSwitcher.cs
@@ -193,7 +193,7 @@ public class PackagePreviewSwitcher : ITransientDependency
             var folder = Path.GetDirectoryName(project);
 
             _packageSourceManager.Add(FindSolutionFolder(project) ?? folder, "ABP Nightly",
-                "https://www.myget.org/F/abp-nightly/api/v3/index.json");
+                "https://www.myget.org/F/abp-nightly/api/v3/index.json", "Volo.*");
 
             await _nugetPackagesVersionUpdater.UpdateSolutionAsync(
                 project,
@@ -213,7 +213,8 @@ public class PackagePreviewSwitcher : ITransientDependency
             var solutionAngularFolder = GetSolutionAngularFolder(solutionFolder);
 
             _packageSourceManager.Add(solutionFolder, "ABP Nightly",
-                "https://www.myget.org/F/abp-nightly/api/v3/index.json");
+                "https://www.myget.org/F/abp-nightly/api/v3/index.json",
+                "Volo.*");
 
             if (solutionPath != null)
             {

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/PackageSourceManager.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/PackageSourceManager.cs
@@ -79,23 +79,25 @@ public class PackageSourceManager : ITransientDependency
     {
         var packageMappingNodes = doc.SelectNodes("/configuration/packageSourceMapping");
 
-        if (packageMappingNodes != null && packageMappingNodes.Count != 0)
+        if (packageMappingNodes == null)
         {
-            var packageSourceNode = doc.CreateElement("packageSource");
-            var sourceAttr = doc.CreateAttribute("key");
-            sourceAttr.Value = sourceKey;
-            packageSourceNode.Attributes.Append(sourceAttr);
-            packageMappingNodes[0]?.AppendChild(packageSourceNode);
-            foreach (var pattern in packageMappingPatterns)
-            {
-                var packageNode = doc.CreateElement("package");
-                var patternAttr = doc.CreateAttribute("pattern");
-                patternAttr.Value = pattern;
-                packageNode.Attributes.Append(patternAttr);
-                packageSourceNode.AppendChild(packageNode);
-            }
+            // If there is no packageSourceMapping node, leave it as it is.
+            Logger.LogWarning($"<packageSourceMapping> node not found in 'NuGet.Config' file. Skipping adding patterns for '{sourceKey}' source.");
+            return;
         }
-        // If there is no packageSourceMapping node, leave it as it is.
+        var packageSourceNode = doc.CreateElement("packageSource");
+        var sourceAttr = doc.CreateAttribute("key");
+        sourceAttr.Value = sourceKey;
+        packageSourceNode.Attributes.Append(sourceAttr);
+        packageMappingNodes[0]?.AppendChild(packageSourceNode);
+        foreach (var pattern in packageMappingPatterns)
+        {
+            var packageNode = doc.CreateElement("package");
+            var patternAttr = doc.CreateAttribute("pattern");
+            patternAttr.Value = pattern;
+            packageNode.Attributes.Append(patternAttr);
+            packageSourceNode.AppendChild(packageNode);
+        }
     }
 
     public void Remove(string solutionFolder, string sourceKey)

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/PackageSourceManager.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/PackageSourceManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Xml;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -16,7 +17,7 @@ public class PackageSourceManager : ITransientDependency
         Logger = NullLogger<PackageSourceManager>.Instance;
     }
 
-    public void Add(string solutionFolder, string sourceKey, string sourceValue)
+    public void Add(string solutionFolder, string sourceKey, string sourceValue, params string[] packageMappingPatterns)
     {
         var nugetConfigPath = GetNugetConfigPath(solutionFolder);
 
@@ -61,11 +62,52 @@ public class PackageSourceManager : ITransientDependency
 
             sourceNodes?[0]?.AppendChild(newNode);
 
+            if (packageMappingPatterns.Any())
+            {
+                ConfigurePackageSourceMappings(doc, sourceKey, packageMappingPatterns);
+            }
+
             File.WriteAllText(nugetConfigPath, doc.OuterXml);
         }
         catch
         {
             Logger.LogWarning($"Adding \"{sourceValue}\" ({sourceKey}) to nuget sources FAILED.");
+        }
+    }
+
+    protected virtual void ConfigurePackageSourceMappings(XmlDocument doc, string sourceKey, string[] packageMappingPatterns)
+    {
+        var packageMappingNodes = doc.SelectNodes("/configuration/packageSourceMapping");
+
+        if (packageMappingNodes == null || packageMappingNodes.Count == 0)
+        {
+            var packageSourcesNode = doc.SelectSingleNode("/configuration/packageSources");
+            var packageMappingNode = doc.CreateElement("packageSourceMapping");
+            foreach (var pattern in packageMappingPatterns)
+            {
+                var patternNode = doc.CreateElement("packageSource");
+                var patternAttr = doc.CreateAttribute("key");
+                patternAttr.Value = pattern;
+                patternNode.Attributes.Append(patternAttr);
+                packageMappingNode.AppendChild(patternNode);
+            }
+            packageSourcesNode?.ParentNode?.InsertAfter(packageMappingNode, packageSourcesNode);
+        }
+        else
+        {
+            var packageSourceNode = doc.CreateElement("packageSource");
+            var sourceAttr = doc.CreateAttribute("key");
+            sourceAttr.Value = sourceKey;
+            packageSourceNode.Attributes.Append(sourceAttr);
+            packageMappingNodes[0]?.AppendChild(packageSourceNode);
+            foreach (var pattern in packageMappingPatterns)
+            {
+                var packageNode = doc.CreateElement("package");
+                var patternAttr = doc.CreateAttribute("pattern");
+                patternAttr.Value = pattern;
+                packageNode.Attributes.Append(patternAttr);
+                packageSourceNode.AppendChild(packageNode);
+            }
         }
     }
 

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/PackageSourceManager.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/PackageSourceManager.cs
@@ -79,21 +79,7 @@ public class PackageSourceManager : ITransientDependency
     {
         var packageMappingNodes = doc.SelectNodes("/configuration/packageSourceMapping");
 
-        if (packageMappingNodes == null || packageMappingNodes.Count == 0)
-        {
-            var packageSourcesNode = doc.SelectSingleNode("/configuration/packageSources");
-            var packageMappingNode = doc.CreateElement("packageSourceMapping");
-            foreach (var pattern in packageMappingPatterns)
-            {
-                var patternNode = doc.CreateElement("packageSource");
-                var patternAttr = doc.CreateAttribute("key");
-                patternAttr.Value = pattern;
-                patternNode.Attributes.Append(patternAttr);
-                packageMappingNode.AppendChild(patternNode);
-            }
-            packageSourcesNode?.ParentNode?.InsertAfter(packageMappingNode, packageSourcesNode);
-        }
-        else
+        if (packageMappingNodes != null && packageMappingNodes.Count != 0)
         {
             var packageSourceNode = doc.CreateElement("packageSource");
             var sourceAttr = doc.CreateAttribute("key");
@@ -109,6 +95,7 @@ public class PackageSourceManager : ITransientDependency
                 packageSourceNode.AppendChild(packageNode);
             }
         }
+        // If there is no packageSourceMapping node, leave it as it is.
     }
 
     public void Remove(string solutionFolder, string sourceKey)


### PR DESCRIPTION
### Description

Resolves https://github.com/volosoft/abp-studio/issues/2006

After this PR, when Nightly source is added to `NuGet.Config` file, also package mapping will be added.
**Line:16** in the following image
![image](https://github.com/user-attachments/assets/0646fc0a-ce96-4114-bff9-4b9554e37712)


### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)


### How to test?

- Remove all `abp` cli variations from dotnet global tools first:
```
dotnet tool uninstall -g volo.abp.Cli
dotnet tool uninstall -g volo.abp.studio.Cli
```

- Go to `Volo.Abp.Cli` folder and pack it and install it:
```
dotnet pack -c Release -o ./nupkg
dotnet tool update -g Volo.Abp.Cli --add-source ./nupkg --prerelease
```

- Then create a project and update it to nightly with command:
```
abp switch-to-nightly
```


