### PR TITLE
CMS: Fix tag & marked item filtering on blogposts

### DIFF
--- a/modules/cms-kit/src/Volo.CmsKit.EntityFrameworkCore/Volo/CmsKit/Blogs/EfCoreBlogPostRepository.cs
+++ b/modules/cms-kit/src/Volo.CmsKit.EntityFrameworkCore/Volo/CmsKit/Blogs/EfCoreBlogPostRepository.cs
@@ -58,31 +58,23 @@ public class EfCoreBlogPostRepository : EfCoreRepository<ICmsKitDbContext, BlogP
         BlogPostStatus? statusFilter = null,
         CancellationToken cancellationToken = default)
     {
-        List<Guid> entityIdFilters = null;
-        if (tagId.HasValue)
-        {
-            entityIdFilters = (await _entityTagManager.GetEntityIdsFilteredByTagAsync(tagId.Value, CurrentTenant.Id, cancellationToken)).Select(Guid.Parse).ToList();
-        }
-
         var tagFilteredEntityIds = tagId.HasValue
-                ? await _entityTagManager.GetEntityIdsFilteredByTagAsync(tagId.Value, CurrentTenant.Id, cancellationToken)
-                : null;
+            ? (await _entityTagManager.GetEntityIdsFilteredByTagAsync(tagId.Value, CurrentTenant.Id, cancellationToken)).Where(x => Guid.TryParse(x, out _)).Select(Guid.Parse).ToList()
+            : [];
 
         var favoriteUserFilteredEntityIds = favoriteUserId.HasValue
-            ? await _markedItemManager.GetEntityIdsFilteredByUserAsync(favoriteUserId.Value, BlogPostConsts.EntityType)
-            : null;
+            ? (await _markedItemManager.GetEntityIdsFilteredByUserAsync(favoriteUserId.Value, BlogPostConsts.EntityType, CurrentTenant.Id, cancellationToken)).Where(x => Guid.TryParse(x, out _)).Select(Guid.Parse).ToList()
+            : [];
 
         var queryable = (await GetDbSetAsync())
-            .WhereIf(entityIdFilters != null, x => entityIdFilters.Contains(x.Id))
-            .WhereIf(tagFilteredEntityIds != null, x => tagFilteredEntityIds.Contains(x.Id.ToString()))
-            .WhereIf(favoriteUserFilteredEntityIds != null, x => favoriteUserFilteredEntityIds.Contains(x.Id.ToString()))
+            .WhereIf(tagFilteredEntityIds.Count > 0, x => tagFilteredEntityIds.Contains(x.Id))
+            .WhereIf(favoriteUserFilteredEntityIds.Count > 0, x => favoriteUserFilteredEntityIds.Contains(x.Id))
             .WhereIf(blogId.HasValue, x => x.BlogId == blogId)
             .WhereIf(authorId.HasValue, x => x.AuthorId == authorId)
             .WhereIf(statusFilter.HasValue, x => x.Status == statusFilter)
             .WhereIf(!string.IsNullOrEmpty(filter), x => x.Title.Contains(filter) || x.Slug.Contains(filter));
 
-        var count = await queryable.CountAsync(GetCancellationToken(cancellationToken));
-        return count;
+        return await queryable.CountAsync(GetCancellationToken(cancellationToken));
     }
 
     public virtual async Task<List<BlogPost>> GetListAsync(
@@ -99,27 +91,19 @@ public class EfCoreBlogPostRepository : EfCoreRepository<ICmsKitDbContext, BlogP
 
     {
         var dbContext = await GetDbContextAsync();
-        var blogPostsDbSet = dbContext.Set<BlogPost>();
         var usersDbSet = dbContext.Set<CmsUser>();
 
-        List<Guid> entityIdFilters = null;
-        if (tagId.HasValue)
-        {
-            entityIdFilters = (await _entityTagManager.GetEntityIdsFilteredByTagAsync(tagId.Value, CurrentTenant.Id, cancellationToken)).Select(Guid.Parse).ToList();
-        }
-
         var tagFilteredEntityIds = tagId.HasValue
-                ? await _entityTagManager.GetEntityIdsFilteredByTagAsync(tagId.Value, CurrentTenant.Id, cancellationToken)
-                : null;
+            ? (await _entityTagManager.GetEntityIdsFilteredByTagAsync(tagId.Value, CurrentTenant.Id, cancellationToken)).Where(x => Guid.TryParse(x, out _)).Select(Guid.Parse).ToList()
+            : [];
 
         var favoriteUserFilteredEntityIds = favoriteUserId.HasValue
-            ? await _markedItemManager.GetEntityIdsFilteredByUserAsync(favoriteUserId.Value, BlogPostConsts.EntityType)
-            : null;
+            ? (await _markedItemManager.GetEntityIdsFilteredByUserAsync(favoriteUserId.Value, BlogPostConsts.EntityType, CurrentTenant.Id, cancellationToken)).Where(x => Guid.TryParse(x, out _)).Select(Guid.Parse).ToList()
+            : [];
 
         var queryable = (await GetDbSetAsync())
-            .WhereIf(entityIdFilters != null, x => entityIdFilters.Contains(x.Id))
-            .WhereIf(tagFilteredEntityIds != null, x => tagFilteredEntityIds.Contains(x.Id.ToString()))
-            .WhereIf(favoriteUserFilteredEntityIds != null, x => favoriteUserFilteredEntityIds.Contains(x.Id.ToString()))
+            .WhereIf(tagFilteredEntityIds.Count > 0, x => tagFilteredEntityIds.Contains(x.Id))
+            .WhereIf(favoriteUserFilteredEntityIds.Count > 0, x => favoriteUserFilteredEntityIds.Contains(x.Id))
             .WhereIf(blogId.HasValue, x => x.BlogId == blogId)
             .WhereIf(!string.IsNullOrWhiteSpace(filter), x => x.Title.Contains(filter) || x.Slug.Contains(filter))
             .WhereIf(authorId.HasValue, x => x.AuthorId == authorId)

--- a/modules/cms-kit/src/Volo.CmsKit.EntityFrameworkCore/Volo/CmsKit/Blogs/EfCoreBlogPostRepository.cs
+++ b/modules/cms-kit/src/Volo.CmsKit.EntityFrameworkCore/Volo/CmsKit/Blogs/EfCoreBlogPostRepository.cs
@@ -58,13 +58,10 @@ public class EfCoreBlogPostRepository : EfCoreRepository<ICmsKitDbContext, BlogP
         BlogPostStatus? statusFilter = null,
         CancellationToken cancellationToken = default)
     {
-        var tagFilteredEntityIds = tagId.HasValue
-            ? (await _entityTagManager.GetEntityIdsFilteredByTagAsync(tagId.Value, CurrentTenant.Id, cancellationToken)).Where(x => Guid.TryParse(x, out _)).Select(Guid.Parse).ToList()
-            : [];
-
-        var favoriteUserFilteredEntityIds = favoriteUserId.HasValue
-            ? (await _markedItemManager.GetEntityIdsFilteredByUserAsync(favoriteUserId.Value, BlogPostConsts.EntityType, CurrentTenant.Id, cancellationToken)).Where(x => Guid.TryParse(x, out _)).Select(Guid.Parse).ToList()
-            : [];
+        cancellationToken = GetCancellationToken(cancellationToken);
+        
+        var tagFilteredEntityIds = await GetEntityIdsByTagId(tagId, cancellationToken);
+        var favoriteUserFilteredEntityIds = await GetFavoriteEntityIdsByUserId(favoriteUserId, cancellationToken);
 
         var queryable = (await GetDbSetAsync())
             .WhereIf(tagFilteredEntityIds.Count > 0, x => tagFilteredEntityIds.Contains(x.Id))
@@ -93,13 +90,10 @@ public class EfCoreBlogPostRepository : EfCoreRepository<ICmsKitDbContext, BlogP
         var dbContext = await GetDbContextAsync();
         var usersDbSet = dbContext.Set<CmsUser>();
 
-        var tagFilteredEntityIds = tagId.HasValue
-            ? (await _entityTagManager.GetEntityIdsFilteredByTagAsync(tagId.Value, CurrentTenant.Id, cancellationToken)).Where(x => Guid.TryParse(x, out _)).Select(Guid.Parse).ToList()
-            : [];
-
-        var favoriteUserFilteredEntityIds = favoriteUserId.HasValue
-            ? (await _markedItemManager.GetEntityIdsFilteredByUserAsync(favoriteUserId.Value, BlogPostConsts.EntityType, CurrentTenant.Id, cancellationToken)).Where(x => Guid.TryParse(x, out _)).Select(Guid.Parse).ToList()
-            : [];
+        cancellationToken = GetCancellationToken(cancellationToken);
+        
+        var tagFilteredEntityIds = await GetEntityIdsByTagId(tagId, cancellationToken);
+        var favoriteUserFilteredEntityIds = await GetFavoriteEntityIdsByUserId(favoriteUserId, cancellationToken);
 
         var queryable = (await GetDbSetAsync())
             .WhereIf(tagFilteredEntityIds.Count > 0, x => tagFilteredEntityIds.Contains(x.Id))
@@ -187,5 +181,65 @@ public class EfCoreBlogPostRepository : EfCoreRepository<ICmsKitDbContext, BlogP
     public virtual async Task DeleteByBlogIdAsync(Guid blogId, CancellationToken cancellationToken = default)
     {
         await DeleteAsync(x => x.BlogId == blogId, cancellationToken: cancellationToken);
+    }
+    
+    private async Task<List<Guid>> GetFavoriteEntityIdsByUserId(Guid? userId, CancellationToken cancellationToken = default)
+    {
+        var entityIdFilters = new List<Guid>();
+        if (!userId.HasValue)
+        {
+            return entityIdFilters;
+        }
+
+        var entityIds = await _markedItemManager.GetEntityIdsFilteredByUserAsync(
+            userId.Value, 
+            BlogPostConsts.EntityType, 
+            CurrentTenant.Id, 
+            cancellationToken
+        );
+
+        if (entityIds.Count == 0)
+        {
+            entityIdFilters.Add(Guid.Empty);
+            return entityIdFilters;
+        }
+        
+        foreach (var entityId in entityIds)
+        {
+            if (Guid.TryParse(entityId, out var parsedEntityId))
+            {
+                entityIdFilters.Add(parsedEntityId);
+            }
+        }
+
+        return entityIdFilters;
+    }
+
+    private async Task<List<Guid>> GetEntityIdsByTagId(Guid? tagId, CancellationToken cancellationToken = default)
+    {
+        var entityIdFilters = new List<Guid>();
+        if (!tagId.HasValue)
+        {
+            return entityIdFilters;
+        }
+
+        var entityIds =
+            await _entityTagManager.GetEntityIdsFilteredByTagAsync(tagId.Value, CurrentTenant.Id, cancellationToken);
+
+        if (entityIds.Count == 0)
+        {
+            entityIdFilters.Add(Guid.Empty);
+            return entityIdFilters;
+        }
+        
+        foreach (var entityId in entityIds)
+        {
+            if (Guid.TryParse(entityId, out var parsedEntityId))
+            {
+                entityIdFilters.Add(parsedEntityId);
+            }
+        }
+
+        return entityIdFilters;
     }
 }

--- a/modules/cms-kit/src/Volo.CmsKit.MongoDB/Volo/CmsKit/MongoDB/Blogs/MongoBlogPostRepository.cs
+++ b/modules/cms-kit/src/Volo.CmsKit.MongoDB/Volo/CmsKit/MongoDB/Blogs/MongoBlogPostRepository.cs
@@ -86,8 +86,9 @@ public class MongoBlogPostRepository : MongoDbRepository<CmsKitMongoDbContext, B
         CancellationToken cancellationToken = default)
     {
         cancellationToken = GetCancellationToken(cancellationToken);
+        
         var dbContext = await GetDbContextAsync(cancellationToken);
-        var blogPostQueryable = await GetQueryableAsync();
+        var blogPostQueryable = await GetQueryableAsync(cancellationToken);
 
         var tagFilteredEntityIds = await GetEntityIdsByTagId(tagId, cancellationToken);
 
@@ -134,6 +135,12 @@ public class MongoBlogPostRepository : MongoDbRepository<CmsKitMongoDbContext, B
         var entityIds =
             await _entityTagManager.GetEntityIdsFilteredByTagAsync(tagId.Value, CurrentTenant.Id, cancellationToken);
 
+        if (entityIds.Count == 0)
+        {
+            entityIdFilters.Add(Guid.Empty);
+            return entityIdFilters;
+        }
+        
         foreach (var entityId in entityIds)
         {
             if (Guid.TryParse(entityId, out var parsedEntityId))
@@ -153,9 +160,19 @@ public class MongoBlogPostRepository : MongoDbRepository<CmsKitMongoDbContext, B
             return entityIdFilters;
         }
 
-        var entityIds =
-            await _markedItemManager.GetEntityIdsFilteredByUserAsync(userId.Value, BlogPostConsts.EntityType, CurrentTenant.Id, cancellationToken);
+        var entityIds = await _markedItemManager.GetEntityIdsFilteredByUserAsync(
+            userId.Value, 
+            BlogPostConsts.EntityType, 
+            CurrentTenant.Id, 
+            cancellationToken
+        );
 
+        if (entityIds.Count == 0)
+        {
+            entityIdFilters.Add(Guid.Empty);
+            return entityIdFilters;
+        }
+        
         foreach (var entityId in entityIds)
         {
             if (Guid.TryParse(entityId, out var parsedEntityId))

--- a/modules/cms-kit/src/Volo.CmsKit.Public.Application/Volo/CmsKit/Public/Blogs/BlogPostPublicAppService.cs
+++ b/modules/cms-kit/src/Volo.CmsKit.Public.Application/Volo/CmsKit/Public/Blogs/BlogPostPublicAppService.cs
@@ -62,8 +62,13 @@ public class BlogPostPublicAppService : CmsKitPublicAppServiceBase, IBlogPostPub
             input.SkipCount, input.Sorting);
 
         return new PagedResultDto<BlogPostCommonDto>(
-            await BlogPostRepository.GetCountAsync(blogId: blog.Id, tagId: input.TagId,
-                statusFilter: BlogPostStatus.Published, authorId: input.AuthorId),
+            await BlogPostRepository.GetCountAsync(
+                blogId: blog.Id, 
+                tagId: input.TagId, 
+                favoriteUserId: favoriteUserId,
+                statusFilter: BlogPostStatus.Published, 
+                authorId: input.AuthorId
+            ),
             ObjectMapper.Map<List<BlogPost>, List<BlogPostCommonDto>>(blogPosts));
     }
 

