### PR TITLE
Disable `MapperlyAutoObjectMappingProvider` if AutoMapper used in app.

### DIFF
--- a/framework/src/Volo.Abp.Mapperly/Volo/Abp/Mapperly/AbpMapperlyModule.cs
+++ b/framework/src/Volo.Abp.Mapperly/Volo/Abp/Mapperly/AbpMapperlyModule.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
 using Volo.Abp.Auditing;
 using Volo.Abp.Modularity;
 using Volo.Abp.ObjectExtending;
@@ -20,6 +21,11 @@ public class AbpMapperlyModule : AbpModule
 
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        context.Services.AddMapperlyObjectMapper();
+        // This is the temporary solution, We will remove it in when all apps are migrated to Mapperly.
+        var autoMapperModule = context.Services.FirstOrDefault(x => x.ServiceType.FullName == "Volo.Abp.AutoMapper.AbpAutoMapperModule");
+        if (autoMapperModule == null)
+        {
+            context.Services.AddMapperlyObjectMapper();
+        }
     }
 }

--- a/framework/src/Volo.Abp.Mapperly/Volo/Abp/Mapperly/AbpMapperlyModule.cs
+++ b/framework/src/Volo.Abp.Mapperly/Volo/Abp/Mapperly/AbpMapperlyModule.cs
@@ -23,11 +23,20 @@ public class AbpMapperlyModule : AbpModule
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
         // This is the temporary solution, We will remove it in when all apps are migrated to Mapperly.
-        var abpApplication = context.Services.GetSingletonInstance<IAbpApplication>();
-        var modules = abpApplication.Modules.ToList();
+        var disableMapperlyAutoObjectMappingProvider = false;
+
+        var modules = context.Services.GetSingletonInstance<IAbpApplication>().Modules.ToList();
         var autoMapperModuleIndex = modules.FindIndex(x => x.Type.FullName!.Equals("Volo.Abp.AutoMapper.AbpAutoMapperModule", StringComparison.OrdinalIgnoreCase));
-        var mapperlyModuleIndex = modules.FindIndex(x => x.Type == typeof(AbpMapperlyModule));
-        if (mapperlyModuleIndex < autoMapperModuleIndex)
+        if (autoMapperModuleIndex >= 0)
+        {
+            var mapperlyModuleIndex = modules.FindIndex(x => x.Type == typeof(AbpMapperlyModule));
+            if (mapperlyModuleIndex > autoMapperModuleIndex)
+            {
+                disableMapperlyAutoObjectMappingProvider = true;
+            }
+        }
+
+        if (!disableMapperlyAutoObjectMappingProvider)
         {
             context.Services.AddMapperlyObjectMapper();
         }

--- a/framework/src/Volo.Abp.Mapperly/Volo/Abp/Mapperly/AbpMapperlyModule.cs
+++ b/framework/src/Volo.Abp.Mapperly/Volo/Abp/Mapperly/AbpMapperlyModule.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Volo.Abp.Auditing;
 using Volo.Abp.Modularity;
@@ -22,8 +23,11 @@ public class AbpMapperlyModule : AbpModule
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
         // This is the temporary solution, We will remove it in when all apps are migrated to Mapperly.
-        var autoMapperModule = context.Services.FirstOrDefault(x => x.ServiceType.FullName == "Volo.Abp.AutoMapper.AbpAutoMapperModule");
-        if (autoMapperModule == null)
+        var abpApplication = context.Services.GetSingletonInstance<IAbpApplication>();
+        var modules = abpApplication.Modules.ToList();
+        var autoMapperModuleIndex = modules.FindIndex(x => x.Type.FullName!.Equals("Volo.Abp.AutoMapper.AbpAutoMapperModule", StringComparison.OrdinalIgnoreCase));
+        var mapperlyModuleIndex = modules.FindIndex(x => x.Type == typeof(AbpMapperlyModule));
+        if (mapperlyModuleIndex < autoMapperModuleIndex)
         {
             context.Services.AddMapperlyObjectMapper();
         }


### PR DESCRIPTION
This is the temporary solution, We will remove it in when all apps are migrated to Mapperly.

We only used **Mapperly** in the module, but the application depends on both **AutoMapper** and **Mapperly**. The current module dependency order has **Mapperly** following **AutoMapper**, however, the app still requires AutoMapper.