### PR TITLE
Fix column width handling in extensible table

### DIFF
--- a/npm/ng-packs/packages/components/extensible/src/lib/components/extensible-table/extensible-table.component.html
+++ b/npm/ng-packs/packages/components/extensible/src/lib/components/extensible-table/extensible-table.component.html
@@ -40,9 +40,9 @@
   @if (actionsTemplate || (actionList.length && hasAtLeastOnePermittedAction)) {
     <ngx-datatable-column
       [name]="actionsText | abpLocalization"
-      [maxWidth]="columnWidths[0] ?? undefined"
-      [width]="columnWidths[0] ?? 200"
-      [canAutoResize]="!columnWidths[0]"
+      [maxWidth]="_actionsColumnWidth() ?? undefined"
+      [width]="_actionsColumnWidth() ?? 200"
+      [canAutoResize]="!_actionsColumnWidth()"
       [sortable]="false"
     >
       <ng-template let-row="row" let-i="rowIndex" ngx-datatable-cell-template>
@@ -60,8 +60,8 @@
   @for (prop of propList; track prop.name; let i = $index) {
     <ngx-datatable-column
       *abpVisible="prop.columnVisible(getInjected)"
-      [width]="columnWidths[i + 1] ?? 200"
-      [canAutoResize]="!columnWidths[i + 1]"
+      [width]="columnWidths[i] ?? 200"
+      [canAutoResize]="!columnWidths[i]"
       [name]="(prop.isExtra ? '::' + prop.displayName : prop.displayName) | abpLocalization"
       [prop]="prop.name"
       [sortable]="prop.sortable"

--- a/npm/ng-packs/packages/components/extensible/src/lib/components/extensible-table/extensible-table.component.ts
+++ b/npm/ng-packs/packages/components/extensible/src/lib/components/extensible-table/extensible-table.component.ts
@@ -130,12 +130,7 @@ export class ExtensibleTableComponent<R = any> implements OnChanges, AfterViewIn
   private readonly _actionsColumnWidth = signal<number | undefined>(DEFAULT_ACTIONS_COLUMN_WIDTH);
 
   readonly columnWidths = computed(() => {
-    const actionsColumn = this._actionsColumnWidth();
-    const widths = [actionsColumn];
-    this.propList.forEach(({ value: prop }) => {
-      widths.push(prop.columnWidth);
-    });
-    return widths;
+    return this.propList.toArray().map(prop => prop.columnWidth);
   });
 
   constructor() {


### PR DESCRIPTION
Refactors how column widths are computed and applied in ExtensibleTableComponent. The actions column now uses a dedicated method for width, and property columns use a corrected index for width assignment, improving alignment and configurability.

### Description

Resolves https://github.com/volosoft/vs-internal/issues/7396 (write the related issue number if available)

TODO: Describe what this PR has changed, add screenshot or animated GIF if available, write if it is a breaking change, and how to fix the breaking changes for existing applications if so.

### Checklist

- [ ] I fully tested it as developer / designer and created unit / integration tests
- [ ] I documented it (or no need to document or I will create a separate documentation issue)

