### PR TITLE
fix: ensure RabbitMQ QueueArguments from appsettings are parsed into correct types

### DIFF
--- a/framework/src/Volo.Abp.EventBus.RabbitMQ/Volo/Abp/EventBus/RabbitMq/AbpEventBusRabbitMqModule.cs
+++ b/framework/src/Volo.Abp.EventBus.RabbitMQ/Volo/Abp/EventBus/RabbitMq/AbpEventBusRabbitMqModule.cs
@@ -1,5 +1,6 @@
-﻿using System.Collections.Generic;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 using Volo.Abp.Modularity;
 using Volo.Abp.RabbitMQ;
 
@@ -10,59 +11,11 @@ namespace Volo.Abp.EventBus.RabbitMq;
     typeof(AbpRabbitMqModule))]
 public class AbpEventBusRabbitMqModule : AbpModule
 {
-    protected HashSet<string> uint64QueueArguments =
-    [
-        "x-delivery-limit",
-        "x-expires",
-        "x-message-ttl",
-        "x-max-length",
-        "x-max-length-bytes",
-        "x-quorum-initial-group-size",
-        "x-quorum-target-group-size",
-        "x-stream-filter-size-bytes",
-        "x-stream-max-segment-size-bytes",
-    ];
-    protected HashSet<string> boolQueueArguments = ["x-single-active-consumer"];
-
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
         var configuration = context.Services.GetConfiguration();
-
         Configure<AbpRabbitMqEventBusOptions>(configuration.GetSection("RabbitMQ:EventBus"));
-
-        context.Services.Configure<AbpRabbitMqEventBusOptions>(options =>
-        {
-            ParseBoolQueueArguments(options);
-            ParseIntegerQueueArguments(options);
-        });
-    }
-
-    protected virtual void ParseBoolQueueArguments(AbpRabbitMqEventBusOptions options)
-    {
-        foreach (var argument in boolQueueArguments)
-        {
-            if (
-                options.QueueArguments.TryGetValue(argument, out var value)
-                && value is string stringValue
-            )
-            {
-                options.QueueArguments[argument] = bool.Parse(stringValue);
-            }
-        }
-    }
-
-    protected virtual void ParseIntegerQueueArguments(AbpRabbitMqEventBusOptions options)
-    {
-        foreach (var argument in uint64QueueArguments)
-        {
-            if (
-                options.QueueArguments.TryGetValue(argument, out var value)
-                && value is string stringValue
-            )
-            {
-                options.QueueArguments[argument] = int.Parse(stringValue);
-            }
-        }
+        context.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<AbpRabbitMqEventBusOptions>, PostConfigureAbpRabbitMqEventBusOptions>());
     }
 
     public override void OnApplicationInitialization(ApplicationInitializationContext context)

--- a/framework/src/Volo.Abp.EventBus.RabbitMQ/Volo/Abp/EventBus/RabbitMq/AbpEventBusRabbitMqModule.cs
+++ b/framework/src/Volo.Abp.EventBus.RabbitMQ/Volo/Abp/EventBus/RabbitMq/AbpEventBusRabbitMqModule.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
 using Volo.Abp.Modularity;
 using Volo.Abp.RabbitMQ;
 
@@ -9,11 +10,59 @@ namespace Volo.Abp.EventBus.RabbitMq;
     typeof(AbpRabbitMqModule))]
 public class AbpEventBusRabbitMqModule : AbpModule
 {
+    protected HashSet<string> uint64QueueArguments =
+    [
+        "x-delivery-limit",
+        "x-expires",
+        "x-message-ttl",
+        "x-max-length",
+        "x-max-length-bytes",
+        "x-quorum-initial-group-size",
+        "x-quorum-target-group-size",
+        "x-stream-filter-size-bytes",
+        "x-stream-max-segment-size-bytes",
+    ];
+    protected HashSet<string> boolQueueArguments = ["x-single-active-consumer"];
+
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
         var configuration = context.Services.GetConfiguration();
 
         Configure<AbpRabbitMqEventBusOptions>(configuration.GetSection("RabbitMQ:EventBus"));
+
+        context.Services.Configure<AbpRabbitMqEventBusOptions>(options =>
+        {
+            ParseBoolQueueArguments(options);
+            ParseIntegerQueueArguments(options);
+        });
+    }
+
+    protected virtual void ParseBoolQueueArguments(AbpRabbitMqEventBusOptions options)
+    {
+        foreach (var argument in boolQueueArguments)
+        {
+            if (
+                options.QueueArguments.TryGetValue(argument, out var value)
+                && value is string stringValue
+            )
+            {
+                options.QueueArguments[argument] = bool.Parse(stringValue);
+            }
+        }
+    }
+
+    protected virtual void ParseIntegerQueueArguments(AbpRabbitMqEventBusOptions options)
+    {
+        foreach (var argument in uint64QueueArguments)
+        {
+            if (
+                options.QueueArguments.TryGetValue(argument, out var value)
+                && value is string stringValue
+            )
+            {
+                options.QueueArguments[argument] = int.Parse(stringValue);
+            }
+        }
     }
 
     public override void OnApplicationInitialization(ApplicationInitializationContext context)

