### PR TITLE
Refactoring schematics for standalone migration

### DIFF
--- a/npm/ng-packs/packages/schematics/src/commands/change-theme/index.ts
+++ b/npm/ng-packs/packages/schematics/src/commands/change-theme/index.ts
@@ -12,11 +12,11 @@ import {
   isStandaloneApp,
   updateWorkspace,
   WorkspaceDefinition,
+  getAppConfigPath,
 } from '../../utils';
 import { ThemeOptionsEnum } from './theme-options.enum';
 import { findNodes, getDecoratorMetadata, getMetadataField } from '../../utils/angular/ast-utils';
-import { findBootstrapApplicationCall, getMainFilePath } from '../../utils/angular/standalone/util';
-import { findAppConfig } from '../../utils/angular/standalone/app_config';
+import { getMainFilePath } from '../../utils/angular/standalone/util';
 
 export default function (_options: ChangeThemeOptions): Rule {
   return async () => {
@@ -346,12 +346,6 @@ export const styleCompareFn = (item1: string | object, item2: string | object) =
   const o2 = item2 as { bundleName?: string };
 
   return o1.bundleName && o2.bundleName && o1.bundleName == o2.bundleName;
-};
-
-export const getAppConfigPath = (host: Tree, mainFilePath: string): string => {
-  const bootstrapCall = findBootstrapApplicationCall(host, mainFilePath);
-  const appConfig = findAppConfig(bootstrapCall, host, mainFilePath);
-  return appConfig?.filePath || '';
 };
 
 export const formatFile = (filePath: string): Rule => {

--- a/npm/ng-packs/packages/schematics/src/commands/change-theme/index.ts
+++ b/npm/ng-packs/packages/schematics/src/commands/change-theme/index.ts
@@ -7,8 +7,7 @@ import { ChangeThemeOptions } from './model';
 import {
   addRootImport,
   addRootProvider,
-  createDefaultPath,
-  getWorkspace,
+  getAppModulePath,
   isLibrary,
   isStandaloneApp,
   updateWorkspace,
@@ -16,6 +15,7 @@ import {
 } from '../../utils';
 import { ThemeOptionsEnum } from './theme-options.enum';
 import { findNodes, getDecoratorMetadata, getMetadataField } from '../../utils/angular/ast-utils';
+import { getMainFilePath } from '../../utils/angular/standalone/util';
 
 export default function (_options: ChangeThemeOptions): Rule {
   return async () => {
@@ -64,14 +64,12 @@ function updateProjectStyle(
 
 function updateAppModule(selectedProject: string, targetThemeName: ThemeOptionsEnum): Rule {
   return async (host: Tree) => {
-    const workspace = await getWorkspace(host);
-    const project = workspace.projects.get(selectedProject);
-    const sourceRoot = project?.sourceRoot || 'src';
-    const isStandalone = isStandaloneApp(host, `${sourceRoot}/main.ts`);
+    const mainFilePath = await getMainFilePath(host, selectedProject);
+    console.log('main file path --->>>>>', mainFilePath);
+    const isStandalone = isStandaloneApp(host, mainFilePath);
     console.log('isStandalone --->>>>>', isStandalone);
-    const defaultPath = await createDefaultPath(host, selectedProject);
-    const appModulePath =
-      defaultPath + `${isStandalone ? `${sourceRoot}/main.ts` : '/app.module.ts'}`;
+    const appModulePath = isStandalone ? mainFilePath : getAppModulePath(host, mainFilePath);
+    console.log('app module path --->>>>>', appModulePath);
 
     return chain([
       removeImportPath(appModulePath, targetThemeName),

--- a/npm/ng-packs/packages/schematics/src/commands/change-theme/index.ts
+++ b/npm/ng-packs/packages/schematics/src/commands/change-theme/index.ts
@@ -79,6 +79,7 @@ function updateAppModule(selectedProject: string, targetThemeName: ThemeOptionsE
         : removeProviderFromNgModuleMetadata(appModulePath, targetThemeName),
       insertImports(selectedProject, targetThemeName),
       insertProviders(selectedProject, targetThemeName),
+      formatFile(appModulePath),
     ]);
   };
 }
@@ -351,4 +352,18 @@ export const getAppConfigPath = (host: Tree, mainFilePath: string): string => {
   const bootstrapCall = findBootstrapApplicationCall(host, mainFilePath);
   const appConfig = findAppConfig(bootstrapCall, host, mainFilePath);
   return appConfig?.filePath || '';
+};
+
+export const formatFile = (filePath: string): Rule => {
+  return (tree: Tree) => {
+    const buffer = tree.read(filePath);
+    if (!buffer) return tree;
+
+    const source = ts.createSourceFile(filePath, buffer.toString(), ts.ScriptTarget.Latest, true);
+    const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
+    const formatted = printer.printFile(source);
+
+    tree.overwrite(filePath, formatted);
+    return tree;
+  };
 };

--- a/npm/ng-packs/packages/schematics/src/commands/change-theme/index.ts
+++ b/npm/ng-packs/packages/schematics/src/commands/change-theme/index.ts
@@ -190,10 +190,8 @@ export function removeImportsFromStandaloneProviders(
         let modules: readonly ts.Expression[] = [];
 
         if (args.length === 1 && ts.isArrayLiteralExpression(args[0])) {
-          // importProvidersFrom([Module1, Module2]) tarzı
           modules = (args[0] as ts.ArrayLiteralExpression).elements;
         } else {
-          // importProvidersFrom(Module1, Module2) tarzı
           modules = args;
         }
 
@@ -219,7 +217,6 @@ export function removeImportsFromStandaloneProviders(
           }
         }
 
-        // Eğer tüm modüller silinirse, importProvidersFrom() fonksiyonunu da kaldır
         const remaining = modules.filter(el => !elementsToRemove.includes(el));
         if (remaining.length === 0) {
           const start = expr.getFullStart();
@@ -236,7 +233,6 @@ export function removeImportsFromStandaloneProviders(
           }
         }
       } else {
-        // Diğer bağımsız provider fonksiyonları için
         const match = impMap.find(({ importName, provider }) => {
           const moduleSymbol = importName?.split('.')[0];
           return (
@@ -306,11 +302,11 @@ export function removeProviderFromNgModuleMetadata(
         const prevChar = source.text.slice(start - 1, start);
 
         if (nextChar === ',') {
-          recorder.remove(start, end - start + 1); // sağ virgül ile
+          recorder.remove(start, end - start + 1);
         } else if (prevChar === ',') {
-          recorder.remove(start - 1, end - start + 1); // sol virgül ile
+          recorder.remove(start - 1, end - start + 1);
         } else {
-          recorder.remove(start, end - start); // direkt
+          recorder.remove(start, end - start);
         }
       }
     }

--- a/npm/ng-packs/packages/schematics/src/commands/change-theme/index.ts
+++ b/npm/ng-packs/packages/schematics/src/commands/change-theme/index.ts
@@ -13,7 +13,8 @@ import {
   updateWorkspace,
   WorkspaceDefinition,
   getAppConfigPath,
-  removeEmptyElementsFromArrayLiteral,
+  cleanEmptyExprFromModule,
+  cleanEmptyExprFromProviders,
 } from '../../utils';
 import { ThemeOptionsEnum } from './theme-options.enum';
 import { findNodes, getDecoratorMetadata, getMetadataField } from '../../utils/angular/ast-utils';
@@ -81,7 +82,7 @@ function updateAppModule(selectedProject: string, targetThemeName: ThemeOptionsE
       insertImports(selectedProject, targetThemeName),
       insertProviders(selectedProject, targetThemeName),
       formatFile(appModulePath),
-      cleanNgModuleCommasRule(appModulePath, isStandalone),
+      cleanEmptyExpressions(appModulePath, isStandalone),
     ]);
   };
 }
@@ -364,7 +365,7 @@ export const formatFile = (filePath: string): Rule => {
   };
 };
 
-export function cleanNgModuleCommasRule(modulePath: string, isStandalone: boolean): Rule {
+export function cleanEmptyExpressions(modulePath: string, isStandalone: boolean): Rule {
   return (host: Tree) => {
     const buffer = host.read(modulePath);
     if (!buffer) throw new SchematicsException(`Cannot read ${modulePath}`);
@@ -376,57 +377,11 @@ export function cleanNgModuleCommasRule(modulePath: string, isStandalone: boolea
       true,
     );
     const recorder = host.beginUpdate(modulePath);
-    const printer = ts.createPrinter();
 
     if (isStandalone) {
-      const varStatements = findNodes(source, ts.isVariableStatement);
-
-      for (const stmt of varStatements) {
-        const declList = stmt.declarationList;
-        for (const decl of declList.declarations) {
-          if (!decl.initializer || !ts.isObjectLiteralExpression(decl.initializer)) continue;
-
-          const obj = decl.initializer;
-
-          const providersProp = obj.properties.find(
-            prop =>
-              ts.isPropertyAssignment(prop) &&
-              ts.isIdentifier(prop.name) &&
-              prop.name.text === 'providers',
-          ) as ts.PropertyAssignment;
-
-          if (!providersProp || !ts.isArrayLiteralExpression(providersProp.initializer)) continue;
-
-          const arrayLiteral = providersProp.initializer;
-          const cleanedArray = removeEmptyElementsFromArrayLiteral(arrayLiteral);
-
-          recorder.remove(arrayLiteral.getStart(), arrayLiteral.getWidth());
-          recorder.insertLeft(
-            arrayLiteral.getStart(),
-            printer.printNode(ts.EmitHint.Expression, cleanedArray, source),
-          );
-        }
-      }
+      cleanEmptyExprFromProviders(source, recorder);
     } else {
-      const ngModuleNode = getDecoratorMetadata(source, 'NgModule', '@angular/core')[0];
-      if (!ngModuleNode) return host;
-
-      const metadataKeys = ['imports', 'providers'];
-      for (const key of metadataKeys) {
-        const metadataField = getMetadataField(ngModuleNode as ts.ObjectLiteralExpression, key);
-        if (!metadataField.length) continue;
-
-        const assignment = metadataField[0] as ts.PropertyAssignment;
-        const arrayLiteral = assignment.initializer as ts.ArrayLiteralExpression;
-
-        const cleanedArray = removeEmptyElementsFromArrayLiteral(arrayLiteral);
-
-        recorder.remove(arrayLiteral.getStart(), arrayLiteral.getWidth());
-        recorder.insertLeft(
-          arrayLiteral.getStart(),
-          printer.printNode(ts.EmitHint.Expression, cleanedArray, source),
-        );
-      }
+      cleanEmptyExprFromModule(source, recorder);
     }
     host.commitUpdate(recorder);
     return host;

--- a/npm/ng-packs/packages/schematics/src/commands/change-theme/index.ts
+++ b/npm/ng-packs/packages/schematics/src/commands/change-theme/index.ts
@@ -293,7 +293,9 @@ export function removeProviderFromNgModuleMetadata(
       const elementText = element.getText();
 
       const match = impMap.find(({ provider }) => {
-        return provider && elementText.includes(provider);
+        if (!provider) return false;
+        const providerName = provider.replace(/\(\s*\)$/, '').trim();
+        return provider && elementText.includes(providerName);
       });
 
       if (match) {

--- a/npm/ng-packs/packages/schematics/src/commands/change-theme/style-map.ts
+++ b/npm/ng-packs/packages/schematics/src/commands/change-theme/style-map.ts
@@ -12,6 +12,7 @@ export type ImportDefinition = {
   path: string;
   importName: string;
   provider?: string;
+  expression?: string;
 };
 
 export const styleMap = new Map<ThemeOptionsEnum, StyleDefinition[]>();
@@ -284,25 +285,30 @@ importMap.set(ThemeOptionsEnum.Lepton, [
 importMap.set(ThemeOptionsEnum.LeptonXLite, [
   {
     path: '@abp/ng.theme.lepton-x',
-    importName: 'ThemeLeptonXModule.forRoot()',
+    importName: 'ThemeLeptonXModule',
+    expression: 'ThemeLeptonXModule.forRoot()',
   },
   {
     path: '@abp/ng.theme.lepton-x/layouts',
-    importName: 'SideMenuLayoutModule.forRoot()',
+    importName: 'SideMenuLayoutModule',
+    expression: 'SideMenuLayoutModule.forRoot()',
   },
   {
     path: '@abp/ng.theme.lepton-x/account',
-    importName: 'AccountLayoutModule.forRoot()',
+    importName: 'AccountLayoutModule',
+    expression: 'AccountLayoutModule.forRoot()',
   },
 ]);
 
 importMap.set(ThemeOptionsEnum.LeptonX, [
   {
     path: '@volosoft/abp.ng.theme.lepton-x',
-    importName: 'ThemeLeptonXModule.forRoot()',
+    importName: 'ThemeLeptonXModule',
+    expression: 'ThemeLeptonXModule.forRoot()',
   },
   {
     path: '@volosoft/abp.ng.theme.lepton-x/layouts',
-    importName: 'SideMenuLayoutModule.forRoot()',
+    importName: 'SideMenuLayoutModule',
+    expression: 'SideMenuLayoutModule.forRoot()',
   },
 ]);

--- a/npm/ng-packs/packages/schematics/src/commands/change-theme/style-map.ts
+++ b/npm/ng-packs/packages/schematics/src/commands/change-theme/style-map.ts
@@ -285,13 +285,14 @@ importMap.set(ThemeOptionsEnum.Basic, [
   {
     path: '@abp/ng.theme.shared',
     importName: 'provideAbpThemeShared',
+    provider: 'provideAbpThemeShared',
   },
 ]);
 
 importMap.set(ThemeOptionsEnum.Lepton, [
   {
     path: '@volo/abp.ng.theme.lepton',
-    importName: 'ThemeLeptonModule',
+    importName: 'provideThemeLepton',
     provider: 'provideThemeLepton',
   },
   {
@@ -310,6 +311,7 @@ importMap.set(ThemeOptionsEnum.Lepton, [
   {
     path: '@abp/ng.theme.shared',
     importName: 'provideAbpThemeShared',
+    provider: 'provideAbpThemeShared',
   },
 ]);
 
@@ -345,6 +347,7 @@ importMap.set(ThemeOptionsEnum.LeptonXLite, [
   {
     path: '@abp/ng.theme.shared',
     importName: 'provideAbpThemeShared',
+    provider: 'provideAbpThemeShared',
   },
 ]);
 
@@ -379,5 +382,6 @@ importMap.set(ThemeOptionsEnum.LeptonX, [
   {
     path: '@abp/ng.theme.shared',
     importName: 'provideAbpThemeShared',
+    provider: 'provideAbpThemeShared',
   },
 ]);

--- a/npm/ng-packs/packages/schematics/src/commands/change-theme/style-map.ts
+++ b/npm/ng-packs/packages/schematics/src/commands/change-theme/style-map.ts
@@ -270,6 +270,7 @@ importMap.set(ThemeOptionsEnum.Basic, [
   {
     path: '@abp/ng.theme.basic',
     importName: 'ThemeBasicModule',
+    expression: 'ThemeBasicModule.forRoot()',
     provider: 'provideThemeBasicConfig',
   },
 ]);
@@ -310,5 +311,9 @@ importMap.set(ThemeOptionsEnum.LeptonX, [
     path: '@volosoft/abp.ng.theme.lepton-x/layouts',
     importName: 'SideMenuLayoutModule',
     expression: 'SideMenuLayoutModule.forRoot()',
+  },
+  {
+    path: '@volosoft/abp.ng.theme.lepton-x',
+    importName: 'HttpErrorComponent',
   },
 ]);

--- a/npm/ng-packs/packages/schematics/src/commands/change-theme/style-map.ts
+++ b/npm/ng-packs/packages/schematics/src/commands/change-theme/style-map.ts
@@ -261,7 +261,7 @@ styleMap.set(ThemeOptionsEnum.LeptonXLite, [
     bundleName: 'bootstrap-icons',
   },
 ]);
-// the code written by Github co-pilot. thank go-pilot. You are the best sidekick.
+
 export const allStyles = Array.from(styleMap.values()).reduce((acc, val) => [...acc, ...val], []);
 
 export const importMap = new Map<ThemeOptionsEnum, ImportDefinition[]>();

--- a/npm/ng-packs/packages/schematics/src/commands/change-theme/style-map.ts
+++ b/npm/ng-packs/packages/schematics/src/commands/change-theme/style-map.ts
@@ -271,7 +271,11 @@ importMap.set(ThemeOptionsEnum.Basic, [
     path: '@abp/ng.theme.basic',
     importName: 'ThemeBasicModule',
     expression: 'ThemeBasicModule',
-    provider: 'provideThemeBasicConfig',
+  },
+  {
+    path: '@abp/ng.theme.basic',
+    importName: 'provideThemeBasicConfig',
+    provider: 'provideThemeBasicConfig()',
   },
   {
     path: '@abp/ng.theme.shared',
@@ -285,7 +289,7 @@ importMap.set(ThemeOptionsEnum.Basic, [
   {
     path: '@abp/ng.theme.shared',
     importName: 'provideAbpThemeShared',
-    provider: 'provideAbpThemeShared',
+    provider: 'provideAbpThemeShared()',
   },
 ]);
 
@@ -293,7 +297,7 @@ importMap.set(ThemeOptionsEnum.Lepton, [
   {
     path: '@volo/abp.ng.theme.lepton',
     importName: 'provideThemeLepton',
-    provider: 'provideThemeLepton',
+    provider: 'provideThemeLepton()',
   },
   {
     path: '@abp/ng.theme.shared',
@@ -311,7 +315,7 @@ importMap.set(ThemeOptionsEnum.Lepton, [
   {
     path: '@abp/ng.theme.shared',
     importName: 'provideAbpThemeShared',
-    provider: 'provideAbpThemeShared',
+    provider: 'provideAbpThemeShared()',
   },
 ]);
 
@@ -347,7 +351,7 @@ importMap.set(ThemeOptionsEnum.LeptonXLite, [
   {
     path: '@abp/ng.theme.shared',
     importName: 'provideAbpThemeShared',
-    provider: 'provideAbpThemeShared',
+    provider: 'provideAbpThemeShared()',
   },
 ]);
 
@@ -382,6 +386,6 @@ importMap.set(ThemeOptionsEnum.LeptonX, [
   {
     path: '@abp/ng.theme.shared',
     importName: 'provideAbpThemeShared',
-    provider: 'provideAbpThemeShared',
+    provider: 'provideAbpThemeShared()',
   },
 ]);

--- a/npm/ng-packs/packages/schematics/src/commands/change-theme/style-map.ts
+++ b/npm/ng-packs/packages/schematics/src/commands/change-theme/style-map.ts
@@ -270,8 +270,21 @@ importMap.set(ThemeOptionsEnum.Basic, [
   {
     path: '@abp/ng.theme.basic',
     importName: 'ThemeBasicModule',
-    expression: 'ThemeBasicModule.forRoot()',
+    expression: 'ThemeBasicModule',
     provider: 'provideThemeBasicConfig',
+  },
+  {
+    path: '@abp/ng.theme.shared',
+    importName: 'ThemeSharedModule',
+    expression: 'ThemeSharedModule',
+  },
+  {
+    path: '@abp/ng.theme.shared',
+    importName: 'withValidationBluePrint',
+  },
+  {
+    path: '@abp/ng.theme.shared',
+    importName: 'provideAbpThemeShared',
   },
 ]);
 
@@ -280,6 +293,23 @@ importMap.set(ThemeOptionsEnum.Lepton, [
     path: '@volo/abp.ng.theme.lepton',
     importName: 'ThemeLeptonModule',
     provider: 'provideThemeLepton',
+  },
+  {
+    path: '@abp/ng.theme.shared',
+    importName: 'ThemeSharedModule',
+    expression: 'ThemeSharedModule',
+  },
+  {
+    path: '@abp/ng.theme.shared',
+    importName: 'withHttpErrorConfig',
+  },
+  {
+    path: '@abp/ng.theme.shared',
+    importName: 'withValidationBluePrint',
+  },
+  {
+    path: '@abp/ng.theme.shared',
+    importName: 'provideAbpThemeShared',
   },
 ]);
 
@@ -299,6 +329,23 @@ importMap.set(ThemeOptionsEnum.LeptonXLite, [
     importName: 'AccountLayoutModule',
     expression: 'AccountLayoutModule.forRoot()',
   },
+  {
+    path: '@abp/ng.theme.shared',
+    importName: 'ThemeSharedModule',
+    expression: 'ThemeSharedModule',
+  },
+  {
+    path: '@abp/ng.theme.shared',
+    importName: 'withHttpErrorConfig',
+  },
+  {
+    path: '@abp/ng.theme.shared',
+    importName: 'withValidationBluePrint',
+  },
+  {
+    path: '@abp/ng.theme.shared',
+    importName: 'provideAbpThemeShared',
+  },
 ]);
 
 importMap.set(ThemeOptionsEnum.LeptonX, [
@@ -313,7 +360,24 @@ importMap.set(ThemeOptionsEnum.LeptonX, [
     expression: 'SideMenuLayoutModule.forRoot()',
   },
   {
+    path: '@abp/ng.theme.shared',
+    importName: 'ThemeSharedModule',
+    expression: 'ThemeSharedModule',
+  },
+  {
     path: '@volosoft/abp.ng.theme.lepton-x',
     importName: 'HttpErrorComponent',
+  },
+  {
+    path: '@abp/ng.theme.shared',
+    importName: 'withHttpErrorConfig',
+  },
+  {
+    path: '@abp/ng.theme.shared',
+    importName: 'withValidationBluePrint',
+  },
+  {
+    path: '@abp/ng.theme.shared',
+    importName: 'provideAbpThemeShared',
   },
 ]);

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/.eslintrc.json.template
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/.eslintrc.json.template
@@ -1,0 +1,44 @@
+{
+  "extends": "../../.eslintrc.json",
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts"
+      ],
+      "parserOptions": {
+        "project": [
+          "projects/<%= kebab(libraryName) %>/tsconfig.lib.json",
+          "projects/<%= kebab(libraryName) %>/tsconfig.spec.json"
+        ],
+        "createDefaultProgram": true
+      },
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "lib",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "lib",
+            "style": "kebab-case"
+          }
+        ]
+      }
+    },
+    {
+      "files": [
+        "*.html"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/config/ng-package.json.template
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/config/ng-package.json.template
@@ -1,0 +1,7 @@
+{
+  "$schema": "../../../node_modules/ng-packagr/ng-entrypoint.schema.json",
+  "dest": "../../dist/<%= kebab(libraryName) %>/config",
+  "lib": {
+    "entryFile": "src/public-api.ts"
+  }
+}

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/config/src/enums/index.ts.template
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/config/src/enums/index.ts.template
@@ -1,0 +1,1 @@
+export * from './route-names';

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/config/src/enums/route-names.ts.template
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/config/src/enums/route-names.ts.template
@@ -1,0 +1,3 @@
+export const enum e<%= pascal(libraryName) %>RouteNames {
+  <%= pascal(libraryName) %> = '<%= pascal(libraryName) %>',
+}

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/config/src/providers/index.ts.template
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/config/src/providers/index.ts.template
@@ -1,0 +1,1 @@
+export * from './route.provider';

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/config/src/providers/route.provider.ts.template
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/config/src/providers/route.provider.ts.template
@@ -1,0 +1,25 @@
+import { APP_INITIALIZER, Provider } from '@angular/core';
+import { eLayoutType, RoutesService } from '@abp/ng.core';
+import { e<%= pascal(libraryName) %>RouteNames } from '../enums/route-names';
+import { makeEnvironmentProviders, provideAppInitializer, inject } from '@angular/core';
+
+export function configureRoutes() {
+  const routes = inject(RoutesService);
+  routes.add([
+      {
+        path: '/<%= kebab(libraryName) %>',
+        name: e<%= pascal(libraryName) %>RouteNames.<%= pascal(libraryName) %>,
+        iconClass: 'fas fa-book',
+        layout: eLayoutType.application,
+        order: 3,
+      },
+  ]);
+}
+
+export function provide<%= pascal(libraryName) %>Config() {
+  return makeEnvironmentProviders([
+    provideAppInitializer(() => {
+      configureRoutes();
+    }),
+  ]);
+}

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/config/src/providers/route.provider.ts.template
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/config/src/providers/route.provider.ts.template
@@ -1,7 +1,12 @@
-import { APP_INITIALIZER, Provider } from '@angular/core';
 import { eLayoutType, RoutesService } from '@abp/ng.core';
 import { e<%= pascal(libraryName) %>RouteNames } from '../enums/route-names';
-import { makeEnvironmentProviders, provideAppInitializer, inject } from '@angular/core';
+import { makeEnvironmentProviders, provideAppInitializer, inject, EnvironmentProviders } from '@angular/core';
+
+export const <%= macro(libraryName) %>_ROUTE_PROVIDERS = [
+  provideAppInitializer(() => {
+    configureRoutes();
+  }),
+];
 
 export function configureRoutes() {
   const routes = inject(RoutesService);
@@ -16,10 +21,10 @@ export function configureRoutes() {
   ]);
 }
 
+export const <%= macro(libraryName) %>_PROVIDERS: EnvironmentProviders[] = [
+  ...<%= macro(libraryName) %>_ROUTE_PROVIDERS,
+];
+
 export function provide<%= pascal(libraryName) %>Config() {
-  return makeEnvironmentProviders([
-    provideAppInitializer(() => {
-      configureRoutes();
-    }),
-  ]);
+  return makeEnvironmentProviders(<%= macro(libraryName) %>_PROVIDERS);
 }

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/config/src/public-api.ts.template
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/config/src/public-api.ts.template
@@ -1,0 +1,2 @@
+export * from './enums';
+export * from './providers';

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/karma.conf.js.template
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/karma.conf.js.template
@@ -1,0 +1,44 @@
+// Karma configuration file, see link for more information
+// https://karma-runner.github.io/1.0/config/configuration-file.html
+
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma')
+    ],
+    client: {
+      jasmine: {
+        // you can add configuration options for Jasmine here
+        // the possible options are listed at https://jasmine.github.io/api/edge/Configuration.html
+        // for example, you can disable the random execution with `random: false`
+        // or set a specific seed with `seed: 4321`
+      },
+      clearContext: false // leave Jasmine Spec Runner output visible in browser
+    },
+    jasmineHtmlReporter: {
+      suppressAll: true // removes the duplicated traces
+    },
+    coverageReporter: {
+      dir: require('path').join(__dirname, '../../coverage/<%= kebab(libraryName) %>'),
+      subdir: '.',
+      reporters: [
+        { type: 'html' },
+        { type: 'text-summary' }
+      ]
+    },
+    reporters: ['progress', 'kjhtml'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: true,
+    browsers: ['Chrome'],
+    singleRun: false,
+    restartOnFileChange: true
+  });
+};

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/ng-package.json.template
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/ng-package.json.template
@@ -1,0 +1,7 @@
+{
+  "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
+  "dest": "../../dist/<%= kebab(libraryName) %>",
+  "lib": {
+    "entryFile": "src/public-api.ts"
+  }
+}

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/package.json.template
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/package.json.template
@@ -1,0 +1,11 @@
+{
+  "name": "@<%= kebab(libraryName) %>/<%= kebab(libraryName) %>",
+  "version": "0.0.1",
+  "peerDependencies": {
+    "@abp/ng.core": "<%= abpVersion %>",
+    "@abp/ng.theme.shared": "<%= abpVersion %>"
+  },
+  "dependencies": {
+    "tslib": "^2.1.0"
+  }
+}

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/src/lib/__libraryName@kebab__-routing.ts.template
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/src/lib/__libraryName@kebab__-routing.ts.template
@@ -1,0 +1,9 @@
+import { Routes } from '@angular/router';
+
+export const <%= pascal(libraryName) %>Routes: Routes = [
+  {
+    path: '',
+    loadComponent: () =>
+      import('./<%= kebab(libraryName) %>.component').then(m => m.<%= pascal(libraryName) %>HomeComponent),
+  },
+];

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/src/lib/__libraryName@kebab__.component.ts.template
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/src/lib/__libraryName@kebab__.component.ts.template
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import {CoreModule} from "@abp/ng.core";
+import {ThemeSharedModule} from "@abp/ng.theme.shared";
+
+@Component({
+  standalone: true,
+  selector: '<%= camel(libraryName) %>-home',
+  template: `<h1>Lazy Loaded Test Component</h1>`,
+  imports: [CoreModule, ThemeSharedModule],
+})
+export class <%= pascal(libraryName) %>HomeComponent {}

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/src/lib/__libraryName@kebab__.component.ts.template
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/src/lib/__libraryName@kebab__.component.ts.template
@@ -8,4 +8,4 @@ import {ThemeSharedModule} from "@abp/ng.theme.shared";
   template: `<h1>Lazy Loaded Test Component</h1>`,
   imports: [CoreModule, ThemeSharedModule],
 })
-export class <%= pascal(libraryName) %>HomeComponent {}
+export class <%= pascal(libraryName) %>Component {}

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/src/lib/__libraryName@kebab__.routes.ts.template
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/src/lib/__libraryName@kebab__.routes.ts.template
@@ -4,6 +4,6 @@ export const <%= macro(libraryName) %>_ROUTES: Routes = [
   {
     path: '',
     loadComponent: () =>
-      import('./<%= kebab(libraryName) %>.component').then(m => m.<%= pascal(libraryName) %>HomeComponent),
+      import('./<%= kebab(libraryName) %>.component').then(m => m.<%= pascal(libraryName) %>Component),
   },
 ];

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/src/lib/__libraryName@kebab__.routes.ts.template
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/src/lib/__libraryName@kebab__.routes.ts.template
@@ -1,6 +1,6 @@
 import { Routes } from '@angular/router';
 
-export const <%= pascal(libraryName) %>Routes: Routes = [
+export const <%= macro(libraryName) %>_ROUTES: Routes = [
   {
     path: '',
     loadComponent: () =>

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/src/lib/index.ts.template
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/src/lib/index.ts.template
@@ -1,0 +1,1 @@
+export * from './<%= kebab(libraryName) %>-routing';

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/src/lib/index.ts.template
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/src/lib/index.ts.template
@@ -1,1 +1,1 @@
-export * from './<%= kebab(libraryName) %>-routing';
+export * from './<%= kebab(libraryName) %>.routes';

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/src/public-api.ts.template
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/src/public-api.ts.template
@@ -1,0 +1,4 @@
+/*
+ * Public API Surface of my-project-name
+ */
+export * from './lib';

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/src/test.ts.template
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/src/test.ts.template
@@ -1,0 +1,26 @@
+// This file is required by karma.conf.js and loads recursively all the .spec and framework files
+
+import 'zone.js';
+import 'zone.js/testing';
+import { getTestBed } from '@angular/core/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting
+} from '@angular/platform-browser-dynamic/testing';
+
+declare const require: {
+  context(path: string, deep?: boolean, filter?: RegExp): {
+    keys(): string[];
+    <T>(id: string): T;
+  };
+};
+
+// First, initialize the Angular testing environment.
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting()
+);
+// Then we find all the tests.
+const context = require.context('./', true, /\.spec\.ts$/);
+// And load the modules.
+context.keys().map(context);

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/tsconfig.lib.json.template
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/tsconfig.lib.json.template
@@ -1,0 +1,20 @@
+/* To learn more about this file see: https://angular.io/config/tsconfig. */
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../out-tsc/lib",
+    "target": "es2020",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": [],
+    "lib": [
+      "dom",
+      "es2018"
+    ]
+  },
+  "exclude": [
+    "src/test.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/tsconfig.lib.prod.json.template
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/tsconfig.lib.prod.json.template
@@ -1,0 +1,10 @@
+/* To learn more about this file see: https://angular.io/config/tsconfig. */
+{
+  "extends": "./tsconfig.lib.json",
+  "compilerOptions": {
+    "declarationMap": false
+  },
+  "angularCompilerOptions": {
+    "compilationMode": "partial"
+  }
+}

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/tsconfig.spec.json.template
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/tsconfig.spec.json.template
@@ -1,0 +1,17 @@
+/* To learn more about this file see: https://angular.io/config/tsconfig. */
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../out-tsc/spec",
+    "types": [
+      "jasmine"
+    ]
+  },
+  "files": [
+    "src/test.ts"
+  ],
+  "include": [
+    "**/*.spec.ts",
+    "**/*.d.ts"
+  ]
+}

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/files-secondary-entrypoint-standalone/__libraryName@kebab__/ng-package.json.template
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/files-secondary-entrypoint-standalone/__libraryName@kebab__/ng-package.json.template
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../node_modules/ng-packagr/ng-entrypoint.schema.json",
+  "lib": {
+    "entryFile": "src/public-api.ts"
+  }
+}

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/files-secondary-entrypoint-standalone/__libraryName@kebab__/src/lib/__target@kebab__-__libraryName@kebab__.ts.template
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/files-secondary-entrypoint-standalone/__libraryName@kebab__/src/lib/__target@kebab__-__libraryName@kebab__.ts.template
@@ -1,0 +1,7 @@
+import { Provider } from '@angular/core';
+
+export function provide<%= pascal(target) %><%= pascal(libraryName) %>(): Provider[] {
+  return [
+    // Add your providers here
+  ];
+}

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/files-secondary-entrypoint-standalone/__libraryName@kebab__/src/lib/index.ts.template
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/files-secondary-entrypoint-standalone/__libraryName@kebab__/src/lib/index.ts.template
@@ -1,0 +1,1 @@
+export * from './<%= kebab(target) %>-<%= kebab(libraryName) %>';

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/files-secondary-entrypoint-standalone/__libraryName@kebab__/src/public-api.ts.template
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/files-secondary-entrypoint-standalone/__libraryName@kebab__/src/public-api.ts.template
@@ -1,0 +1,1 @@
+export * from './lib/index';

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/index.ts
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/index.ts
@@ -16,6 +16,7 @@ import {
   addRootProvider,
   addRouteDeclarationToModule,
   applyWithOverwrite,
+  findAppRoutesPath,
   getFirstApplication,
   getWorkspace,
   InsertChange,
@@ -255,18 +256,16 @@ export function addRoutingToAppRoutingModule(
   return async (tree: Tree) => {
     const projectName = getFirstApplication(tree).name!;
     const project = workspace.projects.get(projectName);
-    console.log('project --->>>', project);
     const mainFilePath = await getMainFilePath(tree, projectName);
-    console.log('main file path ---->>>>', mainFilePath);
     const isSourceStandalone = isStandaloneApp(tree, mainFilePath);
-    console.log('isSourceStandalone ---->>>>', isSourceStandalone);
 
     const pascalName = pascal(packageName);
     const routePath = `${kebab(packageName)}`;
     const moduleName = `${pascalName}Module`;
 
     if (isSourceStandalone) {
-      const appRoutesPath = `${project?.sourceRoot}/app/app.routes.ts`;
+      const appRoutesPath =
+        findAppRoutesPath(tree, mainFilePath) || `${project?.sourceRoot}/app/app.routes.ts`;
       const buffer = tree.read(appRoutesPath);
       if (!buffer) {
         throw new SchematicsException(`Cannot find routes file: ${appRoutesPath}`);

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/index.ts
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/index.ts
@@ -19,6 +19,7 @@ import {
   findAppRoutesPath,
   getFirstApplication,
   getWorkspace,
+  hasProviderInStandaloneAppConfig,
   InsertChange,
   interpolate,
   isLibrary,
@@ -219,11 +220,19 @@ export function importConfigModuleToDefaultProjectAppModule(
   packageName: string,
   options: GenerateLibSchema,
 ) {
-  return (tree: Tree) => {
+  return async (tree: Tree) => {
     const projectName = getFirstApplication(tree).name!;
     const rules: Rule[] = [];
 
     if (options.templateType === 'standalone') {
+      const providerAlreadyExists = await hasProviderInStandaloneAppConfig(
+        tree,
+        projectName,
+        `provide${pascal(packageName)}Config`,
+      );
+      if (providerAlreadyExists) {
+        return;
+      }
       rules.push(
         addRootProvider(projectName, code => {
           const configFn = code.external(

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/index.ts
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/index.ts
@@ -303,7 +303,7 @@ export function addRoutingToAppRoutingModule(
           ? `() => import('${routePath}').then(m => m.${macroName}_ROUTES)`
           : `() => import('${routePath}').then(m => m.${moduleName}.forLazy())`;
       const routeToAdd = `{ path: '${routePath}', loadChildren: ${routeExpr} }`;
-      const change = addRouteToRoutesArray(source, 'routes', routeToAdd);
+      const change = addRouteToRoutesArray(source, 'APP_ROUTES', routeToAdd);
 
       if (change instanceof InsertChange) {
         const recorder = tree.beginUpdate(appRoutesPath);
@@ -396,12 +396,13 @@ export function addRouteToRoutesArray(
     return null;
   }
 
+  const hasTrailingComma = arrayLiteral.elements.hasTrailingComma ?? false;
   const insertPos =
-    arrayLiteral.elements.hasTrailingComma || arrayLiteral.elements.length === 0
+    hasTrailingComma || arrayLiteral.elements.length === 0
       ? arrayLiteral.getEnd() - 1
       : arrayLiteral.elements[arrayLiteral.elements.length - 1].getEnd();
 
-  const prefix = arrayLiteral.elements.length > 0 ? ',\n  ' : '  ';
+  const prefix = arrayLiteral.elements.length > 0 && !hasTrailingComma ? ',\n  ' : '  ';
   const toAdd = `${prefix}${routeToAdd}`;
 
   return new InsertChange(source.fileName, insertPos, toAdd);

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/index.ts
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/index.ts
@@ -322,7 +322,8 @@ export function addRoutingToAppRoutingModule(
         return;
       }
       const appRoutingModuleContent = appRoutingModule.toString();
-      if (appRoutingModuleContent.includes(moduleName)) {
+      const routeExpr = options.templateType === 'standalone' ? `${macroName}_ROUTES` : moduleName;
+      if (appRoutingModuleContent.includes(routeExpr)) {
         return;
       }
 

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/models/generate-lib-schema.ts
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/models/generate-lib-schema.ts
@@ -11,9 +11,7 @@ export interface GenerateLibSchema {
   /**
    * İs the package has standalone template
    */
-  isStandaloneTemplate: boolean;
-
-  isModuleTemplate: boolean;
+  templateType: 'standalone' | 'module';
 
   override: boolean;
 

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/models/generate-lib-schema.ts
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/models/generate-lib-schema.ts
@@ -8,6 +8,10 @@ export interface GenerateLibSchema {
    * İs the package a library or a library module
    */
   isSecondaryEntrypoint: boolean;
+  /**
+   * İs the package has standalone template
+   */
+  isStandaloneTemplate: boolean;
 
   isModuleTemplate: boolean;
 

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/models/generate-lib-schema.ts
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/models/generate-lib-schema.ts
@@ -1,3 +1,8 @@
+export enum GenerateLibTemplateType {
+  Standalone = 'standalone',
+  Module = 'module',
+}
+
 export interface GenerateLibSchema {
   /**
    * Angular package name will create
@@ -11,7 +16,7 @@ export interface GenerateLibSchema {
   /**
    * İs the package has standalone template
    */
-  templateType: 'standalone' | 'module';
+  templateType: GenerateLibTemplateType;
 
   override: boolean;
 

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/schema.json
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/schema.json
@@ -31,12 +31,21 @@
       },
       "x-prompt": "Is module template?"
     },
+    "isStandaloneTemplate": {
+      "description": "Is standalone template",
+      "type": "boolean",
+      "$default": {
+        "$source": "argv",
+        "index": 3
+      },
+      "x-prompt": "Is standalone template?"
+    },
     "override": {
       "description": "Override existing files",
       "type": "boolean",
       "$default": {
         "$source": "argv",
-        "index": 3
+        "index": 4
       },
       "x-prompt": "Override existing files?"
     }

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/schema.json
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/schema.json
@@ -22,23 +22,18 @@
       },
       "x-prompt": "Is secondary entrypoint?"
     },
-    "isModuleTemplate": {
-      "description": "Is module template",
-      "type": "boolean",
-      "$default": {
-        "$source": "argv",
-        "index": 2
-      },
-      "x-prompt": "Is module template?"
-    },
-    "isStandaloneTemplate": {
-      "description": "Is standalone template",
-      "type": "boolean",
-      "$default": {
-        "$source": "argv",
-        "index": 3
-      },
-      "x-prompt": "Is standalone template?"
+    "templateType": {
+      "type": "string",
+      "description": "Type of the template",
+      "enum": ["module", "standalone"],
+      "x-prompt": {
+        "message": "Select the type of template to generate:",
+        "type": "list",
+        "items": [
+          { "value": "module", "label": "Module Template" },
+          { "value": "standalone", "label": "Standalone Template" }
+        ]
+      }
     },
     "override": {
       "description": "Override existing files",

--- a/npm/ng-packs/packages/schematics/src/utils/angular/add-declaration-to-ng-module.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/angular/add-declaration-to-ng-module.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Rule, Tree, strings } from '@angular-devkit/schematics';
@@ -19,6 +19,7 @@ export interface DeclarationToNgModuleOptions {
   flat?: boolean;
   export?: boolean;
   type: string;
+  typeSeparator?: '.' | '-';
   skipImport?: boolean;
   standalone?: boolean;
 }
@@ -30,6 +31,8 @@ export function addDeclarationToNgModule(options: DeclarationToNgModuleOptions):
       return host;
     }
 
+    const typeSeparator = options.typeSeparator ?? '.';
+
     const sourceText = host.readText(modulePath);
     const source = ts.createSourceFile(modulePath, sourceText, ts.ScriptTarget.Latest, true);
 
@@ -37,11 +40,11 @@ export function addDeclarationToNgModule(options: DeclarationToNgModuleOptions):
       `/${options.path}/` +
       (options.flat ? '' : strings.dasherize(options.name) + '/') +
       strings.dasherize(options.name) +
-      (options.type ? '.' : '') +
-      strings.dasherize(options.type);
+      (options.type ? typeSeparator + strings.dasherize(options.type) : '');
 
     const importPath = buildRelativePath(modulePath, filePath);
-    const classifiedName = strings.classify(options.name) + strings.classify(options.type);
+    const classifiedName =
+      strings.classify(options.name) + (options.type ? strings.classify(options.type) : '');
     const changes = addDeclarationToModule(source, modulePath, classifiedName, importPath);
 
     if (options.export) {

--- a/npm/ng-packs/packages/schematics/src/utils/angular/ast-utils.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/angular/ast-utils.ts
@@ -493,8 +493,15 @@ export function addImportToModule(
   modulePath: string,
   classifiedName: string,
   importPath: string,
+  isStandalone = false,
 ): Change[] {
-  return addSymbolToNgModuleMetadata(source, modulePath, 'imports', classifiedName, importPath);
+  return addSymbolToNgModuleMetadata(
+    source,
+    modulePath,
+    isStandalone ? 'providers' : 'imports',
+    classifiedName,
+    importPath,
+  );
 }
 
 /**

--- a/npm/ng-packs/packages/schematics/src/utils/angular/change.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/angular/change.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { UpdateRecorder } from '@angular-devkit/schematics';
@@ -47,7 +47,11 @@ export class InsertChange implements Change {
   order: number;
   description: string;
 
-  constructor(public path: string, public pos: number, public toAdd: string) {
+  constructor(
+    public path: string,
+    public pos: number,
+    public toAdd: string,
+  ) {
     if (pos < 0) {
       throw new Error('Negative positions are invalid');
     }
@@ -59,7 +63,7 @@ export class InsertChange implements Change {
    * This method does not insert spaces if there is none in the original string.
    */
   apply(host: Host) {
-    return host.read(this.path).then((content) => {
+    return host.read(this.path).then(content => {
       const prefix = content.substring(0, this.pos);
       const suffix = content.substring(this.pos);
 
@@ -75,7 +79,11 @@ export class RemoveChange implements Change {
   order: number;
   description: string;
 
-  constructor(public path: string, private pos: number, public toRemove: string) {
+  constructor(
+    public path: string,
+    private pos: number,
+    public toRemove: string,
+  ) {
     if (pos < 0) {
       throw new Error('Negative positions are invalid');
     }
@@ -84,7 +92,7 @@ export class RemoveChange implements Change {
   }
 
   apply(host: Host): Promise<void> {
-    return host.read(this.path).then((content) => {
+    return host.read(this.path).then(content => {
       const prefix = content.substring(0, this.pos);
       const suffix = content.substring(this.pos + this.toRemove.length);
 
@@ -115,7 +123,7 @@ export class ReplaceChange implements Change {
   }
 
   apply(host: Host): Promise<void> {
-    return host.read(this.path).then((content) => {
+    return host.read(this.path).then(content => {
       const prefix = content.substring(0, this.pos);
       const suffix = content.substring(this.pos + this.oldText.length);
       const text = content.substring(this.pos, this.pos + this.oldText.length);

--- a/npm/ng-packs/packages/schematics/src/utils/angular/dependencies.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/angular/dependencies.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Tree } from '@angular-devkit/schematics';

--- a/npm/ng-packs/packages/schematics/src/utils/angular/dependency.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/angular/dependency.ts
@@ -3,12 +3,12 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Rule, SchematicContext } from '@angular-devkit/schematics';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
-import * as path from 'path';
+import * as path from 'node:path';
 
 const installTasks = new WeakMap<SchematicContext, Set<string>>();
 
@@ -41,11 +41,13 @@ export enum InstallBehavior {
    * which may install the dependency.
    */
   None,
+
   /**
    * Automatically determine the need to schedule a {@link NodePackageInstallTask} based on
    * previous usage of the {@link addDependency} within the schematic.
    */
   Auto,
+
   /**
    * Always schedule a {@link NodePackageInstallTask} when the rule is executed.
    */
@@ -62,6 +64,7 @@ export enum ExistingBehavior {
    * The dependency will not be added or otherwise changed if it already exists.
    */
   Skip,
+
   /**
    * The dependency's existing specifier will be replaced with the specifier provided in the
    * {@link addDependency} call. A warning will also be shown during schematic execution to
@@ -95,17 +98,20 @@ export function addDependency(
      * dependency will be added. Defaults to {@link DependencyType.Default} (`dependencies`).
      */
     type?: DependencyType;
+
     /**
      * The path of the package manifest file (`package.json`) that will be modified.
      * Defaults to `/package.json`.
      */
     packageJsonPath?: string;
+
     /**
      * The dependency installation behavior to use to determine whether a
      * {@link NodePackageInstallTask} should be scheduled after adding the dependency.
      * Defaults to {@link InstallBehavior.Auto}.
      */
     install?: InstallBehavior;
+
     /**
      * The behavior to use when the dependency already exists within the `package.json`.
      * Defaults to {@link ExistingBehavior.Replace}.

--- a/npm/ng-packs/packages/schematics/src/utils/angular/eol.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/angular/eol.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { EOL } from 'node:os';
+
+const CRLF = '\r\n';
+const LF = '\n';
+
+export function getEOL(content: string): string {
+  const newlines = content.match(/(?:\r?\n)/g);
+
+  if (newlines?.length) {
+    const crlf = newlines.filter(l => l === CRLF).length;
+    const lf = newlines.length - crlf;
+
+    return crlf > lf ? CRLF : LF;
+  }
+
+  return EOL;
+}

--- a/npm/ng-packs/packages/schematics/src/utils/angular/find-module.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/angular/find-module.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { NormalizedRoot, Path, dirname, join, normalize, relative } from '@angular-devkit/core';
@@ -54,12 +54,12 @@ export function findModuleFromOptions(host: Tree, options: ModuleOptions): Path 
 
     const candidatesDirs = [...candidateSet].sort((a, b) => b.length - a.length);
     for (const c of candidatesDirs) {
-      const candidateFiles = ['', `${moduleBaseName}.ts`, `${moduleBaseName}${moduleExt}`].map(
-        (x) => join(c, x),
+      const candidateFiles = ['', `${moduleBaseName}.ts`, `${moduleBaseName}${moduleExt}`].map(x =>
+        join(c, x),
       );
 
       for (const sc of candidateFiles) {
-        if (host.exists(sc)) {
+        if (host.exists(sc) && host.readText(sc).includes('@NgModule')) {
           return normalize(sc);
         }
       }
@@ -85,8 +85,8 @@ export function findModule(
   let foundRoutingModule = false;
 
   while (dir) {
-    const allMatches = dir.subfiles.filter((p) => p.endsWith(moduleExt));
-    const filteredMatches = allMatches.filter((p) => !p.endsWith(routingModuleExt));
+    const allMatches = dir.subfiles.filter(p => p.endsWith(moduleExt));
+    const filteredMatches = allMatches.filter(p => !p.endsWith(routingModuleExt));
 
     foundRoutingModule = foundRoutingModule || allMatches.length !== filteredMatches.length;
 

--- a/npm/ng-packs/packages/schematics/src/utils/angular/index.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/angular/index.ts
@@ -11,3 +11,4 @@ export * from './project-targets';
 export * from './validation';
 export * from './workspace';
 export * from './workspace-models';
+export * from './standalone';

--- a/npm/ng-packs/packages/schematics/src/utils/angular/parse-name.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/angular/parse-name.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Path, basename, dirname, join, normalize } from '@angular-devkit/core';

--- a/npm/ng-packs/packages/schematics/src/utils/angular/paths.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/angular/paths.ts
@@ -3,17 +3,15 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
-import { normalize, split } from '@angular-devkit/core';
+import { join, relative } from 'node:path/posix';
 
 export function relativePathToWorkspaceRoot(projectRoot: string | undefined): string {
-  const normalizedPath = split(normalize(projectRoot || ''));
-
-  if (normalizedPath.length === 0 || !normalizedPath[0]) {
+  if (!projectRoot) {
     return '.';
-  } else {
-    return normalizedPath.map(() => '..').join('/');
   }
+
+  return relative(join('/', projectRoot), '/') || '.';
 }

--- a/npm/ng-packs/packages/schematics/src/utils/angular/project-targets.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/angular/project-targets.ts
@@ -3,11 +3,21 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SchematicsException } from '@angular-devkit/schematics';
+import { ProjectDefinition } from './workspace';
+import { Builders } from './workspace-models';
 
 export function targetBuildNotFoundError(): SchematicsException {
   return new SchematicsException(`Project target "build" not found.`);
+}
+
+export function isUsingApplicationBuilder(project: ProjectDefinition): boolean {
+  const buildBuilder = project.targets.get('build')?.builder;
+  const isUsingApplicationBuilder =
+    buildBuilder === Builders.Application || buildBuilder === Builders.BuildApplication;
+
+  return isUsingApplicationBuilder;
 }

--- a/npm/ng-packs/packages/schematics/src/utils/angular/standalone/app_component.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/angular/standalone/app_component.ts
@@ -1,0 +1,148 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { SchematicsException, Tree } from '@angular-devkit/schematics';
+import * as ts from 'typescript';
+import { getDecoratorMetadata, getMetadataField } from '../ast-utils';
+import { findBootstrapModuleCall, getAppModulePath } from '../ng-ast-utils';
+import { findBootstrapApplicationCall, getSourceFile } from './util';
+
+/** Data resolved for a bootstrapped component. */
+interface BootstrappedComponentData {
+  /** Original name of the component class. */
+  componentName: string;
+
+  /** Path under which the component was imported in the main entrypoint. */
+  componentImportPathInSameFile: string;
+
+  /** Original name of the NgModule being bootstrapped, null if the app isn't module-based. */
+  moduleName: string | null;
+
+  /**
+   * Path under which the module was imported in the main entrypoint,
+   * null if the app isn't module-based.
+   */
+  moduleImportPathInSameFile: string | null;
+}
+
+/**
+ * Finds the original name and path relative to the `main.ts` of the bootrstrapped app component.
+ * @param tree File tree in which to look for the component.
+ * @param mainFilePath Path of the `main` file.
+ */
+export function resolveBootstrappedComponentData(
+  tree: Tree,
+  mainFilePath: string,
+): BootstrappedComponentData | null {
+  // First try to resolve for a standalone app.
+  try {
+    const call = findBootstrapApplicationCall(tree, mainFilePath);
+
+    if (call.arguments.length > 0 && ts.isIdentifier(call.arguments[0])) {
+      const resolved = resolveIdentifier(call.arguments[0]);
+
+      if (resolved) {
+        return {
+          componentName: resolved.name,
+          componentImportPathInSameFile: resolved.path,
+          moduleName: null,
+          moduleImportPathInSameFile: null,
+        };
+      }
+    }
+  } catch (e) {
+    // `findBootstrapApplicationCall` will throw if it can't find the `bootrstrapApplication` call.
+    // Catch so we can continue to the fallback logic.
+    if (!(e instanceof SchematicsException)) {
+      throw e;
+    }
+  }
+
+  // Otherwise fall back to resolving an NgModule-based app.
+  return resolveNgModuleBasedData(tree, mainFilePath);
+}
+
+/** Resolves the bootstrap data for a NgModule-based app. */
+function resolveNgModuleBasedData(
+  tree: Tree,
+  mainFilePath: string,
+): BootstrappedComponentData | null {
+  const appModulePath = getAppModulePath(tree, mainFilePath);
+  const appModuleFile = getSourceFile(tree, appModulePath);
+  const metadataNodes = getDecoratorMetadata(appModuleFile, 'NgModule', '@angular/core');
+
+  for (const node of metadataNodes) {
+    if (!ts.isObjectLiteralExpression(node)) {
+      continue;
+    }
+
+    const bootstrapProp = getMetadataField(node, 'bootstrap').find(prop => {
+      return (
+        ts.isArrayLiteralExpression(prop.initializer) &&
+        prop.initializer.elements.length > 0 &&
+        ts.isIdentifier(prop.initializer.elements[0])
+      );
+    });
+
+    const componentIdentifier = (bootstrapProp?.initializer as ts.ArrayLiteralExpression)
+      .elements[0] as ts.Identifier | undefined;
+    const componentResult = componentIdentifier ? resolveIdentifier(componentIdentifier) : null;
+    const bootstrapCall = findBootstrapModuleCall(tree, mainFilePath);
+
+    if (
+      componentResult &&
+      bootstrapCall &&
+      bootstrapCall.arguments.length > 0 &&
+      ts.isIdentifier(bootstrapCall.arguments[0])
+    ) {
+      const moduleResult = resolveIdentifier(bootstrapCall.arguments[0]);
+
+      if (moduleResult) {
+        return {
+          componentName: componentResult.name,
+          componentImportPathInSameFile: componentResult.path,
+          moduleName: moduleResult.name,
+          moduleImportPathInSameFile: moduleResult.path,
+        };
+      }
+    }
+  }
+
+  return null;
+}
+
+/** Resolves an identifier to its original name and path that it was imported from. */
+function resolveIdentifier(identifier: ts.Identifier): { name: string; path: string } | null {
+  const sourceFile = identifier.getSourceFile();
+
+  // Try to resolve the import path by looking at the top-level named imports of the file.
+  for (const node of sourceFile.statements) {
+    if (
+      !ts.isImportDeclaration(node) ||
+      !ts.isStringLiteral(node.moduleSpecifier) ||
+      !node.importClause ||
+      !node.importClause.namedBindings ||
+      !ts.isNamedImports(node.importClause.namedBindings)
+    ) {
+      continue;
+    }
+
+    for (const element of node.importClause.namedBindings.elements) {
+      if (element.name.text === identifier.text) {
+        return {
+          // Note that we use `propertyName` if available, because it contains
+          // the real name in the case where the import is aliased.
+          name: (element.propertyName || element.name).text,
+          path: node.moduleSpecifier.text,
+        };
+      }
+    }
+  }
+
+  return null;
+}

--- a/npm/ng-packs/packages/schematics/src/utils/angular/standalone/app_config.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/angular/standalone/app_config.ts
@@ -1,0 +1,127 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { Tree } from '@angular-devkit/schematics';
+import { dirname, join } from 'node:path';
+import * as ts from 'typescript';
+import { getSourceFile } from './util';
+
+/** App config that was resolved to its source node. */
+export interface ResolvedAppConfig {
+  /** Tree-relative path of the file containing the app config. */
+  filePath: string;
+
+  /** Node defining the app config. */
+  node: ts.ObjectLiteralExpression;
+}
+
+/**
+ * Resolves the node that defines the app config from a bootstrap call.
+ * @param bootstrapCall Call for which to resolve the config.
+ * @param tree File tree of the project.
+ * @param filePath File path of the bootstrap call.
+ */
+export function findAppConfig(
+  bootstrapCall: ts.CallExpression,
+  tree: Tree,
+  filePath: string,
+): ResolvedAppConfig | null {
+  if (bootstrapCall.arguments.length > 1) {
+    const config = bootstrapCall.arguments[1];
+
+    if (ts.isObjectLiteralExpression(config)) {
+      return { filePath, node: config };
+    }
+
+    if (ts.isIdentifier(config)) {
+      return resolveAppConfigFromIdentifier(config, tree, filePath);
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Resolves the app config from an identifier referring to it.
+ * @param identifier Identifier referring to the app config.
+ * @param tree File tree of the project.
+ * @param bootstapFilePath Path of the bootstrap call.
+ */
+function resolveAppConfigFromIdentifier(
+  identifier: ts.Identifier,
+  tree: Tree,
+  bootstapFilePath: string,
+): ResolvedAppConfig | null {
+  const sourceFile = identifier.getSourceFile();
+
+  for (const node of sourceFile.statements) {
+    // Only look at relative imports. This will break if the app uses a path
+    // mapping to refer to the import, but in order to resolve those, we would
+    // need knowledge about the entire program.
+    if (
+      !ts.isImportDeclaration(node) ||
+      !node.importClause?.namedBindings ||
+      !ts.isNamedImports(node.importClause.namedBindings) ||
+      !ts.isStringLiteralLike(node.moduleSpecifier) ||
+      !node.moduleSpecifier.text.startsWith('.')
+    ) {
+      continue;
+    }
+
+    for (const specifier of node.importClause.namedBindings.elements) {
+      if (specifier.name.text !== identifier.text) {
+        continue;
+      }
+
+      // Look for a variable with the imported name in the file. Note that ideally we would use
+      // the type checker to resolve this, but we can't because these utilities are set up to
+      // operate on individual files, not the entire program.
+      const filePath = join(dirname(bootstapFilePath), node.moduleSpecifier.text + '.ts');
+      const importedSourceFile = getSourceFile(tree, filePath);
+      const resolvedVariable = findAppConfigFromVariableName(
+        importedSourceFile,
+        (specifier.propertyName || specifier.name).text,
+      );
+
+      if (resolvedVariable) {
+        return { filePath, node: resolvedVariable };
+      }
+    }
+  }
+
+  const variableInSameFile = findAppConfigFromVariableName(sourceFile, identifier.text);
+
+  return variableInSameFile ? { filePath: bootstapFilePath, node: variableInSameFile } : null;
+}
+
+/**
+ * Finds an app config within the top-level variables of a file.
+ * @param sourceFile File in which to search for the config.
+ * @param variableName Name of the variable containing the config.
+ */
+function findAppConfigFromVariableName(
+  sourceFile: ts.SourceFile,
+  variableName: string,
+): ts.ObjectLiteralExpression | null {
+  for (const node of sourceFile.statements) {
+    if (ts.isVariableStatement(node)) {
+      for (const decl of node.declarationList.declarations) {
+        if (
+          ts.isIdentifier(decl.name) &&
+          decl.name.text === variableName &&
+          decl.initializer &&
+          ts.isObjectLiteralExpression(decl.initializer)
+        ) {
+          return decl.initializer;
+        }
+      }
+    }
+  }
+
+  return null;
+}

--- a/npm/ng-packs/packages/schematics/src/utils/angular/standalone/code_block.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/angular/standalone/code_block.ts
@@ -1,0 +1,115 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { Rule, Tree } from '@angular-devkit/schematics';
+import * as ts from 'typescript';
+import { hasTopLevelIdentifier, insertImport } from '../ast-utils';
+import { applyToUpdateRecorder } from '../change';
+
+/** Generated code that hasn't been interpolated yet. */
+export interface PendingCode {
+  /** Code that will be inserted. */
+  expression: string;
+
+  /** Imports that need to be added to the file in which the code is inserted. */
+  imports: PendingImports;
+}
+
+/** Map keeping track of imports and aliases under which they're referred to in an expression. */
+type PendingImports = Map<string, Map<string, string>>;
+
+/** Counter used to generate unique IDs. */
+let uniqueIdCounter = 0;
+
+/**
+ * Callback invoked by a Rule that produces the code
+ * that needs to be inserted somewhere in the app.
+ */
+export type CodeBlockCallback = (block: CodeBlock) => PendingCode;
+
+/**
+ * Utility class used to generate blocks of code that
+ * can be inserted by the devkit into a user's app.
+ */
+export class CodeBlock {
+  private _imports: PendingImports = new Map<string, Map<string, string>>();
+
+  // Note: the methods here are defined as arrow function so that they can be destructured by
+  // consumers without losing their context. This makes the API more concise.
+
+  /** Function used to tag a code block in order to produce a `PendingCode` object. */
+  code = (strings: TemplateStringsArray, ...params: unknown[]): PendingCode => {
+    return {
+      expression: strings.map((part, index) => part + (params[index] || '')).join(''),
+      imports: this._imports,
+    };
+  };
+
+  /**
+   * Used inside of a code block to mark external symbols and which module they should be imported
+   * from. When the code is inserted, the required import statements will be produced automatically.
+   * @param symbolName Name of the external symbol.
+   * @param moduleName Module from which the symbol should be imported.
+   */
+  external = (symbolName: string, moduleName: string): string => {
+    if (!this._imports.has(moduleName)) {
+      this._imports.set(moduleName, new Map());
+    }
+
+    const symbolsPerModule = this._imports.get(moduleName) as Map<string, string>;
+
+    if (!symbolsPerModule.has(symbolName)) {
+      symbolsPerModule.set(symbolName, `@@__SCHEMATIC_PLACEHOLDER_${uniqueIdCounter++}__@@`);
+    }
+
+    return symbolsPerModule.get(symbolName) as string;
+  };
+
+  /**
+   * Produces the necessary rules to transform a `PendingCode` object into valid code.
+   * @param initialCode Code pending transformed.
+   * @param filePath Path of the file in which the code will be inserted.
+   */
+  static transformPendingCode(initialCode: PendingCode, filePath: string) {
+    const code = { ...initialCode };
+    const rules: Rule[] = [];
+
+    code.imports.forEach((symbols, moduleName) => {
+      symbols.forEach((placeholder, symbolName) => {
+        rules.push((tree: Tree) => {
+          const recorder = tree.beginUpdate(filePath);
+          const sourceFile = ts.createSourceFile(
+            filePath,
+            tree.readText(filePath),
+            ts.ScriptTarget.Latest,
+            true,
+          );
+
+          // Note that this could still technically clash if there's a top-level symbol called
+          // `${symbolName}_alias`, however this is unlikely. We can revisit this if it becomes
+          // a problem.
+          const alias = hasTopLevelIdentifier(sourceFile, symbolName, moduleName)
+            ? symbolName + '_alias'
+            : undefined;
+
+          code.expression = code.expression.replace(
+            new RegExp(placeholder, 'g'),
+            alias || symbolName,
+          );
+
+          applyToUpdateRecorder(recorder, [
+            insertImport(sourceFile, filePath, symbolName, moduleName, false, alias),
+          ]);
+          tree.commitUpdate(recorder);
+        });
+      });
+    });
+
+    return { code, rules };
+  }
+}

--- a/npm/ng-packs/packages/schematics/src/utils/angular/standalone/index.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/angular/standalone/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+export { addRootImport, addRootProvider } from './rules';
+export type { PendingCode, CodeBlockCallback, CodeBlock } from './code_block';

--- a/npm/ng-packs/packages/schematics/src/utils/angular/standalone/rules.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/angular/standalone/rules.ts
@@ -1,0 +1,258 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { tags } from '@angular-devkit/core';
+import { Rule, SchematicsException, Tree, chain } from '@angular-devkit/schematics';
+import * as ts from 'typescript';
+import { addSymbolToNgModuleMetadata, insertAfterLastOccurrence } from '../ast-utils';
+import { InsertChange } from '../change';
+import { getAppModulePath, isStandaloneApp } from '../ng-ast-utils';
+import { ResolvedAppConfig, findAppConfig } from './app_config';
+import { CodeBlock, CodeBlockCallback, PendingCode } from './code_block';
+import {
+  applyChangesToFile,
+  findBootstrapApplicationCall,
+  findProvidersLiteral,
+  getMainFilePath,
+  getSourceFile,
+  isMergeAppConfigCall,
+} from './util';
+
+/**
+ * Adds an import to the root of the project.
+ * @param project Name of the project to which to add the import.
+ * @param callback Function that generates the code block which should be inserted.
+ * @example
+ *
+ * ```ts
+ * import { Rule } from '@angular-devkit/schematics';
+ * import { addRootImport } from '@schematics/angular/utility';
+ *
+ * export default function(): Rule {
+ *   return addRootImport('default', ({code, external}) => {
+ *     return code`${external('MyModule', '@my/module')}.forRoot({})`;
+ *   });
+ * }
+ * ```
+ */
+export function addRootImport(project: string, callback: CodeBlockCallback): Rule {
+  return getRootInsertionRule(project, callback, 'imports', {
+    name: 'importProvidersFrom',
+    module: '@angular/core',
+  });
+}
+
+/**
+ * Adds a provider to the root of the project.
+ * @param project Name of the project to which to add the import.
+ * @param callback Function that generates the code block which should be inserted.
+ * @example
+ *
+ * ```ts
+ * import { Rule } from '@angular-devkit/schematics';
+ * import { addRootProvider } from '@schematics/angular/utility';
+ *
+ * export default function(): Rule {
+ *   return addRootProvider('default', ({code, external}) => {
+ *     return code`${external('provideLibrary', '@my/library')}({})`;
+ *   });
+ * }
+ * ```
+ */
+export function addRootProvider(project: string, callback: CodeBlockCallback): Rule {
+  return getRootInsertionRule(project, callback, 'providers');
+}
+
+/**
+ * Creates a rule that inserts code at the root of either a standalone or NgModule-based project.
+ * @param project Name of the project into which to inser tthe code.
+ * @param callback Function that generates the code block which should be inserted.
+ * @param ngModuleField Field of the root NgModule into which the code should be inserted, if the
+ * app is based on NgModule
+ * @param standaloneWrapperFunction Function with which to wrap the code if the app is standalone.
+ */
+function getRootInsertionRule(
+  project: string,
+  callback: CodeBlockCallback,
+  ngModuleField: string,
+  standaloneWrapperFunction?: { name: string; module: string },
+): Rule {
+  return async host => {
+    const mainFilePath = await getMainFilePath(host, project);
+    const codeBlock = new CodeBlock();
+
+    if (isStandaloneApp(host, mainFilePath)) {
+      return tree =>
+        addProviderToStandaloneBootstrap(
+          tree,
+          callback(codeBlock),
+          mainFilePath,
+          standaloneWrapperFunction,
+        );
+    }
+
+    const modulePath = getAppModulePath(host, mainFilePath);
+    const pendingCode = CodeBlock.transformPendingCode(callback(codeBlock), modulePath);
+
+    return chain([
+      ...pendingCode.rules,
+      tree => {
+        const changes = addSymbolToNgModuleMetadata(
+          getSourceFile(tree, modulePath),
+          modulePath,
+          ngModuleField,
+          pendingCode.code.expression,
+          // Explicitly set the import path to null since we deal with imports here separately.
+          null,
+        );
+
+        applyChangesToFile(tree, modulePath, changes);
+      },
+    ]);
+  };
+}
+
+/**
+ * Adds a provider to the root of a standalone project.
+ * @param host Tree of the root rule.
+ * @param pendingCode Code that should be inserted.
+ * @param mainFilePath Path to the project's main file.
+ * @param wrapperFunction Optional function with which to wrap the provider.
+ */
+function addProviderToStandaloneBootstrap(
+  host: Tree,
+  pendingCode: PendingCode,
+  mainFilePath: string,
+  wrapperFunction?: { name: string; module: string },
+): Rule {
+  const bootstrapCall = findBootstrapApplicationCall(host, mainFilePath);
+  const fileToEdit = findAppConfig(bootstrapCall, host, mainFilePath)?.filePath || mainFilePath;
+  const { code, rules } = CodeBlock.transformPendingCode(pendingCode, fileToEdit);
+
+  return chain([
+    ...rules,
+    () => {
+      let wrapped: PendingCode;
+      let additionalRules: Rule[];
+
+      if (wrapperFunction) {
+        const block = new CodeBlock();
+        const result = CodeBlock.transformPendingCode(
+          block.code`${block.external(wrapperFunction.name, wrapperFunction.module)}(${
+            code.expression
+          })`,
+          fileToEdit,
+        );
+
+        wrapped = result.code;
+        additionalRules = result.rules;
+      } else {
+        wrapped = code;
+        additionalRules = [];
+      }
+
+      return chain([
+        ...additionalRules,
+        tree => insertStandaloneRootProvider(tree, mainFilePath, wrapped.expression),
+      ]);
+    },
+  ]);
+}
+
+/**
+ * Inserts a string expression into the root of a standalone project.
+ * @param tree File tree used to modify the project.
+ * @param mainFilePath Path to the main file of the project.
+ * @param expression Code expression to be inserted.
+ */
+function insertStandaloneRootProvider(tree: Tree, mainFilePath: string, expression: string): void {
+  const bootstrapCall = findBootstrapApplicationCall(tree, mainFilePath);
+  const appConfig = findAppConfig(bootstrapCall, tree, mainFilePath);
+
+  if (bootstrapCall.arguments.length === 0) {
+    throw new SchematicsException(
+      `Cannot add provider to invalid bootstrapApplication call in ${
+        bootstrapCall.getSourceFile().fileName
+      }`,
+    );
+  }
+
+  if (appConfig) {
+    addProvidersExpressionToAppConfig(tree, appConfig, expression);
+
+    return;
+  }
+
+  const newAppConfig = `, {\n${tags.indentBy(2)`providers: [${expression}]`}\n}`;
+  let targetCall: ts.CallExpression;
+
+  if (bootstrapCall.arguments.length === 1) {
+    targetCall = bootstrapCall;
+  } else if (isMergeAppConfigCall(bootstrapCall.arguments[1])) {
+    targetCall = bootstrapCall.arguments[1];
+  } else {
+    throw new SchematicsException(
+      `Cannot statically analyze bootstrapApplication call in ${
+        bootstrapCall.getSourceFile().fileName
+      }`,
+    );
+  }
+
+  applyChangesToFile(tree, mainFilePath, [
+    insertAfterLastOccurrence(
+      targetCall.arguments,
+      newAppConfig,
+      mainFilePath,
+      targetCall.getEnd() - 1,
+    ),
+  ]);
+}
+
+/**
+ * Adds a string expression to an app config object.
+ * @param tree File tree used to modify the project.
+ * @param appConfig Resolved configuration object of the project.
+ * @param expression Code expression to be inserted.
+ */
+function addProvidersExpressionToAppConfig(
+  tree: Tree,
+  appConfig: ResolvedAppConfig,
+  expression: string,
+): void {
+  const { node, filePath } = appConfig;
+  const configProps = node.properties;
+  const providersLiteral = findProvidersLiteral(node);
+
+  // If there's a `providers` property, we can add the provider
+  // to it, otherwise we need to declare it ourselves.
+  if (providersLiteral) {
+    applyChangesToFile(tree, filePath, [
+      insertAfterLastOccurrence(
+        providersLiteral.elements,
+        (providersLiteral.elements.length === 0 ? '' : ', ') + expression,
+        filePath,
+        providersLiteral.getStart() + 1,
+      ),
+    ]);
+  } else {
+    const prop = tags.indentBy(2)`providers: [${expression}]`;
+    let toInsert: string;
+    let insertPosition: number;
+
+    if (configProps.length === 0) {
+      toInsert = '\n' + prop + '\n';
+      insertPosition = node.getEnd() - 1;
+    } else {
+      const hasTrailingComma = configProps.hasTrailingComma;
+      toInsert = (hasTrailingComma ? '' : ',') + '\n' + prop;
+      insertPosition = configProps[configProps.length - 1].getEnd() + (hasTrailingComma ? 1 : 0);
+    }
+
+    applyChangesToFile(tree, filePath, [new InsertChange(filePath, insertPosition, toInsert)]);
+  }
+}

--- a/npm/ng-packs/packages/schematics/src/utils/angular/standalone/util.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/angular/standalone/util.ts
@@ -1,0 +1,171 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { SchematicsException, Tree } from '@angular-devkit/schematics';
+import * as ts from 'typescript';
+import { Change, applyToUpdateRecorder } from '../change';
+import { targetBuildNotFoundError } from '../project-targets';
+import { getWorkspace } from '../workspace';
+import { Builders } from '../workspace-models';
+
+/**
+ * Finds the main file of a project.
+ * @param tree File tree for the project.
+ * @param projectName Name of the project in which to search.
+ */
+export async function getMainFilePath(tree: Tree, projectName: string): Promise<string> {
+  const workspace = await getWorkspace(tree);
+  const project = workspace.projects.get(projectName);
+  const buildTarget = project?.targets.get('build');
+
+  if (!buildTarget) {
+    throw targetBuildNotFoundError();
+  }
+
+  const options = buildTarget.options as Record<string, string>;
+
+  return buildTarget.builder === Builders.Application ||
+    buildTarget.builder === Builders.BuildApplication
+    ? options.browser
+    : options.main;
+}
+
+/**
+ * Gets a TypeScript source file at a specific path.
+ * @param tree File tree of a project.
+ * @param path Path to the file.
+ */
+export function getSourceFile(tree: Tree, path: string): ts.SourceFile {
+  const content = tree.readText(path);
+  const source = ts.createSourceFile(path, content, ts.ScriptTarget.Latest, true);
+
+  return source;
+}
+
+/** Finds the call to `bootstrapApplication` within a file. */
+export function findBootstrapApplicationCall(tree: Tree, mainFilePath: string): ts.CallExpression {
+  const sourceFile = getSourceFile(tree, mainFilePath);
+  const localName = findImportLocalName(
+    sourceFile,
+    'bootstrapApplication',
+    '@angular/platform-browser',
+  );
+
+  if (localName) {
+    let result: ts.CallExpression | null = null;
+
+    sourceFile.forEachChild(function walk(node) {
+      if (
+        ts.isCallExpression(node) &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === localName
+      ) {
+        result = node;
+      }
+
+      if (!result) {
+        node.forEachChild(walk);
+      }
+    });
+
+    if (result) {
+      return result;
+    }
+  }
+
+  throw new SchematicsException(`Could not find bootstrapApplication call in ${mainFilePath}`);
+}
+
+/**
+ * Finds the local name of an imported symbol. Could be the symbol name itself or its alias.
+ * @param sourceFile File within which to search for the import.
+ * @param name Actual name of the import, not its local alias.
+ * @param moduleName Name of the module from which the symbol is imported.
+ */
+function findImportLocalName(
+  sourceFile: ts.SourceFile,
+  name: string,
+  moduleName: string,
+): string | null {
+  for (const node of sourceFile.statements) {
+    // Only look for top-level imports.
+    if (
+      !ts.isImportDeclaration(node) ||
+      !ts.isStringLiteral(node.moduleSpecifier) ||
+      node.moduleSpecifier.text !== moduleName
+    ) {
+      continue;
+    }
+
+    // Filter out imports that don't have the right shape.
+    if (
+      !node.importClause ||
+      !node.importClause.namedBindings ||
+      !ts.isNamedImports(node.importClause.namedBindings)
+    ) {
+      continue;
+    }
+
+    // Look through the elements of the declaration for the specific import.
+    for (const element of node.importClause.namedBindings.elements) {
+      if ((element.propertyName || element.name).text === name) {
+        // The local name is always in `name`.
+        return element.name.text;
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Applies a set of changes to a file.
+ * @param tree File tree of the project.
+ * @param path Path to the file that is being changed.
+ * @param changes Changes that should be applied to the file.
+ */
+export function applyChangesToFile(tree: Tree, path: string, changes: Change[]) {
+  if (changes.length > 0) {
+    const recorder = tree.beginUpdate(path);
+    applyToUpdateRecorder(recorder, changes);
+    tree.commitUpdate(recorder);
+  }
+}
+
+/** Checks whether a node is a call to `mergeApplicationConfig`. */
+export function isMergeAppConfigCall(node: ts.Node): node is ts.CallExpression {
+  if (!ts.isCallExpression(node)) {
+    return false;
+  }
+
+  const localName = findImportLocalName(
+    node.getSourceFile(),
+    'mergeApplicationConfig',
+    '@angular/core',
+  );
+
+  return !!localName && ts.isIdentifier(node.expression) && node.expression.text === localName;
+}
+
+/** Finds the `providers` array literal within an application config. */
+export function findProvidersLiteral(
+  config: ts.ObjectLiteralExpression,
+): ts.ArrayLiteralExpression | null {
+  for (const prop of config.properties) {
+    if (
+      ts.isPropertyAssignment(prop) &&
+      ts.isIdentifier(prop.name) &&
+      prop.name.text === 'providers' &&
+      ts.isArrayLiteralExpression(prop.initializer)
+    ) {
+      return prop.initializer;
+    }
+  }
+
+  return null;
+}

--- a/npm/ng-packs/packages/schematics/src/utils/angular/validation.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/angular/validation.ts
@@ -3,14 +3,15 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SchematicsException } from '@angular-devkit/schematics';
 
 // Must start with a letter, and must contain only alphanumeric characters or dashes.
 // When adding a dash the segment after the dash must also start with a letter.
-export const htmlSelectorRe = /^[a-zA-Z][.0-9a-zA-Z]*(:?-[a-zA-Z][.0-9a-zA-Z]*)*$/;
+export const htmlSelectorRe =
+  /^[a-zA-Z][.0-9a-zA-Z]*((:?-[0-9]+)*|(:?-[a-zA-Z][.0-9a-zA-Z]*(:?-[0-9]+)*)*)$/;
 
 // See: https://github.com/tc39/proposal-regexp-unicode-property-escapes/blob/fe6d07fad74cd0192d154966baa1e95e7cda78a1/README.md#other-examples
 const ecmaIdentifierNameRegExp = /^(?:[$_\p{ID_Start}])(?:[$_\u200C\u200D\p{ID_Continue}])*$/u;

--- a/npm/ng-packs/packages/schematics/src/utils/angular/workspace-models.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/angular/workspace-models.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export enum ProjectType {
@@ -18,16 +18,24 @@ export enum ProjectType {
  * `angular.json` workspace file.
  */
 export enum Builders {
+  Application = '@angular-devkit/build-angular:application',
   AppShell = '@angular-devkit/build-angular:app-shell',
   Server = '@angular-devkit/build-angular:server',
   Browser = '@angular-devkit/build-angular:browser',
+  SsrDevServer = '@angular-devkit/build-angular:ssr-dev-server',
+  Prerender = '@angular-devkit/build-angular:prerender',
+  BrowserEsbuild = '@angular-devkit/build-angular:browser-esbuild',
   Karma = '@angular-devkit/build-angular:karma',
+  BuildKarma = '@angular/build:karma',
   TsLint = '@angular-devkit/build-angular:tslint',
-  DeprecatedNgPackagr = '@angular-devkit/build-ng-packagr:build',
   NgPackagr = '@angular-devkit/build-angular:ng-packagr',
+  BuildNgPackagr = '@angular/build:ng-packagr',
   DevServer = '@angular-devkit/build-angular:dev-server',
+  BuildDevServer = '@angular/build:dev-server',
   ExtractI18n = '@angular-devkit/build-angular:extract-i18n',
-  Protractor = '@angular-devkit/build-angular:protractor',
+  BuildExtractI18n = '@angular/build:extract-i18n',
+  Protractor = '@angular-devkit/build-angular:private-protractor',
+  BuildApplication = '@angular/build:application',
 }
 
 export interface FileReplacements {
@@ -70,8 +78,9 @@ export interface BrowserBuilderOptions extends BrowserBuilderBaseOptions {
 }
 
 export interface ServeBuilderOptions {
-  browserTarget: string;
+  buildTarget: string;
 }
+
 export interface LibraryBuilderOptions {
   tsConfig: string;
   project: string;
@@ -138,11 +147,9 @@ export type E2EBuilderTarget = BuilderTarget<Builders.Protractor, E2EOptions>;
 interface WorkspaceCLISchema {
   warnings?: Record<string, boolean>;
   schematicCollections?: string[];
-  defaultCollection?: string;
 }
 export interface WorkspaceSchema {
   version: 1;
-  defaultProject?: string;
   cli?: WorkspaceCLISchema;
   projects: {
     [key: string]: WorkspaceProject<ProjectType.Application | ProjectType.Library>;
@@ -165,6 +172,7 @@ export interface WorkspaceProject<TProjectType extends ProjectType = ProjectType
    * Tool options.
    */
   architect?: WorkspaceTargets<TProjectType>;
+
   /**
    * Tool options.
    */

--- a/npm/ng-packs/packages/schematics/src/utils/angular/workspace.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/angular/workspace.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { json, workspaces } from '@angular-devkit/core';
@@ -20,7 +20,7 @@ export type TargetDefinition = workspaces.TargetDefinition;
 /**
  * A {@link workspaces.WorkspaceHost} backed by a Schematics {@link Tree} instance.
  */
-class TreeWorkspaceHost implements workspaces.WorkspaceHost {
+export class TreeWorkspaceHost implements workspaces.WorkspaceHost {
   constructor(private readonly tree: Tree) {}
 
   async readFile(path: string): Promise<string> {
@@ -58,14 +58,12 @@ class TreeWorkspaceHost implements workspaces.WorkspaceHost {
 export function updateWorkspace(
   updater: (workspace: WorkspaceDefinition) => void | Rule | PromiseLike<void | Rule>,
 ): Rule {
-  return async (tree: Tree) => {
-    const host = new TreeWorkspaceHost(tree);
-
-    const { workspace } = await workspaces.readWorkspace(DEFAULT_WORKSPACE_PATH, host);
+  return async (host: Tree) => {
+    const workspace = await getWorkspace(host);
 
     const result = await updater(workspace);
 
-    await workspaces.writeWorkspace(workspace, host);
+    await workspaces.writeWorkspace(workspace, new TreeWorkspaceHost(host));
 
     return result || noop;
   };

--- a/npm/ng-packs/packages/schematics/src/utils/ast.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/ast.ts
@@ -35,3 +35,10 @@ export function isBooleanStringOrNumberLiteral(
     node.kind === ts.SyntaxKind.FalseKeyword
   );
 }
+
+export function removeEmptyElementsFromArrayLiteral(
+  array: ts.ArrayLiteralExpression,
+): ts.ArrayLiteralExpression {
+  const cleaned = array.elements.filter(el => el.kind !== ts.SyntaxKind.OmittedExpression);
+  return ts.factory.updateArrayLiteralExpression(array, ts.factory.createNodeArray(cleaned));
+}

--- a/npm/ng-packs/packages/schematics/src/utils/index.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/index.ts
@@ -19,3 +19,4 @@ export * from './tree';
 export * from './type';
 export * from './workspace';
 export * from './standalone';
+export * from './ng-module';

--- a/npm/ng-packs/packages/schematics/src/utils/index.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/index.ts
@@ -18,3 +18,4 @@ export * from './text';
 export * from './tree';
 export * from './type';
 export * from './workspace';
+export * from './standalone';

--- a/npm/ng-packs/packages/schematics/src/utils/ng-module.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/ng-module.ts
@@ -1,0 +1,48 @@
+import { SchematicsException, Tree } from '@angular-devkit/schematics';
+import { getMainFilePath } from './angular/standalone/util';
+import * as ts from 'typescript';
+import { getAppModulePath, getDecoratorMetadata, getMetadataField } from './angular';
+import { createSourceFile } from '../commands/change-theme/index';
+
+export const hasImportInNgModule = async (
+  host: Tree,
+  projectName: string,
+  metadataFn: string,
+  metadataName = 'imports',
+): Promise<boolean> => {
+  const mainFilePath = await getMainFilePath(host, projectName);
+  const appModulePath = getAppModulePath(host, mainFilePath);
+  const buffer = host.read(appModulePath);
+
+  if (!buffer) {
+    throw new SchematicsException(`Could not read file: ${appModulePath}`);
+  }
+
+  const source = createSourceFile(host, appModulePath);
+
+  console.log('AppModule content:\n', buffer.toString('utf-8'));
+
+  // Get the NgModule decorator metadata
+  const ngModuleDecorator = getDecoratorMetadata(source, 'NgModule', '@angular/core')[0];
+  console.log(
+    'Found NgModule decorators:',
+    getDecoratorMetadata(source, 'NgModule', '@angular/core'),
+  );
+  if (!ngModuleDecorator) {
+    throw new SchematicsException('The app module does not found');
+  }
+
+  const matchingProperties = getMetadataField(
+    ngModuleDecorator as ts.ObjectLiteralExpression,
+    metadataName,
+  );
+  const assignment = matchingProperties[0] as ts.PropertyAssignment;
+  const assignmentInit = assignment.initializer as ts.ArrayLiteralExpression;
+
+  const elements = assignmentInit.elements;
+  if (!elements || elements.length < 1) {
+    throw new SchematicsException(`Elements could not found: ${elements}`);
+  }
+
+  return elements.some(f => f.getText().match(metadataFn));
+};

--- a/npm/ng-packs/packages/schematics/src/utils/ng-module.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/ng-module.ts
@@ -3,6 +3,8 @@ import { getMainFilePath } from './angular/standalone/util';
 import * as ts from 'typescript';
 import { getAppModulePath, getDecoratorMetadata, getMetadataField } from './angular';
 import { createSourceFile } from '../commands/change-theme/index';
+import { normalize, Path } from '@angular-devkit/core';
+import * as path from 'path';
 
 export const hasImportInNgModule = async (
   host: Tree,
@@ -46,3 +48,53 @@ export const hasImportInNgModule = async (
 
   return elements.some(f => f.getText().match(metadataFn));
 };
+
+export async function findAppRoutesModulePath(
+  tree: Tree,
+  mainFilePath: string,
+): Promise<Path | null> {
+  const appModulePath = getAppModulePath(tree, mainFilePath);
+  if (!appModulePath || !tree.exists(appModulePath)) return null;
+
+  const buffer = tree.read(appModulePath);
+  if (!buffer) return null;
+
+  const source = ts.createSourceFile(
+    appModulePath,
+    buffer.toString('utf-8'),
+    ts.ScriptTarget.Latest,
+    true,
+  );
+
+  for (const stmt of source.statements) {
+    if (!ts.isImportDeclaration(stmt)) continue;
+
+    const importClause = stmt.importClause;
+    if (!importClause?.namedBindings || !ts.isNamedImports(importClause.namedBindings)) continue;
+
+    const isRoutesImport = importClause.namedBindings.elements.some(
+      el => el.name.getText() === 'AppRoutingModule',
+    );
+    if (!isRoutesImport || !ts.isStringLiteral(stmt.moduleSpecifier)) continue;
+
+    let importPath = stmt.moduleSpecifier.text;
+
+    if (!importPath.endsWith('.ts')) {
+      importPath += '.ts';
+    }
+
+    const configDir = path.dirname(appModulePath);
+    const resolvedFsPath = path.resolve(configDir, importPath);
+    const workspaceRelativePath = path.relative(process.cwd(), resolvedFsPath).replace(/\\/g, '/');
+
+    const normalizedPath = normalize(workspaceRelativePath);
+
+    if (!tree.exists(normalizedPath)) {
+      throw new Error(`Cannot find routes file: ${normalizedPath}`);
+    }
+
+    return normalizedPath;
+  }
+
+  return null;
+}

--- a/npm/ng-packs/packages/schematics/src/utils/standalone.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/standalone.ts
@@ -1,0 +1,59 @@
+import { Tree } from '@angular-devkit/schematics';
+import { findBootstrapApplicationCall } from './angular/standalone/util';
+import { findAppConfig } from './angular/standalone/app_config';
+import * as ts from 'typescript';
+import { normalize, Path } from '@angular-devkit/core';
+import * as path from 'path';
+
+export const getAppConfigPath = (host: Tree, mainFilePath: string): string => {
+  const bootstrapCall = findBootstrapApplicationCall(host, mainFilePath);
+  const appConfig = findAppConfig(bootstrapCall, host, mainFilePath);
+  return appConfig?.filePath || '';
+};
+
+export function findAppRoutesPath(tree: Tree, mainFilePath: string): Path | null {
+  const appConfigPath = getAppConfigPath(tree, mainFilePath);
+  if (!appConfigPath || !tree.exists(appConfigPath)) return null;
+
+  const buffer = tree.read(appConfigPath);
+  if (!buffer) return null;
+
+  const source = ts.createSourceFile(
+    appConfigPath,
+    buffer.toString('utf-8'),
+    ts.ScriptTarget.Latest,
+    true,
+  );
+
+  for (const stmt of source.statements) {
+    if (!ts.isImportDeclaration(stmt)) continue;
+
+    const importClause = stmt.importClause;
+    if (!importClause?.namedBindings || !ts.isNamedImports(importClause.namedBindings)) continue;
+
+    const isRoutesImport = importClause.namedBindings.elements.some(
+      el => el.name.getText() === 'routes',
+    );
+    if (!isRoutesImport || !ts.isStringLiteral(stmt.moduleSpecifier)) continue;
+
+    let importPath = stmt.moduleSpecifier.text;
+
+    if (!importPath.endsWith('.ts')) {
+      importPath += '.ts';
+    }
+
+    const configDir = path.dirname(appConfigPath);
+    const resolvedFsPath = path.resolve(configDir, importPath);
+    const workspaceRelativePath = path.relative(process.cwd(), resolvedFsPath).replace(/\\/g, '/');
+
+    const normalizedPath = normalize(workspaceRelativePath);
+
+    if (!tree.exists(normalizedPath)) {
+      throw new Error(`Cannot find routes file: ${normalizedPath}`);
+    }
+
+    return normalizedPath;
+  }
+
+  return null;
+}

--- a/npm/ng-packs/packages/schematics/src/utils/workspace.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/workspace.ts
@@ -13,17 +13,6 @@ export function isLibrary(project: workspaces.ProjectDefinition): boolean {
   return project.extensions['projectType'] === ProjectType.Library;
 }
 
-export function applicationHasStandaloneTemplate(tree: Tree, selectedProject?: string): boolean {
-  const workspace = readWorkspaceSchema(tree);
-  const project = workspace.projects[selectedProject ?? 0];
-
-  const mainPath = project.sourceRoot + '/main.ts';
-  const mainSource = readFileInTree(tree, mainPath);
-  const mainContent = mainSource.toString();
-
-  return mainContent.includes('bootstrapComponent');
-}
-
 export function readEnvironment(tree: Tree, project: workspaces.ProjectDefinition) {
   if (isLibrary(project)) return undefined;
 
@@ -63,7 +52,8 @@ export async function resolveProject<T = any>(
   // @typescript-eslint/no-explicit-any
   notFoundValue: T = NOT_FOUND_VALUE as unknown as any,
 ): Promise<Project | T> {
-  name = name || readWorkspaceSchema(tree).defaultProject || getFirstApplication(tree).name!;
+  // name = name || readWorkspaceSchema(tree).defaultProject || getFirstApplication(tree).name!;
+  name = name || getFirstApplication(tree).name!;
   const workspace = await getWorkspace(tree);
   let definition: Project['definition'] | undefined;
 

--- a/npm/ng-packs/packages/schematics/src/utils/workspace.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/workspace.ts
@@ -13,6 +13,17 @@ export function isLibrary(project: workspaces.ProjectDefinition): boolean {
   return project.extensions['projectType'] === ProjectType.Library;
 }
 
+export function applicationHasStandaloneTemplate(tree: Tree, selectedProject?: string): boolean {
+  const workspace = readWorkspaceSchema(tree);
+  const project = workspace.projects[selectedProject ?? 0];
+
+  const mainPath = project.sourceRoot + '/main.ts';
+  const mainSource = readFileInTree(tree, mainPath);
+  const mainContent = mainSource.toString();
+
+  return mainContent.includes('bootstrapComponent');
+}
+
 export function readEnvironment(tree: Tree, project: workspaces.ProjectDefinition) {
   if (isLibrary(project)) return undefined;
 

--- a/npm/ng-packs/packages/schematics/src/utils/workspace.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/workspace.ts
@@ -52,7 +52,6 @@ export async function resolveProject<T = any>(
   // @typescript-eslint/no-explicit-any
   notFoundValue: T = NOT_FOUND_VALUE as unknown as any,
 ): Promise<Project | T> {
-  // name = name || readWorkspaceSchema(tree).defaultProject || getFirstApplication(tree).name!;
   name = name || getFirstApplication(tree).name!;
   const workspace = await getWorkspace(tree);
   let definition: Project['definition'] | undefined;

--- a/npm/ng-packs/scripts/build-schematics.ts
+++ b/npm/ng-packs/scripts/build-schematics.ts
@@ -23,9 +23,14 @@ const FILES_TO_COPY_AFTER_BUILD: (FileCopy | string)[] = [
   { src: 'src/commands/create-lib/schema.json', dest: 'commands/create-lib/schema.json' },
   { src: 'src/commands/change-theme/schema.json', dest: 'commands/change-theme/schema.json' },
   { src: 'src/commands/create-lib/files-package', dest: 'commands/create-lib/files-package' },
+  { src: 'src/commands/create-lib/files-package-standalone', dest: 'commands/create-lib/files-package-standalone' },
   {
     src: 'src/commands/create-lib/files-secondary-entrypoint',
     dest: 'commands/create-lib/files-secondary-entrypoint',
+  },
+  {
+    src: 'src/commands/create-lib/files-secondary-entrypoint-standalone',
+    dest: 'commands/create-lib/files-secondary-entrypoint-standalone',
   },
   { src: 'src/commands/proxy-add/schema.json', dest: 'commands/proxy-add/schema.json' },
   { src: 'src/commands/proxy-index/schema.json', dest: 'commands/proxy-index/schema.json' },


### PR DESCRIPTION
### Description

Resolves https://github.com/volosoft/volo/issues/19594

## ✅ Test Cases

### 📦 create-lib
- [x] Create library using `--packageName`
- [x] Generates correct structure for `--templateType=module`
- [x] Generates correct structure for `--templateType=standalone`
- [x] Works with `--isSecondaryEntrypoint=true` (nested entrypoint)
- [x] Generated files are exported from `public-api.ts`
- [x] Output is valid TypeScript with no syntax errors
- [x] Respects `--override=false` to skip existing files
- [x] Supports both standalone and module-based apps
- [x] Import generated library correctly into main application
- [x]  No duplicate imports or providers on repeated runs

### 🎨 change-theme
- [x] Removes previous theme imports from `app.module.ts` or `main.ts`
- [x] Removes previous theme providers from `providers: [...]`
- [x] Adds new theme module imports (e.g. `ThemeXModule.forRoot()`)
- [x] Adds new theme providers (e.g. `provideThemeXConfig()`)
- [x] Supports both standalone and module-based apps
- [x] No duplicate imports or providers on repeated runs

## How To Test

#### 1. Build the Schematics Package

Navigate to the `npm/ng-packs` folder and run the following command:

```bash
yarn run build:schematics
```

This will generate the `dist/packages/schematics` folder under `npm/ng-packs`.

---

#### 2. Link the Built Package Locally

Navigate to the generated schematics folder and link it to your local environment:

```bash
cd dist/packages/schematics
yarn link
```

---

#### 3. Link the Package to Your Angular Project

In your Angular project's root directory (where `package.json` is located), run the following command to create a local reference:

```bash
yarn link "@abp/ng.schematics"
```

---

#### 4. Generate a New Library

Use the following schematic command to generate a new library named `Book`:

```bash
npx ng g @abp/ng.schematics:create-lib --package-name "Book"
```

Follow the interactive prompts to complete the setup.

---

#### 5. Change the Default Theme

To replace the theme, run:

```bash
npx ng g @abp/ng.schematics:change-theme
```

