### PR TITLE
Angular - Fixing empty navigation item for a library

### DIFF
--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/config/src/providers/route.provider.ts.template
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package-standalone/__libraryName@kebab__/config/src/providers/route.provider.ts.template
@@ -12,7 +12,7 @@ export function configureRoutes() {
   const routes = inject(RoutesService);
   routes.add([
       {
-        path: '/<%= kebab(libraryName) %>',
+        path: undefined,
         name: e<%= pascal(libraryName) %>RouteNames.<%= pascal(libraryName) %>,
         iconClass: 'fas fa-book',
         layout: eLayoutType.application,

--- a/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package/__libraryName@kebab__/config/src/providers/route.provider.ts.template
+++ b/npm/ng-packs/packages/schematics/src/commands/create-lib/files-package/__libraryName@kebab__/config/src/providers/route.provider.ts.template
@@ -15,7 +15,7 @@ export function configureRoutes(routesService: RoutesService) {
   return () => {
     routesService.add([
       {
-        path: '/<%= kebab(libraryName) %>',
+        path: undefined,
         name: e<%= pascal(libraryName) %>RouteNames.<%= pascal(libraryName) %>,
         iconClass: 'fas fa-book',
         layout: eLayoutType.application,


### PR DESCRIPTION
### Description

Resolves https://github.com/volosoft/volo/issues/19953

### Checklist

- [X] I fully tested it as developer / designer and created unit / integration tests
- [X] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?
- You need to create a microservice app and add a microservice through suite
- Delete the generated library that is `apps/angular/projects/<your-service>`
- Get a build for the schematics package under `npm/ng-packs` by running `yarn build:schematics`
- Go to the `npm/ng-packs/dist/packages/schematics` and run `yarn link`, then copy the link command given in the output
- You need to paste it under `apps/angular` of your microservice. Then, run this command to regenerate your service `yarn ng g @abp/ng.schematics:create-lib --package-name "<your-service>"` (Select false for secondary endpoint and override questions. Pick module as a type since the standalone templates are not published yet.)
- Once you run the app, you should not see the routing of your service in the navbar since it has no valid page in it.
- Create entities for that specific service. This time, you will need to see the route items in the navbar if you have the necessary permissions.
