### PR TITLE
Add guide for integrating public and admin CMS Kit packages

### DIFF
--- a/docs/en/modules/cms-kit/index.md
+++ b/docs/en/modules/cms-kit/index.md
@@ -72,6 +72,23 @@ CMS kit packages are designed for various usage scenarios. If you check the [CMS
  - `Volo.CmsKit.Public.*` packages contain the functionalities used in public websites where users read blog posts or leave comments.
  - `Volo.CmsKit.*` (without Admin/Public suffix) packages are called as unified packages. Unified packages are shortcuts for adding Admin & Public packages (of the related layer) separately. If you have a single application for administration and public web site, you can use these packages.
 
+## Integrating Public and Admin Packages in a Unified Application
+
+If you are using a single application for both admin and public web side, it's important to configure the global layout settings appropriately. By default, the layout is set for a **Public Website**, which is suitable for public-facing pages. However, when your application serves both admin and public pages, you should explicitly set the global layout for all CMS Kit pages.
+
+To do this, add a `_ViewStart.cshtml` file to your web project at `/Pages/Public/CmsKit/_ViewStart.cshtml` and configure the layout as shown below:
+
+```html
+@using Volo.Abp.AspNetCore.Mvc.UI.Theming
+@inject IThemeManager ThemeManager
+@{
+    // default: GetPublicLayout()
+    Layout = ThemeManager.CurrentTheme.GetApplicationLayout(); 
+}
+```
+
+> The `_ViewStart.cshtml` file is used to set the layout for all pages in the `CmsKit` folder.
+
 ## Internals
 
 ### Table / collection prefix & schema

--- a/docs/en/modules/cms-kit/index.md
+++ b/docs/en/modules/cms-kit/index.md
@@ -74,7 +74,7 @@ CMS kit packages are designed for various usage scenarios. If you check the [CMS
 
 ## Integrating Public and Admin Packages in a Unified Application
 
-If you are using a single application for both admin and public web side, it's important to configure the global layout settings appropriately. By default, the layout is set for a **Public Website**, which is suitable for public-facing pages. However, when your application serves both admin and public pages, you should explicitly set the global layout for all CMS Kit pages.
+If you are using a single application for both admin and public web site, it's important to configure the global layout settings appropriately. By default, the layout is set for a **Public Website**, which is suitable for public-facing pages. However, when your application serves both admin and public pages, you should explicitly set the global layout for all CMS Kit pages.
 
 To do this, add a `_ViewStart.cshtml` file to your web project at `/Pages/Public/CmsKit/_ViewStart.cshtml` and configure the layout as shown below:
 


### PR DESCRIPTION
Added documentation on configuring global layout settings when using both admin and public CMS Kit packages in a unified application. Includes instructions for setting up a _ViewStart.cshtml file to ensure correct layout rendering.
