### PR TITLE
Fix: Docs permission problem

### DIFF
--- a/modules/docs/.abpstudio/state.json
+++ b/modules/docs/.abpstudio/state.json
@@ -1,0 +1,16 @@
+﻿{
+  "selectedKubernetesProfile": null,
+  "solutionRunner": {
+    "selectedProfile": "Default",
+    "targetFrameworks": [],
+    "applicationsStartingWithoutBuild": [],
+    "applicationBatchStartStates": [
+      {
+        "profile": "Default",
+        "applicationOrFolder": "VoloDocs.Web",
+        "value": 0
+      }
+    ],
+    "folderBatchStartStates": []
+  }
+}

--- a/modules/docs/Default.abprun.json
+++ b/modules/docs/Default.abprun.json
@@ -1,0 +1,11 @@
+{
+  "metadata": {},
+  "applications": {
+    "VoloDocs.Web": {
+      "type": "dotnet-project",
+      "path": "app/VoloDocs.Web/VoloDocs.Web.csproj",
+      "launchUrl": "https://localhost:5001",
+      "kubernetesService": null
+    }
+  }
+}

--- a/modules/docs/Volo.Docs.abpsln
+++ b/modules/docs/Volo.Docs.abpsln
@@ -3,5 +3,11 @@
     "Volo.Docs": {
       "path": "Volo.Docs.abpmdl"
     }
+  },
+  "id": "c1d848e0-0b53-461b-824a-8533ba1fd82b",
+  "runProfiles": {
+    "Default": {
+      "path": "Default.abprun.json"
+    }
   }
 }

--- a/modules/docs/src/Volo.Docs.Admin.Application.Contracts/Volo/Docs/Admin/Documents/IDocumentAdminAppService.cs
+++ b/modules/docs/src/Volo.Docs.Admin.Application.Contracts/Volo/Docs/Admin/Documents/IDocumentAdminAppService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
+using Volo.Docs.Admin.Projects;
 
 namespace Volo.Docs.Admin.Documents
 {
@@ -21,5 +22,7 @@ namespace Volo.Docs.Admin.Documents
         Task ReindexAsync(Guid documentId);
 
         Task<List<DocumentInfoDto>> GetFilterItemsAsync();
+
+        Task<List<ProjectWithoutDetailsDto>> GetProjectsAsync();
     }
 }

--- a/modules/docs/src/Volo.Docs.Admin.Application/Volo/Docs/Admin/Documents/DocumentAdminAppService.cs
+++ b/modules/docs/src/Volo.Docs.Admin.Application/Volo/Docs/Admin/Documents/DocumentAdminAppService.cs
@@ -8,6 +8,7 @@ using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 using Volo.Abp.Caching;
+using Volo.Docs.Admin.Projects;
 using Volo.Docs.Caching;
 using Volo.Docs.Documents;
 using Volo.Docs.Documents.FullSearch.Elastic;
@@ -218,6 +219,12 @@ namespace Volo.Docs.Admin.Documents
         {
             var documents = await _documentRepository.GetUniqueListDocumentInfoAsync();
             return ObjectMapper.Map<List<DocumentInfo>, List<DocumentInfoDto>>(documents);
+        }
+
+        public virtual async Task<List<ProjectWithoutDetailsDto>> GetProjectsAsync()
+        {
+            var projects = await _projectRepository.GetListWithoutDetailsAsync();
+            return ObjectMapper.Map<List<ProjectWithoutDetails>, List<ProjectWithoutDetailsDto>>(projects);
         }
 
 

--- a/modules/docs/src/Volo.Docs.Admin.HttpApi.Client/ClientProxies/Volo/Docs/Admin/DocumentsAdminClientProxy.Generated.cs
+++ b/modules/docs/src/Volo.Docs.Admin.HttpApi.Client/ClientProxies/Volo/Docs/Admin/DocumentsAdminClientProxy.Generated.cs
@@ -9,6 +9,7 @@ using Volo.Abp.Http.Client;
 using Volo.Abp.Http.Client.ClientProxying;
 using Volo.Abp.Http.Modeling;
 using Volo.Docs.Admin.Documents;
