### PR TITLE
Skip to write audit logs if `auditLogInfo.HttpMethod` is `GET/Head`.

### DIFF
--- a/framework/src/Volo.Abp.Auditing/Volo/Abp/Auditing/AuditingInterceptor.cs
+++ b/framework/src/Volo.Abp.Auditing/Volo/Abp/Auditing/AuditingInterceptor.cs
@@ -191,7 +191,9 @@ public class AuditingInterceptor : AbpInterceptor, ITransientDependency
         }
 
         if (!options.IsEnabledForGetRequests &&
-            invocation.Method.Name.StartsWith("Get", StringComparison.OrdinalIgnoreCase))
+            (string.Equals(auditLogInfo.HttpMethod, "Get", StringComparison.OrdinalIgnoreCase) ||
+             string.Equals(auditLogInfo.HttpMethod, "Head", StringComparison.OrdinalIgnoreCase) ||
+             invocation.Method.Name.StartsWith("Get", StringComparison.OrdinalIgnoreCase)))
         {
             return false;
         }


### PR DESCRIPTION
While `IsEnabledForGetRequests` is `false`.
