### PR TITLE
Increase MaxDeviceInfoLength to 256

### DIFF
--- a/docs/en/release-info/migration-guides/abp-10-0.md
+++ b/docs/en/release-info/migration-guides/abp-10-0.md
@@ -8,6 +8,12 @@ This document is a guide for upgrading ABP v9.x solutions to ABP v10.0. There ar
 
 We've upgraded ABP to .NET 10.0, so you need to move your solutions to .NET 10.0 if you want to use ABP 10.0. You can check Microsoft’s [Migrate from ASP.NET Core 9.0 to 10.0](https://learn.microsoft.com/en-us/aspnet/core/migration/90-to-100) documentation, to see how to update an existing ASP.NET Core 9.0 project to ASP.NET Core 10.0.
 
+### Add new EF Core Migrations
+
+Some entities in certain modules have been modified. If you are using Entity Framework Core, please create a new EF Core migration in your project after upgrading to ABP 10.0.
+
+> If the migration file is empty, you can remove it by `dotnet ef migrations remove` command.
+
 ### Razor Runtime Compilation Obsolete
 
 We removed the Razor Runtime Compilation support since it is obsolete and replaced by [Hot Reload](https://learn.microsoft.com/en-us/aspnet/core/test/hot-reload) in .NET 10.0. 

--- a/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/IdentitySessionConsts.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Domain.Shared/Volo/Abp/Identity/IdentitySessionConsts.cs
@@ -6,7 +6,7 @@ public class IdentitySessionConsts
 
     public static int MaxDeviceLength { get; set; } = 64;
 
-    public static int MaxDeviceInfoLength { get; set; } = 64;
+    public static int MaxDeviceInfoLength { get; set; } = 256;
 
     public static int MaxClientIdLength { get; set; } = 64;
 


### PR DESCRIPTION
Updated the MaxDeviceInfoLength constant from 64 to 256 to allow for longer device information strings in identity sessions.
