### PR TITLE
Angular - Fixing access token parse that fails when encryption is enabled

### DIFF
--- a/npm/ng-packs/packages/oauth/src/lib/services/remember-me.service.ts
+++ b/npm/ng-packs/packages/oauth/src/lib/services/remember-me.service.ts
@@ -22,7 +22,11 @@ export class RememberMeService {
 
   getFromToken(accessToken: string) {
     const tokenBody = accessToken.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');
-    const parsedToken = JSON.parse(atob(tokenBody));
-    return Boolean(parsedToken[this.#rememberMe]);
+    try {
+      const parsedToken = JSON.parse(atob(tokenBody));
+      return Boolean(parsedToken[this.#rememberMe]);
+    } catch {
+      return false;
+    }
   }
 }


### PR DESCRIPTION
### Description

Resolves #22675 

### Checklist

- [X] I fully tested it as developer / designer and created unit / integration tests
- [X] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?
- You need to run `yarn copy-to:app` under `npm > ng-packs` directory to copy the changes.
- Then you can enable the access token encryption to run the necessary tests by following [this documentation](https://abp.io/docs/latest/modules/openiddict-pro#disable-accesstoken-encryption).
- You should not see any errors on console as explained [in the question](https://abp.io/support/questions/9138/Angular-can%27t-read-AccessToken-when-encryption-enabled).
