### PR TITLE
Add provider name support to repository infrastructure

### DIFF
--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/BasicRepositoryBase.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/BasicRepositoryBase.cs
@@ -44,16 +44,18 @@ public abstract class BasicRepositoryBase<TEntity> :
 
     public bool? IsChangeTrackingEnabled { get; protected set; }
     
-    protected string? EntityName { get; private set; }
+    public string? EntityName { get; set; }
     
     public void SetEntityName(string? name)
     {
         EntityName = name;
     }
 
-    protected BasicRepositoryBase()
-    {
+    public string ProviderName { get; }
 
+    protected BasicRepositoryBase(string providerName)
+    {
+        ProviderName = Check.NotNullOrWhiteSpace(providerName, nameof(providerName));
     }
 
     public abstract Task<TEntity> InsertAsync(TEntity entity, bool autoSave = false, CancellationToken cancellationToken = default);
@@ -146,6 +148,12 @@ public abstract class BasicRepositoryBase<TEntity> :
 public abstract class BasicRepositoryBase<TEntity, TKey> : BasicRepositoryBase<TEntity>, IBasicRepository<TEntity, TKey>
     where TEntity : class, IEntity<TKey>
 {
+    protected BasicRepositoryBase(string providerName) 
+        : base(providerName)
+    {
+        
+    }
+
     public virtual async Task<TEntity> GetAsync(TKey id, bool includeDetails = true, CancellationToken cancellationToken = default)
     {
         var entity = await FindAsync(id, includeDetails, cancellationToken);

--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/IRepository.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/IRepository.cs
@@ -8,13 +8,15 @@ using Volo.Abp.Domain.Entities;
 namespace Volo.Abp.Domain.Repositories;
 
 /// <summary>
-/// Just to mark a class as repository.
+/// The base interface to implement a repository for an entity.
 /// </summary>
 public interface IRepository
 {
     bool? IsChangeTrackingEnabled { get; }
 
-    void SetEntityName(string? name);
+    string? EntityName { get; set; }
+    
+    string ProviderName { get; }
 }
 
 public interface IRepository<TEntity> : IReadOnlyRepository<TEntity>, IBasicRepository<TEntity>

--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/RepositoryBase.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/RepositoryBase.cs
@@ -14,6 +14,11 @@ namespace Volo.Abp.Domain.Repositories;
 public abstract class RepositoryBase<TEntity> : BasicRepositoryBase<TEntity>, IRepository<TEntity>, IUnitOfWorkManagerAccessor
     where TEntity : class, IEntity
 {
+    protected RepositoryBase(string providerName)
+        : base(providerName)
+    {
+    }
+
     [Obsolete("Use WithDetailsAsync method.")]
     public virtual IQueryable<TEntity> WithDetails()
     {
@@ -92,6 +97,11 @@ public abstract class RepositoryBase<TEntity> : BasicRepositoryBase<TEntity>, IR
 public abstract class RepositoryBase<TEntity, TKey> : RepositoryBase<TEntity>, IRepository<TEntity, TKey>
     where TEntity : class, IEntity<TKey>
 {
+    protected RepositoryBase(string providerName)
+        : base(providerName)
+    {
+    }
+    
     public abstract Task<TEntity> GetAsync(TKey id, bool includeDetails = true, CancellationToken cancellationToken = default);
 
     public abstract Task<TEntity?> FindAsync(TKey id, bool includeDetails = true, CancellationToken cancellationToken = default);

--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/RepositoryExtensions.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/RepositoryExtensions.cs
@@ -251,12 +251,12 @@ public static class RepositoryExtensions
         await repository.DeleteAsync(entity, autoSave, cancellationToken);
     }
     
-    public static TRepository WithEntityName<TRepository>(
+    public static TRepository SetEntityName<TRepository>(
         this TRepository repository,
         string name
         ) where TRepository : class, IRepository
     {
-        repository.SetEntityName(name);
+        repository.EntityName = name;
         return repository;
     }
 }

--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/Domain/Repositories/EntityFrameworkCore/EfCoreRepository.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/Domain/Repositories/EntityFrameworkCore/EfCoreRepository.cs
@@ -93,6 +93,7 @@ public class EfCoreRepository<TDbContext, TEntity> : RepositoryBase<TEntity>, IE
     public IEfCoreBulkOperationProvider? BulkOperationProvider => LazyServiceProvider.LazyGetService<IEfCoreBulkOperationProvider>();
 
     public EfCoreRepository(IDbContextProvider<TDbContext> dbContextProvider)
+        : base(AbpEfCoreConsts.ProviderName)
     {
         _dbContextProvider = dbContextProvider;
 

--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/AbpEfCoreConsts.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/AbpEfCoreConsts.cs
@@ -1,0 +1,6 @@
+﻿namespace Volo.Abp.EntityFrameworkCore;
+
+public class AbpEfCoreConsts
+{
+    public const string ProviderName = "Volo.Abp.EntityFrameworkCore";
+}

--- a/framework/src/Volo.Abp.MemoryDb/Volo/Abp/Domain/Repositories/MemoryDb/MemoryDbRepository.cs
+++ b/framework/src/Volo.Abp.MemoryDb/Volo/Abp/Domain/Repositories/MemoryDb/MemoryDbRepository.cs
@@ -50,6 +50,7 @@ public class MemoryDbRepository<TMemoryDbContext, TEntity> : RepositoryBase<TEnt
     public IAuditPropertySetter AuditPropertySetter => LazyServiceProvider.LazyGetRequiredService<IAuditPropertySetter>();
 
     public MemoryDbRepository(IMemoryDatabaseProvider<TMemoryDbContext> databaseProvider)
+        : base(AbpMemoryDbConsts.ProviderName)
     {
         DatabaseProvider = databaseProvider;
     }

--- a/framework/src/Volo.Abp.MemoryDb/Volo/Abp/MemoryDb/AbpMemoryDbConsts.cs
+++ b/framework/src/Volo.Abp.MemoryDb/Volo/Abp/MemoryDb/AbpMemoryDbConsts.cs
@@ -1,0 +1,6 @@
+﻿namespace Volo.Abp.MemoryDb;
+
+public class AbpMemoryDbConsts
+{
+    public const string ProviderName = "Volo.Abp.MemoryDb";
+}

--- a/framework/src/Volo.Abp.MongoDB/Volo/Abp/Domain/Repositories/MongoDB/MongoDbRepository.cs
+++ b/framework/src/Volo.Abp.MongoDB/Volo/Abp/Domain/Repositories/MongoDB/MongoDbRepository.cs
@@ -101,6 +101,7 @@ public class MongoDbRepository<TMongoDbContext, TEntity>
     public IMongoDbRepositoryFilterer<TEntity> RepositoryFilterer => LazyServiceProvider.LazyGetService<IMongoDbRepositoryFilterer<TEntity>>()!;
 
     public MongoDbRepository(IMongoDbContextProvider<TMongoDbContext> dbContextProvider)
+        : base(AbpMongoDbConsts.ProviderName)
     {
         DbContextProvider = dbContextProvider;
     }

--- a/framework/src/Volo.Abp.MongoDB/Volo/Abp/MongoDB/AbpMongoDbConsts.cs
+++ b/framework/src/Volo.Abp.MongoDB/Volo/Abp/MongoDB/AbpMongoDbConsts.cs
@@ -1,0 +1,6 @@
+﻿namespace Volo.Abp.MongoDB;
+
+public class AbpMongoDbConsts
+{
+   public const string ProviderName = "Volo.Abp.MongoDB";
+}

--- a/framework/test/Volo.Abp.Ddd.Tests/Volo/Abp/Domain/Repositories/RepositoryRegistration_Tests.cs
+++ b/framework/test/Volo.Abp.Ddd.Tests/Volo/Abp/Domain/Repositories/RepositoryRegistration_Tests.cs
@@ -295,6 +295,10 @@ public class RepositoryRegistration_Tests
     public class MyTestDefaultRepository<TEntity> : RepositoryBase<TEntity>
         where TEntity : class, IEntity
     {
+        public MyTestDefaultRepository() 
+            : base("MyTestDefault")
+        {
+        }
 
         [Obsolete("Use GetQueryableAsync method.")]
         protected override IQueryable<TEntity> GetQueryable()
@@ -408,11 +412,8 @@ public class RepositoryRegistration_Tests
     public class MyTestAggregateRootWithDefaultPkEmptyRepository : IMyTestAggregateRootWithDefaultPkEmptyRepository
     {
         public bool? IsChangeTrackingEnabled { get; set; }
-
-        public void SetEntityName(string name)
-        {
-            
-        }
+        public string EntityName { get; set; }
+        public string ProviderName { get; } = "MyFakeProvider";
     }
 
     public class TestDbContextRegistrationOptions : AbpCommonDbContextRegistrationOptions


### PR DESCRIPTION
### Description

Introduces a ProviderName property to IRepository and related base classes, requiring repositories to specify their provider via constructor. Adds provider constants for EF Core, MemoryDb, and MongoDB, and updates repository implementations and tests accordingly. Also refactors EntityName to a public property and renames WithEntityName extension to SetEntityName.

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue) - https://github.com/abpframework/abp/issues/23637