### PR TITLE
Optimize `permission/setting` lookup in `PermissionStore` and `SettingManagementStore`

### DIFF
--- a/modules/permission-management/src/Volo.Abp.PermissionManagement.Domain/Volo/Abp/PermissionManagement/PermissionStore.cs
+++ b/modules/permission-management/src/Volo.Abp.PermissionManagement.Domain/Volo/Abp/PermissionManagement/PermissionStore.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -175,8 +176,10 @@ public class PermissionStore : IPermissionStore, ITransientDependency
     {
         using (PermissionGrantRepository.DisableTracking())
         {
+            var permissionNames = new HashSet<string>(notCacheKeys.Select(GetPermissionNameFormCacheKeyOrNull));
             var permissions = (await PermissionDefinitionManager.GetPermissionsAsync())
-                .Where(x => notCacheKeys.Any(k => GetPermissionNameFormCacheKeyOrNull(k) == x.Name)).ToList();
+                .Where(x => permissionNames.Contains(x.Name))
+                .ToList();
 
             Logger.LogDebug($"Getting not cache granted permissions from the repository for this provider name,key: {providerName},{providerKey}");
 

--- a/modules/permission-management/src/Volo.Abp.PermissionManagement.Domain/Volo/Abp/PermissionManagement/PermissionStore.cs
+++ b/modules/permission-management/src/Volo.Abp.PermissionManagement.Domain/Volo/Abp/PermissionManagement/PermissionStore.cs
@@ -184,7 +184,7 @@ public class PermissionStore : IPermissionStore, ITransientDependency
             Logger.LogDebug($"Getting not cache granted permissions from the repository for this provider name,key: {providerName},{providerKey}");
 
             var grantedPermissionsHashSet = new HashSet<string>(
-                (await PermissionGrantRepository.GetListAsync(notCacheKeys.Select(GetPermissionNameFormCacheKeyOrNull).ToArray(), providerName, providerKey)).Select(p => p.Name)
+                (await PermissionGrantRepository.GetListAsync(permissionNames.ToArray(), providerName, providerKey)).Select(p => p.Name)
             );
 
             Logger.LogDebug($"Setting the cache items. Count: {permissions.Count}");

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain/Volo/Abp/SettingManagement/SettingManagementStore.cs
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain/Volo/Abp/SettingManagement/SettingManagementStore.cs
@@ -176,9 +176,10 @@ public class SettingManagementStore : ISettingManagementStore, ITransientDepende
         string providerKey,
         List<string> notCacheKeys)
     {
-        var settingDefinitions = (await SettingDefinitionManager.GetAllAsync()).Where(x => notCacheKeys.Any(k => GetSettingNameFormCacheKeyOrNull(k) == x.Name));
+        var settingNames = new HashSet<string>(notCacheKeys.Select(GetSettingNameFormCacheKeyOrNull));
+        var settingDefinitions = (await SettingDefinitionManager.GetAllAsync()).Where(x => settingNames.Contains(x.Name));
 
-        var settingsDictionary = (await SettingRepository.GetListAsync(notCacheKeys.Select(GetSettingNameFormCacheKeyOrNull).ToArray(), providerName, providerKey))
+        var settingsDictionary = (await SettingRepository.GetListAsync(settingNames.ToArray(), providerName, providerKey))
             .ToDictionary(s => s.Name, s => s.Value);
 
         var cacheItems = new List<KeyValuePair<string, SettingCacheItem>>();


### PR DESCRIPTION
Replaces repeated LINQ queries with a HashSet for permission name lookups, improving performance when filtering permissions by cache keys.

https://abp.io/support/questions/9823/abp-permissons-slow