### PR TITLE
Fix base64 padding in JWT token parsing

### DIFF
--- a/npm/ng-packs/packages/oauth/src/lib/services/remember-me.service.ts
+++ b/npm/ng-packs/packages/oauth/src/lib/services/remember-me.service.ts
@@ -38,7 +38,10 @@ export class RememberMeService {
   }
 
   getFromToken(accessToken: string) {
-    const tokenBody = accessToken.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');
+    let tokenBody = accessToken.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');
+    while (tokenBody.length % 4 !== 0) {
+      tokenBody += '=';
+    }
     try {
       const parsedToken = JSON.parse(atob(tokenBody));
       return Boolean(parsedToken[this.#rememberMe]);


### PR DESCRIPTION
Ensures the JWT token body is properly padded before decoding, preventing errors when parsing tokens with missing base64 padding.

Resolves #23796