### PR TITLE
Improve exception message for missing type mapper

### DIFF
--- a/framework/src/Volo.Abp.Mapperly/Volo/Abp/Mapperly/MapperlyAutoObjectMappingProvider.cs
+++ b/framework/src/Volo.Abp.Mapperly/Volo/Abp/Mapperly/MapperlyAutoObjectMappingProvider.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Volo.Abp.Data;
 using Volo.Abp.ObjectExtending;
 using Volo.Abp.ObjectMapping;
-using Volo.Abp.Reflection;
 
 namespace Volo.Abp.Mapperly;
 
@@ -62,8 +61,7 @@ public class MapperlyAutoObjectMappingProvider : IAutoObjectMappingProvider
             return destination;
         }
 
-        throw new AbpException($"No {TypeHelper.GetFullNameHandlingNullableAndGenerics(typeof(IAbpMapperlyMapper<TSource, TDestination>))} or" +
-                               $" {TypeHelper.GetFullNameHandlingNullableAndGenerics(typeof(IAbpReverseMapperlyMapper<TSource, TDestination>))} was found");
+        throw GetNoMapperFoundException<TSource, TDestination>();
     }
 
     public virtual TDestination Map<TSource, TDestination>(TSource source, TDestination destination)
@@ -95,8 +93,34 @@ public class MapperlyAutoObjectMappingProvider : IAutoObjectMappingProvider
             return destination;
         }
 
-        throw new AbpException($"No {TypeHelper.GetFullNameHandlingNullableAndGenerics(typeof(IAbpMapperlyMapper<TSource, TDestination>))} or" +
-                               $" {TypeHelper.GetFullNameHandlingNullableAndGenerics(typeof(IAbpReverseMapperlyMapper<TSource, TDestination>))} was found");
+        throw GetNoMapperFoundException<TSource, TDestination>();
+    }
+
+    protected virtual AbpException GetNoMapperFoundException<TSource, TDestination>()
+    {
+        var newLine = Environment.NewLine;
+        var message = "No type mapper class was found for the given source and destination types." +
+                      newLine +
+                      newLine +
+                      "Mapping types:" +
+                      newLine +
+                      $"{typeof(TSource).Name} -> {typeof(TDestination).Name}" +
+                      newLine +
+                      $"{typeof(TSource).FullName} -> {typeof(TDestination).FullName}" +
+                      newLine +
+                      newLine +
+                      "Define a mapping class to resolve this issue:" +
+                      newLine +
+                      "   - Use MapperBase<TSource, TDestination> for one-way mapping." +
+                      newLine +
+                      "   - Use TwoWayMapperBase<TDestination, TSource> for two-way mapping." +
+                      newLine +
+                      newLine +
+                      "See the Mapperly documentation for details:" +
+                      newLine +
+                      "https://abp.io/docs/latest/framework/infrastructure/object-to-object-mapping#mapperly-integration";
+
+        return new AbpException(message);
     }
 
     protected virtual bool TryToMapCollection<TSource, TDestination>(TSource source, TDestination? destination, out TDestination collectionResult)

--- a/framework/src/Volo.Abp.Mapperly/Volo/Abp/Mapperly/MapperlyAutoObjectMappingProvider.cs
+++ b/framework/src/Volo.Abp.Mapperly/Volo/Abp/Mapperly/MapperlyAutoObjectMappingProvider.cs
@@ -99,26 +99,26 @@ public class MapperlyAutoObjectMappingProvider : IAutoObjectMappingProvider
     protected virtual AbpException GetNoMapperFoundException<TSource, TDestination>()
     {
         var newLine = Environment.NewLine;
-        var message = "No type mapper class was found for the given source and destination types." +
+        var message = "No object mapping was found for the specified source and destination types." +
                       newLine +
                       newLine +
-                      "Mapping types:" +
+                      "Mapping attempted:" +
                       newLine +
                       $"{typeof(TSource).Name} -> {typeof(TDestination).Name}" +
                       newLine +
                       $"{typeof(TSource).FullName} -> {typeof(TDestination).FullName}" +
                       newLine +
                       newLine +
-                      "Define a mapping class to resolve this issue:" +
+                      "How to fix:" +
+                      newLine +
+                      "Define a mapping class for these types:" +
                       newLine +
                       "   - Use MapperBase<TSource, TDestination> for one-way mapping." +
                       newLine +
                       "   - Use TwoWayMapperBase<TDestination, TSource> for two-way mapping." +
                       newLine +
                       newLine +
-                      "See the Mapperly documentation for details:" +
-                      newLine +
-                      "https://abp.io/docs/latest/framework/infrastructure/object-to-object-mapping#mapperly-integration";
+                      "For details, see the Mapperly integration document https://abp.io/docs/latest/framework/infrastructure/object-to-object-mapping#mapperly-integration";
 
         return new AbpException(message);
     }

