### PR TITLE
Disable `PushedAuthorizationBehavior` feature by default.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Authentication.OpenIdConnect/Microsoft/Extensions/DependencyInjection/AbpOpenIdConnectExtensions.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Authentication.OpenIdConnect/Microsoft/Extensions/DependencyInjection/AbpOpenIdConnectExtensions.cs
@@ -88,6 +88,9 @@ public static class AbpOpenIdConnectExtensions
                 }
             };
 
+            // The application needs to be granted the `OpenIddictConstants.Permissions.Endpoints.PushedAuthorization` permission to using PAR endpoint.
+            // You can enable it after you have granted the permission.
+            options.PushedAuthorizationBehavior = PushedAuthorizationBehavior.Disable;
             configureOptions?.Invoke(options);
         });
     }

--- a/framework/src/Volo.Abp.AspNetCore.Authentication.OpenIdConnect/Microsoft/Extensions/DependencyInjection/AbpOpenIdConnectExtensions.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Authentication.OpenIdConnect/Microsoft/Extensions/DependencyInjection/AbpOpenIdConnectExtensions.cs
@@ -88,8 +88,8 @@ public static class AbpOpenIdConnectExtensions
                 }
             };
 
-            // The application needs to be granted the `OpenIddictConstants.Permissions.Endpoints.PushedAuthorization` permission to using PAR endpoint.
-            // You can enable it after you have granted the permission.
+            // The application needs to be granted the `OpenIddictConstants.Permissions.Endpoints.PushedAuthorization` permission to use the PAR endpoint.
+            // You can enable it after you have granted the `PushedAuthorization` permission.
             options.PushedAuthorizationBehavior = PushedAuthorizationBehavior.Disable;
             configureOptions?.Invoke(options);
         });


### PR DESCRIPTION
The application needs to be granted the `OpenIddictConstants.Permissions.Endpoints.PushedAuthorization` permission to use the PAR endpoint.
You can enable it after you have granted the permission.