### PR TITLE
Add custom `IdentityErrorDescriber` for localized error messages.

### DIFF
--- a/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/AbpIdentityErrorDescriber.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/AbpIdentityErrorDescriber.cs
@@ -1,0 +1,33 @@
+using JetBrains.Annotations;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.Identity.Localization;
+using Volo.Abp.Localization;
+
+namespace Volo.Abp.Identity;
+
+[Dependency(ServiceLifetime.Scoped, ReplaceServices = true)]
+[ExposeServices(typeof(IdentityErrorDescriber))]
+public class AbpIdentityErrorDescriber : IdentityErrorDescriber
+{
+    protected IStringLocalizer<IdentityResource> Localizer { get; }
+
+    public AbpIdentityErrorDescriber(IStringLocalizer<IdentityResource> localizer)
+    {
+        Localizer = localizer;
+    }
+
+    public override IdentityError InvalidUserName([CanBeNull] string userName)
+    {
+        using (CultureHelper.Use("en"))
+        {
+            return new IdentityError
+            {
+                Code = nameof(InvalidUserName),
+                Description = Localizer["Volo.Abp.Identity:InvalidUserName", userName ?? ""]
+            };
+        }
+    }
+}

--- a/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/AbpIdentityUserValidator_Tests.cs
+++ b/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/AbpIdentityUserValidator_Tests.cs
@@ -20,6 +20,17 @@ public class AbpIdentityUserValidator_Tests : AbpIdentityAspNetCoreTestBase
     }
 
     [Fact]
+    public async Task InvalidUserName_Messages_Test()
+    {
+        var user = new IdentityUser(Guid.NewGuid(), "abp 123", "user@volosoft.com");
+        var identityResult = await _identityUserManager.CreateAsync(user);
+        identityResult.Succeeded.ShouldBeFalse();
+        identityResult.Errors.Count().ShouldBe(1);
+        identityResult.Errors.First().Code.ShouldBe("InvalidUserName");
+        identityResult.Errors.First().Description.ShouldBe(Localizer["Volo.Abp.Identity:InvalidUserName", "abp 123"]);
+    }
+
+    [Fact]
     public async Task Can_Not_Use_Another_Users_Email_As_Your_Username_Test()
     {
         var user1 = new IdentityUser(Guid.NewGuid(), "user1", "user1@volosoft.com");


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/eff365bc-95ad-4671-9d70-be3127a0afc9)
