### PR TITLE
Add extensibility for DbContext OnConfiguring actions

### DIFF
--- a/docs/en/framework/data/entity-framework-core/index.md
+++ b/docs/en/framework/data/entity-framework-core/index.md
@@ -146,7 +146,7 @@ Configure<AbpDbContextOptions>(options =>
 });
 ````
 
-Add actions for the `ConfigureConventions` and `OnModelCreating` methods of the `DbContext` as shown below:
+Add actions for the `ConfigureConventions`, `OnModelCreating` and `OnConfiguring` methods of the `DbContext` as shown below:
 
 ````csharp
 Configure<AbpDbContextOptions>(options =>
@@ -169,6 +169,15 @@ Configure<AbpDbContextOptions>(options =>
     options.ConfigureOnModelCreating<YourDbContext>((dbContext, builder) =>
     {
         // This action is called for OnModelCreating method of specific DbContext.
+    });
+
+    options.ConfigureDefaultOnConfiguring((dbContext, optionsBuilder) =>
+    {
+        // This action is called for OnConfiguring method of all DbContexts.
+    });
+    options.ConfigureOnConfiguring<YourDbContext>((dbContext, optionsBuilder) =>
+    {
+        // This action is called for OnConfiguring method of specific DbContext.
     });
 });
 ````

--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/AbpDbContext.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/AbpDbContext.cs
@@ -117,7 +117,12 @@ public abstract class AbpDbContext<TDbContext> : DbContext, IAbpEfCoreDbContext,
     {
         optionsBuilder.ConfigureWarnings(c => c.Ignore(RelationalEventId.PendingModelChangesWarning));
         base.OnConfiguring(optionsBuilder);
-        
+
+        if (LazyServiceProvider == null || Options == null)
+        {
+            return;
+        }
+
         Options.Value.DefaultOnConfiguringAction?.Invoke(this, optionsBuilder);
         foreach (var onConfiguringAction in Options.Value.OnConfiguringActions.GetOrDefault(typeof(TDbContext)) ?? [])
         {
@@ -804,7 +809,7 @@ public abstract class AbpDbContext<TDbContext> : DbContext, IAbpEfCoreDbContext,
             modelBuilder,
             mutableEntityType
         );
-        
+
         entityTypeBuilder.ConfigureByConvention();
 
         ConfigureGlobalFilters<TEntity>(modelBuilder, mutableEntityType, entityTypeBuilder);
@@ -821,7 +826,7 @@ public abstract class AbpDbContext<TDbContext> : DbContext, IAbpEfCoreDbContext,
 
     protected virtual void ConfigureGlobalFilters<TEntity>(
         ModelBuilder modelBuilder,
-        IMutableEntityType mutableEntityType, 
+        IMutableEntityType mutableEntityType,
         EntityTypeBuilder<TEntity> entityTypeBuilder)
         where TEntity : class
     {
@@ -852,7 +857,7 @@ public abstract class AbpDbContext<TDbContext> : DbContext, IAbpEfCoreDbContext,
         {
             return;
         }
-        
+
 
         foreach (var property in mutableEntityType.GetProperties().
                      Where(property => property.PropertyInfo != null &&
@@ -864,7 +869,7 @@ public abstract class AbpDbContext<TDbContext> : DbContext, IAbpEfCoreDbContext,
                 modelBuilder,
                 mutableEntityType
             );
-            
+
             entityTypeBuilder
                 .Property(property.Name)
                 .HasConversion(property.ClrType == typeof(DateTime)
@@ -874,7 +879,7 @@ public abstract class AbpDbContext<TDbContext> : DbContext, IAbpEfCoreDbContext,
     }
 
     protected virtual void ConfigureValueGenerated<TEntity>(
-        ModelBuilder modelBuilder, 
+        ModelBuilder modelBuilder,
         IMutableEntityType mutableEntityType)
         where TEntity : class
     {

--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/AbpDbContext.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/AbpDbContext.cs
@@ -117,6 +117,12 @@ public abstract class AbpDbContext<TDbContext> : DbContext, IAbpEfCoreDbContext,
     {
         optionsBuilder.ConfigureWarnings(c => c.Ignore(RelationalEventId.PendingModelChangesWarning));
         base.OnConfiguring(optionsBuilder);
+        
+        Options.Value.DefaultOnConfiguringAction?.Invoke(this, optionsBuilder);
+        foreach (var onConfiguringAction in Options.Value.OnConfiguringActions.GetOrDefault(typeof(TDbContext)) ?? [])
+        {
+            onConfiguringAction.As<Action<DbContext, DbContextOptionsBuilder>>().Invoke(this, optionsBuilder);
+        }
     }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/AbpDbContextOptions.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/AbpDbContextOptions.cs
@@ -26,8 +26,12 @@ public class AbpDbContextOptions
     internal Dictionary<Type, List<object>> ConventionActions { get; }
 
     internal Action<DbContext, ModelBuilder>? DefaultOnModelCreatingAction { get; set; }
+    
+    internal Action<DbContext, DbContextOptionsBuilder>? DefaultOnConfiguringAction { get; set; }
 
     internal Dictionary<Type, List<object>> OnModelCreatingActions { get; }
+    
+    internal Dictionary<Type, List<object>> OnConfiguringActions { get; }
 
     public AbpDbContextOptions()
     {
@@ -37,6 +41,7 @@ public class AbpDbContextOptions
         DbContextReplacements = new Dictionary<MultiTenantDbContextType, Type>();
         ConventionActions = new Dictionary<Type, List<object>>();
         OnModelCreatingActions = new Dictionary<Type, List<object>>();
+        OnConfiguringActions = new Dictionary<Type, List<object>>();
     }
 
     public void PreConfigure([NotNull] Action<AbpDbContextConfigurationContext> action)
@@ -84,6 +89,13 @@ public class AbpDbContextOptions
 
         DefaultOnModelCreatingAction = action;
     }
+    
+    public void ConfigureDefaultOnConfiguring([NotNull] Action<DbContext, DbContextOptionsBuilder> action)
+    {
+        Check.NotNull(action, nameof(action));
+
+        DefaultOnConfiguringAction = action;
+    }
 
     public void ConfigureOnModelCreating<TDbContext>([NotNull] Action<TDbContext, ModelBuilder> action)
         where TDbContext : AbpDbContext<TDbContext>
@@ -96,6 +108,24 @@ public class AbpDbContextOptions
             OnModelCreatingActions[typeof(TDbContext)] = new List<object>
             {
                 new Action<DbContext, ModelBuilder>((dbContext, builder) => action((TDbContext)dbContext, builder))
+            };
+            return;
+        }
+
+        actions.Add(action);
+    }
+    
+    public void ConfigureOnConfiguring<TDbContext>([NotNull] Action<TDbContext, DbContextOptionsBuilder> action)
+        where TDbContext : AbpDbContext<TDbContext>
+    {
+        Check.NotNull(action, nameof(action));
+
+        var actions = OnConfiguringActions.GetOrDefault(typeof(TDbContext));
+        if (actions == null)
+        {
+            OnConfiguringActions[typeof(TDbContext)] = new List<object>
+            {
+                new Action<DbContext, DbContextOptionsBuilder>((dbContext, builder) => action((TDbContext)dbContext, builder))
             };
             return;
         }


### PR DESCRIPTION
Introduced DefaultOnConfiguringAction and OnConfiguringActions in AbpDbContextOptions to allow configuration of actions to be executed during DbContext.OnConfiguring. Updated AbpDbContext to invoke these actions, enabling more flexible and modular configuration of DbContext options.