### PR TITLE
Replace AutoMapper with Mapperly in Virtual File Explorer DemoApp

### DIFF
--- a/modules/virtual-file-explorer/app/DemoApp.csproj
+++ b/modules/virtual-file-explorer/app/DemoApp.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <ProjectReference Include="../../../framework/src/Volo.Abp.AspNetCore.Mvc/Volo.Abp.AspNetCore.Mvc.csproj" />
     <ProjectReference Include="../../../framework/src/Volo.Abp.Autofac/Volo.Abp.Autofac.csproj" />
-    <ProjectReference Include="../../../framework/src/Volo.Abp.AutoMapper/Volo.Abp.AutoMapper.csproj" />
+    <ProjectReference Include="../../../framework/src/Volo.Abp.Mapperly/Volo.Abp.Mapperly.csproj" />
     <ProjectReference Include="../../../framework/src/Volo.Abp.Swashbuckle/Volo.Abp.Swashbuckle.csproj" />
     <ProjectReference Include="../../../framework/src/Volo.Abp.AspNetCore.Serilog/Volo.Abp.AspNetCore.Serilog.csproj" />
     <ProjectReference Include="..\src\Volo.Abp.VirtualFileExplorer.Web\Volo.Abp.VirtualFileExplorer.Web.csproj" />

--- a/modules/virtual-file-explorer/app/DemoAppModule.cs
+++ b/modules/virtual-file-explorer/app/DemoAppModule.cs
@@ -1,4 +1,4 @@
-﻿using DemoApp.Data;
+using DemoApp.Data;
 using Microsoft.EntityFrameworkCore;
 using Volo.Abp;
 using Volo.Abp.Account;
@@ -8,7 +8,7 @@ using Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic;
 using Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared;
 using Volo.Abp.AspNetCore.Serilog;
 using Volo.Abp.Autofac;
-using Volo.Abp.AutoMapper;
+using Volo.Abp.Mapperly;
 using Volo.Abp.Data;
 using Volo.Abp.EntityFrameworkCore;
 using Volo.Abp.EntityFrameworkCore.SqlServer;
@@ -32,7 +32,7 @@ namespace DemoApp;
     // ABP Framework packages
     typeof(AbpAspNetCoreMvcModule),
     typeof(AbpAutofacModule),
-    typeof(AbpAutoMapperModule),
+    typeof(AbpMapperlyModule),
     typeof(AbpSwashbuckleModule),
     typeof(AbpAspNetCoreSerilogModule),
 


### PR DESCRIPTION
Updated project references and module dependencies to use Volo.Abp.Mapperly instead of Volo.Abp.AutoMapper. This change migrates mapping functionality to Mapperly for improved performance and maintainability.

Related to [volo#20451](https://github.com/volosoft/volo/issues/20451)
### Checklist

- [x] I fully tested it as a developer.
- [x] No need to document.