### PR TITLE
Blazor Setting Managements Tabs wrong initialization fix

### DIFF
--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Blazor/Pages/SettingManagement/SettingManagement.razor
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Blazor/Pages/SettingManagement/SettingManagement.razor
@@ -12,31 +12,34 @@
 
 <Card>
     <CardBody Class="pt-3">
-        <Tabs @bind-SelectedTab="@SelectedGroup" TabPosition="TabPosition.Start" Pills="true" RenderMode="TabsRenderMode.LazyReload" VerticalItemsColumnSize="ColumnSize.Is3.OnDesktop.Is6.OnTablet.Is12.OnMobile">
-            <Items>
-                @foreach (var group in SettingComponentCreationContext.Groups)
-                {
-                    <Tab Name="@GetNormalizedString(group.Id)">
-                        @group.DisplayName
-                    </Tab>
-                }
-            </Items>
-            <Content>
-                @foreach (var group in SettingComponentCreationContext.Groups)
-                {
-                    <TabPanel Name="@GetNormalizedString(group.Id)" class="abp-md-form">
-                        @{
-                            SettingItemRenders.Add(builder =>
-                            {
-                                builder.OpenComponent(0, group.ComponentType);
-                                builder.CloseComponent();
-                            });
-                        }
+        @if (!string.IsNullOrEmpty(SelectedGroup))
+        {
+            <Tabs @bind-SelectedTab="@SelectedGroup" TabPosition="TabPosition.Start" Pills="true" RenderMode="TabsRenderMode.LazyReload" VerticalItemsColumnSize="ColumnSize.Is3.OnDesktop.Is6.OnTablet.Is12.OnMobile">
+                <Items>
+                    @foreach (var group in SettingComponentCreationContext.Groups)
+                    {
+                        <Tab Name="@GetNormalizedString(group.Id)">
+                            @group.DisplayName
+                        </Tab>
+                    }
+                </Items>
+                <Content>
+                    @foreach (var group in SettingComponentCreationContext.Groups)
+                    {
+                        <TabPanel Name="@GetNormalizedString(group.Id)" class="abp-md-form">
+                            @{
+                                SettingItemRenders.Add(builder =>
+                                {
+                                    builder.OpenComponent(0, group.ComponentType);
+                                    builder.CloseComponent();
+                                });
+                            }
 
-                        @SettingItemRenders.Last()
-                    </TabPanel>
-                }
-            </Content>
-        </Tabs>
+                            @SettingItemRenders.Last()
+                        </TabPanel>
+                    }
+                </Content>
+            </Tabs>
+        }
     </CardBody>
 </Card>

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Blazor/Pages/SettingManagement/SettingManagement.razor
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Blazor/Pages/SettingManagement/SettingManagement.razor
@@ -11,35 +11,31 @@
 </PageHeader>
 
 <Card>
-    <CardBody Class="pt-0">
+    <CardBody Class="pt-3">
         <Tabs @bind-SelectedTab="@SelectedGroup" TabPosition="TabPosition.Start" Pills="true" RenderMode="TabsRenderMode.LazyReload" VerticalItemsColumnSize="ColumnSize.Is3.OnDesktop.Is6.OnTablet.Is12.OnMobile">
             <Items>
-                <div class="pt-3">
-                    @foreach (var group in SettingComponentCreationContext.Groups)
-                    {
-                        <Tab Name="@GetNormalizedString(group.Id)">
-                            @group.DisplayName
-                        </Tab>
-                    }
-                </div>
+                @foreach (var group in SettingComponentCreationContext.Groups)
+                {
+                    <Tab Name="@GetNormalizedString(group.Id)">
+                        @group.DisplayName
+                    </Tab>
+                }
             </Items>
             <Content>
-                <div class="pt-3">
-                    @foreach (var group in SettingComponentCreationContext.Groups)
-                    {
-                        <TabPanel Name="@GetNormalizedString(group.Id)" class="abp-md-form">
-                            @{
-                                SettingItemRenders.Add(builder =>
-                                {
-                                    builder.OpenComponent(0, group.ComponentType);
-                                    builder.CloseComponent();
-                                });
-                            }
+                @foreach (var group in SettingComponentCreationContext.Groups)
+                {
+                    <TabPanel Name="@GetNormalizedString(group.Id)" class="abp-md-form">
+                        @{
+                            SettingItemRenders.Add(builder =>
+                            {
+                                builder.OpenComponent(0, group.ComponentType);
+                                builder.CloseComponent();
+                            });
+                        }
 
-                            @SettingItemRenders.Last()
-                        </TabPanel>
-                    }
-                </div>
+                        @SettingItemRenders.Last()
+                    </TabPanel>
+                }
             </Content>
         </Tabs>
     </CardBody>

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Blazor/Pages/SettingManagement/SettingManagement.razor.cs
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Blazor/Pages/SettingManagement/SettingManagement.razor.cs
@@ -46,7 +46,6 @@ public partial class SettingManagement
         {
             SelectedGroup = GetNormalizedString(SettingComponentCreationContext.Groups.First().Id);
         }
-
     }
 
     protected virtual string GetNormalizedString(string value)

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Blazor/Pages/SettingManagement/SettingManagement.razor.cs
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Blazor/Pages/SettingManagement/SettingManagement.razor.cs
@@ -42,21 +42,11 @@ public partial class SettingManagement
         SettingComponentCreationContext.Normalize();
         SettingItemRenders.Clear();
 
-        if (SettingComponentCreationContext.Groups.Any())
+        if(SelectedGroup.IsNullOrEmpty() && SettingComponentCreationContext.Groups.Any())
         {
             SelectedGroup = GetNormalizedString(SettingComponentCreationContext.Groups.First().Id);
         }
-    }
 
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        if (firstRender)
-        {
-            await Task.Yield();
-            await InvokeAsync(StateHasChanged);
-        }
-
-        await base.OnAfterRenderAsync(firstRender);
     }
 
     protected virtual string GetNormalizedString(string value)


### PR DESCRIPTION
### Description

Resolves https://github.com/volosoft/volo/issues/20620

Removed extra wrappers between Blazorise Components. And also removed custom triggering rendering that may cause race-condition while rendering tab components

![blazor-setting-menu](https://github.com/user-attachments/assets/4279fbc8-0cdc-4892-b51e-a6ec469f8ef7)

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

Please describe how this can be tested by the test engineers if it is not already explicit - or remove this section if no need to description.
