### PR TITLE
Significant Bug Fix | Resolve Deadlock Between Autofac and UnnamedOptionsManager

### DIFF
--- a/framework/src/Volo.Abp.Autofac/Microsoft/Extensions/Hosting/AbpAutofacHostBuilderExtensions.cs
+++ b/framework/src/Volo.Abp.Autofac/Microsoft/Extensions/Hosting/AbpAutofacHostBuilderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using Autofac;
 using Volo.Abp.Autofac;
 using Microsoft.Extensions.DependencyInjection;
+using Volo.Abp;
 
 namespace Microsoft.Extensions.Hosting;
 
@@ -13,6 +14,7 @@ public static class AbpAutofacHostBuilderExtensions
         return hostBuilder.ConfigureServices((_, services) =>
             {
                 services.AddObjectAccessor(containerBuilder);
+                services.AddAbpAutofacUnnamedOptionsManager();
             })
             .UseServiceProviderFactory(new AbpAutofacServiceProviderFactory(containerBuilder));
     }

--- a/framework/src/Volo.Abp.Autofac/Volo/Abp/AbpAutofacAbpApplicationCreationOptionsExtensions.cs
+++ b/framework/src/Volo.Abp.Autofac/Volo/Abp/AbpAutofacAbpApplicationCreationOptionsExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using Autofac;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 using Volo.Abp.Autofac;
 
 namespace Volo.Abp;
@@ -22,7 +24,13 @@ public static class AbpAutofacAbpApplicationCreationOptionsExtensions
 
         services.AddObjectAccessor(containerBuilder);
         services.AddSingleton((IServiceProviderFactory<ContainerBuilder>)factory);
+        services.AddAbpAutofacUnnamedOptionsManager();
 
         return factory;
+    }
+
+    internal static void AddAbpAutofacUnnamedOptionsManager(this IServiceCollection services)
+    {
+        services.Replace(ServiceDescriptor.Singleton(typeof(IOptions<>), typeof(AbpAutofacUnnamedOptionsManager<>)));
     }
 }

--- a/framework/src/Volo.Abp.Autofac/Volo/Abp/Autofac/AbpAutofacUnamedOptionsManager.cs
+++ b/framework/src/Volo.Abp.Autofac/Volo/Abp/Autofac/AbpAutofacUnamedOptionsManager.cs
@@ -1,0 +1,46 @@
+﻿using System.Threading;
+using Microsoft.Extensions.Options;
+
+namespace Volo.Abp.Autofac;
+
+/// <summary>
+/// The <see cref="AbpAutofacUnnamedOptionsManager"/> class is designed to replace the default
+/// <see cref="Microsoft.Extensions.Options.UnnamedOptionsManager"/> in Microsoft.Extensions.Options.
+/// The default implementation can lead to deadlocks with Autofac when resolving <see cref="IOptions{TOptions}"/>
+/// that have dependencies managed by Autofac.
+///
+/// Deadlocks occur in the following scenarios due to a lack of ordering in lock acquisition:
+///     * "Microsoft.Extensions.Options.UnnamedOptionsManager.get_Value" locking "_syncObj".
+///     * "Autofac.Core.Lifetime.LifetimeScope.CreateSharedInstance" locking "_synchRoot".
+/// </summary>
+/// <typeparam name="TOptions">The type of options being managed.</typeparam>
+public sealed class AbpAutofacUnnamedOptionsManager<TOptions> : IOptions<TOptions>
+    where TOptions : class
+{
+    private readonly IOptionsFactory<TOptions> _factory;
+    private volatile TOptions? _value;
+
+    public AbpAutofacUnnamedOptionsManager(IOptionsFactory<TOptions> factory)
+    {
+        _factory = factory;
+    }
+
+    public TOptions Value
+    {
+        get
+        {
+            if (_value is TOptions value)
+            {
+                return value;
+            }
+
+            // The following code synchronizes the concurrent creation of a new instance of TOptions without using a
+            // pessimistic lock. Instead, it employs an atomic operation to avoid deadlocks that can occur with the
+            // default UnnamedOptionsManager implementation when resolving TOptions dependencies managed by Autofac.
+
+            var newValue = _factory.Create(Microsoft.Extensions.Options.Options.DefaultName);
+            var oldValue = Interlocked.CompareExchange(ref _value, newValue, null);
+            return oldValue ?? newValue;
+        }
+    }
+}

