### PR TITLE
ResponseType Option Added to REST Service

### DIFF
--- a/npm/ng-packs/packages/core/src/lib/models/rest.ts
+++ b/npm/ng-packs/packages/core/src/lib/models/rest.ts
@@ -7,6 +7,7 @@ export namespace Rest {
     skipAddingHeader: boolean;
     observe: Observe;
     httpParamEncoder?: HttpParameterCodec;
+    responseType: ResponseType;
   }>;
 
   export const enum Observe {

--- a/npm/ng-packs/packages/core/src/lib/services/rest.service.ts
+++ b/npm/ng-packs/packages/core/src/lib/services/rest.service.ts
@@ -38,13 +38,14 @@ export class RestService {
     config = config || ({} as Rest.Config);
     api = api || this.getApiFromStore(config.apiName);
     const { method, params, ...options } = request;
-    const { observe = Rest.Observe.Body, skipHandleError } = config;
+    const { observe = Rest.Observe.Body, skipHandleError, responseType = Rest.ResponseType.JSON } = config;
     const url = this.removeDuplicateSlashes(api + request.url);
 
     const httpClient: HttpClient = this.getHttpClient(config.skipAddingHeader);
     return httpClient
       .request<R>(method, url, {
         observe,
+        responseType: responseType as any,
         ...(params && {
           params: this.getParams(params, config.httpParamEncoder),
         }),


### PR DESCRIPTION
### Description

By default, the response type is `JSON`. You can override it by specifying the `responseType `parameter.

### Usage

```ts

    this.restService.request<any, ProductWithCategory>({
        method: 'GET',
        url: `/api/catalog/public/products/${productId}`,
        params: {  },
      },
      { apiName: this.apiName, responseType: ResponseType.Text});

```

