### PR TITLE
Refine tenant property type renaming logic

### DIFF
--- a/npm/ng-packs/packages/schematics/src/utils/model.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/model.ts
@@ -229,7 +229,7 @@ function renamePropForTenant(interfaces: Interface[]) {
       const isTenant = prop.name.toLocaleLowerCase().includes(TENANT_KEY);
       const isSaasDto = prop.refs.filter(f => f.startsWith(SAAS_NAMESPACE)).length > 0;
 
-      if (isTenant && isSaasDto) {
+      if (isTenant && isSaasDto && !prop.type.startsWith('Saas')) {
         prop.type = 'Saas' + prop.type;
       }
     }


### PR DESCRIPTION
Adds a check to prevent prepending 'Saas' to property types that already start with 'Saas' when renaming tenant-related properties in interfaces.

### Description

Resolves #23610 (write the related issue number if available)

### How to test it?