--- a/framework/test/Volo.Abp.Autofac.Tests/Volo/Abp/Autofac/Autofac_Dead_Lock_Tests.cs
+++ b/framework/test/Volo.Abp.Autofac.Tests/Volo/Abp/Autofac/Autofac_Dead_Lock_Tests.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Volo.Abp.Testing;
+using Xunit;
+
+namespace Volo.Abp.Autofac;
+
+public class Autofac_Dead_Lock_Tests : AbpIntegratedTest<AutofacTestModule>
+{
+    private readonly ManualResetEventSlim _optionsAReadyToContinueEvent = new ();
+
+    private readonly ManualResetEventSlim _optionsAContinueEvent = new ();
+
+    private readonly ManualResetEventSlim _optionsBEvent = new ();
+
+    protected override void SetAbpApplicationCreationOptions(AbpApplicationCreationOptions options)
+    {
+        options.UseAutofac();
+    }
+
+    protected override void AfterAddApplication(IServiceCollection services)
+    {
+        base.AfterAddApplication(services);
+
+        services.AddSingleton<SingletonTestService, SingletonTestService>();
+
+        services.AddOptions<OptionsA>()
+            .Configure<IServiceProvider>((optionsA, rootServiceProvider) =>
+            {
+                var optionsB = rootServiceProvider.GetRequiredService<IOptions<OptionsB>>();
+
+                _optionsAReadyToContinueEvent.Set();
+                _optionsAContinueEvent.Wait();
+
+                optionsA.OptionsB = optionsB.Value;
+            });
+
+        services.AddOptions<OptionsB>()
+            .Configure<IServiceProvider>((optionsB, rootServiceProvider) =>
+            {
+                _optionsBEvent.Set();
+                optionsB.OptionsC = rootServiceProvider.GetRequiredService<IOptions<OptionsC>>().Value;
+            });
+
+        services.AddOptions<OptionsC>();
+    }
+
+    /// <summary>
+    /// This test simulates a deadlock scenario that can occur when a specific SingletonService depends on IOptions A,
+    /// which in turn depends on IOptions B, and B depends on IOptions C.
+    /// This mirrors the dependency chain of:
+    /// AbpSystemTextJsonSerializerOptions -> AbpSystemTextJsonSerializerModifiersOptions -> AbpJsonOptions.
+    ///
+    /// The test coordinates two threads using events to ensure a reproducible deadlock situation.
+    ///
+    /// For more details, see the commentary in <see cref="AbpAutofacUnnamedOptionsManager{TOptions}"/>.
+    /// </summary>
+    [Fact]
+    public async Task Should_Not_Deadlock_On_Concurrent_Dependency_Resolution()
+    {
+        // Arrange
+        var thread1 = new Thread(() =>
+        {
+            using var scope = TestServiceScope.ServiceProvider.CreateScope();
+            _ = scope.ServiceProvider.GetRequiredService<SingletonTestService>();
+        });
+
+        var thread2 = new Thread(() =>
+        {
+            using var scope = TestServiceScope.ServiceProvider.CreateScope();
+            _ = scope.ServiceProvider.GetRequiredService<IOptions<OptionsB>>().Value;
+        });
+
+        // Act
+        thread1.Start();
+        _optionsAReadyToContinueEvent.Wait();
+
+        thread2.Start();
+        _optionsBEvent.Wait();
+        _optionsAContinueEvent.Set();
+
+        // Assert
+        thread1.Join(TimeSpan.FromSeconds(60)).ShouldBeTrue("Thread 1 is deadlocked");
+        thread2.Join(TimeSpan.FromSeconds(60)).ShouldBeTrue("Thread 2 is deadlocked");
+    }
+
+    private class SingletonTestService
+    {
+        private readonly OptionsA _optionsA;
+
+        public SingletonTestService(IOptions<OptionsA> optionsA)
+        {
+            _optionsA = optionsA.Value;
+        }
+    }
+
+    private class OptionsA
+    {
+        public OptionsB OptionsB { get; set; }
+    }
+
+    private class OptionsB
+    {
+        public OptionsC OptionsC { get; set; }
+    }
+
+    private class OptionsC
+    {
+
+    }
+}

