### PR TITLE
Fix Datatable fnSetColumnVis legacy method usage issue

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/wwwroot/libs/abp/aspnetcore-mvc-ui-theme-shared/datatables/datatables-extensions.js
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/wwwroot/libs/abp/aspnetcore-mvc-ui-theme-shared/datatables/datatables-extensions.js
@@ -226,7 +226,7 @@ var abp = abp || {};
         };
 
         var hideColumnWithoutRedraw = function (tableInstance, colIndex) {
-            tableInstance.fnSetColumnVis(colIndex, false, false);
+            tableInstance.api().column(colIndex).visible(false);
         };
 
         var hideEmptyColumn = function (cellContent, tableInstance, colIndex) {

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/wwwroot/libs/abp/aspnetcore-mvc-ui-theme-shared/datatables/datatables-extensions.js
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/wwwroot/libs/abp/aspnetcore-mvc-ui-theme-shared/datatables/datatables-extensions.js
@@ -226,7 +226,7 @@ var abp = abp || {};
         };
 
         var hideColumnWithoutRedraw = function (tableInstance, colIndex) {
-            tableInstance.api().column(colIndex).visible(false);
+            tableInstance.api().column(colIndex).visible(false, false);
         };
 
         var hideEmptyColumn = function (cellContent, tableInstance, colIndex) {


### PR DESCRIPTION
### Description

Resolves https://github.com/abpframework/abp/issues/20970

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

