### PR TITLE
Enable object-mapping when source and destination is an enum

### DIFF
--- a/framework/src/Volo.Abp.ObjectMapping/Volo/Abp/ObjectMapping/DefaultObjectMapper.cs
+++ b/framework/src/Volo.Abp.ObjectMapping/Volo/Abp/ObjectMapping/DefaultObjectMapper.cs
@@ -55,13 +55,9 @@ public class DefaultObjectMapper : IObjectMapper, ITransientDependency
                 return specificMapper.Map(source);
             }
 
-            if (!(typeof(TSource).IsEnum || typeof(TSource).IsPrimitive))
+            if (TryToMapCollection<TSource, TDestination>(scope, source, default, out var collectionResult))
             {
-                var result = TryToMapCollection<TSource, TDestination>(scope, source, default);
-                if (result != null)
-                {
-                    return result;
-                }
+                return collectionResult;
             }
         }
 
@@ -103,10 +99,9 @@ public class DefaultObjectMapper : IObjectMapper, ITransientDependency
                 return specificMapper.Map(source, destination);
             }
 
-            var result = TryToMapCollection(scope, source, destination);
-            if (result != null)
+            if (TryToMapCollection(scope, source, destination, out var collectionResult))
             {
-                return result;
+                return collectionResult;
             }
         }
 
@@ -125,11 +120,12 @@ public class DefaultObjectMapper : IObjectMapper, ITransientDependency
         return AutoMap(source, destination);
     }
 
-    protected virtual TDestination? TryToMapCollection<TSource, TDestination>(IServiceScope serviceScope, TSource source, TDestination? destination)
+    protected virtual bool TryToMapCollection<TSource, TDestination>(IServiceScope serviceScope, TSource source, TDestination? destination, out TDestination collectionResult)
     {
         if (!IsCollectionGenericType<TSource, TDestination>(out var sourceArgumentType, out var destinationArgumentType, out var definitionGenericType))
         {
-            return default;
+            collectionResult = default!;
+            return false;
         }
 
         var mapperType = typeof(IObjectMapper<,>).MakeGenericType(sourceArgumentType, destinationArgumentType);
@@ -137,7 +133,8 @@ public class DefaultObjectMapper : IObjectMapper, ITransientDependency
         if (specificMapper == null)
         {
             //skip, no specific mapper
-            return default;
+            collectionResult = default!;
+            return false;
         }
 
         var cacheKey = $"{mapperType.FullName}_{(destination == null ? "MapMethodWithSingleParameter" : "MapMethodWithDoubleParameters")}";
@@ -212,11 +209,13 @@ public class DefaultObjectMapper : IObjectMapper, ITransientDependency
         if (destination != null && destination.GetType().IsArray)
         {
             //Return the new collection if destination is an array,  We won't change array just same behavior as AutoMapper.
-            return (TDestination)result;
+            collectionResult = (TDestination)result;
+            return true;
         }
 
         //Return the destination if destination exists. The parameter reference equals with return object.
-        return destination ?? (TDestination)result;
+        collectionResult = destination ?? (TDestination)result;
+        return true;
     }
 
     protected virtual bool IsCollectionGenericType<TSource, TDestination>(out Type sourceArgumentType, out Type destinationArgumentType, out Type definitionGenericType)

--- a/framework/src/Volo.Abp.ObjectMapping/Volo/Abp/ObjectMapping/DefaultObjectMapper.cs
+++ b/framework/src/Volo.Abp.ObjectMapping/Volo/Abp/ObjectMapping/DefaultObjectMapper.cs
@@ -55,10 +55,13 @@ public class DefaultObjectMapper : IObjectMapper, ITransientDependency
                 return specificMapper.Map(source);
             }
 
-            var result = TryToMapCollection<TSource, TDestination>(scope, source, default);
-            if (result != null)
+            if (!(typeof(TSource).IsEnum || typeof(TSource).IsPrimitive))
             {
-                return result;
+                var result = TryToMapCollection<TSource, TDestination>(scope, source, default);
+                if (result != null)
+                {
+                    return result;
+                }
             }
         }
 

--- a/framework/test/Volo.Abp.AutoMapper.Tests/Volo/Abp/AutoMapper/AbpAutoMapperModule_Basic_Tests.cs
+++ b/framework/test/Volo.Abp.AutoMapper.Tests/Volo/Abp/AutoMapper/AbpAutoMapperModule_Basic_Tests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
 using Volo.Abp.AutoMapper.SampleClasses;
 using Volo.Abp.ObjectMapping;
