### PR TITLE
Set AutoCompleteMessages to false by default

### DIFF
--- a/framework/src/Volo.Abp.AzureServiceBus/Volo/Abp/AzureServiceBus/ClientConfig.cs
+++ b/framework/src/Volo.Abp.AzureServiceBus/Volo/Abp/AzureServiceBus/ClientConfig.cs
@@ -11,5 +11,8 @@ public class ClientConfig
 
     public ServiceBusClientOptions Client { get; set; } = new();
 
-    public ServiceBusProcessorOptions Processor { get; set; } = new();
+    public ServiceBusProcessorOptions Processor { get; set; } = new ()
+    {
+        AutoCompleteMessages = false
+    };
 }


### PR DESCRIPTION
### Description

Reslves: https://github.com/abpframework/abp/issues/23412

**By default or when AutoCompleteMessages is set to true, the processor will complete the message after executing the message handler**

Because ABP handles the error without throwing an exception, Azure Service Bus will think the message has been completed and will not return it to the queue, we need to set `AutoCompleteMessages` to `false` by default.

> After the maximum number of retries, the message will be discarded, users can consider using the Outbox/Inbox

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

Create an app to use Azure Service Bus and throw an exception in the event handler.