### PR TITLE
added interface for rabbitmq eventbus

### DIFF
--- a/framework/src/Volo.Abp.EventBus.RabbitMQ/Volo/Abp/EventBus/RabbitMq/AbpEventBusRabbitMqModule.cs
+++ b/framework/src/Volo.Abp.EventBus.RabbitMQ/Volo/Abp/EventBus/RabbitMq/AbpEventBusRabbitMqModule.cs
@@ -20,7 +20,7 @@ public class AbpEventBusRabbitMqModule : AbpModule
     {
         context
             .ServiceProvider
-            .GetRequiredService<RabbitMqDistributedEventBus>()
+            .GetRequiredService<IRabbitMqDistributedEventBus>()
             .Initialize();
     }
 }

--- a/framework/src/Volo.Abp.EventBus.RabbitMQ/Volo/Abp/EventBus/RabbitMq/IRabbitMqDistributedEventBus.cs
+++ b/framework/src/Volo.Abp.EventBus.RabbitMQ/Volo/Abp/EventBus/RabbitMq/IRabbitMqDistributedEventBus.cs
@@ -1,0 +1,8 @@
+﻿using Volo.Abp.EventBus.Distributed;
+
+namespace Volo.Abp.EventBus.RabbitMq;
+
+public interface IRabbitMqDistributedEventBus : IDistributedEventBus
+{
+    void Initialize();
+}

--- a/framework/src/Volo.Abp.EventBus.RabbitMQ/Volo/Abp/EventBus/RabbitMq/RabbitMqDistributedEventBus.cs
+++ b/framework/src/Volo.Abp.EventBus.RabbitMQ/Volo/Abp/EventBus/RabbitMq/RabbitMqDistributedEventBus.cs
@@ -23,8 +23,8 @@ namespace Volo.Abp.EventBus.RabbitMq;
 /* TODO: How to handle unsubscribe to unbind on RabbitMq (may not be possible for)
  */
 [Dependency(ReplaceServices = true)]
-[ExposeServices(typeof(IDistributedEventBus), typeof(RabbitMqDistributedEventBus))]
-public class RabbitMqDistributedEventBus : DistributedEventBusBase, ISingletonDependency
+[ExposeServices(typeof(IDistributedEventBus), typeof(RabbitMqDistributedEventBus), typeof(IRabbitMqDistributedEventBus)]
+public class RabbitMqDistributedEventBus : DistributedEventBusBase, IRabbitMqDistributedEventBus, ISingletonDependency
 {
     protected AbpRabbitMqEventBusOptions AbpRabbitMqEventBusOptions { get; }
     protected IConnectionPool ConnectionPool { get; }
@@ -72,7 +72,7 @@ public class RabbitMqDistributedEventBus : DistributedEventBusBase, ISingletonDe
         EventTypes = new ConcurrentDictionary<string, Type>();
     }
 
-    public void Initialize()
+    public virtual void Initialize()
     {
         Consumer = MessageConsumerFactory.Create(
             new ExchangeDeclareConfiguration(
@@ -290,7 +290,7 @@ public class RabbitMqDistributedEventBus : DistributedEventBusBase, ISingletonDe
         var eventName = EventNameAttribute.GetNameOrDefault(eventType);
         var body = Serializer.Serialize(eventData);
 
-        return PublishAsync( eventName, body, headersArguments, eventId, correlationId);
+        return PublishAsync(eventName, body, headersArguments, eventId, correlationId);
     }
 
     protected virtual Task PublishAsync(

--- a/framework/src/Volo.Abp.EventBus.RabbitMQ/Volo/Abp/EventBus/RabbitMq/RabbitMqDistributedEventBus.cs
+++ b/framework/src/Volo.Abp.EventBus.RabbitMQ/Volo/Abp/EventBus/RabbitMq/RabbitMqDistributedEventBus.cs
@@ -23,7 +23,7 @@ namespace Volo.Abp.EventBus.RabbitMq;
 /* TODO: How to handle unsubscribe to unbind on RabbitMq (may not be possible for)
  */
 [Dependency(ReplaceServices = true)]
-[ExposeServices(typeof(IDistributedEventBus), typeof(RabbitMqDistributedEventBus), typeof(IRabbitMqDistributedEventBus)]
+[ExposeServices(typeof(IDistributedEventBus), typeof(RabbitMqDistributedEventBus), typeof(IRabbitMqDistributedEventBus))]
 public class RabbitMqDistributedEventBus : DistributedEventBusBase, IRabbitMqDistributedEventBus, ISingletonDependency
 {
     protected AbpRabbitMqEventBusOptions AbpRabbitMqEventBusOptions { get; }


### PR DESCRIPTION
### Description

I have an use case where i need to customize the initialize-Logic of the RabbitMqEventBus.
For that reason i made the method "Initialize" virtual and added an interface  for the RabbitMqEventBus, to use this interface over the implementation in the application initalization.

### Checklist

- [ ] I fully tested it as developer / designer and created unit / integration tests - As no core logic is changed imho no testing is really needed.
- [ x ] I documented it (or no need to document or I will create a separate documentation issue) - Since no core logic is changed i guess there is no need for documentation.

### How to test it?

Create a test app using rabbitmq as distributed event bus.
