### PR TITLE
Handle optional enum types in signature mapper

### DIFF
--- a/npm/ng-packs/packages/schematics/src/utils/service.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/service.ts
@@ -124,7 +124,7 @@ export function createActionToSignatureMapper() {
       }
 
       let type = adaptType(p.typeSimple);
-      if (p.typeSimple === 'enum' || p.typeSimple === '[enum]') {
+      if (p.typeSimple === 'enum' || p.typeSimple === '[enum]' || p.typeSimple === 'enum?' || p.typeSimple === '[enum]?') {
         type = adaptType(p.type);
       }
 


### PR DESCRIPTION
Extended the type check in createActionToSignatureMapper to include 'enum?' and '[enum]?' cases, ensuring optional enum types are correctly adapted.

### Description

Resolves #22408  (write the related issue number if available)

TODO: Describe what this PR has changed, add screenshot or animated GIF if available, write if it is a breaking change, and how to fix the breaking changes for existing applications if so.

### Checklist

- [ ] I fully tested it as developer / designer and created unit / integration tests
- [ ] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

How to Test it?

1. Run the schematics build:
   ```npm run build:schematics```
This command builds the schematics package (located under npm/ng-packs).


2. add sample api defination 
`abp\templates\app\aspnet-core\src\MyCompanyName.MyProjectName.HttpApi\Controllers\MyProjectNameController.cs`

```
using Microsoft.AspNetCore.Mvc;
using MyCompanyName.MyProjectName.Localization;
using Volo.Abp.AspNetCore.Mvc;
```

```
[ApiController]
[Route("api/[controller]")]
public class MyEntityController : MyProjectNameController
{
    [HttpGet]
    public ActionResult MyActionResult(MyEntityType? myEntityType = null)
    {
        return Ok(new { Message = "MyEntityType", Type = myEntityType });
    }
}

public enum MyEntityType
{
    A = 1,
    B = 2,
    C = 3
}

``` 

and run HostWithIds Application 

3. Under `ng-packs`, run the following command to apply the schematic:
`npx -y nx g "./dist/packages/schematics/collection.json:proxy-add" --module app --apiName Default --source dev-app --target dev-app --url https://localhost:44305 --serviceType application`

and check create
