### PR TITLE
Make sure `Value` of `FixedLocalizableString` not null.

### DIFF
--- a/framework/src/Volo.Abp.Localization.Abstractions/Volo/Abp/Localization/FixedLocalizableString.cs
+++ b/framework/src/Volo.Abp.Localization.Abstractions/Volo/Abp/Localization/FixedLocalizableString.cs
@@ -8,6 +8,7 @@ public class FixedLocalizableString : ILocalizableString
 
     public FixedLocalizableString(string value)
     {
+        Check.NotNull(value, nameof(value));
         Value = value;
     }
 

--- a/framework/src/Volo.Abp.Localization/Volo/Abp/Localization/LocalizableStringSerializer.cs
+++ b/framework/src/Volo.Abp.Localization/Volo/Abp/Localization/LocalizableStringSerializer.cs
@@ -35,7 +35,12 @@ public class LocalizableStringSerializer : ILocalizableStringSerializer, ITransi
 
     public virtual ILocalizableString Deserialize(string value)
     {
-        if (value.IsNullOrEmpty() ||
+        if (value == null)
+        {
+            throw new AbpException($"{nameof(value)} can not be null!");
+        }
+
+        if (value.IsNullOrWhiteSpace() ||
             value.Length < 3 ||
             value[1] != ':')
         {

--- a/modules/feature-management/src/Volo.Abp.FeatureManagement.Domain/Volo/Abp/FeatureManagement/DynamicFeatureDefinitionStoreInMemoryCache.cs
+++ b/modules/feature-management/src/Volo.Abp.FeatureManagement.Domain/Volo/Abp/FeatureManagement/DynamicFeatureDefinitionStoreInMemoryCache.cs
@@ -48,7 +48,7 @@ public class DynamicFeatureDefinitionStoreInMemoryCache:
         {
             var featureGroup = context.AddGroup(
                 featureGroupRecord.Name,
-                LocalizableStringSerializer.Deserialize(featureGroupRecord.DisplayName)
+                featureGroupRecord.DisplayName != null ? LocalizableStringSerializer.Deserialize(featureGroupRecord.DisplayName) : null
             );
 
             FeatureGroupDefinitions[featureGroup.Name] = featureGroup;
@@ -92,8 +92,8 @@ public class DynamicFeatureDefinitionStoreInMemoryCache:
         var feature = featureContainer.CreateChildFeature(
             featureRecord.Name,
             featureRecord.DefaultValue,
-            LocalizableStringSerializer.Deserialize(featureRecord.DisplayName),
-            LocalizableStringSerializer.Deserialize(featureRecord.Description),
+            featureRecord.DisplayName != null ? LocalizableStringSerializer.Deserialize(featureRecord.DisplayName) : null,
+            featureRecord.Description != null ? LocalizableStringSerializer.Deserialize(featureRecord.Description) : null,
             StateCheckerSerializer.Deserialize(featureRecord.ValueType),
             featureRecord.IsVisibleToClients,
             featureRecord.IsAvailableToHost


### PR DESCRIPTION
Because the `Name` of [LocalizedString](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.localization.localizedstring?view=net-8.0) can't be `null`.

https://abp.io/support/questions/8169/Bug-in-Localization-logic-causes-feature-management-to-fail