### PR TITLE
Refactor: Use Angular inject() for Dependency Injection Across All Modules - Issue 23231

### DIFF
--- a/npm/ng-packs/packages/account-core/proxy/src/lib/proxy/account/account.service.ts
+++ b/npm/ng-packs/packages/account-core/proxy/src/lib/proxy/account/account.service.ts
@@ -1,12 +1,14 @@
 import type { RegisterDto, ResetPasswordDto, SendPasswordResetCodeDto } from './models';
 import { RestService } from '@abp/ng.core';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import type { IdentityUserDto } from '../identity/models';
 
 @Injectable({
   providedIn: 'root',
 })
 export class AccountService {
+  private restService = inject(RestService);
+
   apiName = 'AbpAccount';
 
   register = (input: RegisterDto) =>
@@ -33,5 +35,8 @@ export class AccountService {
     },
     { apiName: this.apiName });
 
-  constructor(private restService: RestService) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 }

--- a/npm/ng-packs/packages/account-core/proxy/src/lib/proxy/account/profile.service.ts
+++ b/npm/ng-packs/packages/account-core/proxy/src/lib/proxy/account/profile.service.ts
@@ -1,11 +1,13 @@
 import type { ChangePasswordInput, ProfileDto, UpdateProfileDto } from './models';
 import { RestService } from '@abp/ng.core';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 @Injectable({
   providedIn: 'root',
 })
 export class ProfileService {
+  private restService = inject(RestService);
+
   apiName = 'AbpAccount';
 
   changePassword = (input: ChangePasswordInput) =>
@@ -31,5 +33,8 @@ export class ProfileService {
     },
     { apiName: this.apiName });
 
-  constructor(private restService: RestService) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 }

--- a/npm/ng-packs/packages/account-core/proxy/src/lib/proxy/account/web/areas/account/controllers/account.service.ts
+++ b/npm/ng-packs/packages/account-core/proxy/src/lib/proxy/account/web/areas/account/controllers/account.service.ts
@@ -1,11 +1,13 @@
 import type { AbpLoginResult, UserLoginInfo } from './models/models';
 import { RestService } from '@abp/ng.core';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 @Injectable({
   providedIn: 'root',
 })
 export class AccountService {
+  private restService = inject(RestService);
+
   apiName = 'AbpAccount';
 
   checkPasswordByLogin = (login: UserLoginInfo) =>
@@ -31,5 +33,8 @@ export class AccountService {
     },
     { apiName: this.apiName });
 
-  constructor(private restService: RestService) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 }

