### PR TITLE
Refactor connection string checkers to initialize connection settings within try blocks.

### DIFF
--- a/framework/src/Volo.Abp.EntityFrameworkCore.MySQL/Volo/Abp/EntityFrameworkCore/ConnectionStrings/MySqlConnectionStringChecker.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore.MySQL/Volo/Abp/EntityFrameworkCore/ConnectionStrings/MySqlConnectionStringChecker.cs
@@ -12,16 +12,16 @@ public class MySqlConnectionStringChecker : IConnectionStringChecker, ITransient
     public virtual async Task<AbpConnectionStringCheckResult> CheckAsync(string connectionString)
     {
         var result = new AbpConnectionStringCheckResult();
-        var connString = new MySqlConnectionStringBuilder(connectionString)
-        {
-            ConnectionLifeTime = 1
-        };
-
-        var oldDatabaseName = connString.Database;
-        connString.Database = "mysql";
-
         try
         {
+            var connString = new MySqlConnectionStringBuilder(connectionString)
+            {
+                ConnectionLifeTime = 1
+            };
+
+            var oldDatabaseName = connString.Database;
+            connString.Database = "mysql";
+
             await using var conn = new MySqlConnection(connString.ConnectionString);
             await conn.OpenAsync();
             result.Connected = true;

--- a/framework/src/Volo.Abp.EntityFrameworkCore.Oracle.Devart/Volo/Abp/EntityFrameworkCore/ConnectionStrings/OracleDevartConnectionStringChecker.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore.Oracle.Devart/Volo/Abp/EntityFrameworkCore/ConnectionStrings/OracleDevartConnectionStringChecker.cs
@@ -12,13 +12,13 @@ public class OracleDevartConnectionStringChecker : IConnectionStringChecker, ITr
     public virtual async Task<AbpConnectionStringCheckResult> CheckAsync(string connectionString)
     {
         var result = new AbpConnectionStringCheckResult();
-        var connString = new OracleConnectionStringBuilder(connectionString)
-        {
-            ConnectionTimeout = 1
-        };
-
         try
         {
+            var connString = new OracleConnectionStringBuilder(connectionString)
+            {
+                ConnectionTimeout = 1
+            };
+
             await using var conn = new OracleConnection(connString.ConnectionString);
             await conn.OpenAsync();
             result.Connected = true;

--- a/framework/src/Volo.Abp.EntityFrameworkCore.Oracle/Volo/Abp/EntityFrameworkCore/ConnectionStrings/OracleConnectionStringChecker.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore.Oracle/Volo/Abp/EntityFrameworkCore/ConnectionStrings/OracleConnectionStringChecker.cs
@@ -12,13 +12,13 @@ public class OracleConnectionStringChecker : IConnectionStringChecker, ITransien
     public virtual async Task<AbpConnectionStringCheckResult> CheckAsync(string connectionString)
     {
         var result = new AbpConnectionStringCheckResult();
-        var connString = new OracleConnectionStringBuilder(connectionString)
-        {
-            ConnectionTimeout = 1
-        };
-
         try
         {
+            var connString = new OracleConnectionStringBuilder(connectionString)
+            {
+                ConnectionTimeout = 1
+            };
+
             await using var conn = new OracleConnection(connString.ConnectionString);
             await conn.OpenAsync();
             result.Connected = true;

--- a/framework/src/Volo.Abp.EntityFrameworkCore.PostgreSql/Volo/Abp/EntityFrameworkCore/ConnectionStrings/NpgsqlConnectionStringChecker.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore.PostgreSql/Volo/Abp/EntityFrameworkCore/ConnectionStrings/NpgsqlConnectionStringChecker.cs
@@ -12,16 +12,16 @@ public class NpgsqlConnectionStringChecker : IConnectionStringChecker, ITransien
     public virtual async Task<AbpConnectionStringCheckResult> CheckAsync(string connectionString)
     {
         var result = new AbpConnectionStringCheckResult();
-        var connString = new NpgsqlConnectionStringBuilder(connectionString)
-        {
-            Timeout = 1
-        };
-
-        var oldDatabaseName = connString.Database;
-        connString.Database = "postgres";
-
         try
         {
+            var connString = new NpgsqlConnectionStringBuilder(connectionString)
+            {
+                Timeout = 1
+            };
+
+            var oldDatabaseName = connString.Database;
+            connString.Database = "postgres";
+
             await using var conn = new NpgsqlConnection(connString.ConnectionString);
             await conn.OpenAsync();
             result.Connected = true;

--- a/framework/src/Volo.Abp.EntityFrameworkCore.SqlServer/Volo/Abp/EntityFrameworkCore/ConnectionStrings/SqlServerConnectionStringChecker.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore.SqlServer/Volo/Abp/EntityFrameworkCore/ConnectionStrings/SqlServerConnectionStringChecker.cs
@@ -12,16 +12,16 @@ public class SqlServerConnectionStringChecker : IConnectionStringChecker, ITrans
     public virtual async Task<AbpConnectionStringCheckResult> CheckAsync(string connectionString)
     {
         var result = new AbpConnectionStringCheckResult();
-        var connString = new SqlConnectionStringBuilder(connectionString)
-        {
-            ConnectTimeout = 1
-        };
-
-        var oldDatabaseName = connString.InitialCatalog;
-        connString.InitialCatalog = "master";
-
         try
         {
+            var connString = new SqlConnectionStringBuilder(connectionString)
+            {
+                ConnectTimeout = 1
+            };
+
+            var oldDatabaseName = connString.InitialCatalog;
+            connString.InitialCatalog = "master";
+
             await using var conn = new SqlConnection(connString.ConnectionString);
             await conn.OpenAsync();
             result.Connected = true;

--- a/framework/src/Volo.Abp.EntityFrameworkCore.Sqlite/Volo/Abp/EntityFrameworkCore/ConnectionStrings/SqliteConnectionStringChecker.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore.Sqlite/Volo/Abp/EntityFrameworkCore/ConnectionStrings/SqliteConnectionStringChecker.cs
@@ -12,7 +12,6 @@ public class SqliteConnectionStringChecker : IConnectionStringChecker, ITransien
     public virtual async Task<AbpConnectionStringCheckResult> CheckAsync(string connectionString)
     {
         var result = new AbpConnectionStringCheckResult();
-
         try
         {
             await using var conn = new SqliteConnection(connectionString);


### PR DESCRIPTION
`new SqlConnectionStringBuilder(connectionString)` may have exception.