### PR TITLE
Add async auth guard support for OAuth routes 

### DIFF
--- a/npm/ng-packs/packages/core/src/lib/abstracts/auth.guard.ts
+++ b/npm/ng-packs/packages/core/src/lib/abstracts/auth.guard.ts
@@ -21,3 +21,9 @@ export const authGuard: CanActivateFn = () => {
   console.error('You should add @abp/ng-oauth packages or create your own auth packages.');
   return false;
 };
+
+
+export const asyncAuthGuard: CanActivateFn = () => {
+  console.error('You should add @abp/ng-oauth packages or create your own auth packages.');
+  return false;
+};

--- a/npm/ng-packs/packages/oauth/src/lib/providers/oauth-module-config.provider.ts
+++ b/npm/ng-packs/packages/oauth/src/lib/providers/oauth-module-config.provider.ts
@@ -2,6 +2,7 @@ import {
   AuthService,
   AuthGuard,
   authGuard,
+  asyncAuthGuard,
   ApiInterceptor,
   PIPE_TO_LOGIN_FN_KEY,
   CHECK_AUTHENTICATION_STATE_FN_KEY,
@@ -11,7 +12,7 @@ import {
 import { Provider, makeEnvironmentProviders, inject, provideAppInitializer } from '@angular/core';
 import { HTTP_INTERCEPTORS } from '@angular/common/http';
 import { OAuthModule, OAuthStorage } from 'angular-oauth2-oidc';
-import { AbpOAuthGuard, abpOAuthGuard } from '../guards';
+import { AbpOAuthGuard, abpOAuthGuard, asyncAbpOAuthGuard,  } from '../guards';
 import { OAuthConfigurationHandler } from '../handlers';
 import { OAuthApiInterceptor } from '../interceptors';
 import { AbpOAuthService, OAuthErrorFilterService } from '../services';
@@ -31,6 +32,10 @@ export function provideAbpOAuth() {
     {
       provide: authGuard,
       useValue: abpOAuthGuard,
+    },  
+    {
+      provide: asyncAuthGuard,
+      useValue: asyncAbpOAuthGuard,
     },
     {
       provide: ApiInterceptor,


### PR DESCRIPTION
Introduced asyncAuthGuard and asyncAbpOAuthGuard to enable asynchronous authentication checks, particularly for OAuth flows involving code exchange. Updated app routes and OAuth module provider to use the new async guards where appropriate.

### Description

Resolves #23286 (write the related issue number if available)

TODO: Describe what this PR has changed, add screenshot or animated GIF if available, write if it is a breaking change, and how to fix the breaking changes for existing applications if so.

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?
He describe in #23286 

After setting up the environment for `dev-app`, you can start the application by running the following command in the `npm/ng-packs` directory:
`yarn start`

To reproduce the issue, add the `canActivate `guard to the home route in `npm/ng-packs/apps/dev-app/src/app/app.routes.ts `like this:

```
{
  path: '',
  pathMatch: 'full',
  loadComponent: () => import('./home/home.component').then(m => m.HomeComponent),
  canActivate: [AuthGuard]
}

```

Then, try to access the homepage after logging in — the issue (infinite redirect loop) will occur.

To fix the issue, replace `AuthGuard `with `asyncAuthGuard`.