+using Volo.Docs.Admin.Projects;
 
 // ReSharper disable once CheckNamespace
 namespace Volo.Docs.Admin;
@@ -68,5 +69,10 @@ public partial class DocumentsAdminClientProxy : ClientProxyBase<IDocumentAdminA
     public virtual async Task<List<DocumentInfoDto>> GetFilterItemsAsync()
     {
         return await RequestAsync<List<DocumentInfoDto>>(nameof(GetFilterItemsAsync));
+    }
+
+    public virtual async Task<List<ProjectWithoutDetailsDto>> GetProjectsAsync()
+    {
+        return await RequestAsync<List<ProjectWithoutDetailsDto>>(nameof(GetProjectsAsync));
     }
 }

--- a/modules/docs/src/Volo.Docs.Admin.HttpApi.Client/ClientProxies/Volo/Docs/Admin/docs-admin-generate-proxy.json
+++ b/modules/docs/src/Volo.Docs.Admin.HttpApi.Client/ClientProxies/Volo/Docs/Admin/docs-admin-generate-proxy.json
@@ -125,6 +125,14 @@
                     "type": "System.Collections.Generic.List<Volo.Docs.Admin.Documents.DocumentInfoDto>",
                     "typeSimple": "[Volo.Docs.Admin.Documents.DocumentInfoDto]"
                   }
+                },
+                {
+                  "name": "GetProjectsAsync",
+                  "parametersOnMethod": [],
+                  "returnValue": {
+                    "type": "System.Collections.Generic.List<Volo.Docs.Admin.Projects.ProjectWithoutDetailsDto>",
+                    "typeSimple": "[Volo.Docs.Admin.Projects.ProjectWithoutDetailsDto]"
+                  }
                 }
               ]
             }
@@ -555,6 +563,21 @@
               "returnValue": {
                 "type": "System.Collections.Generic.List<Volo.Docs.Admin.Documents.DocumentInfoDto>",
                 "typeSimple": "[Volo.Docs.Admin.Documents.DocumentInfoDto]"
+              },
+              "allowAnonymous": null,
+              "implementFrom": "Volo.Docs.Admin.Documents.IDocumentAdminAppService"
+            },
+            "GetProjectsAsync": {
+              "uniqueName": "GetProjectsAsync",
+              "name": "GetProjectsAsync",
+              "httpMethod": "GET",
+              "url": "api/docs/admin/documents/GetProjects",
+              "supportedVersions": [],
+              "parametersOnMethod": [],
+              "parameters": [],
+              "returnValue": {
+                "type": "System.Collections.Generic.List<Volo.Docs.Admin.Projects.ProjectWithoutDetailsDto>",
+                "typeSimple": "[Volo.Docs.Admin.Projects.ProjectWithoutDetailsDto]"
               },
               "allowAnonymous": null,
               "implementFrom": "Volo.Docs.Admin.Documents.IDocumentAdminAppService"

--- a/modules/docs/src/Volo.Docs.Admin.HttpApi.Client/Volo.Docs.Admin.HttpApi.Client.abppkg
+++ b/modules/docs/src/Volo.Docs.Admin.HttpApi.Client/Volo.Docs.Admin.HttpApi.Client.abppkg
@@ -1,3 +1,15 @@
 {
-  "role": "lib.http-api-client"
+  "role": "lib.http-api-client",
+  "proxies": {
+    "csharp": {
+      "VoloDocs.Web-docs-admin": {
+        "applicationName": "VoloDocs.Web",
+        "module": "docs-admin",
+        "url": "https://localhost:5001",
+        "folder": "ClientProxies\\Volo\\Docs\\Admin",
+        "serviceType": "application",
+        "withoutContracts": true
+      }
+    }
+  }
 }

--- a/modules/docs/src/Volo.Docs.Admin.HttpApi/Volo/Docs/Admin/DocumentsAdminController.cs
+++ b/modules/docs/src/Volo.Docs.Admin.HttpApi/Volo/Docs/Admin/DocumentsAdminController.cs
@@ -7,6 +7,7 @@ using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.AspNetCore.Mvc;
 using Volo.Docs.Admin.Documents;
+using Volo.Docs.Admin.Projects;
 
 namespace Volo.Docs.Admin
 {
@@ -70,6 +71,13 @@ namespace Volo.Docs.Admin
         public virtual async Task<List<DocumentInfoDto>> GetFilterItemsAsync()
         {
             return await _documentAdminAppService.GetFilterItemsAsync();
+        }
+
+        [HttpGet]
+        [Route("GetProjects")]
+        public virtual Task<List<ProjectWithoutDetailsDto>> GetProjectsAsync()
+        {
+            return _documentAdminAppService.GetProjectsAsync();
         }
     }
 }

