### PR TITLE
Add support for `prompt=select_account` in `AuthorizeController`.

### DIFF
--- a/modules/openiddict/src/Volo.Abp.OpenIddict.AspNetCore/Volo/Abp/OpenIddict/AbpOpenIddictOptions.cs
+++ b/modules/openiddict/src/Volo.Abp.OpenIddict.AspNetCore/Volo/Abp/OpenIddict/AbpOpenIddictOptions.cs
@@ -20,4 +20,9 @@ public class AbpOpenIddictAspNetCoreOptions
     /// Attach auth server current culture info to response.
     /// </summary>
     public bool AttachCultureInfo { get; set; } = true;
+
+    /// <summary>
+    /// Set the url of the select account page.
+    /// </summary>
+    public string SelectAccountPage { get; set; } = "~/Account/SelectAccount";
 }


### PR DESCRIPTION
| **Parameter**    | **Description**                                                                                             |
|------------------|-------------------------------------------------------------------------------------------------------------|
| `login`          | Forces the user to re-authenticate, even if they are already logged in.                                      |
| `consent`        | Forces the user to re-consent to the requested permissions, even if they have consented before.             |
| `select_account` | Forces the user to select an account, even if they are already logged in (especially relevant if multiple accounts are available). |
| `none`           | Does not trigger any prompt. If the user is not logged in, or their consent is not granted, it will return an error or redirect accordingly. |