### PR TITLE
Angular - Fix proxy generation problems for the nullable enum types in method signature

### DIFF
--- a/npm/ng-packs/packages/schematics/src/utils/service.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/service.ts
@@ -124,7 +124,7 @@ export function createActionToSignatureMapper() {
       }
 
       let type = adaptType(p.typeSimple);
-      if (p.typeSimple === 'enum' || p.typeSimple === '[enum]') {
+      if (p.typeSimple === 'enum' || p.typeSimple === 'enum?' || p.typeSimple === '[enum]') {
         type = adaptType(p.type);
       }
 


### PR DESCRIPTION
### Description

Fix proxy generation problems for the enum types in method signature

### Checklist

- [ ] I fully tested it as developer / designer and created unit / integration tests
- [ ] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

<code>
public enum AddressType
{
  One = 1,
  Two = 2
}
</code>

<code>
public class SearchAppService : IApplicationService
{
    public async Task GetAddressHintAsync(string searchString, AddressType? addressType)
    {        
    }
}
</code>

### Expected result

<code>
  getAddressHint = (searchString: string, addressType: AddressType, config?: Partial<Rest.Config>) =>
    this.restService.request<any, HintResult>({
      method: 'GET',
      url: '/api/search/address-hint',
      params: { searchString, addressType },
    },
    { apiName: this.apiName,...config });
</code>

### Current result

<code>
  getAddressHint = (searchString: string, addressType: enum, config?: Partial<Rest.Config>) =>
    this.restService.request<any, HintResult>({
      method: 'GET',
      url: '/api/search/address-hint',
      params: { searchString, addressType },
    },
    { apiName: this.apiName,...config });
</code>