### PR TITLE
`AddOrReplaceEvent` when unit of work `CompleteAsync`.

### DIFF
--- a/framework/src/Volo.Abp.Uow/Volo/Abp/Uow/UnitOfWork.cs
+++ b/framework/src/Volo.Abp.Uow/Volo/Abp/Uow/UnitOfWork.cs
@@ -34,7 +34,11 @@ public class UnitOfWork : IUnitOfWork, ITransientDependency
     public string? ReservationName { get; set; }
 
     protected List<Func<Task>> CompletedHandlers { get; } = new List<Func<Task>>();
+
+    protected List<KeyValuePair<UnitOfWorkEventRecord, Predicate<UnitOfWorkEventRecord>?>> DistributedEventWithPredicates { get; } = new List<KeyValuePair<UnitOfWorkEventRecord, Predicate<UnitOfWorkEventRecord>?>>();
     protected List<UnitOfWorkEventRecord> DistributedEvents { get; } = new List<UnitOfWorkEventRecord>();
+
+    protected List<KeyValuePair<UnitOfWorkEventRecord, Predicate<UnitOfWorkEventRecord>?>> LocalEventWithPredicates { get; } = new List<KeyValuePair<UnitOfWorkEventRecord, Predicate<UnitOfWorkEventRecord>?>>();
     protected List<UnitOfWorkEventRecord> LocalEvents { get; } = new List<UnitOfWorkEventRecord>();
 
     public event EventHandler<UnitOfWorkFailedEventArgs> Failed = default!;
@@ -135,24 +139,31 @@ public class UnitOfWork : IUnitOfWork, ITransientDependency
             _isCompleting = true;
             await SaveChangesAsync(cancellationToken);
 
+            DistributedEvents.AddRange(GetEventsRecordsByPredicate(DistributedEventWithPredicates));
+            LocalEvents.AddRange(GetEventsRecordsByPredicate(LocalEventWithPredicates));
+
             while (LocalEvents.Any() || DistributedEvents.Any())
             {
                 if (LocalEvents.Any())
                 {
                     var localEventsToBePublished = LocalEvents.OrderBy(e => e.EventOrder).ToArray();
+                    LocalEventWithPredicates.Clear();
                     LocalEvents.Clear();
                     await UnitOfWorkEventPublisher.PublishLocalEventsAsync(
                         localEventsToBePublished
                     );
+                    LocalEvents.AddRange(GetEventsRecordsByPredicate(LocalEventWithPredicates));
                 }
 
                 if (DistributedEvents.Any())
                 {
                     var distributedEventsToBePublished = DistributedEvents.OrderBy(e => e.EventOrder).ToArray();
+                    DistributedEventWithPredicates.Clear();
                     DistributedEvents.Clear();
                     await UnitOfWorkEventPublisher.PublishDistributedEventsAsync(
                         distributedEventsToBePublished
                     );
+                    DistributedEvents.AddRange(GetEventsRecordsByPredicate(DistributedEventWithPredicates));
                 }
 
                 await SaveChangesAsync(cancellationToken);
@@ -244,38 +255,44 @@ public class UnitOfWork : IUnitOfWork, ITransientDependency
         UnitOfWorkEventRecord eventRecord,
         Predicate<UnitOfWorkEventRecord>? replacementSelector = null)
     {
-        AddOrReplaceEvent(LocalEvents, eventRecord, replacementSelector);
+        LocalEventWithPredicates.Add(new KeyValuePair<UnitOfWorkEventRecord, Predicate<UnitOfWorkEventRecord>?>(eventRecord, replacementSelector));
     }
 
     public virtual void AddOrReplaceDistributedEvent(
         UnitOfWorkEventRecord eventRecord,
         Predicate<UnitOfWorkEventRecord>? replacementSelector = null)
     {
-        AddOrReplaceEvent(DistributedEvents, eventRecord, replacementSelector);
+        DistributedEventWithPredicates.Add(new KeyValuePair<UnitOfWorkEventRecord, Predicate<UnitOfWorkEventRecord>?>(eventRecord, replacementSelector));
     }
 
