### PR TITLE
feat(l8n): add support for nested objects in localization files

### DIFF
--- a/docs/en/framework/fundamentals/localization.md
+++ b/docs/en/framework/fundamentals/localization.md
@@ -91,6 +91,20 @@ A JSON localization file content is shown below:
 
 > ABP will ignore (skip) the JSON file if the `culture` section is missing.
 
+You may also use Nesting in your localization file
+
+````json
+{
+  "culture": "en",
+  "texts": {
+    "HelloWorld": "Hello World!",
+    "MyNestedTranslation": {
+        "SomeKey": "Some nested value"
+    }
+  }
+}
+````
+
 ### Default Resource
 
 `AbpLocalizationOptions.DefaultResourceType` can be set to a resource type, so it is used when the localization resource was not specified:

--- a/docs/en/framework/fundamentals/localization.md
+++ b/docs/en/framework/fundamentals/localization.md
@@ -91,18 +91,32 @@ A JSON localization file content is shown below:
 
 > ABP will ignore (skip) the JSON file if the `culture` section is missing.
 
-You may also use Nesting in your localization file
+You can also use nesting or array in localization files, like this:
 
 ````json
 {
   "culture": "en",
   "texts": {
     "HelloWorld": "Hello World!",
-    "MyNestedTranslation": {
-        "SomeKey": "Some nested value"
-    }
+    "Hello": {
+        "World": "Hello World!"
+    },
+    "Hi":[
+        "Bye": "Bye World!"
+        "Hello": "Hello World!"
+    ]
   }
 }
+````
+
+Then you can use it like this:
+
+> The double underscore (`__`) is used to separate the parent key from the child key.
+
+````csharp
+var str = L["Hello__World"]; // Hello World!
+var str2 = L["Hi__0"]; // Bye World!
+var str3 = L["Hi__1"]; // Hello World!
 ````
 
 ### Default Resource

--- a/framework/src/Volo.Abp.Localization/Volo/Abp/Localization/Json/JsonLocalizationDictionaryBuilder.cs
+++ b/framework/src/Volo.Abp.Localization/Volo/Abp/Localization/Json/JsonLocalizationDictionaryBuilder.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
 using Microsoft.Extensions.Localization;
 
@@ -61,10 +62,7 @@ public static class JsonLocalizationDictionaryBuilder
         var dictionary = new Dictionary<string, LocalizedString>();
         var dublicateNames = new List<string>();
 
-        // Flache Struktur in Dictionary umwandeln
-        var flatTexts = FlattenTexts(jsonFile.Texts);
-
-        foreach (var item in flatTexts)
+        foreach (var item in FlattenTexts(jsonFile.Texts))
         {
             if (string.IsNullOrEmpty(item.Key))
             {
@@ -90,44 +88,63 @@ public static class JsonLocalizationDictionaryBuilder
     private static Dictionary<string, string> FlattenTexts(Dictionary<string, object> texts, string prefix = "")
     {
         var result = new Dictionary<string, string>();
-
-        foreach (var item in texts)
+        foreach (var text in texts)
         {
-            var currentKey = string.IsNullOrEmpty(prefix) ? item.Key : $"{prefix}__{item.Key}";
-
-            if (item.Value is JsonElement jsonElement)
+            var currentKey = string.IsNullOrEmpty(prefix) ? text.Key : $"{prefix}__{text.Key}";
+            switch (text.Value)
             {
-                if (jsonElement.ValueKind == JsonValueKind.String)
-                {
-                    result[currentKey] = jsonElement.GetString() ?? "";
-                }
-                else if (jsonElement.ValueKind == JsonValueKind.Object)
-                {
-                    var nestedDict = JsonSerializer.Deserialize<Dictionary<string, object>>(jsonElement.GetRawText());
-                    if (nestedDict != null)
+                case JsonElement jsonElement:
+                    foreach (var item in FlattenJsonElement(jsonElement, currentKey))
                     {
-                        var flattenedNested = FlattenTexts(nestedDict, currentKey);
-                        foreach (var nested in flattenedNested)
-                        {
-                            result[nested.Key] = nested.Value;
-                        }
+                        result[item.Key] = item.Value;
                     }
-                }
-            }
-            else if (item.Value is string stringValue)
-            {
-                result[currentKey] = stringValue;
-            }
-            else if (item.Value is Dictionary<string, object> nestedDict)
-            {
-                var flattenedNested = FlattenTexts(nestedDict, currentKey);
-                foreach (var nested in flattenedNested)
-                {
-                    result[nested.Key] = nested.Value;
-                }
+                    break;
+                case string str:
+                    result[currentKey] = str;
+                    break;
+                case null:
+                    result[currentKey] = "";
+                    break;
+                default:
+                    result[currentKey] = text.Value.ToString() ?? "";
+                    break;
             }
         }
-
         return result;
+    }
+
+    private static IEnumerable<KeyValuePair<string, string>> FlattenJsonElement(JsonElement element, string prefix)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.String:
+                yield return new KeyValuePair<string, string>(prefix, element.GetString() ?? "");
+                break;
+            case JsonValueKind.Object:
+                foreach (var prop in element.EnumerateObject())
+                {
+                    var newKey = $"{prefix}__{prop.Name}";
+                    foreach (var item in FlattenJsonElement(prop.Value, newKey))
+                    {
+                        yield return item;
+                    }
+                }
+                break;
+            case JsonValueKind.Array:
+                var i = 0;
+                foreach (var prop in element.EnumerateArray())
+                {
+                    var newKey = $"{prefix}__{i}";
+                    foreach (var item in FlattenJsonElement(prop, newKey))
+                    {
+                        yield return item;
+                    }
+                    i++;
+                }
+                break;
+            default:
+                yield return new KeyValuePair<string, string>(prefix, element.ToString());
+                break;
+        }
     }
 }