--- a/framework/test/Volo.Abp.Mapperly.Tests/Volo/Abp/Mapperly/AbpMapperlyModule_Basic_Tests.cs
+++ b/framework/test/Volo.Abp.Mapperly.Tests/Volo/Abp/Mapperly/AbpMapperlyModule_Basic_Tests.cs
@@ -106,9 +106,13 @@ public class AbpMapperlyModule_Basic_Tests : AbpIntegratedTest<MapperlyTestModul
     public void Should_Throw_Exception_If_Mapper_Is_Not_Found()
     {
         var exception = Assert.Throws<AbpException>(() =>_objectMapper.Map<MyEntity, MyClassDto>(new MyEntity()));
-        exception.Message.ShouldBe("No " +
-                                   "Volo.Abp.Mapperly.IAbpMapperlyMapper<Volo.Abp.Mapperly.SampleClasses.MyEntity,Volo.Abp.Mapperly.MyClassDto> or " +
-                                   "Volo.Abp.Mapperly.IAbpReverseMapperlyMapper<Volo.Abp.Mapperly.SampleClasses.MyEntity,Volo.Abp.Mapperly.MyClassDto>" +
-                                   " was found");
+        exception.Message.ShouldBe("No type mapper class was found for the given source and destination types.\n\n" +
+                                   "Mapping types:\n" +
+                                   "MyEntity -> MyClassDto\n" +
+                                   "Volo.Abp.Mapperly.SampleClasses.MyEntity -> Volo.Abp.Mapperly.MyClassDto\n\n" +
+                                   "Define a mapping class to resolve this issue:\n" +
+                                   "   - Use MapperBase<TSource, TDestination> for one-way mapping.\n" +
+                                   "   - Use TwoWayMapperBase<TDestination, TSource> for two-way mapping.\n\n" +
+                                   "See the Mapperly documentation for details:\nhttps://abp.io/docs/latest/framework/infrastructure/object-to-object-mapping#mapperly-integration");
     }
 }

--- a/framework/test/Volo.Abp.Mapperly.Tests/Volo/Abp/Mapperly/AbpMapperlyModule_Basic_Tests.cs
+++ b/framework/test/Volo.Abp.Mapperly.Tests/Volo/Abp/Mapperly/AbpMapperlyModule_Basic_Tests.cs
@@ -106,13 +106,14 @@ public class AbpMapperlyModule_Basic_Tests : AbpIntegratedTest<MapperlyTestModul
     public void Should_Throw_Exception_If_Mapper_Is_Not_Found()
     {
         var exception = Assert.Throws<AbpException>(() =>_objectMapper.Map<MyEntity, MyClassDto>(new MyEntity()));
-        exception.Message.ShouldBe("No type mapper class was found for the given source and destination types.\n\n" +
-                                   "Mapping types:\n" +
+        exception.Message.ShouldBe("No object mapping was found for the specified source and destination types.\n\n" +
+                                   "Mapping attempted:\n" +
                                    "MyEntity -> MyClassDto\n" +
                                    "Volo.Abp.Mapperly.SampleClasses.MyEntity -> Volo.Abp.Mapperly.MyClassDto\n\n" +
-                                   "Define a mapping class to resolve this issue:\n" +
+                                   "How to fix:\n" +
+                                   "Define a mapping class for these types:" + "\n" +
                                    "   - Use MapperBase<TSource, TDestination> for one-way mapping.\n" +
                                    "   - Use TwoWayMapperBase<TDestination, TSource> for two-way mapping.\n\n" +
-                                   "See the Mapperly documentation for details:\nhttps://abp.io/docs/latest/framework/infrastructure/object-to-object-mapping#mapperly-integration");
+                                   "For details, see the Mapperly integration document https://abp.io/docs/latest/framework/infrastructure/object-to-object-mapping#mapperly-integration");
     }
 }


### PR DESCRIPTION
```
Volo.Abp.AbpException: No type mapper class was found for the given source and destination types.

Volo.Abp.AbpException
No type mapper class was found for the given source and destination types.

Mapping types:
MyEntity -> MyEntityDto
Volo.Abp.Mapperly.SampleClasses.MyEntity -> Volo.Abp.Mapperly.SampleClasses.MyEntityDto

Define a mapping class to resolve this issue:
   - Use MapperBase<TSource, TDestination> for one-way mapping.
   - Use TwoWayMapperBase<TDestination, TSource> for two-way mapping.

See the Mapperly documentation for details:
https://abp.io/docs/latest/framework/infrastructure/object-to-object-mapping#mapperly-integration
```