### PR TITLE
Refactor TOC generation logic in project index page

### DIFF
--- a/modules/docs/src/Volo.Docs.Web/Pages/Documents/Project/Index.cshtml.cs
+++ b/modules/docs/src/Volo.Docs.Web/Pages/Documents/Project/Index.cshtml.cs
@@ -542,11 +542,6 @@ namespace Volo.Docs.Pages.Documents.Project
                     DocumentNameWithExtension = Document.Name;
                     SetDocumentPageTitle();
 
-                    if (Document != null && !Document.Content.IsNullOrEmpty())
-                    {
-                        TocItems = _tocGeneratorService.GenerateTocItems(Document.Content, TocLevelCount);
-                    }
-
                     await ConvertDocumentContentToHtmlAsync();
 
                     return true;
@@ -605,6 +600,11 @@ namespace Volo.Docs.Pages.Documents.Project
             else
             {
                 DocumentNavigationsDto = new DocumentNavigationsDto();
+            }
+
+            if (Document != null && !Document.Content.IsNullOrEmpty())
+            {
+                TocItems = _tocGeneratorService.GenerateTocItems(Document.Content, TocLevelCount);
             }
 
             var converter = _documentToHtmlConverterFactory.Create<DocumentToHtmlConverterContext>(Document.Format ?? Project.Format);


### PR DESCRIPTION
Moved the TOC generation for documents to occur after navigation DTO initialization, ensuring TOC items are generated only when document content is available. This improves code clarity and maintains correct TOC population.

### Description

Resolves [vs-internal-issue-#7423](https://github.com/volosoft/vs-internal/issues/7423)

### Checklist

- [ ] I fully tested it as developer
- [ ] no need to document
