### PR TITLE
Update modals.md to use Bootstrap 5 attributes

### DIFF
--- a/docs/en/framework/ui/mvc-razor-pages/tag-helpers/modals.md
+++ b/docs/en/framework/ui/mvc-razor-pages/tag-helpers/modals.md
@@ -9,7 +9,7 @@
 Basic usage:
 
 ````xml
-<abp-button button-type="Primary" data-toggle="modal" data-target="#myModal">Launch modal</abp-button>
+<abp-button button-type="Primary" data-bs-toggle="modal" data-bs-target="#myModal">Launch modal</abp-button>
 
 <abp-modal centered="true" scrollable="true" size="Large" id="myModal">
    <abp-modal-header title="Modal title"></abp-modal-header>


### PR DESCRIPTION
Updated modals documentation to use Bootstrap 5 syntax instead of old Bootstrap 4 syntax.

### Description

Updated the modals.md documentation to use the Bootstrap 5 syntax `data-bs-toggle` and `data-bs-target`.

[https://getbootstrap.com/docs/5.3/components/modal/#live-demo](https://getbootstrap.com/docs/5.3/components/modal/#live-demo)



### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)