--- a/framework/src/Volo.Abp.EventBus.RabbitMQ/Volo/Abp/EventBus/RabbitMq/PostConfigureAbpRabbitMqEventBusOptions.cs
+++ b/framework/src/Volo.Abp.EventBus.RabbitMQ/Volo/Abp/EventBus/RabbitMq/PostConfigureAbpRabbitMqEventBusOptions.cs
@@ -46,7 +46,7 @@ public class PostConfigureAbpRabbitMqEventBusOptions : IPostConfigureOptions<Abp
         {
             if (options.QueueArguments.TryGetValue(argument, out var value) && value is string stringValue && int.TryParse(stringValue, out var intValue))
             {
-                options.QueueArguments[argument] = intValue
+                options.QueueArguments[argument] = intValue;
             }
         }
     }

--- a/framework/src/Volo.Abp.EventBus.RabbitMQ/Volo/Abp/EventBus/RabbitMq/PostConfigureAbpRabbitMqEventBusOptions.cs
+++ b/framework/src/Volo.Abp.EventBus.RabbitMQ/Volo/Abp/EventBus/RabbitMq/PostConfigureAbpRabbitMqEventBusOptions.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using Microsoft.Extensions.Options;
+
+namespace Volo.Abp.EventBus.RabbitMq;
+
+public class PostConfigureAbpRabbitMqEventBusOptions : IPostConfigureOptions<AbpRabbitMqEventBusOptions>
+{
+    private readonly HashSet<string> _uint64QueueArguments =
+    [
+        "x-delivery-limit",
+        "x-expires",
+        "x-message-ttl",
+        "x-max-length",
+        "x-max-length-bytes",
+        "x-quorum-initial-group-size",
+        "x-quorum-target-group-size",
+        "x-stream-filter-size-bytes",
+        "x-stream-max-segment-size-bytes",
+    ];
+
+    private readonly HashSet<string> _boolQueueArguments =
+    [
+        "x-single-active-consumer"
+    ];
+
+    public virtual void PostConfigure(string? name, AbpRabbitMqEventBusOptions options)
+    {
+        ParseBoolQueueArguments(options);
+        ParseIntegerQueueArguments(options);
+    }
+
+    protected virtual void ParseBoolQueueArguments(AbpRabbitMqEventBusOptions options)
+    {
+        foreach (var argument in _boolQueueArguments)
+        {
+            if (options.QueueArguments.TryGetValue(argument, out var value) && value is string stringValue && bool.TryParse(stringValue, out var boolValue))
+            {
+                options.QueueArguments[argument] = boolValue;
+            }
+        }
+    }
+
+    protected virtual void ParseIntegerQueueArguments(AbpRabbitMqEventBusOptions options)
+    {
+        foreach (var argument in _uint64QueueArguments)
+        {
+            if (options.QueueArguments.TryGetValue(argument, out var value) && value is string stringValue && int.TryParse(stringValue, out var intValue))
+            {
+                options.QueueArguments[argument] = intValue
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
### Description

Resolves #23015

When setting `AbpEventBusRabbitMqModule.QueueArguments` via appsettings.json _QueueArguments_ entries are always added as string values. Some queue arguments in RabbitMQ need to be of type integer or bool to be successfully applied.

This PR ensures that queue arguments like `x-message-ttl` are parsed into the type RabbitMq expects them to be after having them read from `appsettings.json`.

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

( See #23015 )

0. `abp new ABPConsoleRabbitMq -t console --old`
1. add Volo.Abp.EventBus.RabbitMq module to it
2. Put RabbitMQ configuration containing bool/numeric queue arguments into appsettings.json like below

```json
  "RabbitMQ": {
    "EventBus": {
      "ClientName": "MyClientName",
      "ExchangeName": "MyExchangeName",

      "QueueArguments": {
        "x-queue-type": "quorum",

        "x-delivery-limit": 10,
        "x-expires": 120000,
        "x-message-ttl": 10000,
        "x-max-length": 100,
        "x-max-length-bytes": 128000,
        "x-quorum-initial-group-size": 1,
        "x-quorum-target-group-size": 1,

        "x-single-active-consumer": true
      }
    }
  }
```

3. Run

-> Check if configured queue arguments have been applied to the queue created in [RabbitMQ Management Interface](https://www.rabbitmq.com/docs/management#getting-started ):
![grafik](https://github.com/user-attachments/assets/191f7aee-76b7-4c45-b1b8-19d2829cb099)

