### PR TITLE
Fix the wrong project naming used in the microservice tutorial's 6th part

### DIFF
--- a/docs/en/tutorials/microservice/part-06.md
+++ b/docs/en/tutorials/microservice/part-06.md
@@ -107,9 +107,9 @@ public class ProductIntegrationService : ApplicationService, IProductIntegration
 
 Now that we have created the `IProductIntegrationService` interface and the `ProductIntegrationService` class, we can consume this service from the Ordering service.
 
-### Adding a Reference to the `CloudCrm.CatalogService.Contracts` Package
+### Adding a Reference to the `CloudCrm.OrderingService` Package
 
-First, we need to add a reference to the `CloudCrm.CatalogService.Contracts` package in the Ordering service. Open the ABP Studio, and stop the application(s) if it is running. Then, open the *Solution Explorer* and right-click on the `CloudCrm.OrderingService` package. Select *Add* -> *Package Reference* command:
+First, we need to add a reference to the `CloudCrm.OrderingService` package in the Ordering service. Open the ABP Studio, and stop the application(s) if it is running. Then, open the *Solution Explorer* and right-click on the `CloudCrm.OrderingService` package. Select *Add* -> *Package Reference* command:
 
 ![add-package-reference-ordering-service](images/add-package-reference-ordering-service.png)
 


### PR DESCRIPTION
It should be as follows:

![image](https://github.com/user-attachments/assets/041f8d6c-75bb-43c0-8a86-bf232d082d5a)
