### PR TITLE
Set the first tab active after search in permissions

### DIFF
--- a/modules/permission-management/src/Volo.Abp.PermissionManagement.Web/Pages/AbpPermissionManagement/permission-management-modal.js
+++ b/modules/permission-management/src/Volo.Abp.PermissionManagement.Web/Pages/AbpPermissionManagement/permission-management-modal.js
@@ -305,7 +305,7 @@ var abp = abp || {};
                         return;
                     }
 
-                    var tabName = $tabItem.find('small').text().toLowerCase();
+                    var tabName = $tabItem.text().toLowerCase();
 
                     var tabContentFilters = $($tabItem.attr('href')).find('[data-filter-text]');
                     let includedInTabContent = false;

--- a/modules/permission-management/src/Volo.Abp.PermissionManagement.Web/Pages/AbpPermissionManagement/permission-management-modal.js
+++ b/modules/permission-management/src/Volo.Abp.PermissionManagement.Web/Pages/AbpPermissionManagement/permission-management-modal.js
@@ -291,6 +291,7 @@ var abp = abp || {};
             $permissionSearchInput.keyup(throttle(function() {
                 var searchTerm = $permissionSearchInput.val().toLowerCase();
                 filterTabs(searchTerm);
+                setFirstVisibleTabActive();
             }, 300));
 
             function filterTabs(searchTerm) {
@@ -322,6 +323,18 @@ var abp = abp || {};
                         $tab.hide();
                     }
                 });
+            }
+
+            function setFirstVisibleTabActive() {
+                $('#PermissionsTabsContent .tab-pane').removeClass('active show');
+
+                var $tabs = $('#PermissionsTabs .nav-link');
+                var $firstVisibleTab = $tabs.filter(':visible').first();
+                $tabs.removeClass('active');
+                $firstVisibleTab.addClass('active');
+                
+                var $firstVisibleTabContent = $($firstVisibleTab.attr('href'));
+                $firstVisibleTabContent.addClass('active show');
             }
 
             function throttle(mainFunction, delay) {


### PR DESCRIPTION
### Description

Resolves https://github.com/volosoft/volo/issues/18704
Resolves https://github.com/volosoft/volo/issues/18703

![permissions-search](https://github.com/user-attachments/assets/950601c0-ddc1-49a9-8dce-b41d2ee26f90)

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

Please describe how this can be tested by the test engineers if it is not already explicit - or remove this section if no need to description.
