### PR TITLE
Show actions text when at least one action exists

### DIFF
--- a/npm/ng-packs/packages/components/extensible/src/lib/components/extensible-table/extensible-table.component.ts
+++ b/npm/ng-packs/packages/components/extensible/src/lib/components/extensible-table/extensible-table.component.ts
@@ -89,7 +89,7 @@ export class ExtensibleTableComponent<R = any> implements OnChanges, AfterViewIn
   }
 
   get actionsText(): string {
-    return this._actionsText ?? (this.actionList.length > 1 ? 'AbpUi::Actions' : '');
+    return this._actionsText ?? (this.actionList.length >= 1 ? 'AbpUi::Actions' : '');
   }
 
   @Input() data!: R[];


### PR DESCRIPTION
Updated the logic in actionsText getter to display 'AbpUi::Actions' when there is at least one action in the actionList, instead of requiring more than one. This improves clarity for tables with a single action.

<img width="2128" height="778" alt="image" src="https://github.com/user-attachments/assets/b3b7ee18-5135-4f5f-92ec-0599c097686f" />


### Description

Resolves https://github.com/volosoft/volo/issues/20533 

TODO: Describe what this PR has changed, add screenshot or animated GIF if available, write if it is a breaking change, and how to fix the breaking changes for existing applications if so.

### Checklist

- [ ] I fully tested it as developer / designer and created unit / integration tests
- [ ] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

you have to select branch `rel-9.3` from abp
you have to run dev app from volo side