### PR TITLE
Remove Yarn dependency warnings from the documentation

### DIFF
--- a/docs/en/framework/real-time/signalr.md
+++ b/docs/en/framework/real-time/signalr.md
@@ -55,7 +55,7 @@ Client side installation depends on your UI framework / client type.
 Run the following command in the root folder of your web project:
 
 ```bash
-npm install @abp/signalr
+abp add-package @abp/signalr
 ```
 
 This will add the `@abp/signalr` to the dependencies in the `package.json` of your project:

--- a/docs/en/framework/real-time/signalr.md
+++ b/docs/en/framework/real-time/signalr.md
@@ -55,10 +55,8 @@ Client side installation depends on your UI framework / client type.
 Run the following command in the root folder of your web project:
 
 ```bash
-yarn add @abp/signalr
+npm install @abp/signalr
 ```
-
-> This requires to [install yarn](https://yarnpkg.com/) if you haven't install before.
 
 This will add the `@abp/signalr` to the dependencies in the `package.json` of your project:
 

--- a/docs/en/framework/ui/mvc-razor-pages/basic-theme.md
+++ b/docs/en/framework/ui/mvc-razor-pages/basic-theme.md
@@ -14,7 +14,7 @@ If you need to manually this theme, follow the steps below:
 
 * Install the [Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic](https://www.nuget.org/packages/Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic) NuGet package to your web project.
 * Add `AbpAspNetCoreMvcUiBasicThemeModule` into the `[DependsOn(...)]` attribute for your [module class](../../architecture/modularity/basics.md) in the web project.
-* Install the [@abp/aspnetcore.mvc.ui.theme.basic](https://www.npmjs.com/package/@abp/aspnetcore.mvc.ui.theme.basic) NPM package to your web project (e.g. `npm install @abp/aspnetcore.mvc.ui.theme.basic` or `yarn add @abp/aspnetcore.mvc.ui.theme.basic`).
+* Install the [@abp/aspnetcore.mvc.ui.theme.basic](https://www.npmjs.com/package/@abp/aspnetcore.mvc.ui.theme.basic) NPM package to your web project (e.g. `abp add-package @abp/aspnetcore.mvc.ui.theme.basic`).
 * Run `abp install-libs` command in a command line terminal in the web project's folder.
 
 ## Layouts

--- a/docs/en/framework/ui/mvc-razor-pages/client-side-package-management.md
+++ b/docs/en/framework/ui/mvc-razor-pages/client-side-package-management.md
@@ -3,9 +3,8 @@
 
 ABP can work with any type of client side package management systems. You can even decide to use no package management system and manage your dependencies manually.
 
-However, ABP works best with **NPM/Yarn**. By default, built-in modules are configured to work with NPM/Yarn.
+However, ABP works best with **NPM**. By default, built-in modules are configured to work with NPM.
 
-Finally, we suggest the [**Yarn**](https://classic.yarnpkg.com/) over the NPM since it's faster, stable and also compatible with the NPM.
 
 ### @ABP NPM Packages
 
@@ -35,13 +34,11 @@ It's suggested to depend on a standard package instead of directly depending on 
 
 #### Package Installation
 
-After depending on a NPM package, all you should do is to run the **yarn** command from the command line to install all the packages and their dependencies:
+After depending on a NPM package, all you should do is to run the **npm install** command from the command line to install all the packages and their dependencies:
 
 ```bash
-yarn
+npm install
 ```
-
-Alternatively, you can use `npm install` but [Yarn v1.22+ (not v2)](https://classic.yarnpkg.com/en/docs/install) is suggested as mentioned before.
 
 #### Package Contribution
 
@@ -57,7 +54,7 @@ See current standard packages for examples.
 
 ### Mapping The Library Resources
 
-Using NPM packages and NPM/Yarn tool is the de facto standard for client side libraries. NPM/Yarn tool creates a **node_modules** folder in the root folder of your web project.
+Using NPM packages and NPM tool is the de facto standard for client side libraries. NPM tool creates a **node_modules** folder in the root folder of your web project.
 
 Next challenge is copying needed resources (js, css, img... files) from the `node_modules` into a folder inside the **wwwroot** folder to make it accessible to the clients/browsers.
 

--- a/docs/en/framework/ui/mvc-razor-pages/client-side-package-management.md
+++ b/docs/en/framework/ui/mvc-razor-pages/client-side-package-management.md
@@ -34,10 +34,10 @@ It's suggested to depend on a standard package instead of directly depending on 
 
 #### Package Installation
 
-After depending on a NPM package, all you should do is to run the **npm install** command from the command line to install all the packages and their dependencies:
+After depending on a NPM package, you should run the **abp install-libs** command from the command line to install all the packages and their dependencies, and copy the required resources to the wwwroot/libs folder:
 
 ```bash
-npm install
+abp install-libs
 ```
 
 #### Package Contribution

--- a/docs/en/get-started/layered-web-application.md
+++ b/docs/en/get-started/layered-web-application.md
@@ -17,7 +17,7 @@ First things first! Let's setup your development environment before creating the
 
 * [Visual Studio 2022](https://visualstudio.microsoft.com/) or another IDE that supports [.NET 9.0+](https://dotnet.microsoft.com/download/dotnet) development.
 * [.NET 9.0+](https://dotnet.microsoft.com/en-us/download/dotnet){{ if UI != "Blazor" }}
-* [Node v22.11+](https://nodejs.org/)
+* [Node v22.11+](https://nodejs.org/){{ end }}{{ if UI == "NG" }}
 * [Yarn v1.22+ (not v2+)](https://classic.yarnpkg.com/en/docs/install) or npm v10+ (already installed with Node){{ end }}
 * [Docker Desktop](https://www.docker.com/products/docker-desktop/)
 

--- a/docs/en/get-started/microservice.md
+++ b/docs/en/get-started/microservice.md
@@ -11,7 +11,7 @@ First things first! Let's setup your development environment before creating the
 * [Visual Studio 2022](https://visualstudio.microsoft.com/vs/) or another IDE that supports .NET development
 * [.NET 9.0+](https://dotnet.microsoft.com/en-us/download/dotnet)
 * [Node v22.11+](https://nodejs.org/)
-* [Yarn v1.22+ (not v2+)](https://classic.yarnpkg.com/en/docs/install) or npm v10+ (already installed with Node)
+* [Yarn v1.22+ (not v2+)](https://classic.yarnpkg.com/en/docs/install) or npm v10+ (already installed with Node), **This is required for the Angular applications.**
 * [Docker Desktop (with Kubernetes enabled)](https://www.docker.com/products/docker-desktop/)
 * [Helm](https://helm.sh/docs/intro/install/)
 * [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/deploy/)

--- a/docs/en/get-started/pre-requirements.md
+++ b/docs/en/get-started/pre-requirements.md
@@ -47,11 +47,13 @@ If you have already installed the `EF Core CLI`, you can update it by running th
 dotnet tool update --global dotnet-ef
 ```
 
-## Node.js and Yarn
+## Node.js
 
-ABP projects include some frontend resource packages, so you need to install Node.js and Yarn to manage these resource packages. You can download Node.js from the [official Node.js website](https://nodejs.org/). We recommend installing version v20.11+.
+ABP projects include some frontend resource packages, so you need to install Node.js/NPM manage these resource packages. You can download Node.js from the [official Node.js website](https://nodejs.org/). We recommend installing version v20.11+.
 
-Using Yarn (classic) to manage frontend resource packages is faster and more stable than using npm. You can download `Yarn` from the [Yarn official website](https://classic.yarnpkg.com/en/docs/install). We recommend installing Yarn v1.22+ (make sure to install the Classic version, not v2+).
+## Yarn (Required Only for Angular Projects)
+
+ABP Angular projects use Yarn as the package manager to manage frontend dependencies and run build tasks, You can download `Yarn` from the [Yarn official website](https://classic.yarnpkg.com/en/docs/install). We recommend installing Yarn v1.22+ (make sure to install the Classic version, not v2+).
 
 To install Yarn using npm, run the following command:
 

--- a/docs/en/get-started/single-layer-web-application.md
+++ b/docs/en/get-started/single-layer-web-application.md
@@ -16,7 +16,7 @@ First things first! Let's setup your development environment before creating the
 
 * [Visual Studio 2022](https://visualstudio.microsoft.com/) or another IDE that supports [.NET 9.0+](https://dotnet.microsoft.com/download/dotnet) development.
 * [.NET 9.0+](https://dotnet.microsoft.com/en-us/download/dotnet){{ if UI != "Blazor" }}
-* [Node v22.11+](https://nodejs.org/)
+* [Node v22.11+](https://nodejs.org/){{ end }}{{ if UI == "NG" }}
 * [Yarn v1.22+ (not v2+)](https://classic.yarnpkg.com/en/docs/install) or npm v10+ (already installed with Node){{ end }}
 
 > Check the [Pre-requirements document](pre-requirements.md) for more detailed information about these tools.

--- a/docs/en/tutorials/book-store/part-01.md
+++ b/docs/en/tutorials/book-store/part-01.md
@@ -34,8 +34,6 @@ For such cases, run the `abp install-libs` command on the root directory of your
 abp install-libs
 ```
 
-> We suggest you install [Yarn v1.22+ (not v2)](https://classic.yarnpkg.com/en/docs/install) to prevent possible package inconsistencies, if you haven't installed it yet.
-
 ## Create the Book Entity
 
 **Domain layer** in the startup template is separated into two projects:

--- a/docs/en/tutorials/todo/layered/index.md
+++ b/docs/en/tutorials/todo/layered/index.md
@@ -61,8 +61,6 @@ This documentation has a video tutorial on **YouTube**!! You can watch it here:
 
 {{end}}
 
-> We suggest you install [Yarn v1.22+ (not v2)](https://classic.yarnpkg.com/en/docs/install) to prevent possible package inconsistencies, if you haven't installed it yet.
-
 ## Install ABP CLI Tool
 
 We will use the [ABP CLI](../../../cli/index.md) to create new ABP solutions. You can run the following command on a terminal window to install this dotnet tool:

--- a/docs/en/tutorials/todo/layered/index.md
+++ b/docs/en/tutorials/todo/layered/index.md
@@ -61,6 +61,8 @@ This documentation has a video tutorial on **YouTube**!! You can watch it here:
 
 {{end}}
 
+> We suggest you install [Yarn v1.22+ (not v2)](https://classic.yarnpkg.com/en/docs/install) to prevent possible package inconsistencies, if you haven't installed it yet.
+
 ## Install ABP CLI Tool
 
 We will use the [ABP CLI](../../../cli/index.md) to create new ABP solutions. You can run the following command on a terminal window to install this dotnet tool:
@@ -110,8 +112,6 @@ For such cases, run the `abp install-libs` command on the root directory of your
 ````bash
 abp install-libs
 ````
-
-> We suggest you install [Yarn v1.22+ (not v2)](https://classic.yarnpkg.com/en/docs/install) to prevent possible package inconsistencies, if you haven't installed it yet.
 
 ### Run the Application
 

--- a/docs/en/tutorials/todo/single-layer/index.md
+++ b/docs/en/tutorials/todo/single-layer/index.md
@@ -57,6 +57,8 @@ This documentation has a video tutorial on **YouTube**!! You can watch it here:
 
 {{end}}
 
+> We suggest you install [Yarn v1.22+ (not v2)](https://classic.yarnpkg.com/en/docs/install) to prevent possible package inconsistencies, if you haven't installed it yet.
+
 ## Creating a New Solution
 
 In this tutorial, we will use the [ABP CLI](../../../cli/index.md) to create the sample application with the ABP. You can run the following command in a command-line terminal to install the **ABP CLI**, if you haven't installed it yet:
@@ -112,8 +114,6 @@ Run the `abp install-libs` command on the root directory of your solution to ins
 ```bash
 abp install-libs
 ```
-
-> We suggest you install [Yarn v1.22+ (not v2)](https://classic.yarnpkg.com/en/docs/install) to prevent possible package inconsistencies, if you haven't installed it yet.
 
 ### Run the Application
 

--- a/docs/en/tutorials/todo/single-layer/index.md
+++ b/docs/en/tutorials/todo/single-layer/index.md
@@ -57,8 +57,6 @@ This documentation has a video tutorial on **YouTube**!! You can watch it here:
 
 {{end}}
 
-> We suggest you install [Yarn v1.22+ (not v2)](https://classic.yarnpkg.com/en/docs/install) to prevent possible package inconsistencies, if you haven't installed it yet.
-
 ## Creating a New Solution
 
 In this tutorial, we will use the [ABP CLI](../../../cli/index.md) to create the sample application with the ABP. You can run the following command in a command-line terminal to install the **ABP CLI**, if you haven't installed it yet:


### PR DESCRIPTION
Because it is not needed to manually and globally installed anymore. ABP CLI handles it.