### PR TITLE
Include `RemoteServiceConfigurationProvider` in the client proxies documentation

### DIFF
--- a/docs/en/framework/api-development/dynamic-csharp-clients.md
+++ b/docs/en/framework/api-development/dynamic-csharp-clients.md
@@ -164,6 +164,7 @@ context.Services.AddHttpClientProxies(
 `remoteServiceConfigurationName` parameter matches the service endpoint configured via `AbpRemoteServiceOptions`. If the `BookStore` endpoint is not defined then it fallbacks to the `Default` endpoint.
 
 #### Remote Service Configuration Provider
+
 You may need to get the remote service configuration for a specific remote service in some cases. For this, you can use the `IRemoteServiceConfigurationProvider` interface.
 
 **Example: Get the remote service configuration for the "BookStore" remote service**

--- a/docs/en/framework/api-development/dynamic-csharp-clients.md
+++ b/docs/en/framework/api-development/dynamic-csharp-clients.md
@@ -171,16 +171,16 @@ You may need to get the remote service configuration for a specific remote servi
 ````csharp
 public class MyService : ITransientDependency
 {
-    private readonly RemoteServiceConfigurationProvider _remoteServiceConfigurationProvider;
+    private readonly IRemoteServiceConfigurationProvider _remoteServiceConfigurationProvider;
 
-    public MyService(RemoteServiceConfigurationProvider remoteServiceConfigurationProvider)
+    public MyService(IRemoteServiceConfigurationProvider remoteServiceConfigurationProvider)
     {
         _remoteServiceConfigurationProvider = remoteServiceConfigurationProvider;
     }
 
     public async Task GetRemoteServiceConfiguration()
     {
-        var configuration = await _remoteServiceConfigurationProvider.GetConfigurationAsync("BookStore");
+        var configuration = await _remoteServiceConfigurationProvider.GetConfigurationOrDefaultAsync("BookStore");
         Console.WriteLine(configuration.BaseUrl);
     }
 }

--- a/docs/en/framework/api-development/dynamic-csharp-clients.md
+++ b/docs/en/framework/api-development/dynamic-csharp-clients.md
@@ -164,7 +164,7 @@ context.Services.AddHttpClientProxies(
 `remoteServiceConfigurationName` parameter matches the service endpoint configured via `AbpRemoteServiceOptions`. If the `BookStore` endpoint is not defined then it fallbacks to the `Default` endpoint.
 
 #### Remote Service Configuration Provider
-You may need to get the remote service configuration for a specific remote service in some cases. For this, you can use the `RemoteServiceConfigurationProvider` interface.
+You may need to get the remote service configuration for a specific remote service in some cases. For this, you can use the `IRemoteServiceConfigurationProvider` interface.
 
 **Example: Get the remote service configuration for the "BookStore" remote service**
 

--- a/docs/en/framework/api-development/dynamic-csharp-clients.md
+++ b/docs/en/framework/api-development/dynamic-csharp-clients.md
@@ -164,7 +164,7 @@ context.Services.AddHttpClientProxies(
 `remoteServiceConfigurationName` parameter matches the service endpoint configured via `AbpRemoteServiceOptions`. If the `BookStore` endpoint is not defined then it fallbacks to the `Default` endpoint.
 
 #### Remote Service Configuration Provider
-Some times you may need to get the remote service configuration for a specific remote service in specific cases. For this, you can use the `RemoteServiceConfigurationProvider` interface.
+You may need to get the remote service configuration for a specific remote service in some cases. For this, you can use the `RemoteServiceConfigurationProvider` interface.
 
 **Example: Get the remote service configuration for the "BookStore" remote service**
 

--- a/docs/en/framework/api-development/dynamic-csharp-clients.md
+++ b/docs/en/framework/api-development/dynamic-csharp-clients.md
@@ -163,6 +163,29 @@ context.Services.AddHttpClientProxies(
 
 `remoteServiceConfigurationName` parameter matches the service endpoint configured via `AbpRemoteServiceOptions`. If the `BookStore` endpoint is not defined then it fallbacks to the `Default` endpoint.
 
+#### Remote Service Configuration Provider
+Some times you may need to get the remote service configuration for a specific remote service in specific cases. For this, you can use the `RemoteServiceConfigurationProvider` interface.
+
+**Example: Get the remote service configuration for the "BookStore" remote service**
+
+````csharp
+public class MyService : ITransientDependency
+{
+    private readonly RemoteServiceConfigurationProvider _remoteServiceConfigurationProvider;
+
+    public MyService(RemoteServiceConfigurationProvider remoteServiceConfigurationProvider)
+    {
+        _remoteServiceConfigurationProvider = remoteServiceConfigurationProvider;
+    }
+
+    public async Task GetRemoteServiceConfiguration()
+    {
+        var configuration = await _remoteServiceConfigurationProvider.GetConfigurationAsync("BookStore");
+        Console.WriteLine(configuration.BaseUrl);
+    }
+}
+````
+
 ### As Default Services
 
 When you create a service proxy for `IBookAppService`, you can directly inject the `IBookAppService` to use the proxy client (as shown in the usage section). You can pass `asDefaultServices: false` to the `AddHttpClientProxies` method to disable this feature.
@@ -203,6 +226,8 @@ public override void PreConfigureServices(ServiceConfigurationContext context)
 ````
 
 This example uses the [Microsoft.Extensions.Http.Polly](https://www.nuget.org/packages/Microsoft.Extensions.Http.Polly) package. You also need to import the `Polly` namespace (`using Polly;`) to be able to use the `WaitAndRetryAsync` method.
+
+
 
 ## See Also
 

--- a/docs/en/framework/api-development/static-csharp-clients.md
+++ b/docs/en/framework/api-development/static-csharp-clients.md
@@ -245,6 +245,7 @@ context.Services.AddStaticHttpClientProxies(
 `remoteServiceConfigurationName` parameter matches the service endpoint configured via `AbpRemoteServiceOptions`. If the `BookStore` endpoint is not defined then it fallbacks to the `Default` endpoint.
 
 #### Remote Service Configuration Provider
+
 You may need to get the remote service configuration for a specific remote service in some cases. For this, you can use the `IRemoteServiceConfigurationProvider` interface.
 
 **Example: Get the remote service configuration for the "BookStore" remote service**

--- a/docs/en/framework/api-development/static-csharp-clients.md
+++ b/docs/en/framework/api-development/static-csharp-clients.md
@@ -245,7 +245,7 @@ context.Services.AddStaticHttpClientProxies(
 `remoteServiceConfigurationName` parameter matches the service endpoint configured via `AbpRemoteServiceOptions`. If the `BookStore` endpoint is not defined then it fallbacks to the `Default` endpoint.
 
 #### Remote Service Configuration Provider
-You may need to get the remote service configuration for a specific remote service in some cases. For this, you can use the `RemoteServiceConfigurationProvider` interface.
+You may need to get the remote service configuration for a specific remote service in some cases. For this, you can use the `IRemoteServiceConfigurationProvider` interface.
 
 **Example: Get the remote service configuration for the "BookStore" remote service**
 

--- a/docs/en/framework/api-development/static-csharp-clients.md
+++ b/docs/en/framework/api-development/static-csharp-clients.md
@@ -244,6 +244,29 @@ context.Services.AddStaticHttpClientProxies(
 
 `remoteServiceConfigurationName` parameter matches the service endpoint configured via `AbpRemoteServiceOptions`. If the `BookStore` endpoint is not defined then it fallbacks to the `Default` endpoint.
 
+#### Remote Service Configuration Provider
+Some times you may need to get the remote service configuration for a specific remote service in specific cases. For this, you can use the `RemoteServiceConfigurationProvider` interface.
+
+**Example: Get the remote service configuration for the "BookStore" remote service**
+
+````csharp
+public class MyService : ITransientDependency
+{
+    private readonly RemoteServiceConfigurationProvider _remoteServiceConfigurationProvider;
+
+    public MyService(RemoteServiceConfigurationProvider remoteServiceConfigurationProvider)
+    {
+        _remoteServiceConfigurationProvider = remoteServiceConfigurationProvider;
+    }
+
+    public async Task GetRemoteServiceConfiguration()
+    {
+        var configuration = await _remoteServiceConfigurationProvider.GetConfigurationAsync("BookStore");
+        Console.WriteLine(configuration.BaseUrl);
+    }
+}
+````
+
 ### Retry/Failure Logic & Polly Integration
 
 If you want to add retry logic for the failing remote HTTP calls for the client proxies, you can configure the `AbpHttpClientBuilderOptions` in the `PreConfigureServices` method of your module class.

--- a/docs/en/framework/api-development/static-csharp-clients.md
+++ b/docs/en/framework/api-development/static-csharp-clients.md
@@ -245,7 +245,7 @@ context.Services.AddStaticHttpClientProxies(
 `remoteServiceConfigurationName` parameter matches the service endpoint configured via `AbpRemoteServiceOptions`. If the `BookStore` endpoint is not defined then it fallbacks to the `Default` endpoint.
 
 #### Remote Service Configuration Provider
-Some times you may need to get the remote service configuration for a specific remote service in specific cases. For this, you can use the `RemoteServiceConfigurationProvider` interface.
+You may need to get the remote service configuration for a specific remote service in some cases. For this, you can use the `RemoteServiceConfigurationProvider` interface.
 
 **Example: Get the remote service configuration for the "BookStore" remote service**
 

--- a/docs/en/framework/api-development/static-csharp-clients.md
+++ b/docs/en/framework/api-development/static-csharp-clients.md
@@ -252,16 +252,16 @@ You may need to get the remote service configuration for a specific remote servi
 ````csharp
 public class MyService : ITransientDependency
 {
-    private readonly RemoteServiceConfigurationProvider _remoteServiceConfigurationProvider;
+    private readonly IRemoteServiceConfigurationProvider _remoteServiceConfigurationProvider;
 
-    public MyService(RemoteServiceConfigurationProvider remoteServiceConfigurationProvider)
+    public MyService(IRemoteServiceConfigurationProvider remoteServiceConfigurationProvider)
     {
         _remoteServiceConfigurationProvider = remoteServiceConfigurationProvider;
     }
 
     public async Task GetRemoteServiceConfiguration()
     {
-        var configuration = await _remoteServiceConfigurationProvider.GetConfigurationAsync("BookStore");
+        var configuration = await _remoteServiceConfigurationProvider.GetConfigurationOrDefaultAsync("BookStore");
         Console.WriteLine(configuration.BaseUrl);
     }
 }


### PR DESCRIPTION
### Description
Added `RemoteServiceConfigurationProvider` since people cannot find it and try to read `IConfiguration` manually and that causes some problems in their cases.
