### PR TITLE
Clarify data seeding in ABP Suite tutorial

### DIFF
--- a/docs/en/tutorials/book-store-with-abp-suite/part-02.md
+++ b/docs/en/tutorials/book-store-with-abp-suite/part-02.md
@@ -135,9 +135,11 @@ It will take some time to complete the process. After the process is completed, 
 
 {{ end }}
 
-After the application is started, you can right-click and *Browse* on the application to open it in the ABP Studio's pre-integrated browser. After logging in using the default credentials (`admin` / `1q2w3E*`), you can see the Books page in the following figure with a single record:
+After the application is started, you can right-click and *Browse* on the application to open it in the ABP Studio's pre-integrated browser. After logging in using the default credentials (`admin` / `1q2w3E*`), you can see the Books page like in the following figure:
 
 ![](./images/suite-book-pages-browser.png)
+
+> By default, ABP Suite doesn't generate data seed contributors for entities, as you'll need to create them manually. This is intentional since having dummy data in development or production environments may not be suitable for your specific needs. However, if you selected the **Create unit & integration tests** option while creating the entity, you can see the sample data-seed contributors under the *Acme.BookStore.Domain.Tests* project to simplify the testing process by having initial data for the entities, which we will see in [the part 4 of this tutorial](part-04.md).
 
 On this page, you can create a new book, update an existing book, delete a book, export all records (or the filtered records) to excel, filter the records by using the advanced filter section, bulk delete multiple records and so on.
 


### PR DESCRIPTION
### Description

Resolves https://github.com/volosoft/vs-internal/issues/6879

Added explanation about ABP Suite's default behavior regarding data seed contributors, noting that they are not generated automatically and must be created manually. Also described the presence of sample data-seed contributors in test projects when unit & integration tests are enabled, with a reference to part 4 of the tutorial.

### Checklist

- [X] I fully tested it as developer / designer and created unit / integration tests
- [X] I documented it (or no need to document or I will create a separate documentation issue)
