### PR TITLE
Do not show a warning for unsaved changes if no changes have been made.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/wwwroot/libs/abp/aspnetcore-mvc-ui-theme-shared/jquery/jquery-extensions.js
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/wwwroot/libs/abp/aspnetcore-mvc-ui-theme-shared/jquery/jquery-extensions.js
@@ -161,9 +161,17 @@
     $.fn.needConfirmationOnUnsavedClose = function ($modal) {
         var $form = $(this);
         var formSaved = false;
-        var unEditedForm = JSON.stringify($form.serializeFormToObject());
+        var unEditedForm;
+        
+        $modal.on("shown.bs.modal", function () {
+            unEditedForm = JSON.stringify($form.serializeFormToObject());
+        });
 
         $modal.on("hide.bs.modal", function (e) {
+            if(unEditedForm === undefined) {
+                return;
+            }
+            
             var currentForm = JSON.stringify($form.serializeFormToObject());
             var thereAreUnsavedChanges = currentForm !== unEditedForm;
 


### PR DESCRIPTION
### Description

Resolves https://github.com/volosoft/vs-internal/issues/5593

When opening a modal, certain elements are loaded dynamically via JavaScript. Previously, the original state of the form was captured before these dynamically loaded changes were applied, causing them to be falsely detected as "unsaved changes."

To address this issue, the original form state is now captured after the modal has fully opened (`shown.bs.modal`). As a result, dynamically loaded content will no longer be incorrectly marked as changes.

### Checklist

- [x] I fully tested it as developer
