### PR TITLE
Allow to define custom conventional entity configurers for EF Core

### DIFF
--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/Modeling/AbpEntityTypeBuilderExtensions.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/Modeling/AbpEntityTypeBuilderExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
@@ -14,20 +15,69 @@ namespace Volo.Abp.EntityFrameworkCore.Modeling;
 
 public static class AbpEntityTypeBuilderExtensions
 {
+    public static List<NamedEntityConfigurer> ConventionalConfigurers { get; }
+
+    static AbpEntityTypeBuilderExtensions()
+    {
+        ConventionalConfigurers = new List<NamedEntityConfigurer>
+        {
+            new NamedEntityConfigurer(
+                "ConcurrencyStamp",
+                b => b.TryConfigureConcurrencyStamp()
+            ),
+            new NamedEntityConfigurer(
+                "ExtraProperties",
+                b => b.TryConfigureExtraProperties()
+            ),
+            new NamedEntityConfigurer(
+                "ObjectExtensions",
+                b => b.TryConfigureObjectExtensions()
+            ),
+            new NamedEntityConfigurer(
+                "MayHaveCreator",
+                b => b.TryConfigureMayHaveCreator()
+            ),
+            new NamedEntityConfigurer(
+                "MustHaveCreator",
+                b => b.TryConfigureMustHaveCreator()
+            ),
+            new NamedEntityConfigurer(
+                "SoftDelete",
+                b => b.TryConfigureSoftDelete()
+            ),
+            new NamedEntityConfigurer(
+                "DeletionTime",
+                b => b.TryConfigureDeletionTime()
+            ),
+            new NamedEntityConfigurer(
+                "DeletionAudited",
+                b => b.TryConfigureDeletionAudited()
+            ),
+            new NamedEntityConfigurer(
+                "CreationTime",
+                b => b.TryConfigureCreationTime()
+            ),
+            new NamedEntityConfigurer(
+                "LastModificationTime",
+                b => b.TryConfigureLastModificationTime()
+            ),
+            new NamedEntityConfigurer(
+                "ModificationAudited",
+                b => b.TryConfigureModificationAudited()
+            ),
+            new NamedEntityConfigurer(
+                "MultiTenant",
+                b => b.TryConfigureMultiTenant()
+            )
+        };
+    }
+    
     public static void ConfigureByConvention(this EntityTypeBuilder b)
     {
-        b.TryConfigureConcurrencyStamp();
-        b.TryConfigureExtraProperties();
-        b.TryConfigureObjectExtensions();
-        b.TryConfigureMayHaveCreator();
-        b.TryConfigureMustHaveCreator();
-        b.TryConfigureSoftDelete();
-        b.TryConfigureDeletionTime();
-        b.TryConfigureDeletionAudited();
-        b.TryConfigureCreationTime();
-        b.TryConfigureLastModificationTime();
-        b.TryConfigureModificationAudited();
-        b.TryConfigureMultiTenant();
+        foreach (var configurer in ConventionalConfigurers)
+        {
+            configurer.ConfigureAction(b);
+        }
     }
 
     public static void ConfigureConcurrencyStamp<T>(this EntityTypeBuilder<T> b)
@@ -308,6 +358,4 @@ public static class AbpEntityTypeBuilderExtensions
         b.As<EntityTypeBuilder>().TryConfigureExtraProperties();
         b.As<EntityTypeBuilder>().TryConfigureConcurrencyStamp();
     }
-
-    //TODO: Add other interfaces (IAuditedObject<TUser>...)
 }

--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/Modeling/NamedEntityConfigurer.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/Modeling/NamedEntityConfigurer.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Volo.Abp.EntityFrameworkCore.Modeling;
+
+public class NamedEntityConfigurer
+{
+    /// <summary>
+    /// Name of the configurer.
+    /// </summary>
+    public string Name { get; set; }
+    
+    /// <summary>
+    /// Action to configure the given <see cref="EntityTypeBuilder"/>.
+    /// </summary>
+    public Action<EntityTypeBuilder> ConfigureAction { get; }
+
+    public NamedEntityConfigurer(string name, Action<EntityTypeBuilder> configureAction)
+    {
+        Name = Check.NotNullOrEmpty(name, nameof(name));
+        ConfigureAction = Check.NotNull(configureAction, nameof(configureAction));
+    }
+}


### PR DESCRIPTION
Allow developers to add their custom conventional mapping logic or customize existing logic when they call the `ConfigureByConvention` method.

Example:

````csharp
builder.Entity<Customer>(b =>
{
    b.ToTable("Customers"); 

    b.ConfigureByConvention(); // Auto configure by conventions

    b.Property(x => x.Name).IsRequired().HasMaxLength(128);
    b.Property(x => x.EmailAddress).IsRequired(false).HasMaxLength(256);
});
````

When we configure our entity like that, the `b.ConfigureByConvention()` method configures ABP's base properties, like `SoftDelete`, `CreationTime`, `TenantId`, ...

See the [AbpEntityTypeBuilderExtensions](https://github.com/abpframework/abp/blob/dev/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/Modeling/AbpEntityTypeBuilderExtensions.cs) class for all.

To add your own convention, add a new item to the static `AbpEntityTypeBuilderExtensions.ConventionalConfigurers` list. Example:

````csharp
AbpEntityTypeBuilderExtensions.ConventionalConfigurers
    .Add(new NamedEntityConfigurer("MyEmailAddressConfigurer", entity =>
    {
        if (entity.Metadata.ClrType.IsAssignableTo<IHasEmailAddress>())
        {
            entity
                .Property("EmailAddress")
                .HasMaxLength(256);
        }
    }));
````

This example checks if the entity implements `IHasEmailAddress` (which defines the `EmailAddress` property), then it sets max length for that property.

You should write this configuration before you first use the `DbContext` object, typically in the `PreConfigureServices` method of your module class, or in the `Program.cs`, before you initialize your application.

You can also remove or replace ABP's default configurers using the `AbpEntityTypeBuilderExtensions.ConventionalConfigurers` list. 
