### PR TITLE
Avoid loading the script twice and style`flicker` problem after prerender.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Bundling/AbpScripts.razor
+++ b/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Bundling/AbpScripts.razor
@@ -29,7 +29,6 @@
         if (!ApplicationState.TryTakeFromJson<string>(PrerenderedKey, out _))
         {
             // We are in prerendering mode
-            ScriptFiles = [];
             if (!BundleName.IsNullOrWhiteSpace())
             {
                 ScriptFiles = (await BundleManager.GetScriptBundleFilesAsync(BundleName!)).ToList();

--- a/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Bundling/AbpScripts.razor
+++ b/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Bundling/AbpScripts.razor
@@ -1,4 +1,6 @@
+@implements IDisposable
 @inject IComponentBundleManager BundleManager
+@inject PersistentComponentState ApplicationState
 @if (ScriptFiles != null)
 {
     foreach (var file in ScriptFiles)
@@ -8,6 +10,9 @@
 }
 
 @code {
+
+    private const string PrerenderedKey = "abp_script_prerendered";
+
     [Parameter]
     public List<string>? WebAssemblyScriptFiles { get; set; }
 
@@ -16,18 +21,34 @@
 
     private List<string>? ScriptFiles { get; set; }
 
+    private PersistingComponentStateSubscription _persistingSubscription;
+
     protected override async Task OnInitializedAsync()
     {
-        ScriptFiles = new List<string>();
-
-        if (!BundleName.IsNullOrWhiteSpace())
+        _persistingSubscription = ApplicationState.RegisterOnPersisting(Callback);
+        if (!ApplicationState.TryTakeFromJson<string>(PrerenderedKey, out _))
         {
-            ScriptFiles = (await BundleManager.GetScriptBundleFilesAsync(BundleName!)).ToList();
+            // We are in prerendering mode
+            ScriptFiles = [];
+            if (!BundleName.IsNullOrWhiteSpace())
+            {
+                ScriptFiles = (await BundleManager.GetScriptBundleFilesAsync(BundleName!)).ToList();
+            }
         }
-
-        if (OperatingSystem.IsBrowser() && WebAssemblyScriptFiles != null)
+        else
         {
-            ScriptFiles.AddIfNotContains(WebAssemblyScriptFiles);
+            if (OperatingSystem.IsBrowser() && WebAssemblyScriptFiles != null)
+            {
+                ScriptFiles = WebAssemblyScriptFiles;
+            }
         }
     }
+
+    private Task Callback()
+    {
+        ApplicationState.PersistAsJson(PrerenderedKey, PrerenderedKey);
+        return Task.CompletedTask;
+    }
+
+    public void Dispose() => _persistingSubscription.Dispose();
 }

--- a/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Bundling/AbpStyles.razor
+++ b/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Bundling/AbpStyles.razor
@@ -29,7 +29,6 @@
         if (!ApplicationState.TryTakeFromJson<List<string>>(PrerenderedKey, out var scriptFiles))
         {
             // We are in prerendering mode
-            StyleFiles = [];
             if (!BundleName.IsNullOrWhiteSpace())
             {
                 StyleFiles = (await BundleManager.GetStyleBundleFilesAsync(BundleName!)).ToList();

--- a/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Bundling/AbpStyles.razor
+++ b/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Bundling/AbpStyles.razor
@@ -1,4 +1,6 @@
+@implements IDisposable
 @inject IComponentBundleManager BundleManager
+@inject PersistentComponentState ApplicationState
 @if (StyleFiles != null)
 {
     foreach (var file in StyleFiles)
@@ -8,6 +10,9 @@
 }
 
 @code {
+
+    private const string PrerenderedKey = "abp_style_prerendered";
+
     [Parameter]
     public List<string>? WebAssemblyStyleFiles { get; set; }
 
@@ -16,18 +21,48 @@
 
     private List<string>? StyleFiles { get; set; }
 
+    private PersistingComponentStateSubscription _persistingSubscription;
+
     protected override async Task OnInitializedAsync()
     {
-        StyleFiles = new List<string>();
-
-        if (!BundleName.IsNullOrWhiteSpace())
+        _persistingSubscription = ApplicationState.RegisterOnPersisting(Callback);
+        if (!ApplicationState.TryTakeFromJson<List<string>>(PrerenderedKey, out var scriptFiles))
         {
-            StyleFiles = (await BundleManager.GetStyleBundleFilesAsync(BundleName!)).ToList();
+            // We are in prerendering mode
+            StyleFiles = [];
+            if (!BundleName.IsNullOrWhiteSpace())
+            {
+                StyleFiles = (await BundleManager.GetStyleBundleFilesAsync(BundleName!)).ToList();
+            }
         }
-
-        if (OperatingSystem.IsBrowser() && WebAssemblyStyleFiles != null)
+        else
         {
-            StyleFiles.AddIfNotContains(WebAssemblyStyleFiles);
+            StyleFiles = scriptFiles;
+            if (OperatingSystem.IsBrowser() && StyleFiles != null && WebAssemblyStyleFiles != null)
+            {
+                StyleFiles.AddIfNotContains(WebAssemblyStyleFiles);
+            }
         }
     }
+
+    private bool _hasRemoveServerStyle = false;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!_hasRemoveServerStyle && OperatingSystem.IsBrowser() && WebAssemblyStyleFiles != null)
+        {
+            _hasRemoveServerStyle = true;
+            await Task.Delay(3000);
+            StyleFiles = WebAssemblyStyleFiles;
+            StateHasChanged();
+        }
+    }
+
+    private Task Callback()
+    {
+        ApplicationState.PersistAsJson(PrerenderedKey, StyleFiles);
+        return Task.CompletedTask;
+    }
+
+    public void Dispose() => _persistingSubscription.Dispose();
 }


### PR DESCRIPTION
We don't need the `bootstrap-patch.js ` after this PR.

The user menu in Blazor Server and WASM will be no problem.


---

Also fix https://github.com/abpframework/abp/issues/19970

Old style changes:

![image](https://github.com/user-attachments/assets/bef073c4-b35c-4931-acf1-025fc93f4d0a)


https://github.com/user-attachments/assets/08addadb-f034-4d54-b9a4-3b575e8ffad0


New style changes:


https://github.com/user-attachments/assets/87bddd5b-f0cb-429f-aa1c-65c6a85d7a56