--- a/modules/docs/src/Volo.Docs.Admin.Web/Pages/Docs/Admin/Documents/Index.cshtml.cs
+++ b/modules/docs/src/Volo.Docs.Admin.Web/Pages/Docs/Admin/Documents/Index.cshtml.cs
@@ -2,23 +2,24 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Volo.Docs.Admin.Documents;
 using Volo.Docs.Admin.Projects;
 
 namespace Volo.Docs.Admin.Pages.Docs.Admin.Documents;
 
-[Authorize(DocsAdminPermissions.Projects.Default)]
+[Authorize(DocsAdminPermissions.Documents.Default)]
 public class IndexModel : DocsAdminPageModel
 {
-    private readonly IProjectAdminAppService _projectAdminAppService;
+    private readonly IDocumentAdminAppService _documentAdminAppService;
     public List<ProjectWithoutDetailsDto> Projects { get; set; }
 
-    public IndexModel(IProjectAdminAppService projectAdminAppService)
+    public IndexModel(IDocumentAdminAppService documentAdminAppService)
     {
-        _projectAdminAppService = projectAdminAppService;
+        _documentAdminAppService = documentAdminAppService;
     }
     public virtual async Task<IActionResult> OnGet()
     {
-        Projects = await _projectAdminAppService.GetListWithoutDetailsAsync();
+        Projects = await _documentAdminAppService.GetProjectsAsync();
         return Page();
     }
 }

--- a/modules/docs/src/Volo.Docs.Admin.Web/Volo.Docs.Admin.Web.abppkg
+++ b/modules/docs/src/Volo.Docs.Admin.Web/Volo.Docs.Admin.Web.abppkg
@@ -1,3 +1,14 @@
 {
-  "role": "lib.mvc"
+  "role": "lib.mvc",
+  "proxies": {
+    "Javascript": {
+      "VoloDocs.Web-docs-admin": {
+        "applicationName": "VoloDocs.Web",
+        "module": "docs-admin",
+        "url": "https://localhost:5001",
+        "output": "wwwroot/client-proxies",
+        "serviceType": "application"
+      }
+    }
+  }
 }

--- a/modules/docs/src/Volo.Docs.Admin.Web/wwwroot/client-proxies/docs-admin-proxy.js
+++ b/modules/docs/src/Volo.Docs.Admin.Web/wwwroot/client-proxies/docs-admin-proxy.js
@@ -68,6 +68,13 @@
       }, ajaxParams));
     };
 
+    volo.docs.admin.documentsAdmin.getProjects = function(ajaxParams) {
+      return abp.ajax($.extend(true, {
+        url: abp.appPath + 'api/docs/admin/documents/GetProjects',
+        type: 'GET'
+      }, ajaxParams));
+    };
+
   })();
 
   // controller volo.docs.admin.projectsAdmin


### PR DESCRIPTION
### Description

Accessing the Docs/Admin/Documents page previously required both the Documents permission and the Project permission. The dependency on the Project permission has been removed.

### Checklist

- [x] I fully tested it as developer

