### PR TITLE
Update CLI sample to use --old flag

### DIFF
--- a/docs/en/cli/new-command-samples.md
+++ b/docs/en/cli/new-command-samples.md
@@ -164,7 +164,7 @@ It's a template of a basic .NET console application with ABP module architecture
 * This project consists of the following files: `Acme.BookStore.csproj`, `appsettings.json`, `BookStoreHostedService.cs`, `BookStoreModule.cs`, `HelloWorldService.cs` and `Program.cs`.
 
   ```bash
-  abp new Acme.BookStore -t console -csf
+  abp new Acme.BookStore -t console --old
   ```
 
 ## Module

--- a/docs/en/cli/new-command-samples.md
+++ b/docs/en/cli/new-command-samples.md
@@ -164,7 +164,7 @@ It's a template of a basic .NET console application with ABP module architecture
 * This project consists of the following files: `Acme.BookStore.csproj`, `appsettings.json`, `BookStoreHostedService.cs`, `BookStoreModule.cs`, `HelloWorldService.cs` and `Program.cs`.
 
   ```bash
-  abp new Acme.BookStore -t console --old
+  abp new Acme.BookStore -t console -csf --old
   ```
 
 ## Module


### PR DESCRIPTION
Resolves [#7077](https://github.com/volosoft/vs-internal/issues/7077)

### Description
Replaces the '-csf' flag with '--old' in the .NET console application template example to reflect updated command usage.

### Checklist

- [x] I fully tested it as a developer.
- [x] No need to document.
