### PR TITLE
Add option to support adding `base` element to layout page.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI/Volo/Abp/AspNetCore/Mvc/UI/Theming/AbpThemingOptions.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI/Volo/Abp/AspNetCore/Mvc/UI/Theming/AbpThemingOptions.cs
@@ -6,6 +6,12 @@ public class AbpThemingOptions
 
     public string? DefaultThemeName { get; set; }
 
+    /// <summary>
+    /// If set, the <c>base</c> element will be added to the <c>head</c> element of the page.
+    /// eg: <base href="/BaseUrl/" />
+    /// </summary>
+    public string? BaseUrl { get; set; }
+
     public AbpThemingOptions()
     {
         Themes = new ThemeDictionary();

--- a/framework/src/Volo.Abp.Swashbuckle/wwwroot/swagger/ui/abp.js
+++ b/framework/src/Volo.Abp.Swashbuckle/wwwroot/swagger/ui/abp.js
@@ -4,7 +4,9 @@ var abp = abp || {};
     /* Application paths *****************************************/
 
     //Current application root path (including virtual directory if exists).
-    abp.appPath = abp.appPath || '/';
+    var baseElement = document.querySelector('base');
+    var baseHref = baseElement ? baseElement.getAttribute('href') : null;
+    abp.appPath = baseHref || abp.appPath || '/';
 
     /* UTILS ***************************************************/
 

--- a/modules/basic-theme/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic/Themes/Basic/Layouts/Account.cshtml
+++ b/modules/basic-theme/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic/Themes/Basic/Layouts/Account.cshtml
@@ -18,6 +18,7 @@
 @inject ICurrentTenant CurrentTenant
 @inject IStringLocalizer<AbpUiMultiTenancyResource> MultiTenancyStringLocalizer
 @inject ITenantResolveResultAccessor TenantResolveResultAccessor
+@inject IOptions<AbpThemingOptions> ThemingOptions
 
 @{
     Layout = null;
@@ -34,6 +35,10 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    @if (!ThemingOptions.Value.BaseUrl.IsNullOrWhiteSpace())
+    {
+        <base href="@ThemingOptions.Value.BaseUrl" />
+    }
 
     <title>@(ViewBag.Title == null ? BrandingProvider.AppName : ViewBag.Title)</title>
 

--- a/modules/basic-theme/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic/Themes/Basic/Layouts/Application.cshtml
+++ b/modules/basic-theme/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic/Themes/Basic/Layouts/Application.cshtml
@@ -1,4 +1,6 @@
-﻿@using Volo.Abp.AspNetCore.Mvc.UI.Components.LayoutHook
+﻿@using Microsoft.Extensions.Options
+@using Volo.Abp.AspNetCore.Mvc.UI.Bundling.TagHelpers
+@using Volo.Abp.AspNetCore.Mvc.UI.Components.LayoutHook
 @using Volo.Abp.AspNetCore.Mvc.UI.Layout
 @using Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic.Bundling
 @using Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic.Themes.Basic.Components.ContentTitle
@@ -12,6 +14,8 @@
 @using Volo.Abp.Ui.LayoutHooks
 @inject IBrandingProvider BrandingProvider
 @inject IPageLayout PageLayout
+@inject IOptions<AbpThemingOptions> ThemingOptions
+
 @{
     Layout = null;
     var containerClass = ViewBag.FluidLayout == true ? "container-fluid" : "container"; //TODO: Better and type-safe options
@@ -40,6 +44,10 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    @if (!ThemingOptions.Value.BaseUrl.IsNullOrWhiteSpace())
+    {
+        <base href="@ThemingOptions.Value.BaseUrl" />
+    }
 
     <title>@pageTitle</title>
 

--- a/modules/basic-theme/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic/Themes/Basic/Layouts/Empty.cshtml
+++ b/modules/basic-theme/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic/Themes/Basic/Layouts/Empty.cshtml
@@ -1,4 +1,6 @@
-﻿@using Volo.Abp.AspNetCore.Mvc.UI.Components.LayoutHook
+﻿@using Microsoft.Extensions.Options
+@using Volo.Abp.AspNetCore.Mvc.UI.Bundling.TagHelpers
+@using Volo.Abp.AspNetCore.Mvc.UI.Components.LayoutHook
 @using Volo.Abp.AspNetCore.Mvc.UI.Layout
 @using Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic.Bundling
 @using Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic.Themes.Basic.Components.PageAlerts
@@ -10,6 +12,8 @@
 @using Volo.Abp.Ui.LayoutHooks
 @inject IBrandingProvider BrandingProvider
 @inject IPageLayout PageLayout
+@inject IOptions<AbpThemingOptions> ThemingOptions
+
 @{
     Layout = null;
     var containerClass = ViewBag.FluidLayout == true ? "container-fluid" : "container"; //TODO: Better and type-safe options
@@ -38,6 +42,10 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    @if (!ThemingOptions.Value.BaseUrl.IsNullOrWhiteSpace())
+    {
+        <base href="@ThemingOptions.Value.BaseUrl" />
+    }
 
     <title>@pageTitle</title>
     @if (ViewBag.Description != null)

--- a/npm/packs/core/src/abp.js
+++ b/npm/packs/core/src/abp.js
@@ -4,7 +4,9 @@ var abp = abp || {};
     /* Application paths *****************************************/
 
     //Current application root path (including virtual directory if exists).
-    abp.appPath = abp.appPath || '/';
+    var baseElement = document.querySelector('base');
+    var baseHref = baseElement ? baseElement.getAttribute('href') : null;
+    abp.appPath = baseHref || abp.appPath || '/';
 
     abp.pageLoadTime = new Date();
 


### PR DESCRIPTION
Resolves #22591

If we have an app deployed to IIS sub-application. We can set `BaseUrl` of `AbpThemingOptions` to the sub-application path.

This style will work regardless of the current page's URL


```cs
.lpx-brand-logo {
    --lpx-logo: url('images/logo/leptonx/icon.svg');
    --lpx-logo-icon: url('images/logo/leptonx/icon.svg');
}

```

https://abp.io/support/questions/9042/ABP-deployed-to-a-subdirectory
