### PR TITLE
Refine type filtering in `ConventionalRegistrarBase`

### DIFF
--- a/framework/src/Volo.Abp.Core/Volo/Abp/DependencyInjection/ConventionalRegistrarBase.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/DependencyInjection/ConventionalRegistrarBase.cs
@@ -19,16 +19,15 @@ public abstract class ConventionalRegistrarBase : IConventionalRegistrar
         {
             types = AssemblyHelper
                 .GetAllTypes(assembly)
-                .Where(
-                    type => type != null &&
-                            type.IsClass &&
-                            !type.IsAbstract &&
-                            !type.IsGenericType
-                ).ToArray();
+                .Where(type => type != null && type.IsClass && !type.IsAbstract && !type.IsGenericType)
+                .ToArray();
         }
         catch (ReflectionTypeLoadException e)
         {
-            types = e.Types.Select(x => x!).ToArray();
+            types = e.Types
+                .Where(type => type != null && type.IsClass && !type.IsAbstract && !type.IsGenericType)
+                .Select(x => x!)
+                .ToArray();
             logger.LogException(e);
         }
         catch (Exception e)


### PR DESCRIPTION
Somehow, the **Types** may contain the **null** element.

<img width="3002" height="964" alt="image" src="https://github.com/user-attachments/assets/39272f60-48dd-4c59-a7fc-cbb3b44654d3" />

https://abp.io/support/questions/9837