### PR TITLE
Angular - Adding HTML encoding utilities 

### DIFF
--- a/npm/ng-packs/packages/core/src/lib/pipes/html-encode.pipe.ts
+++ b/npm/ng-packs/packages/core/src/lib/pipes/html-encode.pipe.ts
@@ -1,0 +1,19 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'htmlEncode',
+})
+export class HtmlEncodePipe implements PipeTransform {
+  transform(value: string): string {
+    if (!value) {
+      return value;
+    }
+
+    return value
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+}

--- a/npm/ng-packs/packages/core/src/lib/pipes/index.ts
+++ b/npm/ng-packs/packages/core/src/lib/pipes/index.ts
@@ -7,3 +7,4 @@ export * from './short-time.pipe';
 export * from './short-date-time.pipe';
 export * from './utc-to-local.pipe';
 export * from './lazy-localization.pipe';
+export * from './html-encode.pipe';

--- a/npm/ng-packs/packages/core/src/lib/services/html-encoding.service.ts
+++ b/npm/ng-packs/packages/core/src/lib/services/html-encoding.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class HtmlEncodingService {
+  encode(value: string): string {
+    if (!value) {
+      return value;
+    }
+
+    return value
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  decode(value: string): string {
+    if (!value) {
+      return value;
+    }
+
+    return value
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&#39;/g, "'");
+  }
+}

--- a/npm/ng-packs/packages/core/src/lib/services/index.ts
+++ b/npm/ng-packs/packages/core/src/lib/services/index.ts
@@ -2,6 +2,7 @@ export * from './config-state.service';
 export * from './content-projection.service';
 export * from './dom-insertion.service';
 export * from './environment.service';
+export * from './html-encoding.service';
 export * from './http-error-reporter.service';
 export * from './http-wait.service';
 export * from './lazy-load.service';


### PR DESCRIPTION
### Description

Relates https://github.com/volosoft/volo/issues/20781

- Adds an HTML encoder service that can be used to encode and decode related inputs.
- Adds an HTML encoder pipe in case we need to use. (We can remove this if you think that this is redundant)