-    public virtual void AddOrReplaceEvent(
-        List<UnitOfWorkEventRecord> eventRecords,
-        UnitOfWorkEventRecord eventRecord,
-        Predicate<UnitOfWorkEventRecord>? replacementSelector = null)
+    protected virtual List<UnitOfWorkEventRecord> GetEventsRecordsByPredicate(List<KeyValuePair<UnitOfWorkEventRecord, Predicate<UnitOfWorkEventRecord>?>> eventWithPredicates)
     {
-        if (replacementSelector == null)
+        var eventRecords = new List<UnitOfWorkEventRecord>();
+        foreach (var eventWithPredicate in eventWithPredicates)
         {
-            eventRecords.Add(eventRecord);
-        }
-        else
-        {
-            var foundIndex = eventRecords.FindIndex(replacementSelector);
-            if (foundIndex < 0)
+            var eventRecord = eventWithPredicate.Key;
+            var replacementSelector = eventWithPredicate.Value;
+
+            if (replacementSelector == null)
             {
                 eventRecords.Add(eventRecord);
             }
             else
             {
-                eventRecord.SetOrder(eventRecords[foundIndex].EventOrder);
-                eventRecords[foundIndex] = eventRecord;
+                var foundIndex = eventRecords.FindIndex(replacementSelector);
+                if (foundIndex < 0)
+                {
+                    eventRecords.Add(eventRecord);
+                }
+                else
+                {
+                    eventRecord.SetOrder(eventRecords[foundIndex].EventOrder);
+                    eventRecords[foundIndex] = eventRecord;
+                }
             }
         }
+
+        return eventRecords;
     }
 
     protected virtual async Task OnCompletedAsync()

--- a/framework/src/Volo.Abp.Uow/Volo/Abp/Uow/UnitOfWork.cs
+++ b/framework/src/Volo.Abp.Uow/Volo/Abp/Uow/UnitOfWork.cs
@@ -139,8 +139,8 @@ public class UnitOfWork : IUnitOfWork, ITransientDependency
             _isCompleting = true;
             await SaveChangesAsync(cancellationToken);
 
-            DistributedEvents.AddRange(GetEventsRecordsByPredicate(DistributedEventWithPredicates));
-            LocalEvents.AddRange(GetEventsRecordsByPredicate(LocalEventWithPredicates));
+            DistributedEvents.AddRange(GetEventsRecords(DistributedEventWithPredicates));
+            LocalEvents.AddRange(GetEventsRecords(LocalEventWithPredicates));
 
             while (LocalEvents.Any() || DistributedEvents.Any())
             {
@@ -152,7 +152,7 @@ public class UnitOfWork : IUnitOfWork, ITransientDependency
                     await UnitOfWorkEventPublisher.PublishLocalEventsAsync(
                         localEventsToBePublished
                     );
-                    LocalEvents.AddRange(GetEventsRecordsByPredicate(LocalEventWithPredicates));
+                    LocalEvents.AddRange(GetEventsRecords(LocalEventWithPredicates));
                 }
 
                 if (DistributedEvents.Any())
@@ -163,7 +163,7 @@ public class UnitOfWork : IUnitOfWork, ITransientDependency
                     await UnitOfWorkEventPublisher.PublishDistributedEventsAsync(
                         distributedEventsToBePublished
                     );
-                    DistributedEvents.AddRange(GetEventsRecordsByPredicate(DistributedEventWithPredicates));
+                    DistributedEvents.AddRange(GetEventsRecords(DistributedEventWithPredicates));
                 }
 
                 await SaveChangesAsync(cancellationToken);
@@ -265,7 +265,7 @@ public class UnitOfWork : IUnitOfWork, ITransientDependency
         DistributedEventWithPredicates.Add(new KeyValuePair<UnitOfWorkEventRecord, Predicate<UnitOfWorkEventRecord>?>(eventRecord, replacementSelector));
     }
 
-    protected virtual List<UnitOfWorkEventRecord> GetEventsRecordsByPredicate(List<KeyValuePair<UnitOfWorkEventRecord, Predicate<UnitOfWorkEventRecord>?>> eventWithPredicates)
+    protected virtual List<UnitOfWorkEventRecord> GetEventsRecords(List<KeyValuePair<UnitOfWorkEventRecord, Predicate<UnitOfWorkEventRecord>?>> eventWithPredicates)
     {
         var eventRecords = new List<UnitOfWorkEventRecord>();
         foreach (var eventWithPredicate in eventWithPredicates)


### PR DESCRIPTION
If we call `Insert` to add many entities, the `AddOrReplaceEvent` check will be polynomial growth. 

We can do the `add or replace` in the `CompleteAsync` method for better performance.


---

```
Check after each addition: Time complexity is O(N * M), which slows down with more projects.
Check after all additions: Time complexity is O(M + N), which is more efficient.
```


Feedback from https://abp.io/support/questions/8152/ABP-InsertManyAsync-extremely-slow-with-many-thousands-of-entities