### PR TITLE
Support dictionary query params in service templates

### DIFF
--- a/npm/ng-packs/packages/schematics/src/commands/api/files-service/proxy/__namespace@dir__/__name@kebab__.service.ts.template
+++ b/npm/ng-packs/packages/schematics/src/commands/api/files-service/proxy/__namespace@dir__/__name@kebab__.service.ts.template
@@ -21,7 +21,11 @@ export class <%= name %>Service {
       if (isBlob) { %>
       responseType: 'blob',<% } %>
       url: <%= body.url %>,<%
-      if (body.params.length) { %>
+      if (body.dictParamVar && !body.params.length) { %>
+      params: <%= body.dictParamVar %>,<% } %><%
+      if (body.dictParamVar && body.params.length) { %>
+      params: { ...<%= body.dictParamVar %>, <%= body.params.join(', ') %> },<% } %><%
+      if (!body.dictParamVar && body.params.length) { %>
       params: { <%= body.params.join(', ') %> },<% }
       if (body.body) { %>
       body: <%= body.body %>,<% } %>

--- a/npm/ng-packs/packages/schematics/src/models/method.ts
+++ b/npm/ng-packs/packages/schematics/src/models/method.ts
@@ -1,11 +1,12 @@
 import { eBindingSourceId, eMethodModifier } from '../enums';
 import { camel, camelizeHyphen } from '../utils/text';
-import { getParamName, getParamValueName } from '../utils/methods';
+import { getParamName, getParamValueName, isDictionaryType } from '../utils/methods';
 import { ParameterInBody } from './api-definition';
 import { Property } from './model';
 import { Omissible } from './util';
 import { VOLO_REMOTE_STREAM_CONTENT } from '../constants';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
+
 const shouldQuote = require('should-quote');
 
 export class Method {
@@ -40,6 +41,7 @@ export class Body {
   body?: string;
   method: string;
   params: string[] = [];
+  dictParamVar?: string;
   responseTypeWithNamespace: string;
   requestType = 'any';
   responseType: string;
@@ -57,6 +59,10 @@ export class Body {
     switch (bindingSourceId) {
       case eBindingSourceId.Model:
       case eBindingSourceId.Query:
+        if (isDictionaryType(param.type, param.typeSimple)) {
+          this.dictParamVar = value;
+          break;
+        }
         this.params.push(paramName === value ? value : `${getParamName(paramName)}: ${value}`);
         break;
       case eBindingSourceId.FormFile:

--- a/npm/ng-packs/packages/schematics/src/utils/methods.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/methods.ts
@@ -1,11 +1,9 @@
 import { camel } from './text';
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const shouldQuote = require('should-quote');
 export const getParamName = (paramName: string) =>
   shouldQuote(paramName) ? `["${paramName}"]` : paramName;
 
-// check dot exists in param name and camelize access continuously
 export const getParamValueName = (paramName: string, descriptorName: string) => {
   if (paramName.includes('.')) {
     const splitted = paramName.split('.');
@@ -17,3 +15,8 @@ export const getParamValueName = (paramName: string, descriptorName: string) => 
   }
   return `${descriptorName}.${paramName}`;
 };
+
+export function isDictionaryType(type?: string, typeSimple?: string): boolean {
+  const haystacks = [type || '', typeSimple || ''];
+  return haystacks.some(t => /(^|\b)(System\.Collections\.Generic\.)?(I)?Dictionary\s*</.test(t));
+}


### PR DESCRIPTION
Added logic to handle dictionary-type query parameters in generated service templates. Updated method model and template to correctly assign dictionary params, and introduced isDictionaryType utility for type detection.

### Description

Resolves #20098 (write the related issue number if available)

### How to test it?

## Test Steps

 1. Run the schematics build:
   ```npm run build:schematics```
This command builds the schematics package (located under npm/ng-packs).

2. add sample api defination 
`templates\app\aspnet-core\src\MyCompanyName.MyProjectName.HttpApi.HostWithIds\Controllers\HomeController.cs`

```
[HttpGet("api/app/my-service/some")]
public IActionResult GetSome([FromQuery] Dictionary<string, string> searchFields)
{
    return Ok(searchFields);
}
```
and run HostWithIds Application 

3. Under `ng-packs`, run the following command to apply the schematic:
`npx -y nx g "./dist/packages/schematics/collection.json:proxy-add" --module app --apiName Default --source dev-app --target dev-app --url https://localhost:44305 --serviceType application`

and check create