### PR TITLE
Improve column width handling in ExtensibleTable

### DIFF
--- a/npm/ng-packs/packages/components/extensible/src/lib/components/extensible-table/extensible-table.component.html
+++ b/npm/ng-packs/packages/components/extensible/src/lib/components/extensible-table/extensible-table.component.html
@@ -40,8 +40,9 @@
   @if (actionsTemplate || (actionList.length && hasAtLeastOnePermittedAction)) {
     <ngx-datatable-column
       [name]="actionsText | abpLocalization"
-      [maxWidth]="columnWidths[0]"
-      [width]="columnWidths[0]"
+      [maxWidth]="columnWidths[0] ?? undefined"
+      [width]="columnWidths[0] ?? 200"
+      [canAutoResize]="!columnWidths[0]"
       [sortable]="false"
     >
       <ng-template let-row="row" let-i="rowIndex" ngx-datatable-cell-template>
@@ -59,7 +60,8 @@
   @for (prop of propList; track prop.name; let i = $index) {
     <ngx-datatable-column
       *abpVisible="prop.columnVisible(getInjected)"
-      [width]="columnWidths[i + 1] || 200"
+      [width]="columnWidths[i + 1] ?? 200"
+      [canAutoResize]="!columnWidths[i + 1]"
       [name]="(prop.isExtra ? '::' + prop.displayName : prop.displayName) | abpLocalization"
       [prop]="prop.name"
       [sortable]="prop.sortable"

--- a/npm/ng-packs/packages/components/extensible/src/lib/components/extensible-table/extensible-table.component.html
+++ b/npm/ng-packs/packages/components/extensible/src/lib/components/extensible-table/extensible-table.component.html
@@ -40,9 +40,8 @@
   @if (actionsTemplate || (actionList.length && hasAtLeastOnePermittedAction)) {
     <ngx-datatable-column
       [name]="actionsText | abpLocalization"
-      [maxWidth]="columnWidths[0] ?? undefined"
-      [width]="columnWidths[0] ?? 200"
-      [canAutoResize]="!columnWidths[0]"
+      [maxWidth]="columnWidths[0]"
+      [width]="columnWidths[0]"
       [sortable]="false"
     >
       <ng-template let-row="row" let-i="rowIndex" ngx-datatable-cell-template>
@@ -60,8 +59,7 @@
   @for (prop of propList; track prop.name; let i = $index) {
     <ngx-datatable-column
       *abpVisible="prop.columnVisible(getInjected)"
-      [width]="columnWidths[i + 1] ?? 200"
-      [canAutoResize]="!columnWidths[i + 1]"
+      [width]="columnWidths[i + 1] || 200"
       [name]="(prop.isExtra ? '::' + prop.displayName : prop.displayName) | abpLocalization"
       [prop]="prop.name"
       [sortable]="prop.sortable"

--- a/npm/ng-packs/packages/components/extensible/src/lib/components/extensible-table/extensible-table.component.ts
+++ b/npm/ng-packs/packages/components/extensible/src/lib/components/extensible-table/extensible-table.component.ts
@@ -212,6 +212,11 @@ export class ExtensibleTableComponent<R = any> implements OnChanges, AfterViewIn
 
       return record;
     });
+
+    if ((this.columnWidths as any)?.some?.((w: number | undefined) => w == null)) {
+      this.setColumnWidths(this.columnWidths?.[0] as any);
+      this.cdr.markForCheck();
+    }
   }
 
   isVisibleActions(rowData: any): boolean {

--- a/npm/ng-packs/packages/components/extensible/src/lib/components/extensible-table/extensible-table.component.ts
+++ b/npm/ng-packs/packages/components/extensible/src/lib/components/extensible-table/extensible-table.component.ts
@@ -212,11 +212,6 @@ export class ExtensibleTableComponent<R = any> implements OnChanges, AfterViewIn
 
       return record;
     });
-
-    if ((this.columnWidths as any)?.some?.((w: number | undefined) => w == null)) {
-      this.setColumnWidths(this.columnWidths?.[0] as any);
-      this.cdr.markForCheck();
-    }
   }
 
   isVisibleActions(rowData: any): boolean {

--- a/npm/ng-packs/packages/components/extensible/src/lib/components/extensible-table/extensible-table.component.ts
+++ b/npm/ng-packs/packages/components/extensible/src/lib/components/extensible-table/extensible-table.component.ts
@@ -3,6 +3,7 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  computed,
   EventEmitter,
   inject,
   Injector,
@@ -10,9 +11,11 @@ import {
   LOCALE_ID,
   OnChanges,
   Output,
+  signal,
   SimpleChanges,
   TemplateRef,
   TrackByFunction,
+  ViewChild,
 } from '@angular/core';
 import { AsyncPipe, NgComponentOutlet, NgTemplateOutlet } from '@angular/common';
 
@@ -97,7 +100,7 @@ export class ExtensibleTableComponent<R = any> implements OnChanges, AfterViewIn
   @Input() recordsTotal!: number;
 
   @Input() set actionsColumnWidth(width: number) {
-    this.setColumnWidths(width ? Number(width) : undefined);
+    this._actionsColumnWidth.set(width ? Number(width) : undefined);
   }
 
   @Input() actionsTemplate?: TemplateRef<any>;
@@ -117,13 +120,23 @@ export class ExtensibleTableComponent<R = any> implements OnChanges, AfterViewIn
 
   hasAtLeastOnePermittedAction: boolean;
 
-  readonly columnWidths!: number[];
-
   readonly propList: EntityPropList<R>;
 
   readonly actionList: EntityActionList<R>;
 
   readonly trackByFn: TrackByFunction<EntityProp<R>> = (_, item) => item.name;
+
+  // Signal for actions column width
+  private readonly _actionsColumnWidth = signal<number | undefined>(DEFAULT_ACTIONS_COLUMN_WIDTH);
+
+  readonly columnWidths = computed(() => {
+    const actionsColumn = this._actionsColumnWidth();
+    const widths = [actionsColumn];
+    this.propList.forEach(({ value: prop }) => {
+      widths.push(prop.columnWidth);
+    });
+    return widths;
+  });
 
   constructor() {
     const extensions = this.#injector.get(ExtensionsService);
@@ -136,15 +149,6 @@ export class ExtensibleTableComponent<R = any> implements OnChanges, AfterViewIn
       this.permissionService.filterItemsByPolicy(
         this.actionList.toArray().map(action => ({ requiredPolicy: action.permission })),
       ).length > 0;
-    this.setColumnWidths(DEFAULT_ACTIONS_COLUMN_WIDTH);
-  }
-
-  private setColumnWidths(actionsColumn: number | undefined) {
-    const widths = [actionsColumn];
-    this.propList.forEach(({ value: prop }) => {
-      widths.push(prop.columnWidth);
-    });
-    (this.columnWidths as any) = widths;
   }
 
   private getIcon(value: boolean) {
@@ -213,10 +217,6 @@ export class ExtensibleTableComponent<R = any> implements OnChanges, AfterViewIn
       return record;
     });
 
-    if ((this.columnWidths as any)?.some?.((w: number | undefined) => w == null)) {
-      this.setColumnWidths(this.columnWidths?.[0] as any);
-      this.cdr.markForCheck();
-    }
   }
 
   isVisibleActions(rowData: any): boolean {


### PR DESCRIPTION
Updated the table to use default widths when columnWidths are undefined and added canAutoResize binding. Added logic in the component to reset column widths if any are missing, ensuring consistent table rendering.

### Description

Resolves  https://github.com/volosoft/vs-internal/issues/7259  (write the related issue number if available)

### How to test it?

run dev app in volo repo
