### PR TITLE
Using `X509CertificateLoader` instead of `new X509Certificate2`.

### DIFF
--- a/modules/openiddict/src/Volo.Abp.OpenIddict.AspNetCore/Microsoft/Extensions/DependencyInjection/OpenIddictServerBuilderExtensions.cs
+++ b/modules/openiddict/src/Volo.Abp.OpenIddict.AspNetCore/Microsoft/Extensions/DependencyInjection/OpenIddictServerBuilderExtensions.cs
@@ -13,8 +13,8 @@ public static class OpenIddictServerBuilderExtensions
         }
 
         var certificate = flag != null
-            ? new X509Certificate2(fileName, passPhrase, flag.Value)
-            : new X509Certificate2(fileName, passPhrase);
+            ? X509CertificateLoader.LoadPkcs12FromFile(fileName, passPhrase, flag.Value)
+            : X509CertificateLoader.LoadPkcs12FromFile(fileName, passPhrase);
 
         builder.AddSigningCertificate(certificate);
         builder.AddEncryptionCertificate(certificate);


### PR DESCRIPTION
Resolve #21839

https://learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib0057#workaround