### PR TITLE
Optimize BlobProvider

### DIFF
--- a/docs/en/framework/infrastructure/blob-storing/minio.md
+++ b/docs/en/framework/infrastructure/blob-storing/minio.md
@@ -31,6 +31,7 @@ Configure<AbpBlobStoringOptions>(options =>
             minio.AccessKey = "your minio accessKey";
             minio.SecretKey = "your minio secretKey";
             minio.BucketName = "your minio bucketName";
+            minio.PresignedGetExpirySeconds = 3600;
         });
     });
 });
@@ -53,6 +54,7 @@ Configure<AbpBlobStoringOptions>(options =>
     * Buckets used with Amazon S3 Transfer Acceleration can't have dots (.) in their names. For more information about transfer acceleration, see Amazon S3 Transfer Acceleration.
 * **WithSSL** (bool): Default value is `false`,Chain to MinIO Client object to use https instead of http.
 * **CreateContainerIfNotExists** (bool): Default value is `false`, If a bucket does not exist in minio, `MinioBlobProvider` will try to create it.
+* **PresignedGetExpirySeconds** (int): Default value is `7 * 24 * 3600`, The expiration time of the pre-specified get url. The is valid within the range of 1 to 604800(corresponding to 7 days).
 
 
 ## Minio Blob Name Calculator

--- a/framework/src/Volo.Abp.BlobStoring.Minio/Microsoft/Extensions/DependencyInjection/MinioHttpClientFactoryServiceCollectionExtensions.cs
+++ b/framework/src/Volo.Abp.BlobStoring.Minio/Microsoft/Extensions/DependencyInjection/MinioHttpClientFactoryServiceCollectionExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System.Net.Http;
+
+namespace Microsoft.Extensions.DependencyInjection;
+internal static class MinioHttpClientFactoryServiceCollectionExtensions
+{
+    private const string HttpClientName = "__MinioApiClient";
+    public static IServiceCollection AddMinioHttpClient(this IServiceCollection services)
+    {
+        services.AddHttpClient(HttpClientName);
+
+        return services;
+    }
+
+    public static HttpClient CreateMinioHttpClient(this IHttpClientFactory httpClientFactory)
+    {
+        return httpClientFactory.CreateClient(HttpClientName);
+    }
+}

--- a/framework/src/Volo.Abp.BlobStoring.Minio/Volo.Abp.BlobStoring.Minio.csproj
+++ b/framework/src/Volo.Abp.BlobStoring.Minio/Volo.Abp.BlobStoring.Minio.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Volo.Abp.BlobStoring\Volo.Abp.BlobStoring.csproj" />
     <PackageReference Include="Minio" />
+	<PackageReference Include="Microsoft.Extensions.Http" />
   </ItemGroup>
 
 </Project>

--- a/framework/src/Volo.Abp.BlobStoring.Minio/Volo/Abp/BlobStoring/Minio/AbpBlobStoringMinioModule.cs
+++ b/framework/src/Volo.Abp.BlobStoring.Minio/Volo/Abp/BlobStoring/Minio/AbpBlobStoringMinioModule.cs
@@ -1,9 +1,13 @@
-﻿using Volo.Abp.Modularity;
+﻿using Microsoft.Extensions.DependencyInjection;
+using Volo.Abp.Modularity;
 
 namespace Volo.Abp.BlobStoring.Minio;
 
 [DependsOn(typeof(AbpBlobStoringModule))]
 public class AbpBlobStoringMinioModule : AbpModule
 {
-
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        context.Services.AddMinioHttpClient();
+    }
 }

--- a/framework/src/Volo.Abp.BlobStoring.Minio/Volo/Abp/BlobStoring/Minio/MinioBlobProvider.cs
+++ b/framework/src/Volo.Abp.BlobStoring.Minio/Volo/Abp/BlobStoring/Minio/MinioBlobProvider.cs
@@ -1,22 +1,27 @@
-﻿using Minio;
-using Minio.Exceptions;
-using System;
+﻿using System;
 using System.IO;
+using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Minio;
 using Minio.DataModel.Args;
+using Minio.Exceptions;
 using Volo.Abp.DependencyInjection;
 
 namespace Volo.Abp.BlobStoring.Minio;
 
 public class MinioBlobProvider : BlobProviderBase, ITransientDependency
 {
+    protected IHttpClientFactory HttpClientFactory { get; }
     protected IMinioBlobNameCalculator MinioBlobNameCalculator { get; }
     protected IBlobNormalizeNamingService BlobNormalizeNamingService { get; }
 
     public MinioBlobProvider(
+        IHttpClientFactory httpClientFactory,
         IMinioBlobNameCalculator minioBlobNameCalculator,
         IBlobNormalizeNamingService blobNormalizeNamingService)
     {
+        HttpClientFactory = httpClientFactory;
         MinioBlobNameCalculator = minioBlobNameCalculator;
         BlobNormalizeNamingService = blobNormalizeNamingService;
     }
@@ -81,21 +86,16 @@ public class MinioBlobProvider : BlobProviderBase, ITransientDependency
             return null;
         }
 
