### PR TITLE
Set provider names to permission groups and permissions

### DIFF
--- a/framework/src/Volo.Abp.Authorization.Abstractions/Properties/AssemblyInfo.cs
+++ b/framework/src/Volo.Abp.Authorization.Abstractions/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Volo.Abp.Authorization.Abstractions")]
+[assembly: AssemblyTrademark("")]
+[assembly: InternalsVisibleTo("Volo.Abp.Authorization")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("83632bec-2f60-4c2b-b964-30e8b37fa9d8")]

--- a/framework/src/Volo.Abp.Authorization.Abstractions/Volo/Abp/Authorization/Permissions/PermissionDefinition.cs
+++ b/framework/src/Volo.Abp.Authorization.Abstractions/Volo/Abp/Authorization/Permissions/PermissionDefinition.cs
@@ -107,6 +107,8 @@ public class PermissionDefinition :
         {
             Parent = this
         };
+        
+        child[PermissionDefinitionContext.KnownPropertyNames.CurrentProviderName] = this[PermissionDefinitionContext.KnownPropertyNames.CurrentProviderName];
 
         _children.Add(child);
 

--- a/framework/src/Volo.Abp.Authorization.Abstractions/Volo/Abp/Authorization/Permissions/PermissionDefinitionContext.cs
+++ b/framework/src/Volo.Abp.Authorization.Abstractions/Volo/Abp/Authorization/Permissions/PermissionDefinitionContext.cs
@@ -35,12 +35,14 @@ public class PermissionDefinitionContext : IPermissionDefinitionContext
             throw new AbpException($"There is already an existing permission group with name: {name}");
         }
         
-        var group = Groups[name] = new PermissionGroupDefinition(name, displayName);
+        var group = new PermissionGroupDefinition(name, displayName);
 
         if (CurrentProvider != null)
         {
             group[KnownPropertyNames.CurrentProviderName] = CurrentProvider.GetType().FullName;
         }
+
+        Groups[name] = group;
         
         return group;
     }

--- a/framework/src/Volo.Abp.Authorization.Abstractions/Volo/Abp/Authorization/Permissions/PermissionDefinitionContext.cs
+++ b/framework/src/Volo.Abp.Authorization.Abstractions/Volo/Abp/Authorization/Permissions/PermissionDefinitionContext.cs
@@ -11,6 +11,13 @@ public class PermissionDefinitionContext : IPermissionDefinitionContext
 
     public Dictionary<string, PermissionGroupDefinition> Groups { get; }
 
+    internal IPermissionDefinitionProvider? CurrentProvider { get; set; }
+
+    public static class KnownPropertyNames
+    {
+        public const string CurrentProviderName = "_CurrentProviderName";
+    }
+
     public PermissionDefinitionContext(IServiceProvider serviceProvider)
     {
         ServiceProvider = serviceProvider;
@@ -27,8 +34,15 @@ public class PermissionDefinitionContext : IPermissionDefinitionContext
         {
             throw new AbpException($"There is already an existing permission group with name: {name}");
         }
+        
+        var group = Groups[name] = new PermissionGroupDefinition(name, displayName);
 
-        return Groups[name] = new PermissionGroupDefinition(name, displayName);
+        if (CurrentProvider != null)
+        {
+            group[KnownPropertyNames.CurrentProviderName] = CurrentProvider.GetType().FullName;
+        }
+        
+        return group;
     }
 
     [NotNull]

--- a/framework/src/Volo.Abp.Authorization.Abstractions/Volo/Abp/Authorization/Permissions/PermissionGroupDefinition.cs
+++ b/framework/src/Volo.Abp.Authorization.Abstractions/Volo/Abp/Authorization/Permissions/PermissionGroupDefinition.cs
@@ -61,6 +61,8 @@ public class PermissionGroupDefinition : ICanAddChildPermission
             isEnabled
         );
 
+        permission[PermissionDefinitionContext.KnownPropertyNames.CurrentProviderName] = this[PermissionDefinitionContext.KnownPropertyNames.CurrentProviderName];
+
         _permissions.Add(permission);
 
         return permission;

--- a/framework/src/Volo.Abp.Authorization/Volo/Abp/Authorization/Permissions/StaticPermissionDefinitionStore.cs
+++ b/framework/src/Volo.Abp.Authorization/Volo/Abp/Authorization/Permissions/StaticPermissionDefinitionStore.cs
@@ -99,6 +99,8 @@ public class StaticPermissionDefinitionStore : IStaticPermissionDefinitionStore,
                 context.CurrentProvider = provider;
                 provider.PostDefine(context);
             }
+            
+            context.CurrentProvider = null;
 
             return context.Groups;
         }

--- a/framework/src/Volo.Abp.Authorization/Volo/Abp/Authorization/Permissions/StaticPermissionDefinitionStore.cs
+++ b/framework/src/Volo.Abp.Authorization/Volo/Abp/Authorization/Permissions/StaticPermissionDefinitionStore.cs
@@ -84,16 +84,19 @@ public class StaticPermissionDefinitionStore : IStaticPermissionDefinitionStore,
 
             foreach (var provider in providers)
             {
+                context.CurrentProvider = provider;
                 provider.PreDefine(context);
             }
 
             foreach (var provider in providers)
             {
+                context.CurrentProvider = provider;
                 provider.Define(context);
             }
 
             foreach (var provider in providers)
             {
+                context.CurrentProvider = provider;
                 provider.PostDefine(context);
             }
 

--- a/framework/test/Volo.Abp.Authorization.Tests/Volo/Abp/Authorization/TestServices/AuthorizationTestPermissionDefinitionProvider.cs
+++ b/framework/test/Volo.Abp.Authorization.Tests/Volo/Abp/Authorization/TestServices/AuthorizationTestPermissionDefinitionProvider.cs
@@ -14,8 +14,12 @@ public class AuthorizationTestPermissionDefinitionProvider : PermissionDefinitio
         }
 
         var group = context.AddGroup("TestGroup");
+        
+        group[PermissionDefinitionContext.KnownPropertyNames.CurrentProviderName].ShouldBe(typeof(AuthorizationTestPermissionDefinitionProvider).FullName);
 
-        group.AddPermission("MyAuthorizedService1");
+        var permission1 = group.AddPermission("MyAuthorizedService1");
+        
+        permission1[PermissionDefinitionContext.KnownPropertyNames.CurrentProviderName].ShouldBe(typeof(AuthorizationTestPermissionDefinitionProvider).FullName);
 
         group.AddPermission("MyPermission1").StateCheckers.Add(new TestRequireEditionPermissionSimpleStateChecker());
         group.AddPermission("MyPermission2");


### PR DESCRIPTION
In this way, we can later understand which permission or group was created by which provider.
https://github.com/abpframework/abp/pull/23059/files
To get the related provider:

````csharp
var groupProvider = group[PermissionDefinitionContext.KnownPropertyNames.CurrentProviderName]; // group: PermissionGroupDefinition
var permissionProvider = permission[PermissionDefinitionContext.KnownPropertyNames.CurrentProviderName]; // permission: PermissionDefinition
````

Results will be the full name of the class that created these objects. It works for static and dynamic permissions.