### PR TITLE
Publish `DistributedEventSent/DistributedEventReceived ` events in unit test for testing.

### DIFF
--- a/framework/src/Volo.Abp.EventBus/Volo/Abp/EventBus/Distributed/LocalDistributedEventBus.cs
+++ b/framework/src/Volo.Abp.EventBus/Volo/Abp/EventBus/Distributed/LocalDistributedEventBus.cs
@@ -28,30 +28,6 @@ public class LocalDistributedEventBus : IDistributedEventBus, ISingletonDependen
         ServiceScopeFactory = serviceScopeFactory;
         AbpDistributedEventBusOptions = distributedEventBusOptions.Value;
         Subscribe(distributedEventBusOptions.Value.Handlers);
-
-        // For unit testing
-        if (localEventBus is LocalEventBus eventBus)
-        {
-            eventBus.OnEventHandleInvoking = async (eventType, eventData) =>
-            {
-                await localEventBus.PublishAsync(new DistributedEventReceived()
-                {
-                    Source = DistributedEventSource.Direct,
-                    EventName = EventNameAttribute.GetNameOrDefault(eventType),
-                    EventData = eventData
-                }, onUnitOfWorkComplete: false);
-            };
-
-            eventBus.OnPublishing = async (eventType, eventData) =>
-            {
-                await localEventBus.PublishAsync(new DistributedEventSent()
-                {
-                    Source = DistributedEventSource.Direct,
-                    EventName = EventNameAttribute.GetNameOrDefault(eventType),
-                    EventData = eventData
-                }, onUnitOfWorkComplete: false);
-            };
-        }
     }
 
     public virtual void Subscribe(ITypeList<IEventHandler> handlers)

--- a/framework/src/Volo.Abp.EventBus/Volo/Abp/EventBus/Local/LocalEventBus.cs
+++ b/framework/src/Volo.Abp.EventBus/Volo/Abp/EventBus/Local/LocalEventBus.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Volo.Abp.DependencyInjection;
-using Volo.Abp.EventBus.Distributed;
 using Volo.Abp.MultiTenancy;
 using Volo.Abp.Reflection;
 using Volo.Abp.Threading;
@@ -174,46 +173,5 @@ public class LocalEventBus : EventBusBase, ILocalEventBus, ISingletonDependency
         }
 
         return false;
-    }
-
-    // Internal for unit testing
-    internal Func<Type, object, Task>? OnEventHandleInvoking { get; set; }
-
-    // Internal for unit testing
-    protected async override Task InvokeEventHandlerAsync(IEventHandler eventHandler, object eventData, Type eventType)
-    {
-        if (OnEventHandleInvoking != null && eventType != typeof(DistributedEventSent) && eventType != typeof(DistributedEventReceived))
-        {
-            await OnEventHandleInvoking(eventType, eventData);
-        }
-
-        await base.InvokeEventHandlerAsync(eventHandler, eventData, eventType);
-    }
-
-    // Internal for unit testing
-    internal Func<Type, object, Task>? OnPublishing { get; set; }
-
-    // For unit testing
-    public async override Task PublishAsync(
-        Type eventType,
-        object eventData,
-        bool onUnitOfWorkComplete = true)
-    {
-        if (onUnitOfWorkComplete && UnitOfWorkManager.Current != null)
-        {
-            AddToUnitOfWork(
-                UnitOfWorkManager.Current,
-                new UnitOfWorkEventRecord(eventType, eventData, EventOrderGenerator.GetNext())
-            );
-            return;
-        }
-
-        // For unit testing
-        if (OnPublishing != null && eventType != typeof(DistributedEventSent) && eventType != typeof(DistributedEventReceived))
-        {
-            await OnPublishing(eventType, eventData);
-        }
-
-        await PublishToEventBusAsync(eventType, eventData);
     }
 }

--- a/framework/test/Volo.Abp.EventBus.Tests/Volo/Abp/EventBus/Distributed/UnitTestLocalEventBus.cs
+++ b/framework/test/Volo.Abp.EventBus.Tests/Volo/Abp/EventBus/Distributed/UnitTestLocalEventBus.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Volo.Abp.EventBus.Local;
+using Volo.Abp.MultiTenancy;
+using Volo.Abp.Uow;
+
+namespace Volo.Abp.EventBus.Distributed;
+
+/// <summary>
+/// This class is used in unit tests and supports to publish DistributedEventSent and DistributedEventReceived events.
+/// </summary>
+public class UnitTestLocalEventBus : LocalEventBus
+{
+    public UnitTestLocalEventBus(
+        [NotNull] IOptions<AbpLocalEventBusOptions> options,
+        [NotNull] IServiceScopeFactory serviceScopeFactory,
+        [NotNull] ICurrentTenant currentTenant,
+        [NotNull] IUnitOfWorkManager unitOfWorkManager,
+        [NotNull] IEventHandlerInvoker eventHandlerInvoker)
+        : base(options, serviceScopeFactory, currentTenant, unitOfWorkManager, eventHandlerInvoker)
+    {
+    }
+
+    public Func<Type, object, Task> OnEventHandleInvoking { get; set; }
+
+    protected async override Task InvokeEventHandlerAsync(IEventHandler eventHandler, object eventData, Type eventType)
+    {
+        if (OnEventHandleInvoking != null && eventType != typeof(DistributedEventSent) && eventType != typeof(DistributedEventReceived))
+        {
+            await OnEventHandleInvoking(eventType, eventData);
+        }
+
+        await base.InvokeEventHandlerAsync(eventHandler, eventData, eventType);
+    }
+
+    public Func<Type, object, Task> OnPublishing { get; set; }
+
+    public async override Task PublishAsync(
+        Type eventType,
+        object eventData,
+        bool onUnitOfWorkComplete = true)
+    {
+        if (onUnitOfWorkComplete && UnitOfWorkManager.Current != null)
+        {
+            AddToUnitOfWork(
+                UnitOfWorkManager.Current,
+                new UnitOfWorkEventRecord(eventType, eventData, EventOrderGenerator.GetNext())
+            );
+            return;
+        }
+
+        if (OnPublishing != null && eventType != typeof(DistributedEventSent) && eventType != typeof(DistributedEventReceived))
+        {
+            await OnPublishing(eventType, eventData);
+        }
+
+        await PublishToEventBusAsync(eventType, eventData);
+    }
+}


### PR DESCRIPTION
Related https://github.com/abpframework/abp/pull/16333/

The previous [PR](https://github.com/abpframework/abp/pull/16333/) unexpectedly published `DistributedEventSent/DistributedEventReceived` events in `LocalDistributedEventBus`.

---

![image](https://github.com/user-attachments/assets/3d1cd36d-026d-442e-a126-cc5429b6b479)

After adding a distributed event bus provider

![image](https://github.com/user-attachments/assets/b953d578-b3ba-4cc6-ad73-f11b8dbf7d5a)
