### PR TITLE
Remove unnecessary color override for dark navbar links

### DIFF
--- a/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.Web.BasicTheme/wwwroot/libs/abp/css/theme.css
+++ b/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.Web.BasicTheme/wwwroot/libs/abp/css/theme.css
@@ -82,10 +82,6 @@ div.dataTables_wrapper div.dataTables_length label {
 
 /* TEMP */
 
-.navbar-dark .navbar-nav .nav-link {
-    color: #000 !important;
-}
-
 .navbar-nav > .nav-item > .nav-link,
 .navbar-nav > .nav-item > .dropdown > .nav-link {
     color: #fff !important;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/863bd50f-0192-47d5-8cf3-5b931b317545)
