### PR TITLE
Fix part-08.md for modular monolith tutorial (delete the wrong project reference)

### DIFF
--- a/docs/en/tutorials/modular-crm/part-08.md
+++ b/docs/en/tutorials/modular-crm/part-08.md
@@ -37,7 +37,7 @@ In this section, we will create an application service in the main application's
 
 ### Defining the Reporting Service Interface
 
-We will define the `IOrderReportingAppService` interface in the `ModularCrm.Application.Contracts` project of the main application's .NET solution.
+We will define the `IOrderReportingAppService` interface in the main application's .NET solution.
 
 #### Adding `ModularCrm.Ordering.Contracts` Package Reference
 


### PR DESCRIPTION
Since the ModularCrm main application is a single-layer solution, there is no `*.Application.Contracts` project.