### PR TITLE
Ignore `defaultLanguage` if there is only one language.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore/Microsoft/AspNetCore/RequestLocalization/DefaultAbpRequestLocalizationOptionsProvider.cs
+++ b/framework/src/Volo.Abp.AspNetCore/Microsoft/AspNetCore/RequestLocalization/DefaultAbpRequestLocalizationOptionsProvider.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using DeviceDetectorNET;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Localization;
 using Microsoft.Extensions.DependencyInjection;
@@ -57,7 +58,7 @@ public class DefaultAbpRequestLocalizationOptionsProvider :
                             ? new RequestLocalizationOptions()
                             : new RequestLocalizationOptions
                             {
-                                DefaultRequestCulture = DefaultGetRequestCulture(defaultLanguage, languages),
+                                DefaultRequestCulture = GetDefaultRequestCulture(defaultLanguage, languages),
                                 SupportedCultures = languages
                                     .Select(l => l.CultureName)
                                     .Distinct()
@@ -87,15 +88,22 @@ public class DefaultAbpRequestLocalizationOptionsProvider :
         return _requestLocalizationOptions;
     }
 
-    private static RequestCulture DefaultGetRequestCulture(string? defaultLanguage, IReadOnlyList<LanguageInfo> languages)
+    private static RequestCulture GetDefaultRequestCulture(string? defaultLanguage, IReadOnlyList<LanguageInfo> languages)
     {
         if (defaultLanguage == null)
+        {
+            var firstLanguage = languages.FirstOrDefault() ?? new LanguageInfo("en", "en");
+            return new RequestCulture(firstLanguage.CultureName, firstLanguage.UiCultureName);
+        }
+
+        var (cultureName, uiCultureName) = LocalizationSettingHelper.ParseLanguageSetting(defaultLanguage);
+
+        if (languages.Any() && languages.All(l => l.CultureName != cultureName))
         {
             var firstLanguage = languages.First();
             return new RequestCulture(firstLanguage.CultureName, firstLanguage.UiCultureName);
         }
 
-        var (cultureName, uiCultureName) = LocalizationSettingHelper.ParseLanguageSetting(defaultLanguage);
         return new RequestCulture(cultureName, uiCultureName);
     }
 

--- a/framework/src/Volo.Abp.Localization/Volo/Abp/Localization/LocalizationSettingHelper.cs
+++ b/framework/src/Volo.Abp.Localization/Volo/Abp/Localization/LocalizationSettingHelper.cs
@@ -8,17 +8,25 @@ public static class LocalizationSettingHelper
     /// Gets a setting value like "en-US;en" and returns as splitted values like ("en-US", "en").
     /// </summary>
     /// <param name="settingValue"></param>
+    /// <param name="defaultCultureName"></param>
     /// <returns></returns>
-    public static (string cultureName, string uiCultureName) ParseLanguageSetting([NotNull] string settingValue)
+    public static (string cultureName, string uiCultureName) ParseLanguageSetting([NotNull] string settingValue, string defaultCultureName = "en")
     {
         Check.NotNull(settingValue, nameof(settingValue));
 
         if (!settingValue.Contains(";"))
         {
-            return (settingValue, settingValue);
+            return CultureHelper.IsValidCultureCode(settingValue)
+                ? (settingValue, settingValue)
+                : (defaultCultureName, defaultCultureName);
         }
 
         var splitted = settingValue.Split(';');
-        return (splitted[0], splitted[1]);
+        if (splitted.Length == 2 && CultureHelper.IsValidCultureCode(splitted[0]) && CultureHelper.IsValidCultureCode(splitted[1]))
+        {
+            return (splitted[0], splitted[1]);
+        }
+
+        return (defaultCultureName, defaultCultureName);
     }
 }


### PR DESCRIPTION
Resolves #21301


1. **If `defaultLanguage` is `null`, take the first language from `languages`.**
2. **If `defaultLanguage` is provided and `cultureName` exists in `languages`, use it.**
3. **If `defaultLanguage` is provided but `cultureName` is not in `languages`, fallback to the first language in `languages`.**
