### PR TITLE
feat: add `AppBasePath` parameter to script and style bundling components

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Bundling/AbpScripts.razor
+++ b/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Bundling/AbpScripts.razor
@@ -5,7 +5,12 @@
 {
     foreach (var file in ScriptFiles)
     {
-        <script src="@file"></script>
+        var src = file;
+        if (!AppBasePath.IsNullOrWhiteSpace())
+        {
+            src = AppBasePath.EnsureEndsWith('/') + file.RemovePreFix("/");
+        }
+        <script src="@src"></script>
     }
 }
 
@@ -18,6 +23,9 @@
 
     [Parameter]
     public string? BundleName { get; set; }
+
+    [Parameter]
+    public string? AppBasePath { get; set; }
 
     private List<string>? ScriptFiles { get; set; }
 

--- a/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Bundling/AbpStyles.razor
+++ b/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Bundling/AbpStyles.razor
@@ -5,7 +5,12 @@
 {
     foreach (var file in StyleFiles)
     {
-        <link rel="stylesheet" href="@file" />
+        var href = file;
+        if (!AppBasePath.IsNullOrWhiteSpace())
+        {
+            href = AppBasePath.EnsureEndsWith('/') + file.RemovePreFix("/");
+        }
+        <link rel="stylesheet" href="@href" />
     }
 }
 
@@ -18,6 +23,9 @@
 
     [Parameter]
     public string? BundleName { get; set; }
+
+    [Parameter]
+    public string? AppBasePath { get; set; }
 
     private List<string>? StyleFiles { get; set; }
 


### PR DESCRIPTION
If you have a subdomain you can set the `AppBasePath` of all resources.

```cs
<AbpStyles AppBasePath="/subdomain" BundleName="@BlazorLeptonXLiteThemeBundles.Styles.Global" />

<AbpScripts AppBasePath="/subdomain"  BundleName="@BlazorLeptonXLiteThemeBundles.Scripts.Global" />

```

From https://abp.io/support/questions/9042/ABP-deployed-to-a-subdirectory