### PR TITLE
Remove the cache prefix configuration from the CmsKit module

### DIFF
--- a/modules/cms-kit/src/Volo.CmsKit.Public.Web/CmsKitPublicWebModule.cs
+++ b/modules/cms-kit/src/Volo.CmsKit.Public.Web/CmsKitPublicWebModule.cs
@@ -79,11 +79,6 @@ public class CmsKitPublicWebModule : AbpModule
             options.DisableModule(CmsKitPublicRemoteServiceConsts.ModuleName);
         });
 
-        Configure<AbpDistributedCacheOptions>(options =>
-        {
-            options.KeyPrefix = "CmsKit:";
-        });
-
         if (GlobalFeatureManager.Instance.IsEnabled<PagesFeature>())
         {
             Configure<AbpEndpointRouterOptions>(options =>


### PR DESCRIPTION
Volo.CmsKit.Public.Web is not a host project, no need to configure the cache prefix.

Depending on this module the problem may be as follows:
<img width="548" alt="image" src="https://github.com/user-attachments/assets/5959b106-a14e-4f9c-b67f-15aefa1aac1d" />
