### PR TITLE
Add `ExcludeExceptionFromLoggerSelectors` to `AbpExceptionHandlingOptions` to skip output exception to logger.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/ExceptionHandling/AbpExceptionFilter.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/ExceptionHandling/AbpExceptionFilter.cs
@@ -109,9 +109,12 @@ public class AbpExceptionFilter : IAsyncExceptionFilter, IAbpFilter, ITransientD
         remoteServiceErrorInfoBuilder.AppendLine($"---------- {nameof(RemoteServiceErrorInfo)} ----------");
         remoteServiceErrorInfoBuilder.AppendLine(context.GetRequiredService<IJsonSerializer>().Serialize(remoteServiceErrorInfo, indented: true));
 
-        var logger = context.GetService<ILogger<AbpExceptionFilter>>(NullLogger<AbpExceptionFilter>.Instance)!;
-        var logLevel = context.Exception.GetLogLevel();
-        logger.LogWithLevel(logLevel, remoteServiceErrorInfoBuilder.ToString());
-        logger.LogException(context.Exception, logLevel);
+        if(exceptionHandlingOptions.ShouldLogException(context.Exception))
+        {
+            var logger = context.GetService<ILogger<AbpExceptionFilter>>(NullLogger<AbpExceptionFilter>.Instance)!;
+            var logLevel = context.Exception.GetLogLevel();
+            logger.LogWithLevel(logLevel, remoteServiceErrorInfoBuilder.ToString());
+            logger.LogException(context.Exception, logLevel);
+        }
     }
 }

--- a/framework/src/Volo.Abp.AspNetCore/Volo/Abp/AspNetCore/ExceptionHandling/AbpExceptionHandlingMiddleware.cs
+++ b/framework/src/Volo.Abp.AspNetCore/Volo/Abp/AspNetCore/ExceptionHandling/AbpExceptionHandlingMiddleware.cs
@@ -58,7 +58,12 @@ public class AbpExceptionHandlingMiddleware : AbpMiddlewareBase, ITransientDepen
 
     private async Task HandleAndWrapException(HttpContext httpContext, Exception exception)
     {
-        _logger.LogException(exception);
+        var exceptionHandlingOptions = httpContext.RequestServices.GetRequiredService<IOptions<AbpExceptionHandlingOptions>>().Value;
+
+        if (exceptionHandlingOptions.ShouldLogException(exception))
+        {
+            _logger.LogException(exception);
+        }
 
         await httpContext
             .RequestServices
@@ -77,7 +82,6 @@ public class AbpExceptionHandlingMiddleware : AbpMiddlewareBase, ITransientDepen
             var errorInfoConverter = httpContext.RequestServices.GetRequiredService<IExceptionToErrorInfoConverter>();
             var statusCodeFinder = httpContext.RequestServices.GetRequiredService<IHttpExceptionStatusCodeFinder>();
             var jsonSerializer = httpContext.RequestServices.GetRequiredService<IJsonSerializer>();
-            var exceptionHandlingOptions = httpContext.RequestServices.GetRequiredService<IOptions<AbpExceptionHandlingOptions>>().Value;
 
             httpContext.Response.Clear();
             httpContext.Response.StatusCode = (int)statusCodeFinder.GetStatusCode(httpContext, exception);

--- a/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/AspNetCore/ExceptionHandling/AbpExceptionHandlingOptions.cs
+++ b/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/AspNetCore/ExceptionHandling/AbpExceptionHandlingOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Volo.Abp.AspNetCore.ExceptionHandling;
 
@@ -11,6 +12,12 @@ public class AbpExceptionHandlingOptions
 
     public List<Type> SendExceptionDataToClientTypes { get; set; }
 
+    /// <summary>
+    /// Selectors to exclude exception from logging.
+    /// If a selector returns true, the exception is not logged in to the logging.
+    /// </summary>
+    public List<Func<Exception, bool>> ExcludeExceptionFromLoggerSelectors { get; }
+
     public AbpExceptionHandlingOptions()
     {
         SendExceptionsDetailsToClients = false;
@@ -19,5 +26,11 @@ public class AbpExceptionHandlingOptions
         [
             typeof(IBusinessException)
         ];
+        ExcludeExceptionFromLoggerSelectors = new List<Func<Exception, bool>>();
+    }
+
+    public bool ShouldLogException(Exception exception)
+    {
+        return ExcludeExceptionFromLoggerSelectors.All(selector => !selector(exception));
     }
 }


### PR DESCRIPTION

Resolves #22384