--- a/framework/src/Volo.Abp.Localization/Volo/Abp/Localization/Json/JsonLocalizationDictionaryBuilder.cs
+++ b/framework/src/Volo.Abp.Localization/Volo/Abp/Localization/Json/JsonLocalizationDictionaryBuilder.cs
@@ -47,12 +47,11 @@ public static class JsonLocalizationDictionaryBuilder
         {
             throw new AbpException("Can not parse json string. " + ex.Message);
         }
-
         if (jsonFile == null)
         {
             return null;
         }
-        
+
         var cultureCode = jsonFile.Culture;
         if (string.IsNullOrEmpty(cultureCode))
         {
@@ -61,18 +60,20 @@ public static class JsonLocalizationDictionaryBuilder
 
         var dictionary = new Dictionary<string, LocalizedString>();
         var dublicateNames = new List<string>();
-        foreach (var item in jsonFile.Texts)
+
+        // Flache Struktur in Dictionary umwandeln
+        var flatTexts = FlattenTexts(jsonFile.Texts);
+
+        foreach (var item in flatTexts)
         {
             if (string.IsNullOrEmpty(item.Key))
             {
                 throw new AbpException("The key is empty in given json string.");
             }
-
             if (dictionary.GetOrDefault(item.Key) != null)
             {
                 dublicateNames.Add(item.Key);
             }
-
             dictionary[item.Key] = new LocalizedString(item.Key, item.Value.NormalizeLineEndings());
         }
 
@@ -84,5 +85,49 @@ public static class JsonLocalizationDictionaryBuilder
         }
 
         return new StaticLocalizationDictionary(cultureCode, dictionary);
+    }
+
+    private static Dictionary<string, string> FlattenTexts(Dictionary<string, object> texts, string prefix = "")
+    {
+        var result = new Dictionary<string, string>();
+
+        foreach (var item in texts)
+        {
+            var currentKey = string.IsNullOrEmpty(prefix) ? item.Key : $"{prefix}__{item.Key}";
+
+            if (item.Value is JsonElement jsonElement)
+            {
+                if (jsonElement.ValueKind == JsonValueKind.String)
+                {
+                    result[currentKey] = jsonElement.GetString() ?? "";
+                }
+                else if (jsonElement.ValueKind == JsonValueKind.Object)
+                {
+                    var nestedDict = JsonSerializer.Deserialize<Dictionary<string, object>>(jsonElement.GetRawText());
+                    if (nestedDict != null)
+                    {
+                        var flattenedNested = FlattenTexts(nestedDict, currentKey);
+                        foreach (var nested in flattenedNested)
+                        {
+                            result[nested.Key] = nested.Value;
+                        }
+                    }
+                }
+            }
+            else if (item.Value is string stringValue)
+            {
+                result[currentKey] = stringValue;
+            }
+            else if (item.Value is Dictionary<string, object> nestedDict)
+            {
+                var flattenedNested = FlattenTexts(nestedDict, currentKey);
+                foreach (var nested in flattenedNested)
+                {
+                    result[nested.Key] = nested.Value;
+                }
+            }
+        }
+
+        return result;
     }
 }