--- a/npm/ng-packs/packages/account-core/src/lib/auth-wrapper.service.ts
+++ b/npm/ng-packs/packages/account-core/src/lib/auth-wrapper.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Injector } from '@angular/core';
+import { Injectable, Injector, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { ActivatedRoute } from '@angular/router';
@@ -6,6 +6,9 @@ import { ConfigStateService, MultiTenancyService } from '@abp/ng.core';
 
 @Injectable()
 export class AuthWrapperService {
+  readonly multiTenancy = inject(MultiTenancyService);
+  private configState = inject(ConfigStateService);
+
   isMultiTenancyEnabled$ = this.configState.getDeep$('multiTenancy.isEnabled');
 
   get enableLocalLogin$(): Observable<boolean> {
@@ -25,11 +28,12 @@ export class AuthWrapperService {
     return this.isTenantBoxVisibleForCurrentRoute && this.multiTenancy.isTenantBoxVisible;
   }
 
-  constructor(
-    public readonly multiTenancy: MultiTenancyService,
-    private configState: ConfigStateService,
-    injector: Injector,
-  ) {
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {
+    const injector = inject(Injector);
+
     this.route = injector.get(ActivatedRoute);
   }
 

--- a/npm/ng-packs/packages/account-core/src/lib/tenant-box.service.ts
+++ b/npm/ng-packs/packages/account-core/src/lib/tenant-box.service.ts
@@ -5,11 +5,16 @@ import {
   SessionStateService,
 } from '@abp/ng.core';
 import { ToasterService } from '@abp/ng.theme.shared';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { finalize } from 'rxjs/operators';
 
 @Injectable()
 export class TenantBoxService {
+  private toasterService = inject(ToasterService);
+  private tenantService = inject(AbpTenantService);
+  private sessionState = inject(SessionStateService);
+  private configState = inject(ConfigStateService);
+
   currentTenant$ = this.sessionState.getTenant$();
 
   name?: string;
@@ -18,12 +23,10 @@ export class TenantBoxService {
 
   modalBusy!: boolean;
 
-  constructor(
-    private toasterService: ToasterService,
-    private tenantService: AbpTenantService,
-    private sessionState: SessionStateService,
-    private configState: ConfigStateService,
-  ) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 
   onSwitch() {
     const tenant = this.sessionState.getTenant();

--- a/npm/ng-packs/packages/account/src/lib/components/change-password/change-password.component.ts
+++ b/npm/ng-packs/packages/account/src/lib/components/change-password/change-password.component.ts
@@ -1,6 +1,6 @@
 import { ProfileService } from '@abp/ng.account.core/proxy';
 import { ButtonComponent, getPasswordValidators, ToasterService } from '@abp/ng.theme.shared';
-import { Component, Injector, OnInit } from '@angular/core';
+import { Component, Injector, OnInit, inject } from '@angular/core';
 import {
   ReactiveFormsModule,
   UntypedFormBuilder,
@@ -32,6 +32,12 @@ const PASSWORD_FIELDS = ['newPassword', 'repeatNewPassword'];
 export class ChangePasswordComponent
   implements OnInit, Account.ChangePasswordComponentInputs, Account.ChangePasswordComponentOutputs
 {
+  private fb = inject(UntypedFormBuilder);
+  private injector = inject(Injector);
+  private toasterService = inject(ToasterService);
+  private profileService = inject(ProfileService);
+  private manageProfileState = inject(ManageProfileStateService);
+
   form!: UntypedFormGroup;
 
   inProgress?: boolean;
@@ -44,13 +50,10 @@ export class ChangePasswordComponent
     return errors.concat(groupErrors.filter(({ key }) => key === 'passwordMismatch'));
   };
 
-  constructor(
-    private fb: UntypedFormBuilder,
-    private injector: Injector,
-    private toasterService: ToasterService,
-    private profileService: ProfileService,
-    private manageProfileState: ManageProfileStateService,
-  ) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 
   ngOnInit(): void {
     this.hideCurrentPassword = !this.manageProfileState.getProfile()?.hasPassword;

--- a/npm/ng-packs/packages/account/src/lib/components/forgot-password/forgot-password.component.ts
+++ b/npm/ng-packs/packages/account/src/lib/components/forgot-password/forgot-password.component.ts
@@ -1,5 +1,5 @@
 import { AccountService } from '@abp/ng.account.core/proxy';
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import {
   ReactiveFormsModule,
   UntypedFormBuilder,
@@ -24,16 +24,19 @@ import { NgxValidateCoreModule } from '@ngx-validate/core';
   ],
 })
 export class ForgotPasswordComponent {
+  private fb = inject(UntypedFormBuilder);
+  private accountService = inject(AccountService);
+
   form: UntypedFormGroup;
 
   inProgress?: boolean;
 
   isEmailSent = false;
 
-  constructor(
-    private fb: UntypedFormBuilder,
-    private accountService: AccountService,
-  ) {
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {
     this.form = this.fb.group({
       email: ['', [Validators.required, Validators.email]],
     });

--- a/npm/ng-packs/packages/account/src/lib/components/manage-profile/manage-profile.component.ts
+++ b/npm/ng-packs/packages/account/src/lib/components/manage-profile/manage-profile.component.ts
@@ -1,7 +1,7 @@
 import { ProfileService } from '@abp/ng.account.core/proxy';
 import { fadeIn, LoadingDirective } from '@abp/ng.theme.shared';
 import { transition, trigger, useAnimation } from '@angular/animations';
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import { eAccountComponents } from '../../enums/components';
 import { ManageProfileStateService } from '../../services/manage-profile.state.service';
 import { CommonModule } from '@angular/common';
@@ -33,6 +33,9 @@ import { ChangePasswordComponent } from '../change-password/change-password.comp
   ],
 })
 export class ManageProfileComponent implements OnInit {
+  protected profileService = inject(ProfileService);
+  protected manageProfileState = inject(ManageProfileStateService);
+
   selectedTab = 0;
 
   changePasswordKey = eAccountComponents.ChangePassword;
@@ -43,10 +46,10 @@ export class ManageProfileComponent implements OnInit {
 
   hideChangePasswordTab?: boolean;
 
-  constructor(
-    protected profileService: ProfileService,
-    protected manageProfileState: ManageProfileStateService,
-  ) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 
   ngOnInit() {
     this.profileService.get().subscribe(profile => {

--- a/npm/ng-packs/packages/account/src/lib/components/personal-settings/personal-settings-half-row.component.ts
+++ b/npm/ng-packs/packages/account/src/lib/components/personal-settings/personal-settings-half-row.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import {
   EXTENSIONS_FORM_PROP,
   FormProp,
@@ -24,12 +24,19 @@ import { LocalizationPipe } from '@abp/ng.core';
   imports: [ReactiveFormsModule, LocalizationPipe],
 })
 export class PersonalSettingsHalfRowComponent {
+  private propData = inject<FormProp>(EXTENSIONS_FORM_PROP);
+
   public displayName: string;
   public name: string;
   public id: string;
   public formGroup!: UntypedFormGroup;
 
-  constructor(@Inject(EXTENSIONS_FORM_PROP) private propData: FormProp) {
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {
+    const propData = this.propData;
+
     this.displayName = propData.displayName;
     this.name = propData.name;
     this.id = propData.id || '';

--- a/npm/ng-packs/packages/account/src/lib/components/register/register.component.ts
+++ b/npm/ng-packs/packages/account/src/lib/components/register/register.component.ts
@@ -6,7 +6,7 @@ import {
   LocalizationPipe,
 } from '@abp/ng.core';
 import { ButtonComponent, getPasswordValidators, ToasterService } from '@abp/ng.theme.shared';
-import { Component, Injector, OnInit } from '@angular/core';
+import { Component, Injector, OnInit, inject } from '@angular/core';
 import {
   ReactiveFormsModule,
   UntypedFormBuilder,
@@ -35,6 +35,13 @@ const { maxLength, required, email } = Validators;
   ],
 })
 export class RegisterComponent implements OnInit {
+  protected fb = inject(UntypedFormBuilder);
+  protected accountService = inject(AccountService);
+  protected configState = inject(ConfigStateService);
+  protected toasterService = inject(ToasterService);
+  protected authService = inject(AuthService);
+  protected injector = inject(Injector);
+
   form!: UntypedFormGroup;
 
   inProgress?: boolean;
@@ -43,14 +50,10 @@ export class RegisterComponent implements OnInit {
 
   authWrapperKey = eAccountComponents.AuthWrapper;
 
-  constructor(
-    protected fb: UntypedFormBuilder,
-    protected accountService: AccountService,
-    protected configState: ConfigStateService,
-    protected toasterService: ToasterService,
-    protected authService: AuthService,
-    protected injector: Injector,
-  ) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 
   ngOnInit() {
     this.init();

--- a/npm/ng-packs/packages/account/src/lib/components/reset-password/reset-password.component.ts
+++ b/npm/ng-packs/packages/account/src/lib/components/reset-password/reset-password.component.ts
@@ -1,6 +1,6 @@
 import { AccountService } from '@abp/ng.account.core/proxy';
 import { ButtonComponent, getPasswordValidators } from '@abp/ng.theme.shared';
-import { Component, Injector, OnInit } from '@angular/core';
+import { Component, Injector, OnInit, inject } from '@angular/core';
 import {
   ReactiveFormsModule,
   UntypedFormBuilder,
@@ -26,6 +26,12 @@ const PASSWORD_FIELDS = ['password', 'confirmPassword'];
   ],
 })
 export class ResetPasswordComponent implements OnInit {
+  private fb = inject(UntypedFormBuilder);
+  private accountService = inject(AccountService);
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private injector = inject(Injector);
+
   form!: UntypedFormGroup;
 
   inProgress = false;
@@ -38,13 +44,10 @@ export class ResetPasswordComponent implements OnInit {
     return errors.concat(groupErrors.filter(({ key }) => key === 'passwordMismatch'));
   };
 
-  constructor(
-    private fb: UntypedFormBuilder,
-    private accountService: AccountService,
-    private route: ActivatedRoute,
-    private router: Router,
-    private injector: Injector,
-  ) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 
   ngOnInit(): void {
     this.route.queryParams.subscribe(({ userId, resetToken }) => {

--- a/npm/ng-packs/packages/components/chart.js/src/chart.component.ts
+++ b/npm/ng-packs/packages/components/chart.js/src/chart.component.ts
@@ -1,17 +1,4 @@
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  EventEmitter,
-  Input,
-  OnChanges,
-  OnDestroy,
-  Output,
-  SimpleChanges,
-  ViewChild,
-} from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, Input, OnChanges, OnDestroy, Output, SimpleChanges, ViewChild, inject } from '@angular/core';
 
 let Chart: any;
 
@@ -35,6 +22,9 @@ let Chart: any;
   exportAs: 'abpChart',
 })
 export class ChartComponent implements AfterViewInit, OnDestroy, OnChanges {
+  el = inject(ElementRef);
+  private cdr = inject(ChangeDetectorRef);
+
   @Input() type!: string;
 
   @Input() data: any = {};
@@ -57,10 +47,10 @@ export class ChartComponent implements AfterViewInit, OnDestroy, OnChanges {
 
   chart: any;
 
-  constructor(
-    public el: ElementRef,
-    private cdr: ChangeDetectorRef,
-  ) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 
   ngAfterViewInit() {
     import('chart.js/auto').then(module => {

--- a/npm/ng-packs/packages/components/extensible/src/lib/components/abstract-actions/abstract-actions.component.ts
+++ b/npm/ng-packs/packages/components/extensible/src/lib/components/abstract-actions/abstract-actions.component.ts
@@ -16,9 +16,6 @@ export abstract class AbstractActionsComponent<
 
   @Input() record!: InferredData<L>['record'];
 
-  /** Inserted by Angular inject() migration for backwards compatibility */
-  constructor(...args: unknown[]);
-
   protected constructor() {
     const injector = inject(Injector);
 

--- a/npm/ng-packs/packages/components/extensible/src/lib/components/abstract-actions/abstract-actions.component.ts
+++ b/npm/ng-packs/packages/components/extensible/src/lib/components/abstract-actions/abstract-actions.component.ts
@@ -1,4 +1,4 @@
-import { Directive, Injector, Input } from '@angular/core';
+import { Directive, Injector, Input, inject } from '@angular/core';
 import { ActionData, ActionList, InferredAction } from '../../models/actions';
 import { ExtensionsService } from '../../services/extensions.service';
 import { EXTENSIONS_ACTION_TYPE, EXTENSIONS_IDENTIFIER } from '../../tokens/extensions.token';
@@ -16,7 +16,12 @@ export abstract class AbstractActionsComponent<
 
   @Input() record!: InferredData<L>['record'];
 
-  protected constructor(injector: Injector) {
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  protected constructor() {
+    const injector = inject(Injector);
+
     super();
     this.getInjected = injector.get.bind(injector);
     const extensions = injector.get(ExtensionsService);

--- a/npm/ng-packs/packages/components/extensible/src/lib/components/grid-actions/grid-actions.component.ts
+++ b/npm/ng-packs/packages/components/extensible/src/lib/components/grid-actions/grid-actions.component.ts
@@ -43,6 +43,6 @@ export class GridActionsComponent<R = any> extends AbstractActionsComponent<Enti
   constructor() {
     const injector = inject(Injector);
 
-    super(injector);
+    super();
   }
 }

--- a/npm/ng-packs/packages/components/extensible/src/lib/components/grid-actions/grid-actions.component.ts
+++ b/npm/ng-packs/packages/components/extensible/src/lib/components/grid-actions/grid-actions.component.ts
@@ -1,10 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Injector,
-  Input,
-  TrackByFunction,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, Injector, Input, TrackByFunction, inject } from '@angular/core';
 import { EntityAction, EntityActionList } from '../../models/entity-actions';
 import { EXTENSIONS_ACTION_TYPE } from '../../tokens/extensions.token';
 import { AbstractActionsComponent } from '../abstract-actions/abstract-actions.component';
@@ -43,7 +37,12 @@ export class GridActionsComponent<R = any> extends AbstractActionsComponent<Enti
 
   readonly trackByFn: TrackByFunction<EntityAction<R>> = (_, item) => item.text;
 
-  constructor(injector: Injector) {
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {
+    const injector = inject(Injector);
+
     super(injector);
   }
 }

--- a/npm/ng-packs/packages/components/extensible/src/lib/components/page-toolbar/page-toolbar.component.ts
+++ b/npm/ng-packs/packages/components/extensible/src/lib/components/page-toolbar/page-toolbar.component.ts
@@ -50,7 +50,7 @@ export class PageToolbarComponent<R = any>
   constructor() {
     const injector = inject(Injector);
 
-    super(injector);
+    super();
   
     this.injector = injector;
   }

--- a/npm/ng-packs/packages/components/extensible/src/lib/components/page-toolbar/page-toolbar.component.ts
+++ b/npm/ng-packs/packages/components/extensible/src/lib/components/page-toolbar/page-toolbar.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Injector, TrackByFunction } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Injector, TrackByFunction, inject } from '@angular/core';
 import {
   HasCreateInjectorPipe,
   ToolbarAction,
@@ -35,6 +35,8 @@ export class PageToolbarComponent<R = any>
   extends AbstractActionsComponent<ToolbarActionList<R>>
   implements HasCreateInjectorPipe<R>
 {
+  readonly injector: Injector;
+
   defaultBtnClass = 'btn btn-sm btn-primary';
 
   getData = () => this.data;
@@ -42,8 +44,15 @@ export class PageToolbarComponent<R = any>
   readonly trackByFn: TrackByFunction<ToolbarComponent<R>> = (_, item) =>
     item.action || item.component;
 
-  constructor(public readonly injector: Injector) {
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {
+    const injector = inject(Injector);
+
     super(injector);
+  
+    this.injector = injector;
   }
 
   asToolbarAction(value: ToolbarActionDefault): { value: ToolbarAction } {

--- a/npm/ng-packs/packages/components/extensible/src/lib/directives/prop-data.directive.ts
+++ b/npm/ng-packs/packages/components/extensible/src/lib/directives/prop-data.directive.ts
@@ -1,13 +1,5 @@
 /* eslint-disable @angular-eslint/no-input-rename */
-import {
-  Directive,
-  Injector,
-  Input,
-  OnChanges,
-  OnDestroy,
-  TemplateRef,
-  ViewContainerRef,
-} from '@angular/core';
+import { Directive, Injector, Input, OnChanges, OnDestroy, TemplateRef, ViewContainerRef, inject } from '@angular/core';
 import { PropData, PropList } from '../models/props';
 
 @Directive({
@@ -18,6 +10,9 @@ export class PropDataDirective<L extends PropList<any>>
   extends PropData<InferredData<L>>
   implements OnChanges, OnDestroy
 {
+  private tempRef = inject<TemplateRef<any>>(TemplateRef);
+  private vcRef = inject(ViewContainerRef);
+
   @Input('abpPropDataFromList') propList?: L;
 
   @Input('abpPropDataWithRecord') record!: InferredData<L>['record'];
@@ -26,11 +21,12 @@ export class PropDataDirective<L extends PropList<any>>
 
   readonly getInjected: InferredData<L>['getInjected'];
 
-  constructor(
-    private tempRef: TemplateRef<any>,
-    private vcRef: ViewContainerRef,
-    injector: Injector,
-  ) {
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {
+    const injector = inject(Injector);
+
     super();
 
     this.getInjected = injector.get.bind(injector);

--- a/npm/ng-packs/packages/components/page/src/page-part.directive.ts
+++ b/npm/ng-packs/packages/components/page/src/page-part.directive.ts
@@ -1,18 +1,4 @@
-import {
-  Directive,
-  TemplateRef,
-  ViewContainerRef,
-  Input,
-  InjectionToken,
-  Optional,
-  Inject,
-  OnInit,
-  OnDestroy,
-  Injector,
-  OnChanges,
-  SimpleChanges,
-  SimpleChange,
-} from '@angular/core';
+import { Directive, TemplateRef, ViewContainerRef, Input, InjectionToken, OnInit, OnDestroy, Injector, OnChanges, SimpleChanges, SimpleChange, inject } from '@angular/core';
 import { Observable, Subscription, of } from 'rxjs';
 
 export interface PageRenderStrategy {
@@ -28,6 +14,11 @@ export const PAGE_RENDER_STRATEGY = new InjectionToken<PageRenderStrategy>('PAGE
   selector: '[abpPagePart]',
 })
 export class PagePartDirective implements OnInit, OnDestroy, OnChanges {
+  private templateRef = inject<TemplateRef<any>>(TemplateRef);
+  private viewContainer = inject(ViewContainerRef);
+  private renderLogic = inject<PageRenderStrategy>(PAGE_RENDER_STRATEGY, { optional: true })!;
+  private injector = inject(Injector);
+
   hasRendered = false;
   type!: string;
   subscription!: Subscription;
@@ -48,12 +39,10 @@ export class PagePartDirective implements OnInit, OnDestroy, OnChanges {
     }
   };
 
-  constructor(
-    private templateRef: TemplateRef<any>,
-    private viewContainer: ViewContainerRef,
-    @Optional() @Inject(PAGE_RENDER_STRATEGY) private renderLogic: PageRenderStrategy,
-    private injector: Injector,
-  ) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 
   ngOnChanges({ context }: SimpleChanges): void {
     if (this.renderLogic?.onContextUpdate) {

--- a/npm/ng-packs/packages/components/tree/src/lib/templates/expanded-icon-template.directive.ts
+++ b/npm/ng-packs/packages/components/tree/src/lib/templates/expanded-icon-template.directive.ts
@@ -1,8 +1,13 @@
-import { Directive, TemplateRef } from '@angular/core';
+import { Directive, TemplateRef, inject } from '@angular/core';
 
 @Directive({
   selector: '[abpTreeExpandedIconTemplate],[abp-tree-expanded-icon-template]',
 })
 export class ExpandedIconTemplateDirective {
-  constructor(public template: TemplateRef<any>) {}
+  template = inject<TemplateRef<any>>(TemplateRef);
+
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 }

--- a/npm/ng-packs/packages/components/tree/src/lib/templates/tree-node-template.directive.ts
+++ b/npm/ng-packs/packages/components/tree/src/lib/templates/tree-node-template.directive.ts
@@ -1,8 +1,13 @@
-import { Directive, TemplateRef } from '@angular/core';
+import { Directive, TemplateRef, inject } from '@angular/core';
 
 @Directive({
   selector: '[abpTreeNodeTemplate],[abp-tree-node-template]',
 })
 export class TreeNodeTemplateDirective {
-  constructor(public template: TemplateRef<any>) {}
+  template = inject<TemplateRef<any>>(TemplateRef);
+
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 }

--- a/npm/ng-packs/packages/core/src/lib/components/dynamic-layout.component.ts
+++ b/npm/ng-packs/packages/core/src/lib/components/dynamic-layout.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, isDevMode, OnInit, Optional, SkipSelf, Type } from '@angular/core';
+import { Component, inject, isDevMode, OnInit, Type } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { eLayoutType } from '../enums/common';
 import { ABP } from '../models';
@@ -39,7 +39,12 @@ export class DynamicLayoutComponent implements OnInit {
   protected readonly routerEvents = inject(RouterEvents);
   protected readonly environment = inject(EnvironmentService);
 
-  constructor(@Optional() @SkipSelf() dynamicLayoutComponent: DynamicLayoutComponent) {
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {
+    const dynamicLayoutComponent = inject(DynamicLayoutComponent, { optional: true, skipSelf: true })!;
+
     if (dynamicLayoutComponent) {
       if (isDevMode()) console.warn('DynamicLayoutComponent must be used only in AppComponent.');
       return;

--- a/npm/ng-packs/packages/core/src/lib/components/replaceable-route-container.component.ts
+++ b/npm/ng-packs/packages/core/src/lib/components/replaceable-route-container.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Type } from '@angular/core';
+import { Component, OnInit, Type, inject } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { distinctUntilChanged } from 'rxjs/operators';
 import { ReplaceableComponents } from '../models/replaceable-components';
@@ -15,17 +15,20 @@ import { CommonModule } from '@angular/common';
   imports: [CommonModule],
 })
 export class ReplaceableRouteContainerComponent implements OnInit {
+  private route = inject(ActivatedRoute);
+  private replaceableComponents = inject(ReplaceableComponentsService);
+  private subscription = inject(SubscriptionService);
+
   defaultComponent!: Type<any>;
 
   componentKey!: string;
 
   externalComponent?: Type<any>;
 
-  constructor(
-    private route: ActivatedRoute,
-    private replaceableComponents: ReplaceableComponentsService,
-    private subscription: SubscriptionService,
-  ) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 
   ngOnInit() {
     this.defaultComponent = this.route.snapshot.data.replaceableComponent.defaultComponent;

--- a/npm/ng-packs/packages/core/src/lib/directives/autofocus.directive.ts
+++ b/npm/ng-packs/packages/core/src/lib/directives/autofocus.directive.ts
@@ -1,9 +1,11 @@
-import { AfterViewInit, Directive, ElementRef, Input } from '@angular/core';
+import { AfterViewInit, Directive, ElementRef, Input, inject } from '@angular/core';
 
 @Directive({
   selector: '[autofocus]',
 })
 export class AutofocusDirective implements AfterViewInit {
+  private elRef = inject(ElementRef);
+
   private _delay = 0;
 
   @Input('autofocus')
@@ -15,7 +17,10 @@ export class AutofocusDirective implements AfterViewInit {
     return this._delay;
   }
 
-  constructor(private elRef: ElementRef) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 
   ngAfterViewInit(): void {
     setTimeout(() => this.elRef.nativeElement.focus(), this.delay as number);

--- a/npm/ng-packs/packages/core/src/lib/directives/debounce.directive.ts
+++ b/npm/ng-packs/packages/core/src/lib/directives/debounce.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Directive, ElementRef, EventEmitter, Input, OnInit, Output, inject } from '@angular/core';
 import { fromEvent } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 import { SubscriptionService } from '../services/subscription.service';
@@ -8,14 +8,17 @@ import { SubscriptionService } from '../services/subscription.service';
   providers: [SubscriptionService],
 })
 export class InputEventDebounceDirective implements OnInit {
+  private el = inject(ElementRef);
+  private subscription = inject(SubscriptionService);
+
   @Input() debounce = 300;
 
   @Output('input.debounce') readonly debounceEvent = new EventEmitter<Event>();
 
-  constructor(
-    private el: ElementRef,
-    private subscription: SubscriptionService,
-  ) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 
   ngOnInit(): void {
     const input$ = fromEvent<InputEvent>(this.el.nativeElement, 'input').pipe(

--- a/npm/ng-packs/packages/core/src/lib/directives/for.directive.ts
+++ b/npm/ng-packs/packages/core/src/lib/directives/for.directive.ts
@@ -1,16 +1,4 @@
-import {
-  Directive,
-  EmbeddedViewRef,
-  Input,
-  IterableChangeRecord,
-  IterableChanges,
-  IterableDiffer,
-  IterableDiffers,
-  OnChanges,
-  TemplateRef,
-  TrackByFunction,
-  ViewContainerRef,
-} from '@angular/core';
+import { Directive, EmbeddedViewRef, Input, IterableChangeRecord, IterableChanges, IterableDiffer, IterableDiffers, OnChanges, TemplateRef, TrackByFunction, ViewContainerRef, inject } from '@angular/core';
 import clone from 'just-clone';
 import compare from 'just-compare';
 
@@ -36,6 +24,10 @@ class RecordView {
   selector: '[abpFor]',
 })
 export class ForDirective implements OnChanges {
+  private tempRef = inject<TemplateRef<AbpForContext>>(TemplateRef);
+  private vcRef = inject(ViewContainerRef);
+  private differs = inject(IterableDiffers);
+
   // eslint-disable-next-line @angular-eslint/no-input-rename
   @Input('abpForOf')
   items!: any[];
@@ -73,11 +65,10 @@ export class ForDirective implements OnChanges {
     return this.trackBy || ((index: number, item: any) => (item as any).id || index);
   }
 
-  constructor(
-    private tempRef: TemplateRef<AbpForContext>,
-    private vcRef: ViewContainerRef,
-    private differs: IterableDiffers,
-  ) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 
   private iterateOverAppliedOperations(changes: IterableChanges<any>) {
     const rw: RecordView[] = [];

--- a/npm/ng-packs/packages/core/src/lib/directives/form-submit.directive.ts
+++ b/npm/ng-packs/packages/core/src/lib/directives/form-submit.directive.ts
@@ -1,13 +1,4 @@
-import {
-  ChangeDetectorRef,
-  Directive,
-  ElementRef,
-  EventEmitter,
-  Input,
-  OnInit,
-  Output,
-  Self,
-} from '@angular/core';
+import { ChangeDetectorRef, Directive, ElementRef, EventEmitter, Input, OnInit, Output, inject } from '@angular/core';
 import { FormGroupDirective, UntypedFormControl, UntypedFormGroup } from '@angular/forms';
 import { fromEvent } from 'rxjs';
 import { debounceTime, filter } from 'rxjs/operators';
@@ -22,6 +13,11 @@ type Controls = { [key: string]: UntypedFormControl } | UntypedFormGroup[];
   providers: [SubscriptionService],
 })
 export class FormSubmitDirective implements OnInit {
+  private formGroupDirective = inject(FormGroupDirective, { self: true });
+  private host = inject<ElementRef<HTMLFormElement>>(ElementRef);
+  private cdRef = inject(ChangeDetectorRef);
+  private subscription = inject(SubscriptionService);
+
   @Input()
   debounce = 200;
 
@@ -36,12 +32,10 @@ export class FormSubmitDirective implements OnInit {
 
   executedNgSubmit = false;
 
-  constructor(
-    @Self() private formGroupDirective: FormGroupDirective,
-    private host: ElementRef<HTMLFormElement>,
-    private cdRef: ChangeDetectorRef,
-    private subscription: SubscriptionService,
-  ) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 
   ngOnInit() {
     this.subscription.addOne(this.formGroupDirective.ngSubmit, () => {

--- a/npm/ng-packs/packages/core/src/lib/directives/init.directive.ts
+++ b/npm/ng-packs/packages/core/src/lib/directives/init.directive.ts
@@ -1,12 +1,17 @@
-import { Directive, Output, EventEmitter, ElementRef, AfterViewInit } from '@angular/core';
+import { Directive, Output, EventEmitter, ElementRef, AfterViewInit, inject } from '@angular/core';
 
 @Directive({
   selector: '[abpInit]',
 })
 export class InitDirective implements AfterViewInit {
+  private elRef = inject(ElementRef);
+
   @Output('abpInit') readonly init = new EventEmitter<ElementRef<any>>();
 
-  constructor(private elRef: ElementRef) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 
   ngAfterViewInit() {
     this.init.emit(this.elRef);

--- a/npm/ng-packs/packages/core/src/lib/directives/permission.directive.ts
+++ b/npm/ng-packs/packages/core/src/lib/directives/permission.directive.ts
@@ -1,15 +1,4 @@
-import {
-  AfterViewInit,
-  ChangeDetectorRef,
-  Directive,
-  Inject,
-  Input,
-  OnChanges,
-  OnDestroy,
-  Optional,
-  TemplateRef,
-  ViewContainerRef,
-} from '@angular/core';
+import { AfterViewInit, ChangeDetectorRef, Directive, Input, OnChanges, OnDestroy, TemplateRef, ViewContainerRef, inject } from '@angular/core';
 import { ReplaySubject, Subscription } from 'rxjs';
 import { distinctUntilChanged, take } from 'rxjs/operators';
 import { PermissionService } from '../services/permission.service';
@@ -20,6 +9,12 @@ import { QueueManager } from '../utils/queue';
   selector: '[abpPermission]',
 })
 export class PermissionDirective implements OnDestroy, OnChanges, AfterViewInit {
+  private templateRef = inject<TemplateRef<any>>(TemplateRef, { optional: true })!;
+  private vcRef = inject(ViewContainerRef);
+  private permissionService = inject(PermissionService);
+  private cdRef = inject(ChangeDetectorRef);
+  queue = inject<QueueManager>(QUEUE_MANAGER);
+
   @Input('abpPermission') condition: string | undefined;
 
   @Input('abpPermissionRunChangeDetection') runChangeDetection = true;
@@ -30,13 +25,10 @@ export class PermissionDirective implements OnDestroy, OnChanges, AfterViewInit 
 
   rendered = false;
 
-  constructor(
-    @Optional() private templateRef: TemplateRef<any>,
-    private vcRef: ViewContainerRef,
-    private permissionService: PermissionService,
-    private cdRef: ChangeDetectorRef,
-    @Inject(QUEUE_MANAGER) public queue: QueueManager,
-  ) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 
   private check() {
     if (this.subscription) {

--- a/npm/ng-packs/packages/core/src/lib/directives/replaceable-template.directive.ts
+++ b/npm/ng-packs/packages/core/src/lib/directives/replaceable-template.directive.ts
@@ -1,14 +1,4 @@
-import {
-  Directive,
-  Injector,
-  Input,
-  OnChanges,
-  OnInit,
-  SimpleChanges,
-  TemplateRef,
-  Type,
-  ViewContainerRef,
-} from '@angular/core';
+import { Directive, Injector, Input, OnChanges, OnInit, SimpleChanges, TemplateRef, Type, ViewContainerRef, inject } from '@angular/core';
 import compare from 'just-compare';
 import { Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
@@ -22,6 +12,12 @@ import { SubscriptionService } from '../services/subscription.service';
   providers: [SubscriptionService],
 })
 export class ReplaceableTemplateDirective implements OnInit, OnChanges {
+  private injector = inject(Injector);
+  private templateRef = inject<TemplateRef<any>>(TemplateRef);
+  private vcRef = inject(ViewContainerRef);
+  private replaceableComponents = inject(ReplaceableComponentsService);
+  private subscription = inject(SubscriptionService);
+
   @Input('abpReplaceableTemplate')
   data!: ReplaceableComponents.ReplaceableTemplateDirectiveInput<any, any>;
 
@@ -40,13 +36,10 @@ export class ReplaceableTemplateDirective implements OnInit, OnChanges {
 
   initialized = false;
 
-  constructor(
-    private injector: Injector,
-    private templateRef: TemplateRef<any>,
-    private vcRef: ViewContainerRef,
-    private replaceableComponents: ReplaceableComponentsService,
-    private subscription: SubscriptionService,
-  ) {
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {
     this.context = {
       initTemplate: (ref: any) => {
         this.resetDefaultComponent();

--- a/npm/ng-packs/packages/core/src/lib/directives/stop-propagation.directive.ts
+++ b/npm/ng-packs/packages/core/src/lib/directives/stop-propagation.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, EventEmitter, OnInit, Output } from '@angular/core';
+import { Directive, ElementRef, EventEmitter, OnInit, Output, inject } from '@angular/core';
 import { fromEvent } from 'rxjs';
 import { SubscriptionService } from '../services/subscription.service';
 
@@ -7,12 +7,15 @@ import { SubscriptionService } from '../services/subscription.service';
   providers: [SubscriptionService],
 })
 export class StopPropagationDirective implements OnInit {
+  private el = inject(ElementRef);
+  private subscription = inject(SubscriptionService);
+
   @Output('click.stop') readonly stopPropEvent = new EventEmitter<MouseEvent>();
 
-  constructor(
-    private el: ElementRef,
-    private subscription: SubscriptionService,
-  ) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 
   ngOnInit(): void {
     this.subscription.addOne(fromEvent<MouseEvent>(this.el.nativeElement, 'click'), event => {

--- a/npm/ng-packs/packages/core/src/lib/handlers/routes.handler.ts
+++ b/npm/ng-packs/packages/core/src/lib/handlers/routes.handler.ts
@@ -1,4 +1,4 @@
-import { Injectable, Optional } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { Route, Router } from '@angular/router';
 import { ABP } from '../models';
 import { RoutesService } from '../services/routes.service';
@@ -7,10 +7,13 @@ import { RoutesService } from '../services/routes.service';
   providedIn: 'root',
 })
 export class RoutesHandler {
-  constructor(
-    private routes: RoutesService,
-    @Optional() private router: Router,
-  ) {
+  private routes = inject(RoutesService);
+  private router = inject(Router, { optional: true })!;
+
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {
     this.addRoutes();
   }
 

--- a/npm/ng-packs/packages/core/src/lib/interceptors/api.interceptor.ts
+++ b/npm/ng-packs/packages/core/src/lib/interceptors/api.interceptor.ts
@@ -1,5 +1,5 @@
 import { HttpHandler, HttpHeaders, HttpInterceptor, HttpRequest } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { finalize } from 'rxjs/operators';
 import { HttpWaitService } from '../services';
 
@@ -7,7 +7,12 @@ import { HttpWaitService } from '../services';
   providedIn: 'root',
 })
 export class ApiInterceptor implements IApiInterceptor {
-  constructor(private httpWaitService: HttpWaitService) {}
+  private httpWaitService = inject(HttpWaitService);
+
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 
   getAdditionalHeaders(existingHeaders?: HttpHeaders) {
     return existingHeaders || new HttpHeaders();

--- a/npm/ng-packs/packages/core/src/lib/pipes/localization.pipe.ts
+++ b/npm/ng-packs/packages/core/src/lib/pipes/localization.pipe.ts
@@ -1,4 +1,4 @@
-import { Injectable, Pipe, PipeTransform } from '@angular/core';
+import { Injectable, Pipe, PipeTransform, inject } from '@angular/core';
 import { LocalizationWithDefault } from '../models/localization';
 import { LocalizationService } from '../services/localization.service';
 
@@ -7,7 +7,12 @@ import { LocalizationService } from '../services/localization.service';
   name: 'abpLocalization',
 })
 export class LocalizationPipe implements PipeTransform {
-  constructor(private localization: LocalizationService) {}
+  private localization = inject(LocalizationService);
+
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 
   transform(
     value: string | LocalizationWithDefault = '',

--- a/npm/ng-packs/packages/core/src/lib/pipes/short-date-time.pipe.ts
+++ b/npm/ng-packs/packages/core/src/lib/pipes/short-date-time.pipe.ts
@@ -1,5 +1,5 @@
 import { DatePipe, DATE_PIPE_DEFAULT_TIMEZONE } from '@angular/common';
-import { Inject, LOCALE_ID, Optional, Pipe, PipeTransform } from '@angular/core';
+import { LOCALE_ID, Pipe, PipeTransform, inject } from '@angular/core';
 import { ConfigStateService } from '../services';
 import { getShortDateShortTimeFormat } from '../utils/date-utils';
 
@@ -8,11 +8,15 @@ import { getShortDateShortTimeFormat } from '../utils/date-utils';
   pure: true,
 })
 export class ShortDateTimePipe extends DatePipe implements PipeTransform {
-  constructor(
-    private configStateService: ConfigStateService,
-    @Inject(LOCALE_ID) locale: string,
-    @Inject(DATE_PIPE_DEFAULT_TIMEZONE) @Optional() defaultTimezone?: string | null,
-  ) {
+  private configStateService = inject(ConfigStateService);
+
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {
+    const locale = inject(LOCALE_ID);
+    const defaultTimezone = inject(DATE_PIPE_DEFAULT_TIMEZONE, { optional: true });
+
     super(locale, defaultTimezone);
   }
 

--- a/npm/ng-packs/packages/core/src/lib/pipes/short-date.pipe.ts
+++ b/npm/ng-packs/packages/core/src/lib/pipes/short-date.pipe.ts
@@ -1,5 +1,5 @@
 import { DatePipe, DATE_PIPE_DEFAULT_TIMEZONE } from '@angular/common';
-import { Inject, LOCALE_ID, Optional, Pipe, PipeTransform } from '@angular/core';
+import { LOCALE_ID, Pipe, PipeTransform, inject } from '@angular/core';
 import { ConfigStateService } from '../services';
 import { getShortDateFormat } from '../utils/date-utils';
 
@@ -8,11 +8,15 @@ import { getShortDateFormat } from '../utils/date-utils';
   pure: true,
 })
 export class ShortDatePipe extends DatePipe implements PipeTransform {
-  constructor(
-    private configStateService: ConfigStateService,
-    @Inject(LOCALE_ID) locale: string,
-    @Inject(DATE_PIPE_DEFAULT_TIMEZONE) @Optional() defaultTimezone?: string | null,
-  ) {
+  private configStateService = inject(ConfigStateService);
+
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {
+    const locale = inject(LOCALE_ID);
+    const defaultTimezone = inject(DATE_PIPE_DEFAULT_TIMEZONE, { optional: true });
+
     super(locale, defaultTimezone);
   }
 

--- a/npm/ng-packs/packages/core/src/lib/pipes/short-time.pipe.ts
+++ b/npm/ng-packs/packages/core/src/lib/pipes/short-time.pipe.ts
@@ -1,5 +1,5 @@
 import { DatePipe, DATE_PIPE_DEFAULT_TIMEZONE } from '@angular/common';
-import { Inject, LOCALE_ID, Optional, Pipe, PipeTransform } from '@angular/core';
+import { LOCALE_ID, Pipe, PipeTransform, inject } from '@angular/core';
 import { ConfigStateService } from '../services';
 import { getShortTimeFormat } from '../utils/date-utils';
 
@@ -8,11 +8,15 @@ import { getShortTimeFormat } from '../utils/date-utils';
   pure: true,
 })
 export class ShortTimePipe extends DatePipe implements PipeTransform {
-  constructor(
-    private configStateService: ConfigStateService,
-    @Inject(LOCALE_ID) locale: string,
-    @Inject(DATE_PIPE_DEFAULT_TIMEZONE) @Optional() defaultTimezone?: string | null,
-  ) {
+  private configStateService = inject(ConfigStateService);
+
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {
+    const locale = inject(LOCALE_ID);
+    const defaultTimezone = inject(DATE_PIPE_DEFAULT_TIMEZONE, { optional: true });
+
     super(locale, defaultTimezone);
   }
 

--- a/npm/ng-packs/packages/core/src/lib/pipes/to-injector.pipe.ts
+++ b/npm/ng-packs/packages/core/src/lib/pipes/to-injector.pipe.ts
@@ -1,4 +1,4 @@
-import { InjectionToken, Injector, Pipe, PipeTransform } from '@angular/core';
+import { InjectionToken, Injector, Pipe, PipeTransform, inject } from '@angular/core';
 
 export const INJECTOR_PIPE_DATA_TOKEN = new InjectionToken<PipeTransform>(
   'INJECTOR_PIPE_DATA_TOKEN',
@@ -8,7 +8,12 @@ export const INJECTOR_PIPE_DATA_TOKEN = new InjectionToken<PipeTransform>(
   name: 'toInjector',
 })
 export class ToInjectorPipe implements PipeTransform {
-  constructor(private injector: Injector) {}
+  private injector = inject(Injector);
+
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
   transform(
     value: any,
     token: InjectionToken<any> = INJECTOR_PIPE_DATA_TOKEN,

--- a/npm/ng-packs/packages/core/src/lib/proxy/pages/abp/multi-tenancy/abp-tenant.service.ts
+++ b/npm/ng-packs/packages/core/src/lib/proxy/pages/abp/multi-tenancy/abp-tenant.service.ts
@@ -1,12 +1,14 @@
 import { RestService } from '../../../../services';
 import { Rest } from '../../../../models';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import type { FindTenantResultDto } from '../../../volo/abp/asp-net-core/mvc/multi-tenancy/models';
 
 @Injectable({
   providedIn: 'root',
 })
 export class AbpTenantService {
+  private restService = inject(RestService);
+
   apiName = 'abp';
   
 
@@ -25,5 +27,8 @@ export class AbpTenantService {
     },
     { apiName: this.apiName,...config });
 
-  constructor(private restService: RestService) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 }

--- a/npm/ng-packs/packages/core/src/lib/proxy/volo/abp/asp-net-core/mvc/api-exploring/abp-api-definition.service.ts
+++ b/npm/ng-packs/packages/core/src/lib/proxy/volo/abp/asp-net-core/mvc/api-exploring/abp-api-definition.service.ts
@@ -1,12 +1,14 @@
 import { RestService } from '../../../../../../services';
 import { Rest } from '../../../../../../models';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import type { ApplicationApiDescriptionModel, ApplicationApiDescriptionModelRequestDto } from '../../../http/modeling/models';
 
 @Injectable({
   providedIn: 'root',
 })
 export class AbpApiDefinitionService {
+  private restService = inject(RestService);
+
   apiName = 'abp';
   
 
@@ -18,5 +20,8 @@ export class AbpApiDefinitionService {
     },
     { apiName: this.apiName,...config });
 
-  constructor(private restService: RestService) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 }

--- a/npm/ng-packs/packages/core/src/lib/proxy/volo/abp/asp-net-core/mvc/application-configurations/abp-application-configuration.service.ts
+++ b/npm/ng-packs/packages/core/src/lib/proxy/volo/abp/asp-net-core/mvc/application-configurations/abp-application-configuration.service.ts
@@ -1,12 +1,14 @@
 import type { ApplicationConfigurationDto, ApplicationConfigurationRequestOptions } from './models';
 import { RestService } from '../../../../../../services';
 import { Rest } from '../../../../../../models';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 @Injectable({
   providedIn: 'root',
 })
 export class AbpApplicationConfigurationService {
+  private restService = inject(RestService);
+
   apiName = 'abp';
 
 
@@ -18,5 +20,8 @@ export class AbpApplicationConfigurationService {
     },
       { apiName: this.apiName, ...config });
 
-  constructor(private restService: RestService) { }
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() { }
 }

--- a/npm/ng-packs/packages/core/src/lib/proxy/volo/abp/asp-net-core/mvc/application-configurations/abp-application-localization.service.ts
+++ b/npm/ng-packs/packages/core/src/lib/proxy/volo/abp/asp-net-core/mvc/application-configurations/abp-application-localization.service.ts
@@ -1,12 +1,14 @@
 import type { ApplicationLocalizationDto, ApplicationLocalizationRequestDto } from './models';
 import { RestService } from '../../../../../../services';
 import { Rest } from '../../../../../../models';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 @Injectable({
   providedIn: 'root',
 })
 export class AbpApplicationLocalizationService {
+  private restService = inject(RestService);
+
   apiName = 'abp';
   
 
@@ -18,5 +20,8 @@ export class AbpApplicationLocalizationService {
     },
     { apiName: this.apiName,...config });
 
-  constructor(private restService: RestService) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 }

--- a/npm/ng-packs/packages/core/src/lib/services/config-state.service.ts
+++ b/npm/ng-packs/packages/core/src/lib/services/config-state.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, Optional } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { Observable, Subject } from 'rxjs';
 import { map, switchMap, take, tap } from 'rxjs/operators';
 import { AbpApplicationConfigurationService } from '../proxy/volo/abp/asp-net-core/mvc/application-configurations/abp-application-configuration.service';
@@ -15,6 +15,10 @@ import { InternalStore } from '../utils/internal-store-utils';
   providedIn: 'root',
 })
 export class ConfigStateService {
+  private abpConfigService = inject(AbpApplicationConfigurationService);
+  private abpApplicationLocalizationService = inject(AbpApplicationLocalizationService);
+  private readonly includeLocalizationResources = inject(INCUDE_LOCALIZATION_RESOURCES_TOKEN, { optional: true });
+
   private updateSubject = new Subject<void>();
   private readonly store = new InternalStore({} as ApplicationConfigurationDto);
 
@@ -27,13 +31,10 @@ export class ConfigStateService {
   get createOnUpdateStream() {
     return this.store.sliceUpdate;
   }
-  constructor(
-    private abpConfigService: AbpApplicationConfigurationService,
-    private abpApplicationLocalizationService: AbpApplicationLocalizationService,
-    @Optional()
-    @Inject(INCUDE_LOCALIZATION_RESOURCES_TOKEN)
-    private readonly includeLocalizationResources: boolean | null,
-  ) {
+
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+  constructor() {
     this.initUpdateStream();
   }
 

--- a/npm/ng-packs/packages/core/src/lib/services/content-projection.service.ts
+++ b/npm/ng-packs/packages/core/src/lib/services/content-projection.service.ts
@@ -1,9 +1,14 @@
-import { Injectable, Injector, TemplateRef, Type } from '@angular/core';
+import { Injectable, Injector, TemplateRef, Type, inject } from '@angular/core';
 import { ProjectionStrategy } from '../strategies/projection.strategy';
 
 @Injectable({ providedIn: 'root' })
 export class ContentProjectionService {
-  constructor(private injector: Injector) {}
+  private injector = inject(Injector);
+
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 
   projectContent<T extends Type<any> | TemplateRef<any>>(
     projectionStrategy: ProjectionStrategy<T>,

--- a/npm/ng-packs/packages/core/src/lib/services/http-wait.service.ts
+++ b/npm/ng-packs/packages/core/src/lib/services/http-wait.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Injector } from '@angular/core';
+import { Injectable, Injector, inject } from '@angular/core';
 import { HttpRequest } from '@angular/common/http';
 import { InternalStore } from '../utils/internal-store-utils';
 import { getPathName } from '../utils/http-utils';
@@ -26,7 +26,12 @@ export class HttpWaitService {
   private delay: number;
   private destroy$ = new Subject<void>();
 
-  constructor(injector: Injector) {
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {
+    const injector = inject(Injector);
+
     this.delay = injector.get(LOADER_DELAY, 500);
   }
 

--- a/npm/ng-packs/packages/core/src/lib/services/lazy-load.service.ts
+++ b/npm/ng-packs/packages/core/src/lib/services/lazy-load.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { concat, Observable, of, pipe, throwError } from 'rxjs';
 import { delay, retryWhen, shareReplay, take, tap } from 'rxjs/operators';
 import { LoadingStrategy } from '../strategies';
@@ -8,9 +8,14 @@ import { ResourceWaitService } from './resource-wait.service';
   providedIn: 'root',
 })
 export class LazyLoadService {
+  private resourceWaitService = inject(ResourceWaitService);
+
   readonly loaded = new Map<string, HTMLScriptElement | HTMLLinkElement | null>();
 
-  constructor(private resourceWaitService: ResourceWaitService) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 
   load(strategy: LoadingStrategy, retryTimes?: number, retryDelay?: number): Observable<Event> {
     if (this.loaded.has(strategy.path)) return of(new CustomEvent('load'));

--- a/npm/ng-packs/packages/core/src/lib/services/list.service.ts
+++ b/npm/ng-packs/packages/core/src/lib/services/list.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Injector, OnDestroy } from '@angular/core';
+import { Injectable, Injector, OnDestroy, inject } from '@angular/core';
 import {
   EMPTY,
   BehaviorSubject,
@@ -119,7 +119,12 @@ export class ListService<QueryParamsType = ABP.PageQueryParams | any> implements
     this.next();
   };
 
-  constructor(injector: Injector) {
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {
+    const injector = inject(Injector);
+
     const delay = injector.get(LIST_QUERY_DEBOUNCE_TIME, 300);
     this.delay = delay ? debounceTime(delay) : tap();
     this.get();

--- a/npm/ng-packs/packages/core/src/lib/services/localization.service.ts
+++ b/npm/ng-packs/packages/core/src/lib/services/localization.service.ts
@@ -1,5 +1,5 @@
 import { registerLocaleData } from '@angular/common';
-import { Injectable, Injector, isDevMode, Optional, SkipSelf } from '@angular/core';
+import { Injectable, Injector, isDevMode, inject } from '@angular/core';
 import { BehaviorSubject, combineLatest, from, Observable, Subject } from 'rxjs';
 import { filter, map, switchMap } from 'rxjs/operators';
 import { ABP } from '../models/common';
@@ -17,6 +17,10 @@ import { SessionStateService } from './session-state.service';
 
 @Injectable({ providedIn: 'root' })
 export class LocalizationService {
+  private sessionState = inject(SessionStateService);
+  private injector = inject(Injector);
+  private configState = inject(ConfigStateService);
+
   private latestLang = this.sessionState.getLanguage();
   private _languageChange$ = new Subject<string>();
 
@@ -44,14 +48,12 @@ export class LocalizationService {
     return this._languageChange$.asObservable();
   }
 
-  constructor(
-    private sessionState: SessionStateService,
-    private injector: Injector,
-    @Optional()
-    @SkipSelf()
-    otherInstance: LocalizationService,
-    private configState: ConfigStateService,
-  ) {
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {
+    const otherInstance = inject(LocalizationService, { optional: true, skipSelf: true })!;
+
     if (otherInstance) throw new Error('LocalizationService should have only one instance.');
 
     this.listenToSetLanguage();

--- a/npm/ng-packs/packages/core/src/lib/services/multi-tenancy.service.ts
+++ b/npm/ng-packs/packages/core/src/lib/services/multi-tenancy.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { map, switchMap } from 'rxjs/operators';
 import { AbpTenantService } from '../proxy/pages/abp/multi-tenancy';
 import {
@@ -12,6 +12,12 @@ import { SessionStateService } from './session-state.service';
 
 @Injectable({ providedIn: 'root' })
 export class MultiTenancyService {
+  private restService = inject(RestService);
+  private sessionState = inject(SessionStateService);
+  private tenantService = inject(AbpTenantService);
+  private configStateService = inject(ConfigStateService);
+  tenantKey = inject(TENANT_KEY);
+
   domainTenant: CurrentTenantDto | null = null;
 
   isTenantBoxVisible = true;
@@ -23,13 +29,10 @@ export class MultiTenancyService {
     return this.configStateService.refreshAppState().pipe(map(_ => tenant));
   };
 
-  constructor(
-    private restService: RestService,
-    private sessionState: SessionStateService,
-    private tenantService: AbpTenantService,
-    private configStateService: ConfigStateService,
-    @Inject(TENANT_KEY) public tenantKey: string,
-  ) { }
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() { }
 
   setTenantByName(tenantName: string) {
     return this.tenantService

--- a/npm/ng-packs/packages/core/src/lib/services/permission.service.ts
+++ b/npm/ng-packs/packages/core/src/lib/services/permission.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { map } from 'rxjs/operators';
 import { ABP } from '../models/common';
 import { ApplicationConfigurationDto } from '../proxy/volo/abp/asp-net-core/mvc/application-configurations/models';
@@ -6,7 +6,12 @@ import { ConfigStateService } from './config-state.service';
 
 @Injectable({ providedIn: 'root' })
 export class PermissionService {
-  constructor(protected configState: ConfigStateService) {}
+  protected configState = inject(ConfigStateService);
+
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 
   getGrantedPolicy$(key: string) {
     return this.getStream().pipe(

--- a/npm/ng-packs/packages/core/src/lib/services/replaceable-components.service.ts
+++ b/npm/ng-packs/packages/core/src/lib/services/replaceable-components.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NgZone } from '@angular/core';
+import { Injectable, NgZone, inject } from '@angular/core';
 import { Router } from '@angular/router';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -8,6 +8,9 @@ import { reloadRoute } from '../utils/route-utils';
 
 @Injectable({ providedIn: 'root' })
 export class ReplaceableComponentsService {
+  private ngZone = inject(NgZone);
+  private router = inject(Router);
+
   private readonly store: InternalStore<ReplaceableComponents.ReplaceableComponent[]>;
 
   get replaceableComponents$(): Observable<ReplaceableComponents.ReplaceableComponent[]> {
@@ -22,7 +25,10 @@ export class ReplaceableComponentsService {
     return this.store.sliceUpdate(state => state);
   }
 
-  constructor(private ngZone: NgZone, private router: Router) {
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {
     this.store = new InternalStore([] as ReplaceableComponents.ReplaceableComponent[]);
   }
 

--- a/npm/ng-packs/packages/core/src/lib/services/rest.service.ts
+++ b/npm/ng-packs/packages/core/src/lib/services/rest.service.ts
@@ -1,5 +1,5 @@
 import { HttpClient, HttpParameterCodec, HttpParams, HttpRequest } from '@angular/common/http';
-import { Inject, Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { Observable, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import { ExternalHttpClient } from '../clients/http.client';
@@ -14,13 +14,16 @@ import { HttpErrorReporterService } from './http-error-reporter.service';
   providedIn: 'root',
 })
 export class RestService {
-  constructor(
-    @Inject(CORE_OPTIONS) protected options: ABP.Root,
-    protected http: HttpClient,
-    protected externalHttp: ExternalHttpClient,
-    protected environment: EnvironmentService,
-    protected httpErrorReporter: HttpErrorReporterService,
-  ) { }
+  protected options = inject<ABP.Root>(CORE_OPTIONS);
+  protected http = inject(HttpClient);
+  protected externalHttp = inject(ExternalHttpClient);
+  protected environment = inject(EnvironmentService);
+  protected httpErrorReporter = inject(HttpErrorReporterService);
+
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() { }
 
   protected getApiFromStore(apiName: string | undefined): string {
     return this.environment.getApiUrl(apiName);

--- a/npm/ng-packs/packages/core/src/lib/services/router-wait.service.ts
+++ b/npm/ng-packs/packages/core/src/lib/services/router-wait.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Injector } from '@angular/core';
+import { Injectable, Injector, inject } from '@angular/core';
 import { NavigationStart } from '@angular/router';
 import { of, Subject, timer } from 'rxjs';
 import { map, mapTo, switchMap, takeUntil, tap } from 'rxjs/operators';
@@ -14,10 +14,17 @@ export interface RouterWaitState {
   providedIn: 'root',
 })
 export class RouterWaitService {
+  private routerEvents = inject(RouterEvents);
+
   private store = new InternalStore<RouterWaitState>({ loading: false });
   private destroy$ = new Subject<void>();
   private delay: number;
-  constructor(private routerEvents: RouterEvents, injector: Injector) {
+
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+  constructor() {
+    const injector = inject(Injector);
+
     this.delay = injector.get(LOADER_DELAY, 500);
     this.updateLoadingStatusOnNavigationEvents();
   }

--- a/npm/ng-packs/packages/core/src/lib/services/routes.service.ts
+++ b/npm/ng-packs/packages/core/src/lib/services/routes.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Injector, OnDestroy } from '@angular/core';
+import { Injectable, Injector, OnDestroy, inject } from '@angular/core';
 import { BehaviorSubject, Observable, Subscription, map } from 'rxjs';
 import { ABP } from '../models/common';
 import { OTHERS_GROUP } from '../tokens';
@@ -201,6 +201,8 @@ export abstract class AbstractNavTreeService<T extends ABP.Nav>
   extends AbstractTreeService<T>
   implements OnDestroy
 {
+  protected injector = inject(Injector);
+
   private subscription: Subscription;
   private permissionService: PermissionService;
   private compareFunc;
@@ -211,8 +213,13 @@ export abstract class AbstractNavTreeService<T extends ABP.Nav>
     return this.compareFunc(a, b);
   };
 
-  constructor(protected injector: Injector) {
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {
     super();
+    const injector = this.injector;
+
     const configState = this.injector.get(ConfigStateService);
     this.subscription = configState
       .createOnUpdateStream(state => state)

--- a/npm/ng-packs/packages/core/src/lib/services/session-state.service.ts
+++ b/npm/ng-packs/packages/core/src/lib/services/session-state.service.ts
@@ -12,6 +12,9 @@ import { AbpLocalStorageService } from './local-storage.service';
   providedIn: 'root',
 })
 export class SessionStateService {
+  private configState = inject(ConfigStateService);
+  private localStorageService = inject(AbpLocalStorageService);
+
   private readonly store = new InternalStore({} as Session.State);
   protected readonly document = inject(DOCUMENT);
 
@@ -19,10 +22,10 @@ export class SessionStateService {
     this.localStorageService.setItem('abpSession', JSON.stringify(this.store.state));
   };
 
-  constructor(
-    private configState: ConfigStateService,
-    private localStorageService: AbpLocalStorageService,
-  ) {
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {
     this.init();
     this.setInitialLanguage();
   }

--- a/npm/ng-packs/packages/core/src/lib/tests/dynamic-layout.component.spec.ts
+++ b/npm/ng-packs/packages/core/src/lib/tests/dynamic-layout.component.spec.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@angular/common/http';
-import { Component, NgModule } from '@angular/core';
+import { Component, NgModule, inject as inject_1 } from '@angular/core';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { createRoutingFactory, SpectatorRouting } from '@ngneat/spectator/jest';
 import { DynamicLayoutComponent, RouterOutletComponent } from '../components';
@@ -44,7 +44,12 @@ class DummyLayoutModule {}
   template: '{{route.snapshot.data?.name}} works!',
 })
 class DummyComponent {
-  constructor(public route: ActivatedRoute) {}
+  route = inject_1(ActivatedRoute);
+
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 }
 
 const routes: ABP.Route[] = [

--- a/npm/ng-packs/packages/core/src/lib/tests/replaceable-template.directive.spec.ts
+++ b/npm/ng-packs/packages/core/src/lib/tests/replaceable-template.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Inject, Input, Optional, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output, inject } from '@angular/core';
 import { Router } from '@angular/router';
 import { createDirectiveFactory, SpectatorDirective } from '@ngneat/spectator/jest';
 import { BehaviorSubject } from 'rxjs';
@@ -35,11 +35,12 @@ class DefaultComponent {
   template: ' <p>external</p> ',
 })
 class ExternalComponent {
-  constructor(
-    @Optional()
-    @Inject('REPLACEABLE_DATA')
-    public data: ReplaceableComponents.ReplaceableTemplateData<any, any>,
-  ) {}
+  data = inject<ReplaceableComponents.ReplaceableTemplateData<any, any>>('REPLACEABLE_DATA' as any, { optional: true })!;
+
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 }
 
 describe('ReplaceableTemplateDirective', () => {

--- a/npm/ng-packs/packages/core/testing/src/lib/services/mock-permission.service.ts
+++ b/npm/ng-packs/packages/core/testing/src/lib/services/mock-permission.service.ts
@@ -1,12 +1,21 @@
 import { ConfigStateService, PermissionService } from '@abp/ng.core';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 @Injectable({
   providedIn: 'root',
 })
 export class MockPermissionService extends PermissionService {
-  constructor(protected configState: ConfigStateService) {
+  protected configState: ConfigStateService;
+
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {
+    const configState = inject(ConfigStateService);
+
     super(configState);
+    this.configState = configState;
+
     this.grantAllPolicies();
   }
 

--- a/npm/ng-packs/packages/core/testing/src/lib/services/mock-rest.service.ts
+++ b/npm/ng-packs/packages/core/testing/src/lib/services/mock-rest.service.ts
@@ -7,20 +7,33 @@ import {
   RestService,
 } from '@abp/ng.core';
 import { HttpClient } from '@angular/common/http';
-import { Inject, Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { Observable, throwError } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
 })
 export class MockRestService extends RestService {
-  constructor(
-    @Inject(CORE_OPTIONS) protected options: ABP.Root,
-    protected http: HttpClient,
-    protected externalhttp: ExternalHttpClient,
-    protected environment: EnvironmentService,
-  ) {
+  protected options: ABP.Root;
+  protected http: HttpClient;
+  protected externalhttp: ExternalHttpClient;
+  protected environment: EnvironmentService;
+
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {
+    const options = inject<ABP.Root>(CORE_OPTIONS);
+    const http = inject(HttpClient);
+    const externalhttp = inject(ExternalHttpClient);
+    const environment = inject(EnvironmentService);
+
     super(options, http,externalhttp, environment, null as unknown as HttpErrorReporterService);
+  
+    this.options = options;
+    this.http = http;
+    this.externalhttp = externalhttp;
+    this.environment = environment;
   }
 
   handleError(err: any): Observable<any> {

--- a/npm/ng-packs/packages/feature-management/proxy/src/lib/proxy/feature-management/features.service.ts
+++ b/npm/ng-packs/packages/feature-management/proxy/src/lib/proxy/feature-management/features.service.ts
@@ -1,11 +1,13 @@
 import type { GetFeatureListResultDto, UpdateFeaturesDto } from './models';
 import { RestService } from '@abp/ng.core';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 @Injectable({
   providedIn: 'root',
 })
 export class FeaturesService {
+  private restService = inject(RestService);
+
   apiName = 'AbpFeatureManagement';
 
   delete = (providerName: string, providerKey: string) =>
@@ -39,5 +41,8 @@ export class FeaturesService {
       { apiName: this.apiName },
     );
 
-  constructor(private restService: RestService) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 }

--- a/npm/ng-packs/packages/identity/proxy/src/lib/proxy/identity/identity-role.service.ts
+++ b/npm/ng-packs/packages/identity/proxy/src/lib/proxy/identity/identity-role.service.ts
@@ -1,12 +1,14 @@
 import type { GetIdentityRolesInput, IdentityRoleCreateDto, IdentityRoleDto, IdentityRoleUpdateDto } from './models';
 import { RestService } from '@abp/ng.core';
 import type { ListResultDto, PagedResultDto } from '@abp/ng.core';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 @Injectable({
   providedIn: 'root',
 })
 export class IdentityRoleService {
+  private restService = inject(RestService);
+
   apiName = 'AbpIdentity';
 
   create = (input: IdentityRoleCreateDto) =>
@@ -54,5 +56,8 @@ export class IdentityRoleService {
     },
     { apiName: this.apiName });
 
-  constructor(private restService: RestService) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 }

--- a/npm/ng-packs/packages/identity/proxy/src/lib/proxy/identity/identity-user-lookup.service.ts
+++ b/npm/ng-packs/packages/identity/proxy/src/lib/proxy/identity/identity-user-lookup.service.ts
@@ -1,13 +1,15 @@
 import type { UserLookupCountInputDto, UserLookupSearchInputDto } from './models';
 import { RestService } from '@abp/ng.core';
 import type { ListResultDto } from '@abp/ng.core';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import type { UserData } from '../users/models';
 
 @Injectable({
   providedIn: 'root',
 })
 export class IdentityUserLookupService {
+  private restService = inject(RestService);
+
   apiName = 'AbpIdentity';
 
   findById = (id: string) =>
@@ -40,5 +42,8 @@ export class IdentityUserLookupService {
     },
     { apiName: this.apiName });
 
-  constructor(private restService: RestService) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 }

--- a/npm/ng-packs/packages/identity/proxy/src/lib/proxy/identity/identity-user.service.ts
+++ b/npm/ng-packs/packages/identity/proxy/src/lib/proxy/identity/identity-user.service.ts
@@ -1,12 +1,14 @@
 import type { GetIdentityUsersInput, IdentityRoleDto, IdentityUserCreateDto, IdentityUserDto, IdentityUserUpdateDto, IdentityUserUpdateRolesDto } from './models';
 import { RestService } from '@abp/ng.core';
 import type { ListResultDto, PagedResultDto } from '@abp/ng.core';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 @Injectable({
   providedIn: 'root',
 })
 export class IdentityUserService {
+  private restService = inject(RestService);
+
   apiName = 'AbpIdentity';
 
   create = (input: IdentityUserCreateDto) =>
@@ -85,5 +87,8 @@ export class IdentityUserService {
     },
     { apiName: this.apiName });
 
-  constructor(private restService: RestService) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 }

--- a/npm/ng-packs/packages/oauth/src/lib/handlers/oauth-configuration.handler.ts
+++ b/npm/ng-packs/packages/oauth/src/lib/handlers/oauth-configuration.handler.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { AuthConfig, OAuthService } from "angular-oauth2-oidc";
 import compare from 'just-compare';
 import { filter, map } from 'rxjs/operators';
@@ -8,11 +8,14 @@ import { ABP, EnvironmentService, CORE_OPTIONS } from '@abp/ng.core';
   providedIn: 'root',
 })
 export class OAuthConfigurationHandler {
-  constructor(
-    private oAuthService: OAuthService,
-    private environmentService: EnvironmentService,
-    @Inject(CORE_OPTIONS) private options: ABP.Root,
-  ) {
+  private oAuthService = inject(OAuthService);
+  private environmentService = inject(EnvironmentService);
+  private options = inject<ABP.Root>(CORE_OPTIONS);
+
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {
     this.listenToSetEnvironment();
   }
 

--- a/npm/ng-packs/packages/oauth/src/lib/interceptors/api.interceptor.ts
+++ b/npm/ng-packs/packages/oauth/src/lib/interceptors/api.interceptor.ts
@@ -1,5 +1,5 @@
 import { HttpHandler, HttpHeaders, HttpRequest } from '@angular/common/http';
-import { Inject, Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { OAuthService } from 'angular-oauth2-oidc';
 import { finalize } from 'rxjs/operators';
 import {
@@ -14,12 +14,15 @@ import {
   providedIn: 'root',
 })
 export class OAuthApiInterceptor implements IApiInterceptor {
-  constructor(
-    private oAuthService: OAuthService,
-    private sessionState: SessionStateService,
-    private httpWaitService: HttpWaitService,
-    @Inject(TENANT_KEY) private tenantKey: string,
-  ) {}
+  private oAuthService = inject(OAuthService);
+  private sessionState = inject(SessionStateService);
+  private httpWaitService = inject(HttpWaitService);
+  private tenantKey = inject(TENANT_KEY);
+
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 
   intercept(request: HttpRequest<any>, next: HttpHandler) {
     this.httpWaitService.addRequest(request);

--- a/npm/ng-packs/packages/oauth/src/lib/services/oauth.service.ts
+++ b/npm/ng-packs/packages/oauth/src/lib/services/oauth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Injector } from '@angular/core';
+import { Injectable, Injector, inject } from '@angular/core';
 import { Params } from '@angular/router';
 import { from, Observable, lastValueFrom, EMPTY } from 'rxjs';
 import { filter, map, switchMap, take, tap } from 'rxjs/operators';
@@ -13,6 +13,8 @@ import { HttpHeaders } from '@angular/common/http';
   providedIn: 'root',
 })
 export class AbpOAuthService implements IAuthService {
+  protected injector = inject(Injector);
+
   private strategy!: AuthFlowStrategy;
   private readonly oAuthService: OAuthService;
 
@@ -28,7 +30,10 @@ export class AbpOAuthService implements IAuthService {
     return this.strategy.isInternalAuth;
   }
 
-  constructor(protected injector: Injector) {
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {
     this.oAuthService = this.injector.get(OAuthService);
   }
 

--- a/npm/ng-packs/packages/permission-management/proxy/src/lib/proxy/permissions.service.ts
+++ b/npm/ng-packs/packages/permission-management/proxy/src/lib/proxy/permissions.service.ts
@@ -1,11 +1,13 @@
 import type { GetPermissionListResultDto, UpdatePermissionsDto } from './models';
 import { RestService } from '@abp/ng.core';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 @Injectable({
   providedIn: 'root',
 })
 export class PermissionsService {
+  private restService = inject(RestService);
+
   apiName = 'AbpPermissionManagement';
 
   get = (providerName: string, providerKey: string) =>
@@ -25,5 +27,8 @@ export class PermissionsService {
     },
     { apiName: this.apiName });
 
-  constructor(private restService: RestService) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 }

--- a/npm/ng-packs/packages/setting-management/config/src/lib/components/email-setting-group/email-setting-group.component.ts
+++ b/npm/ng-packs/packages/setting-management/config/src/lib/components/email-setting-group/email-setting-group.component.ts
@@ -45,6 +45,10 @@ const { required, email } = Validators;
   ],
 })
 export class EmailSettingGroupComponent implements OnInit {
+  private emailSettingsService = inject(EmailSettingsService);
+  private fb = inject(UntypedFormBuilder);
+  private toasterService = inject(ToasterService);
+
   protected readonly localizationService = inject(LocalizationService);
   protected readonly configStateSevice = inject(ConfigStateService);
   protected readonly currentUserEmail = toSignal(
@@ -58,11 +62,10 @@ export class EmailSettingGroupComponent implements OnInit {
   isEmailTestModalOpen = false;
   modalSize: NgbModalOptions = { size: 'lg' };
 
-  constructor(
-    private emailSettingsService: EmailSettingsService,
-    private fb: UntypedFormBuilder,
-    private toasterService: ToasterService,
-  ) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 
   ngOnInit() {
     this.getData();

--- a/npm/ng-packs/packages/setting-management/config/src/lib/proxy/email-settings.service.ts
+++ b/npm/ng-packs/packages/setting-management/config/src/lib/proxy/email-settings.service.ts
@@ -1,6 +1,6 @@
 import type { EmailSettingsDto, SendTestEmailInput, UpdateEmailSettingsDto } from './models';
 import { RestService } from '@abp/ng.core';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 /**
 @deprecated This method is deprecated, use it from @abp/ng.setting-management/proxy
@@ -9,6 +9,8 @@ import { Injectable } from '@angular/core';
   providedIn: 'root',
 })
 export class EmailSettingsService {
+  private restService = inject(RestService);
+
   apiName = 'SettingManagement';
 
   get = () =>
@@ -34,5 +36,8 @@ export class EmailSettingsService {
     },
     { apiName: this.apiName });
 
-  constructor(private restService: RestService) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 }

--- a/npm/ng-packs/packages/setting-management/proxy/src/lib/proxy/email-settings.service.ts
+++ b/npm/ng-packs/packages/setting-management/proxy/src/lib/proxy/email-settings.service.ts
@@ -1,11 +1,13 @@
 import type { EmailSettingsDto, SendTestEmailInput, UpdateEmailSettingsDto } from './models';
 import { RestService, Rest } from '@abp/ng.core';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 @Injectable({
   providedIn: 'root',
 })
 export class EmailSettingsService {
+  private restService = inject(RestService);
+
   apiName = 'SettingManagement';
   
 
@@ -34,5 +36,8 @@ export class EmailSettingsService {
     },
     { apiName: this.apiName,...config });
 
-  constructor(private restService: RestService) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 }

--- a/npm/ng-packs/packages/setting-management/proxy/src/lib/proxy/time-zone-settings.service.ts
+++ b/npm/ng-packs/packages/setting-management/proxy/src/lib/proxy/time-zone-settings.service.ts
@@ -1,11 +1,13 @@
 import type { NameValue } from './volo/abp/models';
 import { RestService, Rest } from '@abp/ng.core';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 @Injectable({
   providedIn: 'root',
 })
 export class TimeZoneSettingsService {
+  private restService = inject(RestService);
+
   apiName = 'SettingManagement';
   
 
@@ -34,5 +36,8 @@ export class TimeZoneSettingsService {
     },
     { apiName: this.apiName,...config });
 
-  constructor(private restService: RestService) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 }

--- a/npm/ng-packs/packages/tenant-management/proxy/src/lib/proxy/tenant.service.ts
+++ b/npm/ng-packs/packages/tenant-management/proxy/src/lib/proxy/tenant.service.ts
@@ -1,12 +1,14 @@
 import type { GetTenantsInput, TenantCreateDto, TenantDto, TenantUpdateDto } from './models';
 import { RestService } from '@abp/ng.core';
 import type { PagedResultDto } from '@abp/ng.core';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 @Injectable({
   providedIn: 'root',
 })
 export class TenantService {
+  private restService = inject(RestService);
+
   apiName = 'AbpTenantManagement';
 
   create = (input: TenantCreateDto) =>
@@ -70,5 +72,8 @@ export class TenantService {
     },
     { apiName: this.apiName });
 
-  constructor(private restService: RestService) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 }

--- a/npm/ng-packs/packages/theme-basic/src/lib/components/account-layout/account-layout.component.ts
+++ b/npm/ng-packs/packages/theme-basic/src/lib/components/account-layout/account-layout.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component } from '@angular/core';
+import { AfterViewInit, Component, inject } from '@angular/core';
 import { eLayoutType, ReplaceableTemplateDirective, SubscriptionService } from '@abp/ng.core';
 import { LayoutService } from '../../services/layout.service';
 import { CommonModule } from '@angular/common';
@@ -25,12 +25,17 @@ import { RouterModule } from '@angular/router';
   ],
 })
 export class AccountLayoutComponent implements AfterViewInit {
+  service = inject(LayoutService);
+
   // required for dynamic component
   static type = eLayoutType.account;
 
   authWrapperKey = 'Account.AuthWrapperComponent';
 
-  constructor(public service: LayoutService) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 
   ngAfterViewInit() {
     this.service.subscribeWindowSize();

--- a/npm/ng-packs/packages/theme-basic/src/lib/components/account-layout/auth-wrapper/auth-wrapper.component.ts
+++ b/npm/ng-packs/packages/theme-basic/src/lib/components/account-layout/auth-wrapper/auth-wrapper.component.ts
@@ -1,5 +1,5 @@
 import { AuthWrapperService } from '@abp/ng.account.core';
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { LocalizationPipe, ReplaceableTemplateDirective } from '@abp/ng.core';
 import { TenantBoxComponent } from '../tenant-box/tenant-box.component';
@@ -11,5 +11,10 @@ import { TenantBoxComponent } from '../tenant-box/tenant-box.component';
   imports: [CommonModule, TenantBoxComponent, ReplaceableTemplateDirective, LocalizationPipe],
 })
 export class AuthWrapperComponent {
-  constructor(public service: AuthWrapperService) {}
+  service = inject(AuthWrapperService);
+
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 }

--- a/npm/ng-packs/packages/theme-basic/src/lib/components/account-layout/tenant-box/tenant-box.component.ts
+++ b/npm/ng-packs/packages/theme-basic/src/lib/components/account-layout/tenant-box/tenant-box.component.ts
@@ -1,5 +1,5 @@
 import { TenantBoxService } from '@abp/ng.account.core';
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { LocalizationPipe } from '@abp/ng.core';
 import { ButtonComponent, ModalCloseDirective, ModalComponent } from '@abp/ng.theme.shared';
@@ -19,5 +19,10 @@ import { FormsModule } from '@angular/forms';
   ],
 })
 export class TenantBoxComponent {
-  constructor(public service: TenantBoxService) {}
+  service = inject(TenantBoxService);
+
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 }

--- a/npm/ng-packs/packages/theme-basic/src/lib/components/logo/logo.component.ts
+++ b/npm/ng-packs/packages/theme-basic/src/lib/components/logo/logo.component.ts
@@ -1,5 +1,5 @@
 import { ApplicationInfo, EnvironmentService } from '@abp/ng.core';
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 @Component({
@@ -16,9 +16,14 @@ import { CommonModule } from '@angular/common';
   imports: [CommonModule],
 })
 export class LogoComponent {
+  private environment = inject(EnvironmentService);
+
   get appInfo(): ApplicationInfo {
     return this.environment.getEnvironment().application;
   }
 
-  constructor(private environment: EnvironmentService) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 }

--- a/npm/ng-packs/packages/theme-basic/src/lib/components/nav-items/current-user.component.ts
+++ b/npm/ng-packs/packages/theme-basic/src/lib/components/nav-items/current-user.component.ts
@@ -9,7 +9,7 @@ import {
   ToInjectorPipe,
 } from '@abp/ng.core';
 import { AbpVisibleDirective, UserMenu, UserMenuService } from '@abp/ng.theme.shared';
-import { Component, Inject, TrackByFunction } from '@angular/core';
+import { Component, TrackByFunction, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import { CommonModule } from '@angular/common';
 import { NgbDropdownModule } from '@ng-bootstrap/ng-bootstrap';
@@ -27,6 +27,12 @@ import { NgbDropdownModule } from '@ng-bootstrap/ng-bootstrap';
   ],
 })
 export class CurrentUserComponent {
+  readonly navigateToManageProfile = inject(NAVIGATE_TO_MANAGE_PROFILE);
+  readonly userMenu = inject(UserMenuService);
+  private authService = inject(AuthService);
+  private configState = inject(ConfigStateService);
+  private sessionState = inject(SessionStateService);
+
   currentUser$: Observable<CurrentUserDto> = this.configState.getOne$('currentUser');
   selectedTenant$ = this.sessionState.getTenant$();
 
@@ -36,13 +42,10 @@ export class CurrentUserComponent {
     return window.innerWidth < 992;
   }
 
-  constructor(
-    @Inject(NAVIGATE_TO_MANAGE_PROFILE) public readonly navigateToManageProfile: () => void,
-    public readonly userMenu: UserMenuService,
-    private authService: AuthService,
-    private configState: ConfigStateService,
-    private sessionState: SessionStateService,
-  ) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 
   navigateToLogin() {
     this.authService.navigateToLogin();

--- a/npm/ng-packs/packages/theme-basic/src/lib/components/nav-items/languages.component.ts
+++ b/npm/ng-packs/packages/theme-basic/src/lib/components/nav-items/languages.component.ts
@@ -1,5 +1,5 @@
 import { ConfigStateService, LanguageInfo, SessionStateService } from '@abp/ng.core';
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { CommonModule } from '@angular/common';
@@ -42,6 +42,9 @@ import { NgbDropdownModule } from '@ng-bootstrap/ng-bootstrap';
   imports: [CommonModule, NgbDropdownModule],
 })
 export class LanguagesComponent {
+  private sessionState = inject(SessionStateService);
+  private configState = inject(ConfigStateService);
+
   get smallScreen(): boolean {
     return window.innerWidth < 992;
   }
@@ -69,10 +72,10 @@ export class LanguagesComponent {
     return this.sessionState.getLanguage();
   }
 
-  constructor(
-    private sessionState: SessionStateService,
-    private configState: ConfigStateService,
-  ) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 
   onChangeLang(cultureName: string) {
     this.sessionState.setLanguage(cultureName);

--- a/npm/ng-packs/packages/theme-basic/src/lib/components/nav-items/nav-items.component.ts
+++ b/npm/ng-packs/packages/theme-basic/src/lib/components/nav-items/nav-items.component.ts
@@ -1,5 +1,5 @@
 import { AbpVisibleDirective, NavItem, NavItemsService } from '@abp/ng.theme.shared';
-import { Component, TrackByFunction } from '@angular/core';
+import { Component, TrackByFunction, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { PermissionDirective, ToInjectorPipe } from '@abp/ng.core';
 
@@ -9,7 +9,12 @@ import { PermissionDirective, ToInjectorPipe } from '@abp/ng.core';
   imports: [CommonModule, AbpVisibleDirective, PermissionDirective, ToInjectorPipe],
 })
 export class NavItemsComponent {
+  readonly navItems = inject(NavItemsService);
+
   trackByFn: TrackByFunction<NavItem> = (_, element) => element.id;
 
-  constructor(public readonly navItems: NavItemsService) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 }

--- a/npm/ng-packs/packages/theme-basic/src/lib/components/page-alert-container/page-alert-container.component.ts
+++ b/npm/ng-packs/packages/theme-basic/src/lib/components/page-alert-container/page-alert-container.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component, ViewEncapsulation, inject } from '@angular/core';
 import { PageAlertService } from '@abp/ng.theme.shared';
 import { CommonModule } from '@angular/common';
 import { LocalizationPipe, SafeHtmlPipe } from '@abp/ng.core';
@@ -10,5 +10,10 @@ import { LocalizationPipe, SafeHtmlPipe } from '@abp/ng.core';
   imports: [CommonModule, LocalizationPipe, SafeHtmlPipe],
 })
 export class PageAlertContainerComponent {
-  constructor(public service: PageAlertService) {}
+  service = inject(PageAlertService);
+
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 }

--- a/npm/ng-packs/packages/theme-basic/src/lib/handlers/lazy-style.handler.ts
+++ b/npm/ng-packs/packages/theme-basic/src/lib/handlers/lazy-style.handler.ts
@@ -1,6 +1,6 @@
 import { LazyLoadService, LOADING_STRATEGY } from '@abp/ng.core';
 import { DocumentDirHandlerService, LocaleDirection } from '@abp/ng.theme.shared';
-import { Injectable, Injector } from '@angular/core';
+import { Injectable, Injector, inject } from '@angular/core';
 import { LAZY_STYLES } from '../tokens/lazy-styles.token';
 export const BOOTSTRAP = 'bootstrap-{{dir}}.min.css';
 
@@ -23,7 +23,12 @@ export class LazyStyleHandler {
     return this._dir;
   }
 
-  constructor(injector: Injector) {
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {
+    const injector = inject(Injector);
+
     this.setStyles(injector);
     this.setLazyLoad(injector);
     this.listenToDirectionChanges(injector);

--- a/npm/ng-packs/packages/theme-basic/src/lib/services/layout.service.ts
+++ b/npm/ng-packs/packages/theme-basic/src/lib/services/layout.service.ts
@@ -1,11 +1,14 @@
 import {RouterEvents, SubscriptionService} from '@abp/ng.core';
-import { ChangeDetectorRef, Injectable } from '@angular/core';
+import { ChangeDetectorRef, Injectable, inject } from '@angular/core';
 import { fromEvent } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 import { eThemeBasicComponents } from '../enums';
 
 @Injectable()
 export class LayoutService {
+  private subscription = inject(SubscriptionService);
+  private cdRef = inject(ChangeDetectorRef);
+
   isCollapsed = true;
 
   smallScreen!: boolean; // do not set true or false
@@ -16,9 +19,13 @@ export class LayoutService {
 
   navItemsComponentKey = eThemeBasicComponents.NavItems;
 
-  constructor(private subscription: SubscriptionService,
-              private cdRef: ChangeDetectorRef,
-              routerEvents:RouterEvents) {
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {
+    const subscription = this.subscription;
+    const routerEvents = inject(RouterEvents);
+
     subscription.addOne(routerEvents.getNavigationEvents("End"),() => {
       this.isCollapsed = true;
     })

--- a/npm/ng-packs/packages/theme-shared/src/lib/components/breadcrumb/breadcrumb.component.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/components/breadcrumb/breadcrumb.component.ts
@@ -6,7 +6,7 @@ import {
   SubscriptionService,
   TreeNode,
 } from '@abp/ng.core';
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject } from '@angular/core';
 import { Router } from '@angular/router';
 import { map, startWith } from 'rxjs/operators';
 import { eThemeSharedRouteNames } from '../../enums/route-names';
@@ -20,15 +20,18 @@ import { BreadcrumbItemsComponent } from '../breadcrumb-items/breadcrumb-items.c
   imports: [BreadcrumbItemsComponent],
 })
 export class BreadcrumbComponent implements OnInit {
+  readonly cdRef = inject(ChangeDetectorRef);
+  private router = inject(Router);
+  private routes = inject(RoutesService);
+  private subscription = inject(SubscriptionService);
+  private routerEvents = inject(RouterEvents);
+
   segments: Partial<ABP.Route>[] = [];
 
-  constructor(
-    public readonly cdRef: ChangeDetectorRef,
-    private router: Router,
-    private routes: RoutesService,
-    private subscription: SubscriptionService,
-    private routerEvents: RouterEvents,
-  ) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 
   ngOnInit(): void {
     this.subscription.addOne(

--- a/npm/ng-packs/packages/theme-shared/src/lib/components/button/button.component.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/components/button/button.component.ts
@@ -1,14 +1,5 @@
 /* eslint-disable @angular-eslint/no-output-native */
-import {
-  Component,
-  ElementRef,
-  EventEmitter,
-  Input,
-  OnInit,
-  Output,
-  Renderer2,
-  ViewChild,
-} from '@angular/core';
+import { Component, ElementRef, EventEmitter, Input, OnInit, Output, Renderer2, ViewChild, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ABP } from '@abp/ng.core';
 
@@ -32,6 +23,8 @@ import { ABP } from '@abp/ng.core';
   imports: [CommonModule],
 })
 export class ButtonComponent implements OnInit {
+  private renderer = inject(Renderer2);
+
   @Input()
   buttonId = '';
 
@@ -75,7 +68,10 @@ export class ButtonComponent implements OnInit {
     return `${this.loading ? 'fa fa-spinner fa-spin' : this.iconClass || 'd-none'}`;
   }
 
-  constructor(private renderer: Renderer2) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 
   ngOnInit() {
     if (this.attributes) {

--- a/npm/ng-packs/packages/theme-shared/src/lib/components/confirmation/confirmation.component.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/components/confirmation/confirmation.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReplaySubject } from 'rxjs';
 import { Confirmation } from '../../models/confirmation';
@@ -12,7 +12,12 @@ import { LocalizationPipe } from '@abp/ng.core';
   imports: [CommonModule, LocalizationPipe],
 })
 export class ConfirmationComponent {
-  constructor(@Inject(CONFIRMATION_ICONS) private icons: ConfirmationIcons) {}
+  private icons = inject<ConfirmationIcons>(CONFIRMATION_ICONS);
+
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 
   confirm = Confirmation.Status.confirm;
   reject = Confirmation.Status.reject;

--- a/npm/ng-packs/packages/theme-shared/src/lib/components/loader-bar/loader-bar.component.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/components/loader-bar/loader-bar.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, Input, OnDestroy, OnInit, inject } from '@angular/core';
 import { Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { combineLatest, Subscription, timer } from 'rxjs';
@@ -24,6 +24,12 @@ import { HttpWaitService, RouterWaitService, SubscriptionService } from '@abp/ng
   imports: [CommonModule],
 })
 export class LoaderBarComponent implements OnDestroy, OnInit {
+  private router = inject(Router);
+  private cdRef = inject(ChangeDetectorRef);
+  private subscription = inject(SubscriptionService);
+  private httpWaitService = inject(HttpWaitService);
+  private routerWaitService = inject(RouterWaitService);
+
   protected _isLoading!: boolean;
 
   @Input()
@@ -73,13 +79,10 @@ export class LoaderBarComponent implements OnDestroy, OnInit {
     return `0 0 10px rgba(${this.color}, 0.5)`;
   }
 
-  constructor(
-    private router: Router,
-    private cdRef: ChangeDetectorRef,
-    private subscription: SubscriptionService,
-    private httpWaitService: HttpWaitService,
-    private routerWaitService: RouterWaitService,
-  ) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 
   ngOnInit() {
     this.subscribeLoading();

--- a/npm/ng-packs/packages/theme-shared/src/lib/components/modal/modal-close.directive.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/components/modal/modal-close.directive.ts
@@ -1,11 +1,18 @@
-import { Directive, HostListener, Optional } from '@angular/core';
+import { Directive, HostListener, inject } from '@angular/core';
 import { ModalComponent } from './modal.component';
 
 @Directive({
   selector: '[abpClose]',
 })
 export class ModalCloseDirective {
-  constructor(@Optional() private modal: ModalComponent) {
+  private modal = inject(ModalComponent, { optional: true })!;
+
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {
+    const modal = this.modal;
+
     if (!modal) {
       console.error('Please use abpClose within an abp-modal');
     }

--- a/npm/ng-packs/packages/theme-shared/src/lib/directives/disabled.directive.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/directives/disabled.directive.ts
@@ -1,14 +1,19 @@
-import { Directive, Host, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { Directive, Input, OnChanges, SimpleChanges, inject } from '@angular/core';
 import { NgControl } from '@angular/forms';
 
 @Directive({
   selector: '[abpDisabled]',
 })
 export class DisabledDirective implements OnChanges {
+  private ngControl = inject(NgControl, { host: true });
+
   @Input()
   abpDisabled = false;
 
-  constructor(@Host() private ngControl: NgControl) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 
   // Related issue: https://github.com/angular/angular/issues/35330
   ngOnChanges({ abpDisabled }: SimpleChanges) {

--- a/npm/ng-packs/packages/theme-shared/src/lib/directives/ellipsis.directive.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/directives/ellipsis.directive.ts
@@ -1,17 +1,12 @@
-import {
-  AfterViewInit,
-  ChangeDetectorRef,
-  Directive,
-  ElementRef,
-  HostBinding,
-  Input,
-  NgModule,
-} from '@angular/core';
+import { AfterViewInit, ChangeDetectorRef, Directive, ElementRef, HostBinding, Input, NgModule, inject } from '@angular/core';
 
 @Directive({
   selector: '[abpEllipsis]',
 })
 export class EllipsisDirective implements AfterViewInit {
+  private cdRef = inject(ChangeDetectorRef);
+  private elRef = inject(ElementRef);
+
   @Input('abpEllipsis')
   width?: string;
 
@@ -37,10 +32,10 @@ export class EllipsisDirective implements AfterViewInit {
     return this.enabled && this.width ? this.width || '170px' : undefined;
   }
 
-  constructor(
-    private cdRef: ChangeDetectorRef,
-    private elRef: ElementRef,
-  ) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 
   ngAfterViewInit() {
     this.title = this.title || (this.elRef.nativeElement as HTMLElement).innerText;

--- a/npm/ng-packs/packages/theme-shared/src/lib/directives/loading.directive.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/directives/loading.directive.ts
@@ -1,17 +1,4 @@
-import {
-  ComponentFactoryResolver,
-  ComponentRef,
-  Directive,
-  ElementRef,
-  EmbeddedViewRef,
-  HostBinding,
-  Injector,
-  Input,
-  OnDestroy,
-  OnInit,
-  Renderer2,
-  ViewContainerRef,
-} from '@angular/core';
+import { ComponentFactoryResolver, ComponentRef, Directive, ElementRef, EmbeddedViewRef, HostBinding, Injector, Input, OnDestroy, OnInit, Renderer2, ViewContainerRef, inject } from '@angular/core';
 import { Subscription, timer } from 'rxjs';
 import { take } from 'rxjs/operators';
 import { LoadingComponent } from '../components';
@@ -20,6 +7,12 @@ import { LoadingComponent } from '../components';
   selector: '[abpLoading]',
 })
 export class LoadingDirective implements OnInit, OnDestroy {
+  private elRef = inject<ElementRef<HTMLElement>>(ElementRef);
+  private vcRef = inject(ViewContainerRef);
+  private cdRes = inject(ComponentFactoryResolver);
+  private injector = inject(Injector);
+  private renderer = inject(Renderer2);
+
   private _loading!: boolean;
 
   @HostBinding('style.position')
@@ -77,13 +70,10 @@ export class LoadingDirective implements OnInit, OnDestroy {
   rootNode: HTMLDivElement | null = null;
   timerSubscription: Subscription | null = null;
 
-  constructor(
-    private elRef: ElementRef<HTMLElement>,
-    private vcRef: ViewContainerRef,
-    private cdRes: ComponentFactoryResolver,
-    private injector: Injector,
-    private renderer: Renderer2,
-  ) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 
   ngOnInit() {
     if (!this.targetElement) {

--- a/npm/ng-packs/packages/theme-shared/src/lib/directives/ngx-datatable-default.directive.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/directives/ngx-datatable-default.directive.ts
@@ -1,5 +1,5 @@
 import { DOCUMENT } from '@angular/common';
-import { AfterViewInit, Directive, HostBinding, Inject, Input, OnDestroy } from '@angular/core';
+import { AfterViewInit, Directive, HostBinding, Input, OnDestroy, inject } from '@angular/core';
 import { ColumnMode, DatatableComponent, ScrollerComponent } from '@swimlane/ngx-datatable';
 import { fromEvent, Subscription } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
@@ -10,6 +10,9 @@ import { debounceTime } from 'rxjs/operators';
   exportAs: 'ngxDatatableDefault',
 })
 export class NgxDatatableDefaultDirective implements AfterViewInit, OnDestroy {
+  private table = inject(DatatableComponent);
+  private document = inject<MockDocument>(DOCUMENT);
+
   private subscription = new Subscription();
   private resizeDiff = 0;
 
@@ -20,10 +23,10 @@ export class NgxDatatableDefaultDirective implements AfterViewInit, OnDestroy {
     return `ngx-datatable ${this.class}`;
   }
 
-  constructor(
-    private table: DatatableComponent,
-    @Inject(DOCUMENT) private document: MockDocument,
-  ) {
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {
     this.table.columnMode = ColumnMode.force;
     this.table.footerHeight = 50;
     this.table.headerHeight = 50;

--- a/npm/ng-packs/packages/theme-shared/src/lib/directives/visible.directive.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/directives/visible.directive.ts
@@ -1,10 +1,13 @@
-import { OnInit, Directive, OnDestroy, Input, ViewContainerRef, TemplateRef } from '@angular/core';
+import { OnInit, Directive, OnDestroy, Input, ViewContainerRef, TemplateRef, inject } from '@angular/core';
 import { EMPTY, from, Observable, of, Subscription } from 'rxjs';
 
 @Directive({
   selector: '[abpVisible]',
 })
 export class AbpVisibleDirective implements OnDestroy, OnInit {
+  private viewContainerRef = inject(ViewContainerRef);
+  private templateRef = inject<TemplateRef<unknown>>(TemplateRef);
+
   conditionSubscription: Subscription | undefined;
   isVisible: boolean | undefined;
 
@@ -17,10 +20,10 @@ export class AbpVisibleDirective implements OnDestroy, OnInit {
 
   private condition$: Observable<boolean> = of(false);
 
-  constructor(
-    private viewContainerRef: ViewContainerRef,
-    private templateRef: TemplateRef<unknown>,
-  ) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
   ngOnInit(): void {
     this.updateVisibility();
   }

--- a/npm/ng-packs/packages/theme-shared/src/lib/handlers/document-dir.handler.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/handlers/document-dir.handler.ts
@@ -1,14 +1,19 @@
 import { getLocaleDirection, LocalizationService } from '@abp/ng.core';
-import { Injectable, Injector } from '@angular/core';
+import { Injectable, Injector, inject } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { LocaleDirection } from '../models/common';
 
 @Injectable()
 export class DocumentDirHandlerService {
+  protected injector = inject(Injector);
+
   private dir = new BehaviorSubject<LocaleDirection>('ltr');
   dir$ = this.dir.asObservable();
-  constructor(protected injector: Injector) {
+
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+  constructor() {
     this.listenToLanguageChanges();
   }
 

--- a/npm/ng-packs/packages/theme-shared/src/lib/handlers/error.handler.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/handlers/error.handler.ts
@@ -17,6 +17,8 @@ import { RouterErrorHandlerService } from '../services/router-error-handler.serv
 
 @Injectable({ providedIn: 'root' })
 export class ErrorHandler {
+  protected injector = inject(Injector);
+
   protected readonly httpErrorReporter = inject(HttpErrorReporterService);
   protected readonly confirmationService = inject(ConfirmationService);
   protected readonly routerErrorHandlerService = inject(RouterErrorHandlerService);
@@ -24,7 +26,10 @@ export class ErrorHandler {
   protected readonly customErrorHandlers = inject(CUSTOM_ERROR_HANDLERS);
   protected readonly httpErrorHandler = inject(HTTP_ERROR_HANDLER, { optional: true });
 
-  constructor(protected injector: Injector) {
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {
     this.listenToRestError();
     this.listenToRouterError();
   }

--- a/npm/ng-packs/packages/theme-shared/src/lib/services/confirmation.service.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/services/confirmation.service.ts
@@ -1,5 +1,5 @@
 import { ContentProjectionService, LocalizationParam, PROJECTION_STRATEGY } from '@abp/ng.core';
-import { ComponentRef, Injectable } from '@angular/core';
+import { ComponentRef, Injectable, inject } from '@angular/core';
 import { fromEvent, Observable, ReplaySubject, Subject } from 'rxjs';
 import { debounceTime, filter, takeUntil } from 'rxjs/operators';
 import { ConfirmationComponent } from '../components/confirmation/confirmation.component';
@@ -7,6 +7,8 @@ import { Confirmation } from '../models/confirmation';
 
 @Injectable({ providedIn: 'root' })
 export class ConfirmationService {
+  private contentProjectionService = inject(ContentProjectionService);
+
   status$!: Subject<Confirmation.Status>;
   confirmation$ = new ReplaySubject<Confirmation.DialogData | null>(1);
 
@@ -17,7 +19,10 @@ export class ConfirmationService {
     this.status$.next(status);
   };
 
-  constructor(private contentProjectionService: ContentProjectionService) {}
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {}
 
   private setContainer() {
     this.containerComponentRef = this.contentProjectionService.projectContent(

--- a/npm/ng-packs/packages/theme-shared/src/lib/utils/date-parser-formatter.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/utils/date-parser-formatter.ts
@@ -1,6 +1,6 @@
 import { ApplicationLocalizationConfigurationDto, ConfigStateService } from '@abp/ng.core';
 import { formatDate } from '@angular/common';
-import { Inject, Injectable, LOCALE_ID } from '@angular/core';
+import { Injectable, LOCALE_ID, inject } from '@angular/core';
 import { NgbDateParserFormatter, NgbDateStruct } from '@ng-bootstrap/ng-bootstrap';
 
 function isNumber(value: any): boolean {
@@ -13,7 +13,13 @@ function toInteger(value: any): number {
 
 @Injectable()
 export class DateParserFormatter extends NgbDateParserFormatter {
-  constructor(private configState: ConfigStateService, @Inject(LOCALE_ID) private locale: string) {
+  private configState = inject(ConfigStateService);
+  private locale = inject(LOCALE_ID);
+
+  /** Inserted by Angular inject() migration for backwards compatibility */
+  constructor(...args: unknown[]);
+
+  constructor() {
     super();
   }
 


### PR DESCRIPTION
### Description 

This PR refactors all Angular services, components, and directives in the repository to use the Angular v14+ inject() function for dependency injection instead of constructor-based DI. All DI dependencies are now initialized as class properties using inject(), and constructors have been removed or simplified where appropriate. This change aligns the codebase with Angular's latest best practices for dependency injection, improves code readability, and prepares the project for future Angular versions.

Highlights:

All services, components, and directives now use inject() for DI.
Constructors that only existed for DI have been removed.
No functional or API changes were made; only the DI pattern was updated.
No breaking changes for consumers unless they relied on constructor injection in extended classes.
No screenshots or GIFs are required as this is a code refactor.

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?
Run the application and ensure all features work as before.
Pay special attention to areas where services, components, or directives are injected.
Run all existing unit and integration tests to confirm there are no regressions.


for @sumeyyeKurtulus 
### Migration Options & Rationale
1. Migration Path: [abp](vscode-file://vscode-app/c:/Users/fahri/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)
Choice: Migrate entire project
Rationale: Ensure consistency across all code and avoid mixed DI patterns.

2. Abstract Classes Migration: Yes
Choice: Include abstract classes
Rationale: Maintain uniform DI patterns throughout the codebase, including base classes.

3. Backwards Compatible Constructors: Yes
Choice: Keep constructor(...args: unknown[]); signature
Rationale: Prevent breaking changes for existing sub-classes and maintain compatibility.

4. Optional Inject Non-nullable: Yes
Choice: Match @Optional() behavior
Rationale: Keep consistent API behavior with existing optional injection patterns.