### PR TITLE
Fix Features modal padding

### DIFF
--- a/modules/feature-management/src/Volo.Abp.FeatureManagement.Web/Pages/FeatureManagement/FeatureManagementModal.cshtml
+++ b/modules/feature-management/src/Volo.Abp.FeatureManagement.Web/Pages/FeatureManagement/FeatureManagementModal.cshtml
@@ -41,7 +41,7 @@
                             <h4>@featureGroup.DisplayName</h4>
                             <hr class="mt-2 mb-3"/>
                             <div class="custom-scroll-content" style="height: 400px;">
-                                <div class="pl-1 pt-1">
+                                <div class="ps-1 pt-1">
                                     @for (var j = 0; j < featureGroup.Features.Count; j++)
                                     {
                                         var feature = featureGroup.Features[j];

--- a/modules/permission-management/src/Volo.Abp.PermissionManagement.Blazor/Components/PermissionManagementModal.razor
+++ b/modules/permission-management/src/Volo.Abp.PermissionManagement.Blazor/Components/PermissionManagementModal.razor
@@ -64,7 +64,7 @@
                                     @foreach (var group in _groups)
                                     {
                                         <TabPanel Name="@GetNormalizedGroupName(group.Name)">
-                                            <div class="w-100" style="height: 500px;overflow-y: auto">
+                                            <div class="w-100 ps-1" style="height: 500px;overflow-y: auto">
                                                 <Field>
                                                     <Check
                                                         Disabled="@(IsPermissionGroupDisabled(group))"


### PR DESCRIPTION
### Description
Updated the class from 'pl-1' to 'ps-1' to use the correct Bootstrap 5 padding utility for start padding in the FeatureManagementModal.cshtml file.

Before:
<img width="480" height="907" alt="image" src="https://github.com/user-attachments/assets/b8c635cf-3e25-48ff-bb6e-900332155c7e" />

After:
<img width="480" alt="image" src="https://github.com/user-attachments/assets/4015425a-c848-4161-b835-53ba649140c7" />

This PR also solves https://github.com/volosoft/lepton/issues/3149 issue on Blazor too.

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

Please describe how this can be tested by the test engineers if it is not already explicit - or remove this section if no need to description.
