### PR TITLE
Use `UseVirtualStaticFiles` for `AllowedExtraWebContentFolders` first.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore/Microsoft/AspNetCore/Builder/AbpApplicationBuilderExtensions.cs
+++ b/framework/src/Volo.Abp.AspNetCore/Microsoft/AspNetCore/Builder/AbpApplicationBuilderExtensions.cs
@@ -177,13 +177,13 @@ public static class AbpApplicationBuilderExtensions
             throw new AbpException("The app(IApplicationBuilder) is not an IEndpointRouteBuilder.");
         }
 
-        app.UseVirtualStaticFiles();
-
         var options = app.ApplicationServices.GetRequiredService<IOptions<AbpAspNetCoreContentOptions>>().Value;
         foreach (var folder in options.AllowedExtraWebContentFolders)
         {
             app.UseVirtualStaticFiles(folder);
         }
+
+        app.UseVirtualStaticFiles();
 
         return endpoints.MapStaticAssets(staticAssetsManifestPath);
     }


### PR DESCRIPTION
Resolve #21592

That allows us to use `ExtraWebContentFolders("Pages, Views, Themes, Components")` to override the files from `Virtual Files`.