### PR TITLE
change the is satisfied and to expression examples

### DIFF
--- a/docs/en/framework/architecture/domain-driven-design/specifications.md
+++ b/docs/en/framework/architecture/domain-driven-design/specifications.md
@@ -81,7 +81,7 @@ namespace MyProject
 {
     public class CustomerService : ITransientDependency
     {
-        public async Task BuyAlcohol(Customer customer)
+        public async Task BookRoom(Customer customer)
         {
             if (!new Age18PlusCustomerSpecification().IsSatisfiedBy(customer))
             {
@@ -120,7 +120,7 @@ namespace MyProject
             _customerRepository = customerRepository;
         }
 
-        public async Task<List<Customer>> GetCustomersCanBuyAlcohol()
+        public async Task<List<Customer>> GetCustomersCanBookRoom()
         {
             var queryable = await _customerRepository.GetQueryableAsync();
             var query = queryable.Where(


### PR DESCRIPTION
Resolves #21090 - Updated the documentation and examples to replace the alcohol purchase scenario with a more globally applicable and neutral example, focusing on booking a room. The previous example might not have been suitable for all cultures or regions, so the change ensures inclusivity and relevance to a broader audience.
