### PR TITLE
Publishing `DynamicPermissionDefinitionsChangedEto` in uow.

### DIFF
--- a/modules/permission-management/src/Volo.Abp.PermissionManagement.Domain/Volo/Abp/PermissionManagement/StaticPermissionSaver.cs
+++ b/modules/permission-management/src/Volo.Abp.PermissionManagement.Domain/Volo/Abp/PermissionManagement/StaticPermissionSaver.cs
@@ -141,15 +141,15 @@ public class StaticPermissionSaver : IStaticPermissionSaver, ITransientDependenc
                     throw;
                 }
 
-                await unitOfWork.CompleteAsync();
-            }
-
-            if (newOrChangedPermissions.Any())
-            {
-                await DistributedEventBus.PublishAsync(new DynamicPermissionDefinitionsChangedEto
+                if (newOrChangedPermissions.Any())
                 {
-                    Permissions = newOrChangedPermissions.Distinct().ToList()
-                });
+                    await DistributedEventBus.PublishAsync(new DynamicPermissionDefinitionsChangedEto
+                    {
+                        Permissions = newOrChangedPermissions.Distinct().ToList()
+                    });
+                }
+
+                await unitOfWork.CompleteAsync();
             }
         }
 


### PR DESCRIPTION
Otherwise, the outbox won't work, and there's no consistency.

