### PR TITLE
Fix Blazor.Client appsettings.Development.json not working

### DIFF
--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor/App.razor
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor/App.razor
@@ -22,8 +22,18 @@
 
 <body class="abp-application-layout bg-light">
 
-    <script src="_framework/blazor.web.js"></script>
-
+    <script src="_framework/blazor.web.js" autostart="false"></script>
+    <script>
+        if (window.location.hostname.includes("localhost")) {
+          Blazor.start({
+            webAssembly: {
+              environment: "Development"
+            }
+          });
+        } else {
+          Blazor.start();
+        }
+    </script>
     <div id="ApplicationContainer">
         <div class="spinner">
             <div class="double-bounce1"></div>


### PR DESCRIPTION
### Description

Resolves #xxxx (write the related issue number if available)

TODO: Describe what this PR has changed, add screenshot or animated GIF if available, write if it is a breaking change, and how to fix the breaking changes for existing applications if so.

### Checklist

- [✔] I fully tested it as developer / designer and created unit / integration tests
- [✔] I documented it (or no need to document or I will create a separate documentation issue)


https://learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/environments?view=aspnetcore-9.0#set-the-client-side-environment-via-blazor-startup-configuration
When start to debug,the server side is development (use appsettings.Development.json),but the client side is production (use appsettings.json).After modification, the environment consistency between the server and client can be ensured(Both use appsettings.Development.json or appsettings.json)
