### PR TITLE
When the value of 'SendExceptionsDetailsToClients' is set to true, the exception should be localized

### DIFF
--- a/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/AspNetCore/ExceptionHandling/DefaultExceptionToErrorInfoConverter.cs
+++ b/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/AspNetCore/ExceptionHandling/DefaultExceptionToErrorInfoConverter.cs
@@ -230,6 +230,8 @@ public class DefaultExceptionToErrorInfoConverter : IExceptionToErrorInfoConvert
         AddExceptionToDetails(exception, detailBuilder, sendStackTraceToClients);
 
         var errorInfo = new RemoteServiceErrorInfo(exception.Message, detailBuilder.ToString(), data: exception.Data);
+        
+        TryToLocalizeExceptionMessage(exception, errorInfo);
 
         if (exception is AbpValidationException)
         {

--- a/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/AspNetCore/ExceptionHandling/DefaultExceptionToErrorInfoConverter.cs
+++ b/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/AspNetCore/ExceptionHandling/DefaultExceptionToErrorInfoConverter.cs
@@ -230,13 +230,13 @@ public class DefaultExceptionToErrorInfoConverter : IExceptionToErrorInfoConvert
         AddExceptionToDetails(exception, detailBuilder, sendStackTraceToClients);
 
         var errorInfo = new RemoteServiceErrorInfo(exception.Message, detailBuilder.ToString(), data: exception.Data);
-        
-        TryToLocalizeExceptionMessage(exception, errorInfo);
 
         if (exception is AbpValidationException)
         {
             errorInfo.ValidationErrors = GetValidationErrorInfos((exception as AbpValidationException)!);
         }
+
+        TryToLocalizeExceptionMessage(exception, errorInfo);
 
         return errorInfo;
     }


### PR DESCRIPTION
Old: 
![image](https://github.com/user-attachments/assets/9465d5b7-60a1-4b66-a2e7-9d237bbb95c7)

New:
![image](https://github.com/user-attachments/assets/6c4bed69-4dd9-4804-9a31-c4023ece376d)