--- a/framework/src/Volo.Abp.Localization/Volo/Abp/Localization/Json/JsonLocalizationFile.cs
+++ b/framework/src/Volo.Abp.Localization/Volo/Abp/Localization/Json/JsonLocalizationFile.cs
@@ -9,10 +9,5 @@ public class JsonLocalizationFile
     /// </summary>
     public string Culture { get; set; } = default!;
 
-    public Dictionary<string, string> Texts { get; set; }
-
-    public JsonLocalizationFile()
-    {
-        Texts = new Dictionary<string, string>();
-    }
+    public Dictionary<string, object> Texts { get; set; } = [];
 }

--- a/framework/test/Volo.Abp.Localization.Tests/Volo/Abp/Localization/AbpLocalization_Tests.cs
+++ b/framework/test/Volo.Abp.Localization.Tests/Volo/Abp/Localization/AbpLocalization_Tests.cs
@@ -375,4 +375,17 @@ public class AbpLocalization_Tests : AbpIntegratedTest<AbpLocalizationTestModule
         var externalLocalizer = _localizerFactory.CreateByResourceName(TestExternalLocalizationStore.TestExternalResourceNames.ExternalResource1);
         externalLocalizer["Car"].Value.ShouldBe("Car");
     }
+
+    /// <summary>
+    /// <see href="https://github.com/abpframework/abp/issues/18208"/>
+    /// </summary>
+    [Fact]
+    public void Should_Get_Nested_Translations()
+    {
+        using (CultureHelper.Use("en"))
+        {
+            _localizer["MyNestedTranslation__SomeKey"].Value.ShouldBe("Some nested value");
+            _localizer["MyNestedTranslation__SomeOtherKey"].Value.ShouldBe("Some other nested value");
+        }
+    }
 }

--- a/framework/test/Volo.Abp.Localization.Tests/Volo/Abp/Localization/AbpLocalization_Tests.cs
+++ b/framework/test/Volo.Abp.Localization.Tests/Volo/Abp/Localization/AbpLocalization_Tests.cs
@@ -196,7 +196,7 @@ public class AbpLocalization_Tests : AbpIntegratedTest<AbpLocalizationTestModule
         {
             _localizer["CarPlural"].Value.ShouldBe("汽车");
         }
-        
+
         using (CultureHelper.Use(CultureInfo.GetCultureInfo("zh-Hans-CN")))
         {
             _localizer["Car"].Value.ShouldBe("汽车");
@@ -214,7 +214,7 @@ public class AbpLocalization_Tests : AbpIntegratedTest<AbpLocalizationTestModule
         {
             _localizer["CarPlural"].Value.ShouldBe("汽車");
         }
-        
+
         using (CultureHelper.Use(CultureInfo.GetCultureInfo("zh-TW")))
         {
             _localizer["Car"].Value.ShouldBe("汽車");
@@ -223,7 +223,7 @@ public class AbpLocalization_Tests : AbpIntegratedTest<AbpLocalizationTestModule
         {
             _localizer["CarPlural"].Value.ShouldBe("汽車");
         }
-        
+
         using (CultureHelper.Use(CultureInfo.GetCultureInfo("zh-Hant-TW")))
         {
             _localizer["Car"].Value.ShouldBe("汽車");
@@ -376,9 +376,6 @@ public class AbpLocalization_Tests : AbpIntegratedTest<AbpLocalizationTestModule
         externalLocalizer["Car"].Value.ShouldBe("Car");
     }
 
-    /// <summary>
-    /// <see href="https://github.com/abpframework/abp/issues/18208"/>
-    /// </summary>
     [Fact]
     public void Should_Get_Nested_Translations()
     {
@@ -387,6 +384,12 @@ public class AbpLocalization_Tests : AbpIntegratedTest<AbpLocalizationTestModule
             _localizer["MyNestedTranslation__SomeKey"].Value.ShouldBe("Some nested value");
             _localizer["MyNestedTranslation__SomeOtherKey"].Value.ShouldBe("Some other nested value");
             _localizer["MyNestedTranslation__DeeplyNested__DeepKey"].Value.ShouldBe("A deeply nested value");
+
+            _localizer["MyNestedTranslation__DeeplyNestedArray__0"].Value.ShouldBe("First value in array");
+            _localizer["MyNestedTranslation__DeeplyNestedArray__1"].Value.ShouldBe("Second value in array");
+            _localizer["MyNestedTranslation__DeeplyNestedArray__2__InnerDeepKey"].Value.ShouldBe("Inner deeply nested value");
+            _localizer["MyNestedTranslation__DeeplyNestedArray__3__InnerDeepArray__0"].Value.ShouldBe("First inner deep array value");
+            _localizer["MyNestedTranslation__DeeplyNestedArray__3__InnerDeepArray__1"].Value.ShouldBe("Second inner deep array value");
         }
     }
 }

