### PR TITLE
Update AbpTabTagHelperService.cs.  Fix content-class attributes to use the .Value property

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Tab/AbpTabTagHelperService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Tab/AbpTabTagHelperService.cs
@@ -89,7 +89,7 @@ public class AbpTabTagHelperService : AbpTagHelperService<AbpTabTagHelper>
         var id = TagHelper.Name;
         var attributes = GetTabContentAttributes(context, output);
 
-        var classAttributesAsString = attributes.Where(a => a.Name == "class").ToList().Select(a => a.Name).JoinAsString(" ");
+        var classAttributesAsString = attributes.Where(a => a.Name == "class").ToList().Select(a => a.Value).JoinAsString(" ");
         var otherAttributes = attributes.Where(a => a.Name != "class").ToList();
 
         var wrapper = new TagBuilder("div");


### PR DESCRIPTION
…e the .Value property

This needs to use the .Value property of the 'content-class' attribute, just like on line 37 where it uses the .Value property of the 'header-class' attribute.

### Description

Resolves #xxxx (write the related issue number if available)

TODO: Describe what this PR has changed, add screenshot or animated GIF if available, write if it is a breaking change, and how to fix the breaking changes for existing applications if so.

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

Add the following tag
```
<abp-tabs>
<abp-tab content-class="border">
</abp-tab>
</abp-tabs>
```
It should display a border around the content and add "border" to the <div class="border"> for the tab conent.
