### PR TITLE
Use `cultureNameLocaleFileMap` to determine supported locales

### DIFF
--- a/npm/ng-packs/packages/core/locale/src/utils/register-locale.ts
+++ b/npm/ng-packs/packages/core/locale/src/utils/register-locale.ts
@@ -55,7 +55,7 @@ export function registerLocaleForEsBuild(
       const l = localeMap[locale] || locale;
       const localeSupportList = "ar|cs|en|en-GB|es|de|fi|fr|hi|hu|is|it|pt|tr|ru|ro|sk|sl|zh-Hans|zh-Hant".split("|");
 
-      if (localeSupportList.indexOf(locale) == -1) {
+      if (localeSupportList.indexOf(l) == -1) {
           return;
       }
       return new Promise((resolve, reject) => {


### PR DESCRIPTION
Fixes #21483.
This pull request includes a change to the `registerLocaleForEsBuild` function in the `npm/ng-packs/packages/core/locale/src/utils/register-locale.ts` file. The change ensures that the correct locale variable is checked against the `localeSupportList`.