### PR TITLE
Downgrade codemirror to 5.65.1 version

### DIFF
--- a/npm/packs/codemirror/package.json
+++ b/npm/packs/codemirror/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "@abp/core": "~8.3.1",
-    "codemirror": "^6.0.1"
+    "codemirror": "^5.65.1"
   },
   "gitHead": "bb4ea17d5996f01889134c138d00b6c8f858a431",
   "homepage": "https://abp.io",


### PR DESCRIPTION
### Description

Resolves https://github.com/volosoft/volo/issues/18381

Codemirror 6 has break changes, we downgrade it now to make it work, and will migrate to version 6 in the future 

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

