### PR TITLE
Angular - Fixing the Vite builder warning problem

### DIFF
--- a/npm/ng-packs/packages/core/locale/src/utils/register-locale.ts
+++ b/npm/ng-packs/packages/core/locale/src/utils/register-locale.ts
@@ -96,6 +96,7 @@ export function registerLocale(
         /* webpackChunkName: "locales"*/
         /* webpackInclude: /[/\\](ar|cs|en|en-GB|es|de|fi|fr|hi|hu|is|it|pt|tr|ru|ro|sk|sl|zh-Hans|zh-Hant)\.(mjs|js)$/ */
         /* webpackExclude: /[/\\]global|extra/ */
+        /* @vite-ignore */
         `@angular/common${localePath}`
       )
         .then(val => {


### PR DESCRIPTION
### Description

Resolves #21448

There should not be any warning as in the record

https://github.com/user-attachments/assets/f75bbf7a-40cb-4539-a403-d6a68871c938


### Checklist

- [X] I fully tested it as developer / designer and created unit / integration tests
- [X] No need to update documentation specifically for this.

### How to test it?

- You need to get the latest changes to the app template by running `yarn copy-to:app` under `npm > ng-pack` directory.
- You need to replace the `registerLocale()` function with `registerLocaleForEsBuild()` function in `templates > app > angular > src > app > app.module.ts`
- You need to run this command `ng update @angular/cli --name use-application-builder` under `templates > app > angular`
- Then you can start the app check the console for this specific warning and it should not be there 😄

```
vite/deps/@abp_ng__core_locale.js
87 |          /* webpackInclude: /[/\\](ar|cs|en|en-GB|es|de|fi|fr|hi|hu|is|it|pt|tr|ru|ro|sk|sl|zh-Hans|zh-Hant)\.(mjs|js)$/ */
88 |          /* webpackExclude: /[/\\]global|extra/ */
89 |          `@angular/common${localePath}`
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
90 |        ).then((val) => {
91 |          let module = val;
The above dynamic import cannot be analyzed by Vite.
See https://github.com/rollup/plugins/tree/master/packages/dynamic-import-vars#limitations for supported dynamic import formats. If this is intended to be left as-is, you can use the /* @vite-ignore */ comment inside the import() call to suppress this warning.
```
