### PR TITLE
Improve spinner insertion in ngx-datatable-list directive

### DIFF
--- a/npm/ng-packs/packages/theme-shared/src/lib/directives/ngx-datatable-list.directive.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/directives/ngx-datatable-list.directive.ts
@@ -111,10 +111,13 @@ export class NgxDatatableListDirective implements OnChanges, OnInit, DoCheck {
 
     const spinnerRef = this.viewContainerRef.createComponent(SpinnerComponent);
     const spinnerElement = spinnerRef.location.nativeElement;
-    if (placeholder?.parentNode === parent) {
-      this.renderer.insertBefore(parent, spinnerElement, placeholder);
+
+    this.renderer.insertBefore(parent, spinnerElement, parent.firstChild);
+    
+    const placeholderParent = placeholder?.parentNode as Element | null;
+    if (placeholderParent) {
+      this.renderer.removeChild(placeholderParent, placeholder);
     }
-    this.renderer.removeChild(parent, placeholder);
   }
 
   protected setInitialValues() {


### PR DESCRIPTION
Refactored the logic for inserting the spinner component to always place it as the first child and safely remove the placeholder if present.  

[ABP Demo (1).webm](https://github.com/user-attachments/assets/09fa7bec-6363-4c99-984e-923dfd9fa5ad)

Resolves https://github.com/volosoft/volo/issues/20642 (write the related issue number if available)

### Checklist

- [ ] I fully tested it as developer / designer and created unit / integration tests
- [ ] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

1. Select issue-20642 branch of the abp repository
2. Select the dev branch of the volo repository
3. Run the dev-app on volo repository.

