### PR TITLE
Perf(mongodb): Optimize event inbox query for better index utilization

### DIFF
--- a/framework/src/Volo.Abp.MongoDB/Volo/Abp/MongoDB/DistributedEvents/MongoDbContextEventInbox.cs
+++ b/framework/src/Volo.Abp.MongoDB/Volo/Abp/MongoDB/DistributedEvents/MongoDbContextEventInbox.cs
@@ -64,7 +64,7 @@ public class MongoDbContextEventInbox<TMongoDbContext> : IMongoDbContextEventInb
         var outgoingEventRecords = await dbContext
             .IncomingEvents
             .AsQueryable()
-            .Where(x => !x.Processed)
+            .Where(x => x.Processed == false)
             .WhereIf(transformedFilter != null, transformedFilter!)
             .OrderBy(x => x.CreationTime)
             .Take(maxCount)


### PR DESCRIPTION
## MongoDB Query Optimization for Event Inbox

### Description

This PR improves query performance for MongoDB-based applications by converting a range-based match (`$ne`) to an equality match, which significantly improves performance, especially when the application is handling a large amount of Incoming Events.

#### Technical Details

In the current implementation, `MongoDbContextEventInbox.GetWaitingEventsAsync()` uses a negation expression:
```csharp
.Where(x => !x.Processed)
```
 
The System.Linq.Queryable.Where method translates this negation of a boolean to a $ne operator in MongoDB, which is considered a range operation. This results in the following query:

In the current code state, it will produce a query like that:

```
  command: {
    aggregate: 'IncomingEvents',
    pipeline: [
      {
        '$match': {
          Processed: {
            '$ne': true
          }
        }
      },
      {
        '$sort': {
          CreationTime: 1
        }
      },
      {
        '$limit': 1000
      }
    ],
    cursor: {},
    '$db': 'myDb'
  },
```

With this PR, the expression is changed to an explicit equality comparison:

```csharp
.Where(x => x.Processed == false)
```

Which produces a more efficient query:


```
  command: {
    aggregate: 'IncomingEvents',
    pipeline: [
      {
        '$match': {
          Processed: false
        }
      },
      {
        '$sort': {
          CreationTime: 1
        }
      },
      {
        '$limit': 1000
      }
    ],
    cursor: {},
    '$db': 'myDb'
  },
```

Performance Impact
This change has significant performance implications:

1. Better Index Utilization: MongoDB's "ESR" rule (Equality, Sort, Range) guides index creation and usage. By converting a range operation ($ne) to an equality operation, indexes can be utilized more efficiently.
2. Query Selectivity: The $ne operator is less selective and often forces MongoDB to perform collection scans rather than using indexes effectively. An equality match is highly selective and allows for more efficient index usage.
3. Predictable Behavior: The original query ($ne: true) would match documents where:
Processed is false
Processed is null
Processed field doesn't exist
The new query (Processed: false) only matches documents where Processed is explicitly false, which is more predictable and likely the intended behavior.
4. Scalability: This optimization becomes increasingly important as the collection size grows, providing better performance for applications with large event volumes.



- [ ] I fully tested it as developer / designer and created unit / integration tests
- [X] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

The change is straightforward and maintains the same logical behavior while improving the underlying query execution. To test:

1. Compare query execution plans before and after the change using MongoDB's explain() method
2. Verify that the same documents are returned by both query forms
3. Measure performance improvements on collections with various sizes, especially large ones

I appreciate your consideration of this performance enhancement and am happy to provide any additional information or make adjustments as needed.


### References

* [MongoDB ESR (Equality, Sort, Range) Rule](https://www.mongodb.com/docs/manual/tutorial/equality-sort-range-guideline/#range) - Official MongoDB documentation on index optimization guidelines

Respectfully submitted,
Gilcemir


