### PR TITLE
Fixing local registration for es-build function to consider `cultureNameLocaleFileMap`

### DIFF
--- a/npm/ng-packs/packages/core/locale/src/utils/register-locale.ts
+++ b/npm/ng-packs/packages/core/locale/src/utils/register-locale.ts
@@ -55,7 +55,7 @@ export function registerLocaleForEsBuild(
       const l = localeMap[locale] || locale;
       const localeSupportList = "ar|cs|en|en-GB|es|de|fi|fr|hi|hu|is|it|pt|tr|ru|ro|sk|sl|zh-Hans|zh-Hant".split("|");
 
-      if (localeSupportList.indexOf(locale) == -1) {
+      if (localeSupportList.indexOf(l) == -1) {
           return;
       }
       return new Promise((resolve, reject) => {


### PR DESCRIPTION
### Description

Rebased the branch with the same commit here: https://github.com/abpframework/abp/pull/21484

Resolves #21483

### Checklist

- [X] I fully tested it as developer / designer and created unit / integration tests
- [X] I documented it (or no need to document or I will create a separate documentation issue)

