### PR TITLE
Add SEO section extraction and usage for documents

### DIFF
--- a/modules/docs/src/Volo.Docs.Domain.Shared/Volo/Docs/Documents/Rendering/ScribanDocumentSectionRenderer.cs
+++ b/modules/docs/src/Volo.Docs.Domain.Shared/Volo/Docs/Documents/Rendering/ScribanDocumentSectionRenderer.cs
@@ -22,6 +22,7 @@ public class ScribanDocumentSectionRenderer : IDocumentSectionRenderer
     protected const string DocsParam = "//[doc-params]";
     protected const string DocsTemplates = "//[doc-template]";
     protected const string DocsNav = "//[doc-nav]";
+    protected const string DocsSeo = "//[doc-seo]";
 
     public ILogger<ScribanDocumentSectionRenderer> Logger { get; set; }
 
@@ -49,7 +50,7 @@ public class ScribanDocumentSectionRenderer : IDocumentSectionRenderer
 
         var result = await scribanTemplate.RenderAsync(parameters);
 
-        return RemoveOptionsJson(result, DocsParam, DocsNav);
+        return RemoveOptionsJson(result, DocsParam, DocsNav, DocsSeo);
     }
 
     public Task<Dictionary<string, List<string>>> GetAvailableParametersAsync(string document)

--- a/modules/docs/src/Volo.Docs.Web/HtmlConverting/DocumentSeoDto.cs
+++ b/modules/docs/src/Volo.Docs.Web/HtmlConverting/DocumentSeoDto.cs
@@ -1,0 +1,6 @@
+namespace Volo.Docs.HtmlConverting;
+
+public class DocumentSeoDto
+{
+    public string Description { get; set; }
+}

--- a/modules/docs/src/Volo.Docs.Web/HtmlConverting/IWebDocumentSectionRenderer.cs
+++ b/modules/docs/src/Volo.Docs.Web/HtmlConverting/IWebDocumentSectionRenderer.cs
@@ -10,5 +10,7 @@ namespace Volo.Docs.HtmlConverting
         Task<List<DocumentPartialTemplateWithValues>> GetPartialTemplatesInDocumentAsync(string documentContent);
         
         Task<DocumentNavigationsDto> GetDocumentNavigationsAsync(string documentContent);
+        
+        Task<DocumentSeoDto> GetDocumentSeoAsync(string documentContent);
     }
 }

--- a/modules/docs/src/Volo.Docs.Web/HtmlConverting/ScribanWebDocumentSectionRenderer.cs
+++ b/modules/docs/src/Volo.Docs.Web/HtmlConverting/ScribanWebDocumentSectionRenderer.cs
@@ -11,6 +11,11 @@ namespace Volo.Docs.HtmlConverting
             return GetSectionAsync<DocumentNavigationsDto>(documentContent, DocsNav);
         }
 
+        public Task<DocumentSeoDto> GetDocumentSeoAsync(string documentContent)
+        {
+            return GetSectionAsync<DocumentSeoDto>(documentContent, DocsSeo);
+        }
+
         public async Task<List<DocumentPartialTemplateWithValues>> GetPartialTemplatesInDocumentAsync(
             string documentContent)
         {

--- a/modules/docs/src/Volo.Docs.Web/Pages/Documents/Project/Index.cshtml.cs
+++ b/modules/docs/src/Volo.Docs.Web/Pages/Documents/Project/Index.cshtml.cs
@@ -99,6 +99,8 @@ namespace Volo.Docs.Pages.Documents.Project
         public bool HasDownloadPdf { get; set; }
 
         public DocumentNavigationsDto DocumentNavigationsDto { get; private set; }
+        
+        public DocumentSeoDto DocumentSeoDto { get; private set; }
 
         private const int MaxDescriptionMetaTagLength = 200;
         private const int TocLevelCount = 2;
@@ -587,6 +589,7 @@ namespace Volo.Docs.Pages.Documents.Project
                 var partialTemplates = await GetDocumentPartialTemplatesAsync();
 
                 DocumentNavigationsDto = await _webDocumentSectionRenderer.GetDocumentNavigationsAsync(Document.Content);
+                DocumentSeoDto = await _webDocumentSectionRenderer.GetDocumentSeoAsync(Document.Content);
 
                 try
                 {
@@ -600,6 +603,7 @@ namespace Volo.Docs.Pages.Documents.Project
             else
             {
                 DocumentNavigationsDto = new DocumentNavigationsDto();
+                DocumentSeoDto = new DocumentSeoDto();
             }
 
             if (Document != null && !Document.Content.IsNullOrEmpty())
@@ -886,6 +890,11 @@ namespace Volo.Docs.Pages.Documents.Project
             if (Document == null || Document.Content.IsNullOrWhiteSpace())
             {
                 return null;
+            }
+
+            if (DocumentSeoDto?.Description.IsNullOrWhiteSpace() == false)
+            {
+                return DocumentSeoDto.Description;
             }
 
             var firstParagraph = new Regex(@"<p>(.*?)</p>", RegexOptions.IgnoreCase);

--- a/modules/docs/src/Volo.Docs.Web/Pages/Documents/Shared/Scripts/vs.js
+++ b/modules/docs/src/Volo.Docs.Web/Pages/Documents/Shared/Scripts/vs.js
@@ -63,10 +63,13 @@
 
             var $myNav = $('#docs-sticky-index');
 
-            $('body').scrollspy({
-                target: $myNav,
-                offset:100
-            });
+            try {
+                $('body').scrollspy({
+                    target: $myNav,
+                    offset:100
+                });
+            } catch {
+            }
 
             $('#docs-sticky-index a').on('click', function (event) {
                 if (this.hash !== '') {


### PR DESCRIPTION
### Fixes
Resolves https://github.com/volosoft/vs-internal/issues/7279

### Summary
This PR adds SEO metadata support for documentation pages through a special comment syntax in Markdown files.

### Changes
- Added SEO metadata parser that extracts metadata from `//[doc-seo]` comment blocks in documentation files
- Implemented support for custom `Description` meta tag
- Metadata is defined in JSON format within the comment block

### Usage
Documentation authors can now add SEO metadata at the beginning of their Markdown files using the following syntax:

````text
```json
//[doc-seo]
{
    "Description": "Custom page description for SEO"
}
```
````

The parser will extract this metadata and apply it to the page's meta tags, improving search engine visibility and social media sharing.