### PR TITLE
Critical Bug Fix | Nested generated Distributed Event is not being published

### DIFF
--- a/framework/src/Volo.Abp.Uow/Volo/Abp/Uow/UnitOfWork.cs
+++ b/framework/src/Volo.Abp.Uow/Volo/Abp/Uow/UnitOfWork.cs
@@ -139,15 +139,14 @@ public class UnitOfWork : IUnitOfWork, ITransientDependency
             _isCompleting = true;
             await SaveChangesAsync(cancellationToken);
 
-            DistributedEvents.AddRange(GetEventsRecords(DistributedEventWithPredicates));
-            LocalEvents.AddRange(GetEventsRecords(LocalEventWithPredicates));
+            DistributedEvents.AddRange(ExtractEventsRecords(DistributedEventWithPredicates));
+            LocalEvents.AddRange(ExtractEventsRecords(LocalEventWithPredicates));
 
             while (LocalEvents.Any() || DistributedEvents.Any())
             {
                 if (LocalEvents.Any())
                 {
                     var localEventsToBePublished = LocalEvents.OrderBy(e => e.EventOrder).ToArray();
-                    LocalEventWithPredicates.Clear();
                     LocalEvents.Clear();
                     await UnitOfWorkEventPublisher.PublishLocalEventsAsync(
                         localEventsToBePublished
@@ -157,7 +156,6 @@ public class UnitOfWork : IUnitOfWork, ITransientDependency
                 if (DistributedEvents.Any())
                 {
                     var distributedEventsToBePublished = DistributedEvents.OrderBy(e => e.EventOrder).ToArray();
-                    DistributedEventWithPredicates.Clear();
                     DistributedEvents.Clear();
                     await UnitOfWorkEventPublisher.PublishDistributedEventsAsync(
                         distributedEventsToBePublished
@@ -166,8 +164,8 @@ public class UnitOfWork : IUnitOfWork, ITransientDependency
 
                 await SaveChangesAsync(cancellationToken);
 
-                LocalEvents.AddRange(GetEventsRecords(LocalEventWithPredicates));
-                DistributedEvents.AddRange(GetEventsRecords(DistributedEventWithPredicates));
+                LocalEvents.AddRange(ExtractEventsRecords(LocalEventWithPredicates));
+                DistributedEvents.AddRange(ExtractEventsRecords(DistributedEventWithPredicates));
             }
 
             await CommitTransactionsAsync(cancellationToken);
@@ -294,6 +292,14 @@ public class UnitOfWork : IUnitOfWork, ITransientDependency
         }
 
         return eventRecords;
+    }
+
+    protected virtual List<UnitOfWorkEventRecord> ExtractEventsRecords(
+        List<KeyValuePair<UnitOfWorkEventRecord, Predicate<UnitOfWorkEventRecord>?>> eventWithPredicates)
+    {
+        var eventRecordList = GetEventsRecords(eventWithPredicates);
+        eventWithPredicates.Clear();
+        return eventRecordList;
     }
 
     protected virtual async Task OnCompletedAsync()

--- a/framework/test/Volo.Abp.Uow.Tests/Volo/Abp/Uow/UnitOfWork_Event_Publisher_Tests.cs
+++ b/framework/test/Volo.Abp.Uow.Tests/Volo/Abp/Uow/UnitOfWork_Event_Publisher_Tests.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using NSubstitute;
+using Volo.Abp.Testing;
+
+namespace Volo.Abp.Uow;
+
+public class UnitOfWork_Event_Publisher_Tests : AbpIntegratedTest<AbpUnitOfWorkModule>
+{
+    private readonly IUnitOfWorkManager _unitOfWorkManager;
+    private readonly IUnitOfWorkEventPublisher _mockedUnitOfWorkEventPublisher;
+
+    public UnitOfWork_Event_Publisher_Tests()
+    {
+        _unitOfWorkManager = GetRequiredService<IUnitOfWorkManager>();
+        _mockedUnitOfWorkEventPublisher = GetRequiredService<IUnitOfWorkEventPublisher>();
+    }
+
+    protected override void AfterAddApplication(IServiceCollection services)
+    {
+        services.AddSingleton(Substitute.For<IUnitOfWorkEventPublisher>());
+        base.AfterAddApplication(services);
+    }
+
+    [Fact]
+    public async Task Should_Publish_Nested_Generated_Distributed_Event_On_Complete_Async()
+    {
+        // Arrange
+        using var uow = _unitOfWorkManager.Begin();
+
+        var localEventA = new TestEventData();
+        var distributedEventB = new TestEventData();
+        var nestedDistributedEventC = new TestEventData();
+
+        _mockedUnitOfWorkEventPublisher
+            .PublishLocalEventsAsync(Arg.Any<IEnumerable<UnitOfWorkEventRecord>>())
+            .Returns(_ =>
+            {
+                /* This code simulates a ILocalEventHandler<> that publishes a new distributed event while
+                /* the code is running inside a UnitOfWork.CompleteAsync() call
+                */
+
+                uow.AddOrReplaceDistributedEvent(new UnitOfWorkEventRecord(nestedDistributedEventC.GetType(),
+                    nestedDistributedEventC, 2));
+
+                return Task.CompletedTask;
+            });
+
+        uow.AddOrReplaceLocalEvent(new UnitOfWorkEventRecord(localEventA.GetType(), localEventA, 0));
+        uow.AddOrReplaceDistributedEvent(new UnitOfWorkEventRecord(distributedEventB.GetType(), distributedEventB, 1));
+
+        // Act
+        await uow.CompleteAsync();
+
+        // Assert
+        await _mockedUnitOfWorkEventPublisher.Received(1).PublishLocalEventsAsync(
+            Arg.Is<IEnumerable<UnitOfWorkEventRecord>>(events => events.Any(x => x.EventData == localEventA)));
+
+        await _mockedUnitOfWorkEventPublisher.Received(1).PublishDistributedEventsAsync(
+            Arg.Is<IEnumerable<UnitOfWorkEventRecord>>(events => events.Any(x => x.EventData == distributedEventB)));
+
+        await _mockedUnitOfWorkEventPublisher.Received(1).PublishDistributedEventsAsync(
+            Arg.Is<IEnumerable<UnitOfWorkEventRecord>>(events => events.Any(x => x.EventData == nestedDistributedEventC)));
+    }
+
+    private class TestEventData
+    {
+    }
+}


### PR DESCRIPTION
### Description

This pull request fixes a bug related to the publication of distributed events when they are generated in a nested manner during the completion of a `UnitOfWork`.

**Scenario in Which the Bug Occurs**

1. **Initiating a UnitOfWork**: A new `UnitOfWork` is started.

2. **Appending Events**: Both a **Local Event** and a **Distributed Event** are appended to the `UnitOfWork`.

3. **Completing the UnitOfWork**: The `CompleteAsync` method is called on the `UnitOfWork`.

4. **Handling the Local Event**: The `ILocalEventHandler` for the local event is invoked.

5. **Nested Generation of a Distributed Event**: During the execution of the `ILocalEventHandler`, a new **Distributed Event** is generated in a nested manner.

**Identified Issue**

- The **Distributed Event** generated in step 5 is **not being published** to the `IUnitOfWorkEventPublisher`.
- This occurs because the loop that publishes local and distributed events in `UnitOfWork.CompleteAsync()` is not correctly handling this nestedly generated event.
- As a result, there is a **critical miss in event publication**, leading to potential inconsistencies in the system and affecting functionalities that rely on the proper propagation of distributed events.

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to Test It?

I have included a unit test in this pull request: `Volo.Abp.Uow.UnitOfWork_Event_Publisher_Tests` that tests this scenario. To observe the bug, simply run this test with the previous version of `UnitOfWork.cs` to see the issue occur.