### PR TITLE
Fix: User menu item visibility not triggered (#23993)

### DIFF
--- a/npm/ng-packs/packages/theme-shared/src/lib/directives/visible.directive.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/directives/visible.directive.ts
@@ -15,6 +15,7 @@ export class AbpVisibleDirective implements OnDestroy, OnInit {
     value: boolean | Promise<boolean> | Observable<boolean> | undefined | null,
   ) {
     this.condition$ = checkType(value);
+    this.conditionSubscription?.unsubscribe();
     this.subscribeToCondition();
   }
 


### PR DESCRIPTION
### Description

Resolves #23993

This PR fixes the issue where user menu items with `visible: () => false` were still being displayed in the user dropdown menu.

**Root Cause:**
The `AbpVisibleDirective` had a memory leak where it wasn't unsubscribing from previous subscriptions when the input value changed. This could cause multiple active subscriptions to interfere with each other.

**Changes Made:**

- Fixed memory leak in `AbpVisibleDirective` where previous subscriptions weren't unsubscribed
- Added proper cleanup (`this.conditionSubscription?.unsubscribe()`) before creating new subscriptions in the `abpVisible` setter
- This ensures `visible: () => false` properly hides menu items

**Files Changed:**

- `npm/ng-packs/packages/theme-shared/src/lib/directives/visible.directive.ts`

**Breaking Changes:**
None. This is a bug fix with no breaking changes.

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

1. Create a test provider in your Angular application:

```typescript
// angular/src/app/test-provider.ts
import { UserMenuService } from "@abp/ng.theme.shared";
import { inject, provideAppInitializer } from "@angular/core";

export function testUserMenuProvider() {
  const userMenu = inject(UserMenuService);
  userMenu.addItems([
    {
      id: "TEST_HIDDEN",
      order: 106,
      textTemplate: {
        text: "Should Be Hidden",
        icon: "bi bi-x-circle",
      },
      visible: () => false,
      action: () => console.log("Should not be clickable"),
    },
    {
      id: "TEST_VISIBLE",
      order: 107,
      textTemplate: {
        text: "Should Be Visible",
        icon: "bi bi-check-circle",
      },
      visible: () => true,
      action: () => console.log("Should be clickable"),
    },
  ]);
}

export const TEST_PROVIDERS = [
  provideAppInitializer(() => {
    testUserMenuProvider();
  }),
];
```

2. Add the provider to `app.config.ts`:

```typescript
export const appConfig: ApplicationConfig = {
  providers: [
    // ...
    TEST_PROVIDERS,
  ],
};
```

3. Run the application and click on the user menu in the top-right corner

**Expected Results:**

- Only "Should Be Visible" item appears in the dropdown
- "Should Be Hidden" item is not displayed
- No memory leaks when navigating between pages
