### PR TITLE
configure via ConfigureDefaultConvention() and ConfigureDefaultOnMode…

### DIFF
--- a/docs/en/framework/data/entity-framework-core/index.md
+++ b/docs/en/framework/data/entity-framework-core/index.md
@@ -142,24 +142,27 @@ Configure<AbpDbContextOptions>(options =>
 Add actions for the `ConfigureConventions` and `OnModelCreating` methods of the `DbContext` as shown below:
 
 ````csharp
-options.ConfigureDefaultConvention((dbContext, builder) =>
+Configure<AbpDbContextOptions>(options =>
 {
-    // This action is called for ConfigureConventions method of all DbContexts.
-}); 
+    options.ConfigureDefaultConvention((dbContext, builder) =>
+    {
+        // This action is called for ConfigureConventions method of all DbContexts.
+    });
 
-options.ConfigureConventions<YourDbContext>((dbContext, builder) =>
-{
-    // This action is called for ConfigureConventions method of specific DbContext.
-});
+    options.ConfigureConventions<YourDbContext>((dbContext, builder) =>
+    {
+        // This action is called for ConfigureConventions method of specific DbContext.
+    });
 
-options.ConfigureDefaultOnModelCreatingAction ( (dbContext, builder) =>
-{
-    // This action is called for OnModelCreating method of all DbContexts.
-});
+    options.ConfigureDefaultOnModelCreating((dbContext, builder) =>
+    {
+        // This action is called for OnModelCreating method of all DbContexts.
+    });
 
-options.ConfigureOnModelCreating<YourDbContext>((dbContext, builder) =>
-{
-    // This action is called for OnModelCreating method of specific DbContext.
+    options.ConfigureOnModelCreating<YourDbContext>((dbContext, builder) =>
+    {
+        // This action is called for OnModelCreating method of specific DbContext.
+    });
 });
 ````
 

--- a/docs/en/framework/data/entity-framework-core/index.md
+++ b/docs/en/framework/data/entity-framework-core/index.md
@@ -142,20 +142,20 @@ Configure<AbpDbContextOptions>(options =>
 Add actions for the `ConfigureConventions` and `OnModelCreating` methods of the `DbContext` as shown below:
 
 ````csharp
-options.DefaultConventionAction = (dbContext, builder) =>
+options.ConfigureDefaultConvention((dbContext, builder) =>
 {
     // This action is called for ConfigureConventions method of all DbContexts.
-};
+}); 
 
 options.ConfigureConventions<YourDbContext>((dbContext, builder) =>
 {
     // This action is called for ConfigureConventions method of specific DbContext.
 });
 
-options.DefaultOnModelCreatingAction = (dbContext, builder) =>
+options.ConfigureDefaultOnModelCreatingAction ( (dbContext, builder) =>
 {
     // This action is called for OnModelCreating method of all DbContexts.
-};
+});
 
 options.ConfigureOnModelCreating<YourDbContext>((dbContext, builder) =>
 {


### PR DESCRIPTION

The DefaultConventionAction and DefaultOnModelCreatingAction properties have internal access modifiers and cannot be accessed directly. They can only be configured through the ConfigureDefaultConvention() and ConfigureDefaultOnModelCreating() methods.
