### PR TITLE
FIx PreConfigure<OpenIddictBuilder> is called twice

### DIFF
--- a/modules/openiddict/src/Volo.Abp.OpenIddict.AspNetCore/Volo/Abp/OpenIddict/AbpOpenIddictAspNetCoreModule.cs
+++ b/modules/openiddict/src/Volo.Abp.OpenIddict.AspNetCore/Volo/Abp/OpenIddict/AbpOpenIddictAspNetCoreModule.cs
@@ -138,7 +138,5 @@ public class AbpOpenIddictAspNetCoreModule : AbpModule
 
                 services.ExecutePreConfiguredActions(builder);
             });
-
-        services.ExecutePreConfiguredActions(openIddictBuilder);
     }
 }


### PR DESCRIPTION
### Description

Resolves https://github.com/abpframework/abp/issues/21377

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?


