### PR TITLE
Return a new list from `WebRequestResources`.

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Resources/WebRequestResources.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bundling/Volo/Abp/AspNetCore/Mvc/UI/Resources/WebRequestResources.cs
@@ -30,6 +30,6 @@ public class WebRequestResources : IWebRequestResources, IScopedDependency
         }
 
         Resources.Add(path, resources);
-        return resources;
+        return resources.ToList();
     }
 }


### PR DESCRIPTION
Otherwise, the content in `Resources` may return inconsistent data.