### PR TITLE
Clear Breadcrumbs & Page ToolbarItems while disposing PageHeader

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Layout/PageHeader.razor.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Layout/PageHeader.razor.cs
@@ -4,10 +4,11 @@ using System.Threading.Tasks;
 using Volo.Abp.AspNetCore.Components.Web.Theming.PageToolbars;
 using Volo.Abp.BlazoriseUI;
 using System.Linq;
+using System;
 
 namespace Volo.Abp.AspNetCore.Components.Web.Theming.Layout;
 
-public partial class PageHeader : ComponentBase
+public partial class PageHeader : ComponentBase, IDisposable
 {
     protected List<RenderFragment> ToolbarItemRenders { get; set; }
 
@@ -106,5 +107,12 @@ public partial class PageHeader : ComponentBase
     protected async override Task OnInitializedAsync()
     {
         await base.OnInitializedAsync();
+    }
+    
+    public void Dispose()
+    {
+        PageLayout.ToolbarItems.Clear();
+        PageLayout.BreadcrumbItems.Clear();
+        ToolbarItemRenders.Clear();
     }
 }


### PR DESCRIPTION


### Description

Resolves https://github.com/abpframework/abp/issues/21185

Implement IDisposable in PageHeader component to clear toolbar and breadcrumb items on disposal.

> ⚠️ This may cause other issues with multiple `PageHeader` component usage in a same page. But this is not the main scenario at the moment.

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

![blazor-pageheader](https://github.com/user-attachments/assets/a7b8f3c0-e849-473b-b47c-3791a28c70bd)
