### PR TITLE
Refactor TocHeading and TocItem from records to classes

### DIFF
--- a/modules/docs/src/Volo.Docs.Application.Contracts/Volo/Docs/TableOfContents/TocHeading.cs
+++ b/modules/docs/src/Volo.Docs.Application.Contracts/Volo/Docs/TableOfContents/TocHeading.cs
@@ -2,6 +2,31 @@
 
 namespace Volo.Docs.TableOfContents;
 
-public record TocHeading(int Level, string Text, string Id);
+public class TocHeading
+{
+    public int Level { get; set; }
 
-public record TocItem(TocHeading Heading, List<TocItem> Children);
+    public string Text { get; set; }
+
+    public string Id { get; set; }
+
+    public TocHeading(int level, string text, string id)
+    {
+        Level = level;
+        Text = text;
+        Id = id;
+    }
+}
+
+public class TocItem
+{
+    public TocHeading Heading { get; set; }
+
+    public List<TocItem> Children { get; set; }
+
+    public TocItem(TocHeading heading, List<TocItem> children)
+    {
+        Heading = heading;
+        Children = children;
+    }
+}


### PR DESCRIPTION
https://github.com/abpframework/abp/pull/23666

```cs
Volo.Docs.Application.Contracts/Volo/Docs/TableOfContents/TocHeading.cs(5,30): error CS0518: Predefined type 'System.Runtime.CompilerServices.IsExternalInit' is not defined or imported
Volo.Docs.Application.Contracts/Volo/Docs/TableOfContents/TocHeading.cs(5,44): error CS0518: Predefined type 'System.Runtime.CompilerServices.IsExternalInit' is not defined or imported
Volo.Docs.Application.Contracts/Volo/Docs/TableOfContents/TocHeading.cs(5,57): error CS0518: Predefined type 'System.Runtime.CompilerServices.IsExternalInit' is not defined or imported
Volo.Docs.Application.Contracts/Volo/Docs/TableOfContents/TocHeading.cs(7,34): error CS0518: Predefined type 'System.Runtime.CompilerServices.IsExternalInit' is not defined or imported
Volo.Docs.Application.Contracts/Volo/Docs/TableOfContents/TocHeading.cs(7,57): error CS0518: Predefined type 'System.Runtime.CompilerServices.IsExternalInit' is not defined or imported
```