-        var memoryStream = new MemoryStream();
-        await client.GetObjectAsync(new GetObjectArgs().WithBucket(containerName).WithObject(blobName).WithCallbackStream(stream =>
-        {
-            if (stream != null)
-            {
-                stream.CopyTo(memoryStream);
-                memoryStream.Seek(0, SeekOrigin.Begin);
-            }
-            else
-            {
-                memoryStream = null;
-            }
-        }));
+        var configuration = args.Configuration.GetMinioConfiguration();
+        var downloadUrl = await client.PresignedGetObjectAsync(
+            new PresignedGetObjectArgs()
+                .WithBucket(containerName)
+                .WithObject(blobName)
+                .WithExpiry(configuration.PresignedGetExpirySeconds));
 
-        return memoryStream;
+        var httpClient = HttpClientFactory.CreateMinioHttpClient();
+
+        return await httpClient.GetStreamAsync(downloadUrl, args.CancellationToken);
     }
 
     protected virtual IMinioClient GetMinioClient(BlobProviderArgs args)

--- a/framework/src/Volo.Abp.BlobStoring.Minio/Volo/Abp/BlobStoring/Minio/MinioBlobProviderConfiguration.cs
+++ b/framework/src/Volo.Abp.BlobStoring.Minio/Volo/Abp/BlobStoring/Minio/MinioBlobProviderConfiguration.cs
@@ -47,6 +47,16 @@ public class MinioBlobProviderConfiguration
         set => _containerConfiguration.SetConfiguration(MinioBlobProviderConfigurationNames.CreateBucketIfNotExists, value);
     }
 
+    /// <summary>
+    /// Default value: 7 * 24 * 3600.
+    /// </summary>
+    public int PresignedGetExpirySeconds {
+        get => _containerConfiguration.GetConfigurationOrDefault(MinioBlobProviderConfigurationNames.PresignedGetExpirySeconds, _defaultExpirySeconds);
+        set => _containerConfiguration.SetConfiguration(MinioBlobProviderConfigurationNames.PresignedGetExpirySeconds, value);
+    }
+
+    private int _defaultExpirySeconds = 7 * 24 * 3600;
+
     private readonly BlobContainerConfiguration _containerConfiguration;
 
     public MinioBlobProviderConfiguration(BlobContainerConfiguration containerConfiguration)

--- a/framework/src/Volo.Abp.BlobStoring.Minio/Volo/Abp/BlobStoring/Minio/MinioBlobProviderConfigurationNames.cs
+++ b/framework/src/Volo.Abp.BlobStoring.Minio/Volo/Abp/BlobStoring/Minio/MinioBlobProviderConfigurationNames.cs
@@ -8,4 +8,5 @@ public static class MinioBlobProviderConfigurationNames
     public const string SecretKey = "Minio.SecretKey";
     public const string WithSSL = "Minio.WithSSL";
     public const string CreateBucketIfNotExists = "Minio.CreateBucketIfNotExists";
+    public const string PresignedGetExpirySeconds = "Minio.PresignedGetExpirySeconds";
 }

--- a/framework/test/Volo.Abp.BlobStoring.Minio.Tests/Volo/Abp/BlobStoring/Minio/AbpBlobStoringMinioTestModule.cs
+++ b/framework/test/Volo.Abp.BlobStoring.Minio.Tests/Volo/Abp/BlobStoring/Minio/AbpBlobStoringMinioTestModule.cs
@@ -57,6 +57,7 @@ public class AbpBlobStoringMinioTestModule : AbpModule
                     minio.WithSSL = false;
                     minio.BucketName = _randomContainerName;
                     minio.CreateBucketIfNotExists = true;
+                    minio.PresignedGetExpirySeconds = 3600;
                 });
             });
         });


### PR DESCRIPTION
### Description

Resolves #23962 

- Build an object download link using **`PresignedGetObjectAsync`** and directly download the network stream through `HttpClient`.
- ` MinioBlobProviderConfiguration ` add a ` PresignedGetExpirySeconds ` configuration items, used to configure expiration time component link, the default is 7 days.

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [ ] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

Please describe how this can be tested by the test engineers if it is not already explicit - or remove this section if no need to description.
