### PR TITLE
Angular - Fixing proxy generation problem for the enum type

### DIFF
--- a/npm/ng-packs/packages/schematics/src/utils/model.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/model.ts
@@ -148,7 +148,7 @@ export function createImportRefToInterfaceReducerCreator(params: ModelGeneratorP
     typeDef.properties?.forEach(prop => {
       let name = prop.jsonName || camel(prop.name);
       name = shouldQuote(name) ? `'${name}'` : name;
-      const type = simplifyType(prop.typeSimple);
+      const type = simplifyType(prop.type);
       const refs = parseType(prop.type).reduce(
         (acc: string[], r) => acc.concat(parseGenerics(r).toGenerics()),
         [],


### PR DESCRIPTION
### Description

Resolves #21910 and relates https://github.com/abpframework/abp/pull/21675

### Checklist

- [X] I fully tested it as developer / designer and created unit / integration tests
- [X] No need for an action for the documentation

### How to test it?

I have used **this service**
```c#
//ProductAppService.cs

using System;
using System.Collections.Generic;
using System.Threading.Tasks;

using MyCompanyName.MyProjectName.TeklifEnum;
using MyCompanyName.MyProjectName.Teklif;

namespace MyCompanyName.MyProjectName.Services
{
    public class ProductAppService : MyProjectNameAppService
    {
        public async Task<TeklifDto> GetListAsync()
        {
            await Task.Delay(100);

            return new TeklifDto
            {
                IhtiyacId = Guid.NewGuid(),
                Tip = TeklifTip.Tip1, 
            };
        }
    }
}
```

along with these example enum and dto

```c#
// TeklifEnum.cs

namespace MyCompanyName.MyProjectName.TeklifEnum
{
    public enum TeklifTip
    {
        Tip1,
        Tip2,
        Tip3
    }
}
```

```c#
//TeklifDto.cs

using System;
using Volo.Abp.Application.Dtos;
using MyCompanyName.MyProjectName.TeklifEnum;

namespace MyCompanyName.MyProjectName.Teklif
{
    public class TeklifDto : EntityDto<Guid>
    {
        public Guid IhtiyacId { get; set; }
        public TeklifTip Tip { get; set; }
        public double? BirimFiyat { get; set; }
        public double? TeklifFiyat { get; set; }
        public int? KdvOran { get; set; }
        public double? KdvTutar { get; set; }
        public double? Toplam { get; set; }
        public string? Aciklama { get; set; }
    }
}
```
