### PR TITLE
fix: column name display logic to include extra prefix

### DIFF
--- a/npm/ng-packs/packages/components/extensible/src/lib/components/extensible-table/extensible-table.component.html
+++ b/npm/ng-packs/packages/components/extensible/src/lib/components/extensible-table/extensible-table.component.html
@@ -28,7 +28,7 @@
     <ngx-datatable-column
       *abpVisible="prop.columnVisible(getInjected)"
       [width]="columnWidths[i + 1] || 200"
-      [name]="prop.displayName | abpLocalization"
+      [name]="(prop.isExtra ? '::' + prop.displayName : prop.displayName) | abpLocalization"
       [prop]="prop.name"
       [sortable]="prop.sortable"
     >


### PR DESCRIPTION
Resolves #22539 

![image](https://github.com/user-attachments/assets/265faf00-3cad-4fcb-8833-f4890282fb12)
