### PR TITLE
Refactor AbpDatePickerBaseTagHelper to accept IOptions<AbpDatePickerOptions> for improved configuration

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/DatePicker/AbpDatePickerBaseTagHelper.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/DatePicker/AbpDatePickerBaseTagHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.Extensions.Options;
 
 namespace Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Form.DatePicker;
 
@@ -45,9 +46,9 @@ public abstract class
 
     public bool AddMarginBottomClass  { get; set; } = true;
 
-    protected AbpDatePickerBaseTagHelper(AbpDatePickerBaseTagHelperService<TTagHelper> service) : base(service)
+    protected AbpDatePickerBaseTagHelper(AbpDatePickerBaseTagHelperService<TTagHelper> service, IOptions<AbpDatePickerOptions> options) : base(service)
     {
-        _abpDatePickerOptionsImplementation = new AbpDatePickerOptions();
+        _abpDatePickerOptionsImplementation = options.Value;
     }
 
     public void SetDatePickerOptions(IAbpDatePickerOptions options)

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/DatePicker/AbpDatePickerTagHelper.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/DatePicker/AbpDatePickerTagHelper.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.Extensions.Options;
 
 namespace Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Form.DatePicker;
 
@@ -8,7 +9,7 @@ public class AbpDatePickerTagHelper : AbpDatePickerBaseTagHelper<AbpDatePickerTa
 {
     public ModelExpression? AspFor { get; set; }
     
-    public AbpDatePickerTagHelper(AbpDatePickerTagHelperService service) : base(service)
+    public AbpDatePickerTagHelper(AbpDatePickerTagHelperService service, IOptions<AbpDatePickerOptions> options) : base(service, options)
     {
     }
 }

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/DatePicker/AbpDateRangePickerTagHelper.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/DatePicker/AbpDateRangePickerTagHelper.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.Extensions.Options;
 
 namespace Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Form.DatePicker;
 
@@ -10,8 +11,8 @@ public class AbpDateRangePickerTagHelper : AbpDatePickerBaseTagHelper<AbpDateRan
 
     public ModelExpression? AspForEnd { get; set; }
 
-    public AbpDateRangePickerTagHelper(AbpDateRangePickerTagHelperService tagHelperService) :
-        base(tagHelperService)
+    public AbpDateRangePickerTagHelper(AbpDateRangePickerTagHelperService tagHelperService, IOptions<AbpDatePickerOptions> options) :
+        base(tagHelperService, options)
     {
     }
 }

--- a/modules/basic-theme/test/Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic.Demo/AbpAspNetCoreMvcUiThemeBasicDemoModule.cs
+++ b/modules/basic-theme/test/Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic.Demo/AbpAspNetCoreMvcUiThemeBasicDemoModule.cs
@@ -55,7 +55,7 @@ public class AbpAspNetCoreMvcUiThemeBasicDemoModule : AbpModule
             app.UseDeveloperExceptionPage();
         }
 
-        app.MapAbpStaticAssets();
+        app.UseStatic();
         app.UseRouting();
         app.UseConfiguredEndpoints();
     }

--- a/modules/basic-theme/test/Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic.Demo/AbpAspNetCoreMvcUiThemeBasicDemoModule.cs
+++ b/modules/basic-theme/test/Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic.Demo/AbpAspNetCoreMvcUiThemeBasicDemoModule.cs
@@ -55,7 +55,7 @@ public class AbpAspNetCoreMvcUiThemeBasicDemoModule : AbpModule
             app.UseDeveloperExceptionPage();
         }
 
-        app.UseStatic();
+        app.MapAbpStaticAssets();
         app.UseRouting();
         app.UseConfiguredEndpoints();
     }


### PR DESCRIPTION
### Description

Related: https://github.com/volosoft/vs-internal/pull/6087

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

Configure `AbpDatePickerOptions`

```csharp
Configure<AbpDatePickerOptions>(options => 
{
      options.IsIso = true; // Global default configuration 
});
```