### PR TITLE
Add `IgnoredNavigationEntitySelectors` to `AbpEntityChangeOptions` to ignore navigation properties.

### DIFF
--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Entities/Events/AbpEntityChangeOptions.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Entities/Events/AbpEntityChangeOptions.cs
@@ -7,4 +7,11 @@ public class AbpEntityChangeOptions
     /// Publish the EntityUpdatedEvent when any navigation property changes.
     /// </summary>
     public bool PublishEntityUpdatedEventWhenNavigationChanges { get; set; } = true;
+
+    public IEntitySelectorList IgnoredNavigationEntitySelectors { get; set; }
+
+    public AbpEntityChangeOptions()
+    {
+        IgnoredNavigationEntitySelectors = new EntitySelectorList();
+    }
 }

--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Entities/Events/EntitySelectorList.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Entities/Events/EntitySelectorList.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+
+namespace Volo.Abp.Domain.Entities.Events;
+
+internal class EntitySelectorList : List<NamedTypeSelector>, IEntitySelectorList
+{
+
+}

--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Entities/Events/EntitySelectorListExtensions.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Entities/Events/EntitySelectorListExtensions.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Volo.Abp.Domain.Entities.Events;
+
+public static class EntitySelectorListExtensions
+{
+    public static IEntitySelectorList Add(this IEntitySelectorList selectors, string name, Func<Type, bool> predicate)
+    {
+        selectors.Add(new NamedTypeSelector(name, predicate));
+        return selectors;
+    }
+}

--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Entities/Events/IEntitySelectorList.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Entities/Events/IEntitySelectorList.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+
+namespace Volo.Abp.Domain.Entities.Events;
+
+public interface IEntitySelectorList : IList<NamedTypeSelector>
+{
+
+}

--- a/framework/test/Volo.Abp.EntityFrameworkCore.Tests/Volo/Abp/EntityFrameworkCore/DomainEvents/DomainEvents_Tests.cs
+++ b/framework/test/Volo.Abp.EntityFrameworkCore.Tests/Volo/Abp/EntityFrameworkCore/DomainEvents/DomainEvents_Tests.cs
@@ -18,8 +18,31 @@ public class DomainEvents_Tests : DomainEvents_Tests<AbpEntityFrameworkCoreTestM
 {
 }
 
-public class AbpEntityChangeOptions_DomainEvents_Tests : AbpEntityChangeOptions_DomainEvents_Tests<AbpEntityFrameworkCoreTestModule>
+public class AbpEntityChangeOptions_DomainEvents_PublishEntityUpdatedEventWhenNavigationChanges_Tests : AbpEntityChangeOptions_DomainEvents_Tests<AbpEntityFrameworkCoreTestModule>
 {
+    protected override void AfterAddApplication(IServiceCollection services)
+    {
+        services.Configure<AbpEntityChangeOptions>(options =>
+        {
+            options.PublishEntityUpdatedEventWhenNavigationChanges = false;
+        });
+
+        base.AfterAddApplication(services);
+    }
+}
+
+public class AbpEntityChangeOptions_DomainEvents_IgnoreEntityChangeSelectorList_Tests : AbpEntityChangeOptions_DomainEvents_Tests<AbpEntityFrameworkCoreTestModule>
+{
+    protected override void AfterAddApplication(IServiceCollection services)
+    {
+        services.Configure<AbpEntityChangeOptions>(options =>
+        {
+            options.PublishEntityUpdatedEventWhenNavigationChanges = true;
+            options.IgnoredNavigationEntitySelectors.Add("DisableAllEntity", _ => true);
+        });
+
+        base.AfterAddApplication(services);
+    }
 }
 
 public class AbpEfCoreDomainEvents_Tests : EntityFrameworkCoreTestBase

--- a/framework/test/Volo.Abp.TestApp/Volo/Abp/TestApp/Testing/DomainEvents_Tests.cs
+++ b/framework/test/Volo.Abp.TestApp/Volo/Abp/TestApp/Testing/DomainEvents_Tests.cs
@@ -259,16 +259,6 @@ public abstract class AbpEntityChangeOptions_DomainEvents_Tests<TStartupModule> 
         LocalEventBus = GetRequiredService<ILocalEventBus>();
     }
 
-    protected override void AfterAddApplication(IServiceCollection services)
-    {
-        services.Configure<AbpEntityChangeOptions>(options =>
-        {
-            options.PublishEntityUpdatedEventWhenNavigationChanges = false;
-        });
-
-        base.AfterAddApplication(services);
-    }
-
     [Fact]
     public async Task Should_Not_Trigger_Domain_Events_For_Aggregate_Root_When_Navigation_Changes_Tests()
     {

--- a/modules/openiddict/src/Volo.Abp.OpenIddict.EntityFrameworkCore/Volo/Abp/OpenIddict/EntityFrameworkCore/AbpOpenIddictEntityFrameworkCoreModule.cs
+++ b/modules/openiddict/src/Volo.Abp.OpenIddict.EntityFrameworkCore/Volo/Abp/OpenIddict/EntityFrameworkCore/AbpOpenIddictEntityFrameworkCoreModule.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using Volo.Abp.Domain.Entities.Events;
 using Volo.Abp.EntityFrameworkCore;
 using Volo.Abp.Modularity;
 using Volo.Abp.OpenIddict.Applications;
@@ -24,6 +25,11 @@ public class AbpOpenIddictEntityFrameworkCoreModule : AbpModule
             options.AddRepository<OpenIddictAuthorization, EfCoreOpenIddictAuthorizationRepository>();
             options.AddRepository<OpenIddictScope, EfCoreOpenIddictScopeRepository>();
             options.AddRepository<OpenIddictToken, EfCoreOpenIddictTokenRepository>();
+        });
+
+        Configure<AbpEntityChangeOptions>(options =>
+        {
+            options.IgnoredNavigationEntitySelectors.Add("DisableOpenIddictApplication", type => type == typeof(OpenIddictApplication));
         });
     }
 }


### PR DESCRIPTION
Do not change `OpenIddictApplication` if its navigation changed, We don't need to worry about the changes to `OpenIddictAuthorization` or `OpenIddictToken` 

Related: https://abp.io/support/questions/8917/VoloAbpDataAbpDbConcurrencyException-The-database-operation-was-expected-to-affect-1-rows