--- a/modules/cms-kit/src/Volo.CmsKit.Public.Web/Pages/Public/CmsKit/Blogs/Index.cshtml
+++ b/modules/cms-kit/src/Volo.CmsKit.Public.Web/Pages/Public/CmsKit/Blogs/Index.cshtml
@@ -14,7 +14,8 @@
 
 @{
     const string dummyImageSource = "/cms-kit/dummy-placeholder-320x180.png";
-    var isMarkedItemFeatureEnabled = GlobalFeatureManager.Instance.IsEnabled<MarkedItemsFeature>() && Model.MarkedItemsFeature?.IsEnabled == true;
+    var isMarkedItemFeatureEnabled = GlobalFeatureManager.Instance.IsEnabled<MarkedItemsFeature>() && 
+                                     (Model.MarkedItemsFeature?.IsEnabled == true || Model.FilterOnFavorites.HasValue);
 }
 
 @section styles {
@@ -68,20 +69,20 @@
     <hr />
 }
 
+@if (isMarkedItemFeatureEnabled)
+{
+    var filterOnFavorites = Model.FilterOnFavorites.GetValueOrDefault();
+    string icon = filterOnFavorites ? "heart" : "heart-o";
+    <abp-button class="favorite-button badge text-bg-light my-2 border-light-subtle"
+                button-type="Light"
+                icon="@icon text-danger"
+                text="@L["FilterOnFavorites"]"
+                filter-on-favorites="@filterOnFavorites">
+    </abp-button>
+}
+
 @if (Model.Blogs.TotalCount > 0)
 {
-    @if (isMarkedItemFeatureEnabled)
-    {
-        var filterOnFavorties = Model.FilterOnFavorites.GetValueOrDefault();
-        string icon = filterOnFavorties ? "heart" : "heart-o";
-        <abp-button class="favorite-button badge text-bg-light my-2 border-light-subtle"
-            button-type="Light" 
-            icon="@icon text-danger"
-            text="@L["FilterOnFavorites"]" 
-            filter-on-favorites="@filterOnFavorties">
-        </abp-button>
-
-    }
     <abp-row id="blogs-container">
         @foreach (var blog in Model.Blogs.Items)
         {


### PR DESCRIPTION
This pull request refactors and improves the filtering logic in the `EfCoreBlogPostRepository` for both the `GetCountAsync` and `GetListAsync` methods. The main focus is on making the filtering for tag and favorite user IDs more robust and efficient, as well as simplifying the code by removing unnecessary variables and checks.

**Filtering and Query Improvements:**

* Updated the filtering logic for `tagId` and `favoriteUserId` to ensure only valid GUIDs are used, preventing potential runtime errors from invalid IDs. Now, the code filters and parses IDs in one step using `Where(x => Guid.TryParse(x, out _)).Select(Guid.Parse).ToList()`. [[1]](diffhunk://#diff-119ca8fadaa02ac206c6f6aa8aa7b40fa42ec4d3d9c8731b25a7efda5bea60e2L61-R77) [[2]](diffhunk://#diff-119ca8fadaa02ac206c6f6aa8aa7b40fa42ec4d3d9c8731b25a7efda5bea60e2L102-R106)
* Changed the default values for filtered entity ID lists to empty lists (`[]`) instead of `null`, and updated the query conditions to check for `.Count > 0` instead of null checks. This simplifies the logic and avoids null reference issues. [[1]](diffhunk://#diff-119ca8fadaa02ac206c6f6aa8aa7b40fa42ec4d3d9c8731b25a7efda5bea60e2L61-R77) [[2]](diffhunk://#diff-119ca8fadaa02ac206c6f6aa8aa7b40fa42ec4d3d9c8731b25a7efda5bea60e2L102-R106)

**Code Simplification:**

* Removed unused variables and redundant code, such as the `entityIdFilters` variable and unnecessary calls to `ToString()` on GUIDs in query filters. [[1]](diffhunk://#diff-119ca8fadaa02ac206c6f6aa8aa7b40fa42ec4d3d9c8731b25a7efda5bea60e2L61-R77) [[2]](diffhunk://#diff-119ca8fadaa02ac206c6f6aa8aa7b40fa42ec4d3d9c8731b25a7efda5bea60e2L102-R106)
* Streamlined the return statement in `GetCountAsync` by returning the result of `CountAsync` directly.
