### PR TITLE
Add 'Configuring Forwarded Headers' to docs navigation under the 'Deployment' section

### DIFF
--- a/docs/en/docs-nav.json
+++ b/docs/en/docs-nav.json
@@ -2625,6 +2625,10 @@
         {
           "text": "Optimizing for Production",
           "path": "deployment/optimizing-production.md"
+        },
+        {
+          "text": "Configuring Forwarded Headers for Reverse Proxies",
+          "path": "deployment/forwarded-headers.md"
         }
       ]
     },


### PR DESCRIPTION
If there is no specific reason, we can show the **Forwarded Headers** document under the *Deployment* section. It's a really good document, and I personally used it while answering questions in our support platform a few times, so it might be good to make it visible on the menu.