--- a/framework/test/Volo.Abp.Json.Tests/Volo/Abp/Json/AbpJsonSystemTextJson_DeadLock_Tests.cs
+++ b/framework/test/Volo.Abp.Json.Tests/Volo/Abp/Json/AbpJsonSystemTextJson_DeadLock_Tests.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Volo.Abp.Autofac;
+using Volo.Abp.Json.SystemTextJson;
+using Xunit;
+
+namespace Volo.Abp.Json;
+
+public class AbpJsonSystemTextJson_DeadLock_Tests : AbpJsonSystemTextJsonTestBase
+{
+    protected override void AfterAddApplication(IServiceCollection services)
+    {
+        base.AfterAddApplication(services);
+
+        services.AddSingleton(new ThreadSynchronizationEvents());
+        services.AddSingleton<TestSingletonService, TestSingletonService>();
+    }
+
+    /// <summary>
+    /// Simulates a deadlock scenario that may occur when a singleton service (TestSingletonService) and
+    /// direct IOptions resolution concurrently access interdependent options configurations.
+    ///
+    /// The test coordinates thread execution using synchronization events to create a race condition
+    /// between option value resolution paths. Verifies the framework's ability to handle concurrent
+    /// option dependencies without deadlocks.
+    ///
+    /// For implementation details, see <see cref="AbpAutofacUnnamedOptionsManager{TOptions}"/>.
+    /// </summary>
+    [Fact]
+    public async Task Should_Not_Deadlock_On_Concurrent_Dependency_Resolution()
+    {
+        // Arrange
+        var threadSynchronizationEvents = GetRequiredService<ThreadSynchronizationEvents>();
+
+        var thread1 = new Thread(() =>
+        {
+            // Resolves TestSingletonService which has a dependency chain:
+            // TestSingletonService -> IOptions<AbpSystemTextJsonSerializerOptions> ->
+            // IOptions<AbpSystemTextJsonSerializerModifiersOptions>
+
+            using var scope = TestServiceScope.ServiceProvider.CreateScope();
+            var _ = scope.ServiceProvider.GetRequiredService<TestSingletonService>();
+        });
+
+        var thread2 = new Thread(() =>
+        {
+            // Directly resolves IOptions<AbpSystemTextJsonSerializerOptions>
+            using var scope = TestServiceScope.ServiceProvider.CreateScope();
+            var options = scope.ServiceProvider.GetRequiredService<IOptions<AbpSystemTextJsonSerializerOptions>>();
+
+            // Signal main thread before accessing Value to create synchronization point
+            threadSynchronizationEvents.Thread2Event.Set();
+
+            var _ = options.Value; // Potential deadlock point
+        });
+
+        // Act
+        thread1.Start();
+        threadSynchronizationEvents.Thread1ObtainedIOptionsEvent.Wait(); // Wait for Thread1 to reach value access point
+
+        thread2.Start();
+        threadSynchronizationEvents.Thread2Event.Wait(); // Wait for Thread2 to reach value access point
+
+        Thread.Sleep(TimeSpan.FromSeconds(1)); // Allow potential deadlock state to manifest
+
+        // Release Thread1 to proceed with value access
+        threadSynchronizationEvents.Thread1ContinueSignalEvent.Set();
+
+        // Assert
+        thread1.Join(TimeSpan.FromSeconds(45)).ShouldBeTrue("Thread 1 deadlocked during options resolution");
+        thread2.Join(TimeSpan.FromSeconds(45)).ShouldBeTrue("Thread 2 deadlocked during options resolution");
+    }
+
+    private class ThreadSynchronizationEvents
+    {
+        // Signals when Thread1 has resolved IOptions but before accessing Value
+        public ManualResetEventSlim Thread1ObtainedIOptionsEvent { get; init; } = new();
+
+        // Allows main thread to control when Thread1 proceeds to access Value
+        public ManualResetEventSlim Thread1ContinueSignalEvent { get; init; } = new();
+
+        // Signals when Thread2 has resolved IOptions and is about to access Value
+        public ManualResetEventSlim Thread2Event { get; init; } = new();
+    }
+
+    private class TestSingletonService
+    {
+        private readonly AbpSystemTextJsonSerializerOptions _jsonSerializerOptions;
+
+        public TestSingletonService(
+            IOptions<AbpSystemTextJsonSerializerOptions> jsonSerializerOptions,
+            ThreadSynchronizationEvents threadSynchronizationEvents)
+        {
+            // Notify main thread that IOptions resolution is complete
+            threadSynchronizationEvents.Thread1ObtainedIOptionsEvent.Set();
+
+            // Wait for controlled release to access Value
+            threadSynchronizationEvents.Thread1ContinueSignalEvent.Wait();
+
+            _jsonSerializerOptions = jsonSerializerOptions.Value; // Contended access point
+        }
+    }
+}


### PR DESCRIPTION
### Description

**Problem:** The default `Microsoft.Extensions.Options.UnnamedOptionsManager` implementation can lead to deadlocks when resolving `IOptions<TOptions>` that have dependencies managed by Autofac. These deadlocks occur due to a lack of order in lock acquisition between:

- `Microsoft.Extensions.Options.UnnamedOptionsManager.get_Value` locking `_syncObj`.
- `Autofac.Core.Lifetime.LifetimeScope.CreateSharedInstance` locking `_synchRoot`.

**Proposed Solution:** This pull request introduces the `AbpAutofacUnnamedOptionsManager<TOptions>` class, which replaces the default implementation with an atomic operation instead of a pessimistic lock. This synchronizes the concurrent creation of a new instance of `TOptions` without causing deadlocks.

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

To validate this fix and reproduce the original deadlock issue:

1. **Run the Test:** Execute the unit test `Volo.Abp.Autofac.Autofac_Dead_Lock_Tests`, specifically designed to simulate the deadlock scenario.

2. **Modify the Code:** Before running the test, remove or comment out line **34** in the method `Volo.Abp.AbpAutofacAbpApplicationCreationOptionsExtensions.AddAbpAutofacUnnamedOptionsManager`. 

```csharp
   // options.Services.Replace(ServiceDescriptor.Singleton(typeof(IOptions<>), typeof(AbpAutofacUnnamedOptionsManager<>)));
```
   
3. **Observe the Deadlock:** With this modification, running the test should reproduce the deadlock,

4. **Apply the Fix:** Restore line 34 to reintroduce the AbpAutofacUnnamedOptionsManager. Run the test again, and you should observe that the deadlock no longer occurs.