### PR TITLE
Fixing the folder check while validating the versions in `validate-versions` script

### DIFF
--- a/npm/scripts/validate-versions.ts
+++ b/npm/scripts/validate-versions.ts
@@ -35,11 +35,18 @@ async function compare() {
   for (let i = 0; i < packageFolders.length; i++) {
     const folder = packageFolders[i];
     const pkgJsonPath = `${packagesPath}/${folder}/package.json`;
+
+    if (!(await fse.pathExists(pkgJsonPath))) {
+      continue;
+    }
+
     let pkgJson;
 
     try {
       pkgJson = await fse.readJSON(pkgJsonPath);
-    } catch (error) {}
+    } catch (error) {
+      continue;
+    }
 
     if (
       !excludedPackages.includes(pkgJson.name) &&


### PR DESCRIPTION
### Description

We need to check for the folder having a `package.json` file inside to continue updating the versions.