--- a/framework/test/Volo.Abp.Localization.Tests/Volo/Abp/Localization/AbpLocalization_Tests.cs
+++ b/framework/test/Volo.Abp.Localization.Tests/Volo/Abp/Localization/AbpLocalization_Tests.cs
@@ -386,6 +386,7 @@ public class AbpLocalization_Tests : AbpIntegratedTest<AbpLocalizationTestModule
         {
             _localizer["MyNestedTranslation__SomeKey"].Value.ShouldBe("Some nested value");
             _localizer["MyNestedTranslation__SomeOtherKey"].Value.ShouldBe("Some other nested value");
+            _localizer["MyNestedTranslation__DeeplyNested__DeepKey"].Value.ShouldBe("A deeply nested value");
         }
     }
 }

--- a/framework/test/Volo.Abp.Localization.Tests/Volo/Abp/Localization/TestResources/SourceExt/en.json
+++ b/framework/test/Volo.Abp.Localization.Tests/Volo/Abp/Localization/TestResources/SourceExt/en.json
@@ -7,7 +7,20 @@
       "SomeOtherKey": "Some other nested value",
       "DeeplyNested": {
         "DeepKey": "A deeply nested value"
-      }
+      },
+      "DeeplyNestedArray": [
+        "First value in array",
+        "Second value in array",
+        {
+          "InnerDeepKey": "Inner deeply nested value"
+        },
+        {
+          "InnerDeepArray": [
+            "First inner deep array value",
+            "Second inner deep array value"
+          ]
+        }
+      ]
     }
   }
 }

--- a/framework/test/Volo.Abp.Localization.Tests/Volo/Abp/Localization/TestResources/SourceExt/en.json
+++ b/framework/test/Volo.Abp.Localization.Tests/Volo/Abp/Localization/TestResources/SourceExt/en.json
@@ -4,7 +4,10 @@
     "SeeYou": "See you",
     "MyNestedTranslation": {
       "SomeKey": "Some nested value",
-      "SomeOtherKey": "Some other nested value"
+      "SomeOtherKey": "Some other nested value",
+      "DeeplyNested": {
+        "DeepKey": "A deeply nested value"
+      }
     }
   }
 }

--- a/framework/test/Volo.Abp.Localization.Tests/Volo/Abp/Localization/TestResources/SourceExt/en.json
+++ b/framework/test/Volo.Abp.Localization.Tests/Volo/Abp/Localization/TestResources/SourceExt/en.json
@@ -1,6 +1,10 @@
 {
   "culture": "en",
   "texts": {
-    "SeeYou": "See you"
+    "SeeYou": "See you",
+    "MyNestedTranslation": {
+      "SomeKey": "Some nested value",
+      "SomeOtherKey": "Some other nested value"
+    }
   }
 }


### PR DESCRIPTION
### Description

Resolves #18208

Add suport for something like this:

```json
{
  "culture": "en",
  "texts": {
    "SeeYou": "See you"
    "MyNestedTranslation": {
      "SomeKey": "Some nested value",
      "SomeOtherKey": "Some other nested value"
    }
  }
}
```

using `L["MyNestedTranslation__SomeKey"]`

IMHO the seperator schould be `__` because as far as I know that is the default.

### Checklist

- [ ] I fully tested it as developer / designer and created unit / integration tests
- [X] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

Added a unit test. let's see if it passes :O