@@ -34,6 +35,13 @@ public class AbpAutoMapperModule_Basic_Tests : AbpIntegratedTest<AutoMapperTestM
     {
         var dto = _objectMapper.Map<MyEntity, MyEntityDto>(new MyEntity { Number = 42 });
         dto.Number.ShouldBe(42);
+    }
+
+    [Fact]
+    public void Should_Map_Enum()
+    {
+        var dto = _objectMapper.Map<MyEnum, MyEnumDto>(MyEnum.Value3);
+        dto.ShouldBe(MyEnumDto.Value3);
     }
 
     //[Fact] TODO: Disabled because of https://github.com/AutoMapper/AutoMapper/pull/2379#issuecomment-355899664

--- a/framework/test/Volo.Abp.AutoMapper.Tests/Volo/Abp/AutoMapper/AbpAutoMapperModule_Basic_Tests.cs
+++ b/framework/test/Volo.Abp.AutoMapper.Tests/Volo/Abp/AutoMapper/AbpAutoMapperModule_Basic_Tests.cs
@@ -41,7 +41,7 @@ public class AbpAutoMapperModule_Basic_Tests : AbpIntegratedTest<AutoMapperTestM
     public void Should_Map_Enum()
     {
         var dto = _objectMapper.Map<MyEnum, MyEnumDto>(MyEnum.Value3);
-        dto.ShouldBe(MyEnumDto.Value3);
+        dto.ShouldBe(MyEnumDto.Value2); //Value2 is same as Value3
     }
 
     //[Fact] TODO: Disabled because of https://github.com/AutoMapper/AutoMapper/pull/2379#issuecomment-355899664

--- a/framework/test/Volo.Abp.AutoMapper.Tests/Volo/Abp/AutoMapper/SampleClasses/MyEnum.cs
+++ b/framework/test/Volo.Abp.AutoMapper.Tests/Volo/Abp/AutoMapper/SampleClasses/MyEnum.cs
@@ -1,0 +1,8 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Volo.Abp.AutoMapper.SampleClasses;
+public enum MyEnum { Value1, Value2, Value3 };

--- a/framework/test/Volo.Abp.AutoMapper.Tests/Volo/Abp/AutoMapper/SampleClasses/MyEnum.cs
+++ b/framework/test/Volo.Abp.AutoMapper.Tests/Volo/Abp/AutoMapper/SampleClasses/MyEnum.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Volo.Abp.AutoMapper.SampleClasses;
 
-namespace Volo.Abp.AutoMapper.SampleClasses;
-public enum MyEnum { Value1, Value2, Value3 };
+public enum MyEnum
+{
+    Value1 = 1,
+    Value2,
+    Value3
+}

--- a/framework/test/Volo.Abp.AutoMapper.Tests/Volo/Abp/AutoMapper/SampleClasses/MyEnumDto.cs
+++ b/framework/test/Volo.Abp.AutoMapper.Tests/Volo/Abp/AutoMapper/SampleClasses/MyEnumDto.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Volo.Abp.AutoMapper.SampleClasses;
 
-namespace Volo.Abp.AutoMapper.SampleClasses;
-public enum MyEnumDto { Value1, Value2, Value3 };
+public enum MyEnumDto
+{
+    Value1 = 2,
+    Value2,
+    Value3
+}

--- a/framework/test/Volo.Abp.AutoMapper.Tests/Volo/Abp/AutoMapper/SampleClasses/MyEnumDto.cs
+++ b/framework/test/Volo.Abp.AutoMapper.Tests/Volo/Abp/AutoMapper/SampleClasses/MyEnumDto.cs
@@ -1,0 +1,8 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Volo.Abp.AutoMapper.SampleClasses;
+public enum MyEnumDto { Value1, Value2, Value3 };

--- a/framework/test/Volo.Abp.AutoMapper.Tests/Volo/Abp/AutoMapper/SampleClasses/MyMapProfile.cs
+++ b/framework/test/Volo.Abp.AutoMapper.Tests/Volo/Abp/AutoMapper/SampleClasses/MyMapProfile.cs
@@ -9,6 +9,8 @@ public class MyMapProfile : Profile
     {
         CreateMap<MyEntity, MyEntityDto>().ReverseMap();
 
+        CreateMap<MyEnum, MyEnumDto>().ReverseMap();
+
         CreateMap<ExtensibleTestPerson, ExtensibleTestPersonDto>()
             .MapExtraProperties(ignoredProperties: new[] { "CityName" });
 


### PR DESCRIPTION
Before always the default value of the enum was returned from the Map function

### Description

Resolves #21659

Object mapping does not work when source and destination are of type enum.
I added an additional check to DefaultObjectMapper.Map function that fixes this problem.

### Checklist

- [ ] I fully tested it as developer / designer and created unit / integration tests
- [ ] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

Test: AbpAutoMapperModule_Basic_Tests.Should_Map_Enum()
