### PR TITLE
Don't write remote exceptions to console for Blazor WASM.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Components.Web/Volo/Abp/AspNetCore/Components/Web/ExceptionHandling/UserExceptionInformer.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Components.Web/Volo/Abp/AspNetCore/Components/Web/ExceptionHandling/UserExceptionInformer.cs
@@ -8,6 +8,7 @@ using Volo.Abp.AspNetCore.Components.Messages;
 using Volo.Abp.AspNetCore.ExceptionHandling;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Http;
+using Volo.Abp.Http.Client;
 
 namespace Volo.Abp.AspNetCore.Components.Web.ExceptionHandling;
 
@@ -35,6 +36,8 @@ public class UserExceptionInformer : IUserExceptionInformer, IScopedDependency
     {
         //TODO: Create sync versions of the MessageService APIs.
 
+        LogException(context);
+
         var errorInfo = GetErrorInfo(context);
 
         if (errorInfo.Details.IsNullOrEmpty())
@@ -49,6 +52,8 @@ public class UserExceptionInformer : IUserExceptionInformer, IScopedDependency
 
     public async Task InformAsync(UserExceptionInformerContext context)
     {
+        LogException(context);
+
         var errorInfo = GetErrorInfo(context);
 
         if (errorInfo.Details.IsNullOrEmpty())
@@ -69,5 +74,15 @@ public class UserExceptionInformer : IUserExceptionInformer, IScopedDependency
             options.SendStackTraceToClients = Options.SendStackTraceToClients;
             options.SendExceptionDataToClientTypes = Options.SendExceptionDataToClientTypes;
         });
+    }
+
+    protected virtual void LogException(UserExceptionInformerContext context)
+    {
+        if (context.Exception is AbpRemoteCallException && OperatingSystem.IsBrowser())
+        {
+            return;
+        }
+
+        Logger.LogException(context.Exception);
     }
 }

--- a/framework/src/Volo.Abp.AspNetCore.Components/Volo/Abp/AspNetCore/Components/AbpComponentBase.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Components/Volo/Abp/AspNetCore/Components/AbpComponentBase.cs
@@ -172,8 +172,7 @@ public abstract class AbpComponentBase : OwningComponentBase
         {
             return;
         }
-       
-        Logger.LogException(exception);
+
         await InvokeAsync(async () =>
         {
             await UserExceptionInformer.InformAsync(new UserExceptionInformerContext(exception));


### PR DESCRIPTION
Resolve #22431 

[AbpAspNetCoreComponentsModule](https://github.com/abpframework/abp/blob/5f6d94e74d9a364a589c33928a207726ba7262d1/framework/src/Volo.Abp.AspNetCore.Components/Volo/Abp/AspNetCore/Components/AbpAspNetCoreComponentsModule.cs) doesn't directly depend on [AbpExceptionHandlingModule](https://github.com/abpframework/abp/blob/dev/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/ExceptionHandling/AbpExceptionHandlingModule.cs)'s `AbpRemoteCallException`, so move the log code to [AbpAspNetCoreComponentsWebModule](https://github.com/abpframework/abp/blob/5f6d94e74d9a364a589c33928a207726ba7262d1/framework/src/Volo.Abp.AspNetCore.Components.Web/Volo/Abp/AspNetCore/Components/Web/AbpAspNetCoreComponentsWebModule.cs)'s `UserExceptionInformer`.

![screenshot-2025-03-9 T25-40-31@2x](https://github.com/user-attachments/assets/9d6b6d4b-6a7d-4ec9-abad-b5da1175c7cf)
