### PR TITLE
Support DateOnly and TimeOnly in type checks

### DIFF
--- a/framework/src/Volo.Abp.Core/Volo/Abp/Reflection/TypeHelper.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/Reflection/TypeHelper.cs
@@ -176,6 +176,10 @@ public static class TypeHelper
                type == typeof(decimal) ||
                type == typeof(DateTime) ||
                type == typeof(DateTimeOffset) ||
+#if NETCOREAPP
+               type == typeof(DateOnly) ||
+               type == typeof(TimeOnly) ||
+#endif
                type == typeof(TimeSpan) ||
                type == typeof(Guid);
     }

--- a/framework/src/Volo.Abp.Validation/Volo/Abp/Validation/MethodInvocationValidator.cs
+++ b/framework/src/Volo.Abp.Validation/Volo/Abp/Validation/MethodInvocationValidator.cs
@@ -95,6 +95,7 @@ public class MethodInvocationValidator : IMethodInvocationValidator, ITransientD
     {
         var allowNulls = parameterInfo.IsOptional ||
                          parameterInfo.IsOut ||
+                         TypeHelper.IsNullable(parameterInfo.ParameterType) ||
                          TypeHelper.IsPrimitiveExtended(parameterInfo.ParameterType, includeEnums: true);
 
         context.Errors.AddRange(


### PR DESCRIPTION
Added DateOnly and TimeOnly to TypeHelper.IsPrimitiveExtended for .NET Core. Also updated MethodInvocationValidator to allow nulls for nullable parameter types, improving validation logic for modern .NET types.

https://abp.io/support/questions/9736/DateOnly-and-DateTime-return-validation-errors-when-null-or-empty#answer-3a1bcc76-594a-7256-4327-a0dd22c9df2a
