### PR TITLE
Remove duplicate entry for lang-utils.js in BlazorWebAssemblyScriptContributor

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Components.WebAssembly.Theming.Bundling/BlazorWebAssemblyScriptContributor.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Components.WebAssembly.Theming.Bundling/BlazorWebAssemblyScriptContributor.cs
@@ -10,7 +10,6 @@ public class BlazorWebAssemblyScriptContributor : BundleContributor
         context.Files.AddIfNotContains("_content/Microsoft.AspNetCore.Components.WebAssembly.Authentication/AuthenticationService.js");
         context.Files.AddIfNotContains("_content/Volo.Abp.AspNetCore.Components.Web/libs/abp/js/abp.js");
         context.Files.AddIfNotContains("_content/Volo.Abp.AspNetCore.Components.Web/libs/abp/js/lang-utils.js");
-        context.Files.AddIfNotContains("_content/Volo.Abp.AspNetCore.Components.Web/libs/abp/js/lang-utils.js");
         context.Files.AddIfNotContains("_content/Volo.Abp.AspNetCore.Components.Web/libs/abp/js/authentication-state-listener.js");
     }
 }


### PR DESCRIPTION
### Description

Here are duplicate JS references

https://github.com/abpframework/abp/blob/e88c860692d84e6f623a803a7eac1bba29823eee/framework/src/Volo.Abp.AspNetCore.Components.WebAssembly.Theming.Bundling/BlazorWebAssemblyScriptContributor.cs#L12-L13

Remove duplicate entry for lang-utils.js in BlazorWebAssemblyScriptContributor

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?


