### PR TITLE
Skip disable feature if `value` or `provider name` is `null`.

### DIFF
--- a/modules/feature-management/src/Volo.Abp.FeatureManagement.Blazor/Components/FeatureManagementModal.razor.cs
+++ b/modules/feature-management/src/Volo.Abp.FeatureManagement.Blazor/Components/FeatureManagementModal.razor.cs
@@ -152,10 +152,13 @@ public partial class FeatureManagementModal
 
     protected virtual bool IsDisabled(FeatureDto feature)
     {
-        return feature.Provider.Name != ProviderName && feature.Provider.Name != DefaultValueFeatureValueProvider.ProviderName;
+        return feature.Value != null &&
+               feature.Provider.Name != null &&
+               feature.Provider.Name != ProviderName &&
+               feature.Provider.Name != DefaultValueFeatureValueProvider.ProviderName;
     }
 
-    public string GetShownName(FeatureDto featureDto)
+    public virtual string GetShownName(FeatureDto featureDto)
     {
         return !IsDisabled(featureDto)
             ? featureDto.DisplayName

--- a/modules/feature-management/src/Volo.Abp.FeatureManagement.Web/Pages/FeatureManagement/FeatureManagementModal.cshtml.cs
+++ b/modules/feature-management/src/Volo.Abp.FeatureManagement.Web/Pages/FeatureManagement/FeatureManagementModal.cshtml.cs
@@ -85,12 +85,15 @@ public class FeatureManagementModal : AbpPageModel
         return NoContent();
     }
 
-    public bool IsDisabled(FeatureDto featureDto)
+    public virtual bool IsDisabled(FeatureDto feature)
     {
-        return featureDto.Provider.Name != ProviderName && featureDto.Provider.Name != DefaultValueFeatureValueProvider.ProviderName;
+        return feature.Value != null &&
+               feature.Provider.Name != null &&
+               feature.Provider.Name != ProviderName &&
+               feature.Provider.Name != DefaultValueFeatureValueProvider.ProviderName;
     }
 
-    public string GetShownName(FeatureDto featureDto)
+    public virtual string GetShownName(FeatureDto featureDto)
     {
         return !IsDisabled(featureDto)
             ? featureDto.DisplayName


### PR DESCRIPTION
Compatible with feature without a default value.

https://abp.io/support/questions/9243/Custom-FeatureValueProvider-Not-Invoked-When-DefaultValue-Is-Set-in-AddFeature#answer-3a19e011-c1cf-6995-b0fe-9d93300d29e4

