### PR TITLE
Fix null reference in extra properties mapping

### DIFF
--- a/framework/src/Volo.Abp.Mapperly/Volo/Abp/Mapperly/MapperlyAutoObjectMappingProvider.cs
+++ b/framework/src/Volo.Abp.Mapperly/Volo/Abp/Mapperly/MapperlyAutoObjectMappingProvider.cs
@@ -227,10 +227,15 @@ public class MapperlyAutoObjectMappingProvider : IAutoObjectMappingProvider
             return extraProperties;
         }
 
-        foreach (var property in hasExtraProperties.ExtraProperties)
+
+        if(hasExtraProperties.ExtraProperties is not null)
         {
-            extraProperties.Add(property.Key, property.Value);
+            foreach (var property in hasExtraProperties.ExtraProperties)
+            {
+                extraProperties.Add(property.Key, property.Value);
+            }
         }
+        
         return extraProperties;
     }
 


### PR DESCRIPTION
Related [vs-internal issue 7377](https://github.com/volosoft/vs-internal/issues/7377)

Added a null check for ExtraProperties before iterating to prevent possible NullReferenceException when mapping extra properties.

### Description

Added a null check for ExtraProperties before iterating to prevent possible NullReferenceException when mapping extra properties.

### Checklist

- [x] I fully tested it as a developer.
- [x] No need to document.

### How to test it?

Take your abp repository to this pr's branch, then graph build your project and run. 
