### PR TITLE
Use `EntityCacheItemWrapper` to prevent duplicate queries.

### DIFF
--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Entities/Caching/EntityCacheBase.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Entities/Caching/EntityCacheBase.cs
@@ -69,11 +69,6 @@ public abstract class EntityCacheBase<TEntity, TEntityCacheItem, TKey> :
 
     public async Task HandleEventAsync(EntityChangedEventData<TEntity> eventData)
     {
-        if (eventData is EntityCreatedEventData<TEntity>)
-        {
-            return;
-        }
-
         /* Why we are using double remove:
          * First Cache.RemoveAsync drops the cache item in a unit of work.
          * Some other application / thread may read the value from database and put it to the cache again

--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Entities/Caching/EntityCacheItemWrapper.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Entities/Caching/EntityCacheItemWrapper.cs
@@ -1,0 +1,12 @@
+namespace Volo.Abp.Domain.Entities.Caching;
+
+public class EntityCacheItemWrapper<TEntityCacheItem>
+    where TEntityCacheItem : class
+{
+    public TEntityCacheItem? Value { get; set; }
+
+    public EntityCacheItemWrapper(TEntityCacheItem? value)
+    {
+        Value = value;
+    }
+}

--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Entities/Caching/EntityCacheWithObjectMapper.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Entities/Caching/EntityCacheWithObjectMapper.cs
@@ -15,7 +15,7 @@ public class EntityCacheWithObjectMapper<TEntity, TEntityCacheItem, TKey> :
 
     public EntityCacheWithObjectMapper(
         IReadOnlyRepository<TEntity, TKey> repository,
-        IDistributedCache<TEntityCacheItem, TKey> cache,
+        IDistributedCache<EntityCacheItemWrapper<TEntityCacheItem>, TKey> cache,
         IUnitOfWorkManager unitOfWorkManager,
         IObjectMapper objectMapper)
         : base(repository, cache, unitOfWorkManager)
@@ -23,7 +23,7 @@ public class EntityCacheWithObjectMapper<TEntity, TEntityCacheItem, TKey> :
         ObjectMapper = objectMapper;
     }
 
-    protected override TEntityCacheItem? MapToCacheItem(TEntity? entity)
+    protected override EntityCacheItemWrapper<TEntityCacheItem>? MapToCacheItem(TEntity? entity)
     {
         if (entity == null)
         {
@@ -32,9 +32,9 @@ public class EntityCacheWithObjectMapper<TEntity, TEntityCacheItem, TKey> :
 
         if (typeof(TEntity) == typeof(TEntityCacheItem))
         {
-            return entity.As<TEntityCacheItem>();
+            return new EntityCacheItemWrapper<TEntityCacheItem>(entity.As<TEntityCacheItem>());
         }
 
-        return ObjectMapper.Map<TEntity, TEntityCacheItem>(entity);
+        return new EntityCacheItemWrapper<TEntityCacheItem>(ObjectMapper.Map<TEntity, TEntityCacheItem>(entity));
     }
 }

--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Entities/Caching/EntityCacheWithObjectMapperContext.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Entities/Caching/EntityCacheWithObjectMapperContext.cs
@@ -12,7 +12,7 @@ public class EntityCacheWithObjectMapperContext<TObjectMapperContext, TEntity, T
 {
     public EntityCacheWithObjectMapperContext(
         IReadOnlyRepository<TEntity, TKey> repository,
-        IDistributedCache<TEntityCacheItem, TKey> cache,
+        IDistributedCache<EntityCacheItemWrapper<TEntityCacheItem>, TKey> cache,
         IUnitOfWorkManager unitOfWorkManager,
         IObjectMapper objectMapper)// Intentionally injected with TContext
         : base(repository, cache, unitOfWorkManager, objectMapper)

--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Entities/Caching/EntityCacheWithoutCacheItem.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Entities/Caching/EntityCacheWithoutCacheItem.cs
@@ -10,14 +10,14 @@ public class EntityCacheWithoutCacheItem<TEntity, TKey> :
 {
     public EntityCacheWithoutCacheItem(
         IReadOnlyRepository<TEntity, TKey> repository,
-        IDistributedCache<TEntity, TKey> cache,
+        IDistributedCache<EntityCacheItemWrapper<TEntity>, TKey> cache,
         IUnitOfWorkManager unitOfWorkManager)
         : base(repository, cache, unitOfWorkManager)
     {
     }
 
-    protected override TEntity? MapToCacheItem(TEntity? entity)
+    protected override EntityCacheItemWrapper<TEntity>? MapToCacheItem(TEntity? entity)
     {
-        return entity;
+         return new EntityCacheItemWrapper<TEntity>(entity);
     }
 }

--- a/framework/test/Volo.Abp.TestApp/Volo/Abp/TestApp/Testing/EntityCache_Tests.cs
+++ b/framework/test/Volo.Abp.TestApp/Volo/Abp/TestApp/Testing/EntityCache_Tests.cs
@@ -71,6 +71,29 @@ public abstract class EntityCache_Tests<TStartupModule> : TestAppTestBase<TStart
     }
 
     [Fact]
+    public async Task Should_Return_New_EntityCache_IF_Added()
+    {
+        var productId = Guid.NewGuid();
+        (await ProductEntityCache.FindAsync(productId)).ShouldBeNull();
+        (await ProductCacheItem.FindAsync(productId)).ShouldBeNull();
+
+        var product = new Product(productId, "Product2", decimal.Zero);
+        await ProductRepository.InsertAsync(product);
+
+        product = await ProductEntityCache.FindAsync(product.Id);
+        product.ShouldNotBeNull();
+        product.Id.ShouldBe(productId);
+        product.Name.ShouldBe("Product2");
+        product.Price.ShouldBe(decimal.Zero);
+
+        var productCacheItem = await ProductCacheItem.FindAsync(product.Id);
+        productCacheItem.ShouldNotBeNull();
+        productCacheItem.Id.ShouldBe(productId);
+        productCacheItem.Name.ShouldBe("Product2");
+        productCacheItem.Price.ShouldBe(decimal.Zero);
+    }
+
+    [Fact]
     public async Task Should_Return_New_EntityCache_IF_Updated()
     {
         (await ProductEntityCache.FindAsync(TestDataBuilder.ProductId)).ShouldNotBeNull();


### PR DESCRIPTION
Resolves #22715

Old behavior:

If `entity` doesn't exist in the database, the `null` will be written to the cache. Next time, it will query the database again.

New behavior:

If `entity` doesn't exist in the database, the `EntityCacheItemWrapper` with `null` will be written to the cache. Next time, it will return `null` instead of querying the database.