### PR TITLE
Make `AddBlazorWebAppServices` method as obsolete.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Components.WebAssembly/Microsoft/Extensions/DependencyInjection/AbpBlazorWebAppServiceCollectionExtensions.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Components.WebAssembly/Microsoft/Extensions/DependencyInjection/AbpBlazorWebAppServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -19,9 +20,13 @@ public static class AbpBlazorWebAppServiceCollectionExtensions
         return services;
     }
 
+    [Obsolete("Use AddBlazorWebAppServices instead. See https://github.com/abpframework/abp/issues/22622")]
     public static IServiceCollection AddBlazorWebAppTieredServices([NotNull] this IServiceCollection services)
     {
         Check.NotNull(services, nameof(services));
+
+        // Compatibility with old template code
+        services.AddTransient<AddBlazorWebAppTieredServicesHasBeenCalled>();
 
         services.AddScoped<AuthenticationStateProvider, RemoteAuthenticationStateProvider>();
         services.Replace(ServiceDescriptor.Singleton<IAbpAccessTokenProvider, PersistentComponentStateAbpAccessTokenProvider>());

--- a/framework/src/Volo.Abp.AspNetCore.Components.WebAssembly/Volo/Abp/AspNetCore/Components/WebAssembly/WebApp/RemoteAuthenticationStateProvider.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Components.WebAssembly/Volo/Abp/AspNetCore/Components/WebAssembly/WebApp/RemoteAuthenticationStateProvider.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.Extensions.DependencyInjection;
 using Volo.Abp.Security.Claims;
 
 namespace Volo.Abp.AspNetCore.Components.WebAssembly.WebApp;
@@ -8,21 +10,26 @@ public class RemoteAuthenticationStateProvider : AuthenticationStateProvider
 {
     protected ICurrentPrincipalAccessor CurrentPrincipalAccessor { get; }
     protected WebAssemblyCachedApplicationConfigurationClient WebAssemblyCachedApplicationConfigurationClient { get; }
+    protected IServiceProvider ServiceProvider { get; }
 
     public RemoteAuthenticationStateProvider(
         ICurrentPrincipalAccessor currentPrincipalAccessor,
-        WebAssemblyCachedApplicationConfigurationClient webAssemblyCachedApplicationConfigurationClient)
+        WebAssemblyCachedApplicationConfigurationClient webAssemblyCachedApplicationConfigurationClient,
+        IServiceProvider serviceProvider)
     {
         CurrentPrincipalAccessor = currentPrincipalAccessor;
         WebAssemblyCachedApplicationConfigurationClient = webAssemblyCachedApplicationConfigurationClient;
+        ServiceProvider = serviceProvider;
     }
 
     public async override Task<AuthenticationState> GetAuthenticationStateAsync()
     {
-        if (CurrentPrincipalAccessor.Principal.Identity == null ||
-            !CurrentPrincipalAccessor.Principal.Identity.IsAuthenticated)
+        if (ServiceProvider.GetService<AddBlazorWebAppTieredServicesHasBeenCalled>() != null)
         {
-            await WebAssemblyCachedApplicationConfigurationClient.InitializeAsync();
+            if (CurrentPrincipalAccessor.Principal.Identity == null || !CurrentPrincipalAccessor.Principal.Identity.IsAuthenticated)
+            {
+                await WebAssemblyCachedApplicationConfigurationClient.InitializeAsync();
+            }
         }
 
         return new AuthenticationState(CurrentPrincipalAccessor.Principal);

--- a/framework/src/Volo.Abp.AspNetCore.Components.WebAssembly/Volo/Abp/AspNetCore/Components/WebAssembly/WebApp/RemoteAuthenticationStateProviderCompatible.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Components.WebAssembly/Volo/Abp/AspNetCore/Components/WebAssembly/WebApp/RemoteAuthenticationStateProviderCompatible.cs
@@ -1,0 +1,8 @@
+namespace Volo.Abp.AspNetCore.Components.WebAssembly.WebApp;
+
+/// <summary>
+/// This class is used to indicate that the AddBlazorWebAppTieredServices method has been called for compatibility with the old template code
+/// </summary>
+internal sealed class AddBlazorWebAppTieredServicesHasBeenCalled
+{
+}


### PR DESCRIPTION
Resolves #22622