### PR TITLE
Handle missing closer in Scriban section renderer

### DIFF
--- a/modules/docs/src/Volo.Docs.Domain.Shared/Volo/Docs/Documents/Rendering/ScribanDocumentSectionRenderer.cs
+++ b/modules/docs/src/Volo.Docs.Domain.Shared/Volo/Docs/Documents/Rendering/ScribanDocumentSectionRenderer.cs
@@ -213,12 +213,15 @@ public class ScribanDocumentSectionRenderer : IDocumentSectionRenderer
                     documentContent.IndexOf(Opener, StringComparison.Ordinal) + Opener.Length
                 );
 
-                var betweenJsonOpenerAndCloser = afterJsonOpener.Substring(0,
-                    afterJsonOpener.IndexOf(Closer, StringComparison.Ordinal)
-                );
+                var closerIndex = afterJsonOpener.IndexOf(Closer, StringComparison.Ordinal);
+                if(closerIndex < 0)
+                {
+                    break;
+                }
+                var betweenJsonOpenerAndCloser = afterJsonOpener.Substring(0, closerIndex);
 
                 documentContent = afterJsonOpener.Substring(
-                    afterJsonOpener.IndexOf(Closer, StringComparison.Ordinal) + Closer.Length
+                    closerIndex + Closer.Length
                 );
 
                 if (!betweenJsonOpenerAndCloser.Contains(DocsTemplates))
@@ -257,9 +260,12 @@ public class ScribanDocumentSectionRenderer : IDocumentSectionRenderer
                     document.IndexOf(Opener, StringComparison.Ordinal) + Opener.Length
                 );
 
-                var betweenJsonOpenerAndCloser = afterJsonOpener.Substring(0,
-                    afterJsonOpener.IndexOf(Closer, StringComparison.Ordinal)
-                );
+                var closerIndex = afterJsonOpener.IndexOf(Closer, StringComparison.Ordinal);
+                if (closerIndex < 0)
+                {
+                    break;
+                }
+                var betweenJsonOpenerAndCloser = afterJsonOpener.Substring(0, closerIndex);
 
                 if (!betweenJsonOpenerAndCloser.Contains(DocsTemplates))
                 {


### PR DESCRIPTION
Added checks for the presence of the 'Closer' string before substring operations in ScribanDocumentSectionRenderer. This prevents exceptions when the closer is not found in the document content.