### PR TITLE
Check if folder exist in NugetPackageToLocalReferenceConverter

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/NugetPackageToLocalReferenceConverter.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/NugetPackageToLocalReferenceConverter.cs
@@ -142,6 +142,11 @@ public class NugetPackageToLocalReferenceConverter : ITransientDependency
 
     private static string[] GetProjectFilesUnder(string path)
     {
+        if (!Directory.Exists(path))
+        {
+            return [];
+        }
+        
         return Directory.GetFiles(path,
             "*.csproj",
             SearchOption.AllDirectories);


### PR DESCRIPTION
fixes:
![image](https://github.com/user-attachments/assets/87a2e84f-bbc1-4f20-ac76-dd32b26ef87e)
