### PR TITLE
Update datatable footer border styles - issue-20624

### DIFF
--- a/npm/ng-packs/packages/theme-basic/src/lib/constants/styles.ts
+++ b/npm/ng-packs/packages/theme-basic/src/lib/constants/styles.ts
@@ -151,4 +151,15 @@ background-color: rgba(0, 0, 0, 0.6);
 .abp-md-form {
     max-width: 540px;
   }
+
+.ngx-datatable.material:has(.datatable-body-row) .datatable-footer {
+  border-top: none;
+}
+
+.ngx-datatable.material:not(:has(.datatable-body-row)) .datatable-footer {
+  border-top: 1px solid #dee2e6;
+}
+
 `;
+
+


### PR DESCRIPTION
Added CSS rules to conditionally set the border-top of .datatable-footer in ngx-datatable based on the presence of .datatable-body-row. This improves visual consistency when the datatable has no rows.

[Tenants _ MyProjectName.webm](https://github.com/user-attachments/assets/0a2d40d3-9f87-4fc1-bd11-01adf8714a9d)

### Description

Resolves https://github.com/volosoft/volo/issues/20624 (write the related issue number if available)

TODO: Describe what this PR has changed, add screenshot or animated GIF if available, write if it is a breaking change, and how to fix the breaking changes for existing applications if so.

### Checklist

- [ ] I fully tested it as developer / designer and created unit / integration tests
- [ ] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

run `yarn start` on `abp\npm\ng-packs`