### PR TITLE
Add methods to remove bundle files by name or predicate

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling.Abstractions/Volo/Abp/AspNetCore/Mvc/UI/Bundling/BundleConfigurationExtensions.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling.Abstractions/Volo/Abp/AspNetCore/Mvc/UI/Bundling/BundleConfigurationExtensions.cs
@@ -23,6 +23,18 @@ public static class BundleConfigurationExtensions
         return bundleConfiguration;
     }
 
+    public static BundleConfiguration RemoveFiles(this BundleConfiguration bundleConfiguration, params string[] files)
+    {
+        bundleConfiguration.Contributors.RemoveBundleFile(files.ToArray());
+        return bundleConfiguration;
+    }
+
+    public static BundleConfiguration RemoveFiles(this BundleConfiguration bundleConfiguration, Func<string, bool> predicate)
+    {
+        bundleConfiguration.Contributors.RemoveBundleFile(predicate);
+        return bundleConfiguration;
+    }
+
     public static BundleConfiguration AddContributors(this BundleConfiguration bundleConfiguration, params IBundleContributor[] contributors)
     {
         Check.NotNull(contributors, nameof(contributors));

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling.Abstractions/Volo/Abp/AspNetCore/Mvc/UI/Bundling/BundleContributorCollection.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling.Abstractions/Volo/Abp/AspNetCore/Mvc/UI/Bundling/BundleContributorCollection.cs
@@ -76,6 +76,36 @@ public class BundleContributorCollection
         }
     }
 
+    public void RemoveBundleFile(string fileName)
+    {
+        RemoveBundleFile([fileName]);
+    }
+
+    public void RemoveBundleFile(string[] fileNames)
+    {
+        var contributors = _contributors
+            .Where(x => x is BundleFileContributor bundleContributor &&
+                        bundleContributor.Files.Any(f => fileNames.Any(name => name.Equals(f.FileName, StringComparison.OrdinalIgnoreCase))))
+            .Cast<BundleFileContributor>();
+        foreach (var contributor in contributors)
+        {
+            contributor.Files.RemoveAll(x => fileNames.Any(name => name.Equals(x.FileName, StringComparison.OrdinalIgnoreCase)));
+        }
+    }
+
+    public void RemoveBundleFile(Func<string, bool> predicate)
+    {
+        var contributors = _contributors
+            .Where(x => x is BundleFileContributor bundleContributor &&
+                        bundleContributor.Files.Any(f => predicate(f.FileName)))
+            .Cast<BundleFileContributor>();
+
+        foreach (var contributor in contributors)
+        {
+            contributor.Files.RemoveAll(x => predicate(x.FileName));
+        }
+    }
+
     public IReadOnlyList<IBundleContributor> GetAll()
     {
         return _contributors.ToImmutableList();

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling.Abstractions/Volo/Abp/AspNetCore/Mvc/UI/Bundling/BundleContributorCollectionExtensions.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling.Abstractions/Volo/Abp/AspNetCore/Mvc/UI/Bundling/BundleContributorCollectionExtensions.cs
@@ -1,4 +1,7 @@
-﻿namespace Volo.Abp.AspNetCore.Mvc.UI.Bundling;
+﻿using System;
+using System.Linq;
+
+namespace Volo.Abp.AspNetCore.Mvc.UI.Bundling;
 
 public static class BundleContributorCollectionExtensions
 {
@@ -15,5 +18,15 @@ public static class BundleContributorCollectionExtensions
     public static void AddExternalFiles(this BundleContributorCollection contributors, params BundleFile[] files)
     {
         contributors.Add(new BundleFileContributor(files));
+    }
+
+    public static void RemoveFile(this BundleContributorCollection contributors, params string[] files)
+    {
+        contributors.RemoveBundleFile(files.ToArray());
+    }
+
+    public static void RemoveFile(this BundleContributorCollection contributors, Func<string, bool> predicate)
+    {
+        contributors.RemoveBundleFile(predicate);
     }
 }


### PR DESCRIPTION
Resolve #23169

```cs
Configure<AbpBundlingOptions>(options =>
{
    options.ScriptBundles
        .Configure(typeof(ManageModel).FullName,
            configuration =>
            {
                configuration.RemoveFiles("/Pages/Account/Default.js");
                configuration.AddFiles("/Pages/Account/MyDefault.js");
            });
});
```