### PR TITLE
Fix formatting of Scriban syntax in Docs module documentation

### DIFF
--- a/docs/en/modules/docs.md
+++ b/docs/en/modules/docs.md
@@ -507,6 +507,7 @@ Now you can use **Scriban** syntax to create sections in your document.
 
 For example:
 
+{%{
 ```txt
 {{ if UI == "NG" }}
 
@@ -527,6 +528,7 @@ For example:
 {{ end }}
 
 ```
+}%}
 
 You can also use variables in a text, adding **_Value** postfix to its key:
 


### PR DESCRIPTION
https://github.com/scriban/scriban/blob/master/doc/language.md#13-escape-block