### PR TITLE
Angular - When top menu switches a project to lepton theme, an error is thrown

### DIFF
--- a/npm/ng-packs/packages/schematics/src/commands/change-theme/index.ts
+++ b/npm/ng-packs/packages/schematics/src/commands/change-theme/index.ts
@@ -321,7 +321,7 @@ export function removeProviderFromNgModuleMetadata(
 export function insertImports(projectName: string, selectedTheme: ThemeOptionsEnum): Rule {
   return addRootImport(projectName, code => {
     const selectedThemeImports = importMap.get(selectedTheme);
-    const selected = selectedThemeImports?.filter(s => !!s.doNotImport);
+    const selected = selectedThemeImports?.filter(s => !s.doNotImport);
     if (!selected?.length) return code.code``;
 
     const expressions: string[] = [];
@@ -340,7 +340,7 @@ export function insertImports(projectName: string, selectedTheme: ThemeOptionsEn
 export function insertProviders(projectName: string, selectedTheme: ThemeOptionsEnum): Rule {
   return addRootProvider(projectName, code => {
     const selectedThemeImports = importMap.get(selectedTheme);
-    const selected = selectedThemeImports?.filter(s => !!s.doNotImport);
+    const selected = selectedThemeImports?.filter(s => !s.doNotImport);
     if (!selected || selected.length === 0) return code.code``;
 
     const providers = selected

--- a/npm/ng-packs/packages/schematics/src/commands/change-theme/index.ts
+++ b/npm/ng-packs/packages/schematics/src/commands/change-theme/index.ts
@@ -320,7 +320,8 @@ export function removeProviderFromNgModuleMetadata(
 
 export function insertImports(projectName: string, selectedTheme: ThemeOptionsEnum): Rule {
   return addRootImport(projectName, code => {
-    const selected = importMap.get(selectedTheme);
+    const selectedThemeImports = importMap.get(selectedTheme);
+    const selected = selectedThemeImports?.filter(s => !!s.doNotImport);
     if (!selected?.length) return code.code``;
 
     const expressions: string[] = [];
@@ -338,7 +339,8 @@ export function insertImports(projectName: string, selectedTheme: ThemeOptionsEn
 }
 export function insertProviders(projectName: string, selectedTheme: ThemeOptionsEnum): Rule {
   return addRootProvider(projectName, code => {
-    const selected = importMap.get(selectedTheme);
+    const selectedThemeImports = importMap.get(selectedTheme);
+    const selected = selectedThemeImports?.filter(s => !!s.doNotImport);
     if (!selected || selected.length === 0) return code.code``;
 
     const providers = selected

--- a/npm/ng-packs/packages/schematics/src/commands/change-theme/style-map.ts
+++ b/npm/ng-packs/packages/schematics/src/commands/change-theme/style-map.ts
@@ -13,6 +13,7 @@ export type ImportDefinition = {
   importName: string;
   provider?: string;
   expression?: string;
+  doNotImport?: boolean;
 };
 
 export const styleMap = new Map<ThemeOptionsEnum, StyleDefinition[]>();
@@ -365,6 +366,12 @@ importMap.set(ThemeOptionsEnum.LeptonX, [
     path: '@volosoft/abp.ng.theme.lepton-x/layouts',
     importName: 'SideMenuLayoutModule',
     expression: 'SideMenuLayoutModule.forRoot()',
+  },
+  {
+    path: '@volosoft/abp.ng.theme.lepton-x/layouts',
+    importName: 'TopMenuLayoutModule',
+    expression: 'TopMenuLayoutModule.forRoot()',
+    doNotImport: true,
   },
   {
     path: '@abp/ng.theme.shared',


### PR DESCRIPTION
### Description

Resolves https://github.com/volosoft/volo/issues/19862

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests

### How To Test

#### 1. Build the Schematics Package

Navigate to the `npm/ng-packs` folder and run the following command:

```bash
yarn run build:schematics
```

This will generate the `dist/packages/schematics` folder under `npm/ng-packs`.

---

#### 2. Link the Built Package Locally

Navigate to the generated schematics folder and link it to your local environment:

```bash
cd dist/packages/schematics
yarn link
```

---

#### 3. Link the Package to Your Angular Project

In your Angular project's root directory (where `package.json` is located), run the following command to create a local reference:

```bash
yarn link "@abp/ng.schematics"
```

---

#### 4. Change the Default Theme

To replace the theme, run:

```bash
npx ng g @abp/ng.schematics:change-theme
```