### PR TITLE
Add error message for post creation failure

### DIFF
--- a/abp_io/AbpIoLocalization/AbpIoLocalization/Www/Localization/Resources/en.json
+++ b/abp_io/AbpIoLocalization/AbpIoLocalization/Www/Localization/Resources/en.json
@@ -616,6 +616,7 @@
     "QuestionItemErrorMessage": "Could not get the latest question details from Stackoverflow.",
     "Oops": "Oops!",
     "CreatePostSuccessMessage": "The Post has been successfully submitted. It will be published after a review from the site admin.",
+    "PostCreationFailed": "An error occurred while creating the post. Please try again later.",
     "Browse": "Browse",
     "CoverImage": "Cover Image",
     "ShareYourExperiencesWithTheABPFramework": "ABP Community Articles | Read or Submit Articles",


### PR DESCRIPTION
Introduced a new localization string 'PostCreationFailed' to provide feedback when post creation encounters an error.


Resolves [7406](https://github.com/volosoft/vs-internal/issues/7406)

