### PR TITLE
Do not set `StatusCode` to `NoContent` if `Response.Body` has been written.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/Response/AbpNoContentActionFilter.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/Response/AbpNoContentActionFilter.cs
@@ -26,6 +26,12 @@ public class AbpNoContentActionFilter : IAsyncActionFilter, IAbpFilter, ITransie
             var returnType = context.ActionDescriptor.GetReturnType();
             if (returnType == typeof(Task) || returnType == typeof(void))
             {
+                if (context.HttpContext.Response.Body.CanSeek && context.HttpContext.Response.Body.Length != 0)
+                {
+                    // Body has been written, so we should not change the status code.
+                    return;
+                }
+
                 context.HttpContext.Response.StatusCode = (int)HttpStatusCode.NoContent;
             }
         }

--- a/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/Response/NoContentTestController.cs
+++ b/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/Response/NoContentTestController.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Text;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Volo.Abp.AspNetCore.Mvc.Response;
@@ -54,5 +56,12 @@ public class NoContentTestController : AbpController
     public async Task TestAsyncMethodWithResultFilter()
     {
         await Task.CompletedTask;
+    }
+
+    [HttpGet]
+    [Route("TestAsyncMethodChangeBody")]
+    public async Task TestAsyncMethodChangeBody()
+    {
+        await Response.Body.WriteAsync("TestBody"u8.ToArray());
     }
 }

--- a/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/Response/NoContentTestController_Tests.cs
+++ b/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/Response/NoContentTestController_Tests.cs
@@ -55,4 +55,12 @@ public class NoContentTestController_Tests : AspNetCoreMvcTestBase
         var result = await GetResponseAsync("/api/NoContent-Test/TestAsyncMethodWithResultFilter");
         result.StatusCode.ShouldBe(HttpStatusCode.OK);
     }
+
+    [Fact]
+    public async Task Should_Not_Set_No_Content_If_Body_Changed()
+    {
+        var result = await GetResponseAsync("/api/NoContent-Test/TestAsyncMethodChangeBody");
+        result.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
 }


### PR DESCRIPTION
https://abp.io/support/questions/8570/Abp-Studio-Middleware-Problem-When--try-to-flush-outputstream-ResponseBodyOutputStream
