### PR TITLE
feat(): add generic EntityNotFoundException

### DIFF
--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/BasicRepositoryBase.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/BasicRepositoryBase.cs
@@ -1,9 +1,9 @@
-﻿using JetBrains.Annotations;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Volo.Abp.Data;
@@ -43,9 +43,9 @@ public abstract class BasicRepositoryBase<TEntity> :
     public IEntityChangeTrackingProvider EntityChangeTrackingProvider => LazyServiceProvider.LazyGetRequiredService<IEntityChangeTrackingProvider>();
 
     public bool? IsChangeTrackingEnabled { get; protected set; }
-    
+
     public string? EntityName { get; set; }
-    
+
     public void SetEntityName(string? name)
     {
         EntityName = name;
@@ -148,10 +148,10 @@ public abstract class BasicRepositoryBase<TEntity> :
 public abstract class BasicRepositoryBase<TEntity, TKey> : BasicRepositoryBase<TEntity>, IBasicRepository<TEntity, TKey>
     where TEntity : class, IEntity<TKey>
 {
-    protected BasicRepositoryBase(string providerName) 
+    protected BasicRepositoryBase(string providerName)
         : base(providerName)
     {
-        
+
     }
 
     public virtual async Task<TEntity> GetAsync(TKey id, bool includeDetails = true, CancellationToken cancellationToken = default)
@@ -160,7 +160,7 @@ public abstract class BasicRepositoryBase<TEntity, TKey> : BasicRepositoryBase<T
 
         if (entity == null)
         {
-            throw new EntityNotFoundException(typeof(TEntity), id);
+            throw new EntityNotFoundException<TEntity>(id);
         }
 
         return entity;

--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/RepositoryBase.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/RepositoryBase.cs
@@ -1,10 +1,10 @@
-﻿using JetBrains.Annotations;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using Volo.Abp.Domain.Entities;
 using Volo.Abp.MultiTenancy;
 using Volo.Abp.Uow;
@@ -60,7 +60,7 @@ public abstract class RepositoryBase<TEntity> : BasicRepositoryBase<TEntity>, IR
 
         if (entity == null)
         {
-            throw new EntityNotFoundException(typeof(TEntity));
+            throw new EntityNotFoundException<TEntity>();
         }
 
         return entity;
@@ -101,7 +101,7 @@ public abstract class RepositoryBase<TEntity, TKey> : RepositoryBase<TEntity>, I
         : base(providerName)
     {
     }
-    
+
     public abstract Task<TEntity> GetAsync(TKey id, bool includeDetails = true, CancellationToken cancellationToken = default);
 
     public abstract Task<TEntity?> FindAsync(TKey id, bool includeDetails = true, CancellationToken cancellationToken = default);

--- a/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/RepositoryExtensions.cs
+++ b/framework/src/Volo.Abp.Ddd.Domain/Volo/Abp/Domain/Repositories/RepositoryExtensions.cs
@@ -56,7 +56,7 @@ public static class RepositoryExtensions
     {
         if (!await repository.AnyAsync(x => x.Id!.Equals(id), cancellationToken))
         {
-            throw new EntityNotFoundException(typeof(TEntity), id);
+            throw new EntityNotFoundException<TEntity>(id);
         }
     }
 
@@ -69,7 +69,7 @@ public static class RepositoryExtensions
     {
         if (!await repository.AnyAsync(expression, cancellationToken))
         {
-            throw new EntityNotFoundException(typeof(TEntity));
+            throw new EntityNotFoundException<TEntity>();
         }
     }
 
@@ -250,7 +250,7 @@ public static class RepositoryExtensions
         hardDeleteEntities.Add(entity);
         await repository.DeleteAsync(entity, autoSave, cancellationToken);
     }
-    
+
     public static TRepository SetEntityName<TRepository>(
         this TRepository repository,
         string name

--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/Domain/Repositories/EntityFrameworkCore/EfCoreRepository.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/Domain/Repositories/EntityFrameworkCore/EfCoreRepository.cs
@@ -1,6 +1,3 @@
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -8,7 +5,10 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Volo.Abp.Domain.Entities;
 using Volo.Abp.EntityFrameworkCore;
 using Volo.Abp.EntityFrameworkCore.DependencyInjection;
@@ -468,7 +468,7 @@ public class EfCoreRepository<TDbContext, TEntity, TKey> : EfCoreRepository<TDbC
 
         if (entity == null)
         {
-            throw new EntityNotFoundException(typeof(TEntity), id);
+            throw new EntityNotFoundException<TEntity>(id);
         }
 
         return entity;
@@ -480,7 +480,7 @@ public class EfCoreRepository<TDbContext, TEntity, TKey> : EfCoreRepository<TDbC
             ? await (await WithDetailsAsync()).OrderBy(e => e.Id).FirstOrDefaultAsync(e => e.Id!.Equals(id), GetCancellationToken(cancellationToken))
             : !ShouldTrackingEntityChange()
                 ? await (await GetQueryableAsync()).OrderBy(e => e.Id).FirstOrDefaultAsync(e => e.Id!.Equals(id), GetCancellationToken(cancellationToken))
-                : await (await GetDbSetAsync()).FindAsync(new object[] {id!}, GetCancellationToken(cancellationToken));
+                : await (await GetDbSetAsync()).FindAsync(new object[] { id! }, GetCancellationToken(cancellationToken));
     }
 
     public virtual async Task DeleteAsync(TKey id, bool autoSave = false, CancellationToken cancellationToken = default)

--- a/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/Domain/Entities/EntityNotFoundException.cs
+++ b/framework/src/Volo.Abp.ExceptionHandling/Volo/Abp/Domain/Entities/EntityNotFoundException.cs
@@ -5,6 +5,34 @@ namespace Volo.Abp.Domain.Entities;
 /// <summary>
 /// This exception is thrown if an entity is expected to be found but not found.
 /// </summary>
+public class EntityNotFoundException<TEntityType> : EntityNotFoundException
+{
+    /// <summary>
+    /// Creates a new <see cref="EntityNotFoundException{TEntityType}"/> object.
+    /// </summary>
+    public EntityNotFoundException()
+        : base(typeof(TEntityType))
+    {
+    }
+    /// <summary>
+    /// Creates a new <see cref="EntityNotFoundException{TEntityType}"/> object.
+    /// </summary>
+    public EntityNotFoundException(object? id)
+        : base(typeof(TEntityType), id)
+    {
+    }
+    /// <summary>
+    /// Creates a new <see cref="EntityNotFoundException{TEntityType}"/> object.
+    /// </summary>
+    public EntityNotFoundException(object? id, Exception? innerException)
+        : base(typeof(TEntityType), id, innerException)
+    {
+    }
+}
+
+/// <summary>
+/// This exception is thrown if an entity is expected to be found but not found.
+/// </summary>
 public class EntityNotFoundException : AbpException
 {
     /// <summary>

--- a/framework/src/Volo.Abp.MemoryDb/Volo/Abp/Domain/Repositories/MemoryDb/MemoryDbRepository.cs
+++ b/framework/src/Volo.Abp.MemoryDb/Volo/Abp/Domain/Repositories/MemoryDb/MemoryDbRepository.cs
@@ -334,7 +334,7 @@ public class MemoryDbRepository<TMemoryDbContext, TEntity, TKey> : MemoryDbRepos
 
         if (entity == null)
         {
-            throw new EntityNotFoundException(typeof(TEntity), id);
+            throw new EntityNotFoundException<TEntity>(id);
         }
 
         return entity;

--- a/framework/src/Volo.Abp.MongoDB/Volo/Abp/Domain/Repositories/MongoDB/MongoDbRepository.cs
+++ b/framework/src/Volo.Abp.MongoDB/Volo/Abp/Domain/Repositories/MongoDB/MongoDbRepository.cs
@@ -1,12 +1,12 @@
-using JetBrains.Annotations;
-using MongoDB.Driver;
-using MongoDB.Driver.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
+using MongoDB.Driver;
+using MongoDB.Driver.Linq;
 using Volo.Abp.Auditing;
 using Volo.Abp.Data;
 using Volo.Abp.Domain.Entities;
@@ -803,7 +803,7 @@ public class MongoDbRepository<TMongoDbContext, TEntity, TKey>
 
         if (entity == null)
         {
-            throw new EntityNotFoundException(typeof(TEntity), id);
+            throw new EntityNotFoundException<TEntity>(id);
         }
 
         return entity;

--- a/framework/test/Volo.Abp.TestApp/Volo/Abp/TestApp/Testing/EntityCache_Tests.cs
+++ b/framework/test/Volo.Abp.TestApp/Volo/Abp/TestApp/Testing/EntityCache_Tests.cs
@@ -37,7 +37,7 @@ public abstract class EntityCache_Tests<TStartupModule> : TestAppTestBase<TStart
     public async Task Should_Throw_EntityNotFoundException_IF_Entity_Not_Exist()
     {
         var notExistId = Guid.NewGuid();
-        await Assert.ThrowsAsync<EntityNotFoundException>(() => ProductEntityCache.GetAsync(notExistId));
+        await Assert.ThrowsAsync<EntityNotFoundException<Product>>(() => ProductEntityCache.GetAsync(notExistId));
         await Assert.ThrowsAsync<EntityNotFoundException>(() => ProductCacheItem.GetAsync(notExistId));
     }
 

--- a/framework/test/Volo.Abp.TestApp/Volo/Abp/TestApp/Testing/EntityCache_Tests.cs
+++ b/framework/test/Volo.Abp.TestApp/Volo/Abp/TestApp/Testing/EntityCache_Tests.cs
@@ -38,7 +38,7 @@ public abstract class EntityCache_Tests<TStartupModule> : TestAppTestBase<TStart
     {
         var notExistId = Guid.NewGuid();
         await Assert.ThrowsAsync<EntityNotFoundException<Product>>(() => ProductEntityCache.GetAsync(notExistId));
-        await Assert.ThrowsAsync<EntityNotFoundException>(() => ProductCacheItem.GetAsync(notExistId));
+        await Assert.ThrowsAsync<EntityNotFoundException<Product>>(() => ProductCacheItem.GetAsync(notExistId));
     }
 
     [Fact]

--- a/framework/test/Volo.Abp.TestApp/Volo/Abp/TestApp/Testing/RepositoryExtensions_Tests.cs
+++ b/framework/test/Volo.Abp.TestApp/Volo/Abp/TestApp/Testing/RepositoryExtensions_Tests.cs
@@ -24,10 +24,10 @@ public abstract class RepositoryExtensions_Tests<TStartupModule> : TestAppTestBa
         await WithUnitOfWorkAsync(async () =>
         {
             var id = Guid.NewGuid();
-            await Assert.ThrowsAsync<EntityNotFoundException>(async () =>
+            await Assert.ThrowsAsync<EntityNotFoundException<Person>>(async () =>
                 await PersonRepository.EnsureExistsAsync(Guid.NewGuid())
             );
-            await Assert.ThrowsAsync<EntityNotFoundException>(async () =>
+            await Assert.ThrowsAsync<EntityNotFoundException<Person>>(async () =>
                 await PersonRepository.EnsureExistsAsync(x => x.Id == id)
             );
 


### PR DESCRIPTION
Implements solution for #23733 

### Description

This pr adds a generic version of the `EntityNotFoundException`.
Its much more convinient to throw a `EntityNotFoundException<MyEntity>(id)` exception than always using the `EntityNotFoundException(typeof(MyEntity), id)` alternative we currently have.

I guess this is a relativly small change if zero impact.

I already changed some lines where the Exception was used to use the generic version.
My auto formating fixed some formating issues on those files. Like whitespaces or import order.

### Checklist

- [ ] I fully tested it as developer / designer and created unit / integration tests
   - Nope as imho this does change nothing on current behavior at all. Let my know it this would be required
- [ ] I documented it (or no need to document or I will create a separate documentation issue)
   - Nope. Let me know if required and i´ll update some docs.

### How to test it?
Rather than using this `throw new EntityNotFoundException(typeof(MyEntity), id)` just use this `throw new EntityNotFoundException<MyEntity>(id)`.