### PR TITLE
Add pricing link to license requirement notices

### DIFF
--- a/docs/en/modules/account-pro.md
+++ b/docs/en/modules/account-pro.md
@@ -7,7 +7,7 @@
 
 # Account Module (Pro)
 
-> You must have an ABP Team or a higher license to use this module.
+> You must have an [ABP Team or a higher license](https://abp.io/pricing) to use this module.
 
 This module implements the Login, Register, Forgot Password, Email Confirmation, Password Reset, sending and confirming Two-Factor Authentication, user lockout, switch between tenants functionalities of an application;
 

--- a/docs/en/modules/audit-logging-pro.md
+++ b/docs/en/modules/audit-logging-pro.md
@@ -7,7 +7,7 @@
 
 # Audit Logging Module (Pro)
 
-> You must have an ABP Team or a higher license to use this module.
+> You must have an [ABP Team or a higher license](https://abp.io/pricing) to use this module.
 
 This module implements the Audit Logging system of an application;
 

--- a/docs/en/modules/chat.md
+++ b/docs/en/modules/chat.md
@@ -7,7 +7,7 @@
 
 # Chat Module (Pro)
 
-> You must have an ABP Team or a higher license to use this module.
+> You must have an [ABP Team or a higher license](https://abp.io/pricing) to use this module.
 
 This module implements real time messaging between users for an application.
 

--- a/docs/en/modules/cms-kit-pro/contact-form.md
+++ b/docs/en/modules/cms-kit-pro/contact-form.md
@@ -7,7 +7,7 @@
 
 # CMS Kit Pro: Contact Management
 
-> You must have an ABP Team or a higher license to use CMS Kit Pro module's features.
+> You must have an [ABP Team or a higher license](https://abp.io/pricing) to use CMS Kit Pro module's features.
 
 CMS Kit provides a widget to create a contact form on your website.
 

--- a/docs/en/modules/cms-kit-pro/faq.md
+++ b/docs/en/modules/cms-kit-pro/faq.md
@@ -7,7 +7,7 @@
 
 # CMS Kit Pro: FAQ System
 
-> You must have an ABP Team or a higher license to use CMS Kit Pro module's features.
+> You must have an [ABP Team or a higher license](https://abp.io/pricing) to use CMS Kit Pro module's features.
 
 The CMS kit provides a **FAQ** system to allow users to create, edit and delete FAQ's. Here is a screenshot of the FAQ widget:
 

--- a/docs/en/modules/cms-kit-pro/index.md
+++ b/docs/en/modules/cms-kit-pro/index.md
@@ -7,7 +7,7 @@
 
 # CMS Kit Module (Pro)
 
-> You must have an ABP Team or a higher license to use this module.
+> You must have an [ABP Team or a higher license](https://abp.io/pricing) to use this module.
 
 This module extends the [open-source CMS Kit module](../cms-kit) and adds additional CMS (Content Management System) capabilities to your application.
 

--- a/docs/en/modules/cms-kit-pro/newsletter.md
+++ b/docs/en/modules/cms-kit-pro/newsletter.md
@@ -7,7 +7,7 @@
 
 # CMS Kit Pro: Newsletter System
 
-> You must have an ABP Team or a higher license to use CMS Kit Pro module's features.
+> You must have an [ABP Team or a higher license](https://abp.io/pricing) to use CMS Kit Pro module's features.
 
 CMS Kit provides a **newsletter** system to allow users to subscribe to newsletters. Here a screenshot of the newsletter subscription widget:
 

--- a/docs/en/modules/cms-kit-pro/page-feedback.md
+++ b/docs/en/modules/cms-kit-pro/page-feedback.md
@@ -7,7 +7,7 @@
 
 # CMS Kit Pro: Page Feedback System
 
-> You must have an ABP Team or a higher license to use CMS Kit Pro module's features.
+> You must have an [ABP Team or a higher license](https://abp.io/pricing) to use CMS Kit Pro module's features.
 
 The CMS Kit Pro module provides a comprehensive **Page Feedback** system that enables you to collect valuable user feedback about your website pages. This system allows visitors to quickly rate their experience and provide comments, helping you understand user satisfaction and identify areas for improvement.
 

--- a/docs/en/modules/cms-kit-pro/poll.md
+++ b/docs/en/modules/cms-kit-pro/poll.md
@@ -7,7 +7,7 @@
 
 # CMS Kit Pro: Poll System
 
-> You must have an ABP Team or a higher license to use CMS Kit Pro module's features.
+> You must have an [ABP Team or a higher license](https://abp.io/pricing) to use CMS Kit Pro module's features.
 
 CMS Kit provides a **poll** system to allow users to create, edit and delete polls. Here is a screenshot of the poll widget:
 

--- a/docs/en/modules/cms-kit-pro/url-forwarding.md
+++ b/docs/en/modules/cms-kit-pro/url-forwarding.md
@@ -7,7 +7,7 @@
 
 # CMS Kit Pro: URL Forwarding System
 
-> You must have an ABP Team or a higher license to use CMS Kit Pro module's features.
+> You must have an [ABP Team or a higher license](https://abp.io/pricing) to use CMS Kit Pro module's features.
 
 CMS Kit provides a **URL forwarding** system to create URLs that redirect to other pages or external websites.
 

--- a/docs/en/modules/file-management.md
+++ b/docs/en/modules/file-management.md
@@ -7,7 +7,7 @@
 
 # File Management Module (Pro)
 
-> You must have an ABP Team or a higher license to use this module.
+> You must have an [ABP Team or a higher license](https://abp.io/pricing) to use this module.
 
 This module is used to upload, download and organize files in a hierarchical folder structure. It is also compatible to multi-tenancy and you can determine total size limit for your tenants.
 

--- a/docs/en/modules/forms.md
+++ b/docs/en/modules/forms.md
@@ -7,7 +7,7 @@
 
 # Forms Module (Pro)
 
-> You must have an ABP Team or a higher license to use this module.
+> You must have an [ABP Team or a higher license](https://abp.io/pricing) to use this module.
 
 This module allows you to create questionnaires  to gather information. The forms module can store responses as they come in and you can export the data to a CSV file. You can share your form with others with your form unique link. You can request authentication or allow anonymous reply. It is similar to the Google Form application. Usage area is quite wide, you can create surveys, manage event registrations, collect email addresses for a newsletter, create a quiz, and even receive an order request.
 

--- a/docs/en/modules/gdpr.md
+++ b/docs/en/modules/gdpr.md
@@ -7,7 +7,7 @@
 
 # GDPR Module (Pro)
 
-> You must have an ABP Team or a higher license to use this module.
+> You must have an [ABP Team or a higher license](https://abp.io/pricing) to use this module.
 
 This module allows users to download and delete their personal data collected by the application. 
 

--- a/docs/en/modules/identity-pro.md
+++ b/docs/en/modules/identity-pro.md
@@ -7,7 +7,7 @@
 
 # Identity Module (Pro)
 
-> You must have an ABP Team or a higher license to use this module.
+> You must have an [ABP Team or a higher license](https://abp.io/pricing) to use this module.
 
 This module implements the User and Role system of an application;
 

--- a/docs/en/modules/identity-server-pro.md
+++ b/docs/en/modules/identity-server-pro.md
@@ -7,7 +7,7 @@
 
 # Identity Server Module (Pro)
 
-> You must have an ABP Team or a higher license to use this module.
+> You must have an [ABP Team or a higher license](https://abp.io/pricing) to use this module.
 
 This module provides integration and management functionality for Identity Server;
 

--- a/docs/en/modules/identity/idap.md
+++ b/docs/en/modules/identity/idap.md
@@ -9,13 +9,13 @@
 
 ## Introduction
 
-> You must have an ABP Team or a higher license to use this module & its features.
+> You must have an [ABP Team or a higher license](https://abp.io/pricing) to use this module & its features.
 
 The Identity PRO module has built-in `LdapExternalLoginProvider` and `OpenLdapManager` services. It implements LDAP authentication and gets user info for [external login](https://github.com/abpframework/abp/issues/4977).
 
 The cross-platform [LdapForNet](https://www.nuget.org/packages/LdapForNet/) library is used for Windows LDAP authentication. See [LdapForNet GitHub repository](https://github.com/flamencist/ldap4net) for more information.
 
-> You must have an ABP Team or a higher license to use this module & its features.
+> You must have an [ABP Team or a higher license](https://abp.io/pricing) to use this module & its features.
 
 ## How to enable LDAP external login?
 

--- a/docs/en/modules/identity/import-external-users.md
+++ b/docs/en/modules/identity/import-external-users.md
@@ -9,7 +9,7 @@
 
 ## Introduction
 
-> You must have an ABP Team or a higher license to use this module & its features.
+> You must have an [ABP Team or a higher license](https://abp.io/pricing) to use this module & its features.
 
 The Identity PRO module has built-in `LdapExternalLoginProvider` and `OAuthExternalLoginProvider` services. They not only support external login but also import users.
 

--- a/docs/en/modules/identity/oauth-login.md
+++ b/docs/en/modules/identity/oauth-login.md
@@ -9,7 +9,7 @@
 
 ## Introduction
 
-> You must have an ABP Team or a higher license to use this module & its features.
+> You must have an [ABP Team or a higher license](https://abp.io/pricing) to use this module & its features.
 
 The Identity PRO module has built-in `OAuthExternalLoginProvider` service. It implements OAuth Resource Owner Password authentication and gets user info for [external login](https://github.com/abpframework/abp/issues/4977).
 

--- a/docs/en/modules/identity/periodic-password-change.md
+++ b/docs/en/modules/identity/periodic-password-change.md
@@ -9,7 +9,7 @@
 
 ## Introduction
 
-> You must have an ABP Team or a higher license to use this module & its features.
+> You must have an [ABP Team or a higher license](https://abp.io/pricing) to use this module & its features.
 
 The Identity PRO module has a built-in password aging function.
 

--- a/docs/en/modules/identity/two-factor-authentication.md
+++ b/docs/en/modules/identity/two-factor-authentication.md
@@ -7,7 +7,7 @@
 
 # Two Factor Authentication
 
-> You must have an ABP Team or a higher license to use this module & its features.
+> You must have an [ABP Team or a higher license](https://abp.io/pricing) to use this module & its features.
 
 Two-factor authentication (**2FA**) is a specific type of multi-factor authentication (MFA) that requires the authenticating party to produce two separate identifying factors to verify your identity. The first factor is something you know "**username & password**" and the second factor is something you have "**mobile device or email**" to verify authentication requests. 2FA protects against phishing, social  engineering and password brute-force attacks and secures your logins  from attackers exploiting weak or stolen credentials.
 

--- a/docs/en/modules/language-management.md
+++ b/docs/en/modules/language-management.md
@@ -7,7 +7,7 @@
 
 # Language Management Module (Pro)
 
-> You must have an ABP Team or a higher license to use this module.
+> You must have an [ABP Team or a higher license](https://abp.io/pricing) to use this module.
 
 This module implements the Language management system of an application;
 

--- a/docs/en/modules/openiddict-pro.md
+++ b/docs/en/modules/openiddict-pro.md
@@ -7,7 +7,7 @@
 
 # OpenIddict Module (Pro)
 
-> You must have an ABP Team or a higher license to use this module.
+> You must have an [ABP Team or a higher license](https://abp.io/pricing) to use this module.
 
 This module provides integration and management functionality for the OpenIddict library;
 

--- a/docs/en/modules/payment-custom-gateway.md
+++ b/docs/en/modules/payment-custom-gateway.md
@@ -7,7 +7,7 @@
 
 # Creating a Custom Payment Gateway
 
-> You must have an ABP Team or a higher license to use this module.
+> You must have an [ABP Team or a higher license](https://abp.io/pricing) to use this module.
 
 This document explains creating custom a payment gateway that's different than the existing ones in the [Payment Module](payment#packages).
 

--- a/docs/en/modules/payment.md
+++ b/docs/en/modules/payment.md
@@ -7,7 +7,7 @@
 
 # Payment Module (Pro)
 
-> You must have an ABP Team or a higher license to use this module.
+> You must have an [ABP Team or a higher license](https://abp.io/pricing) to use this module.
 
 Payment module implements payment gateway integration of an application. It provides one time payment and recurring payment options. 
 

--- a/docs/en/modules/saas.md
+++ b/docs/en/modules/saas.md
@@ -7,7 +7,7 @@
 
 # SaaS Module (Pro)
 
-> You must have an ABP Team or a higher license to use this module.
+> You must have an [ABP Team or a higher license](https://abp.io/pricing) to use this module.
 
 This module is used to manage your tenants and editions in multi-tenant applications;
 

--- a/docs/en/modules/text-template-management.md
+++ b/docs/en/modules/text-template-management.md
@@ -7,7 +7,7 @@
 
 # Text Template Management Module (Pro)
 
-> You must have an ABP Team or a higher license to use this module.
+> You must have an [ABP Team or a higher license](https://abp.io/pricing) to use this module.
 
 This module is used to store and edit template contents for [the text templating system](../framework/infrastructure/text-templating/index.md) of the ABP. So, you may need to understand it to better understand the purpose of this module.
 

--- a/docs/en/modules/twilio-sms.md
+++ b/docs/en/modules/twilio-sms.md
@@ -7,7 +7,7 @@
 
 # Twilio SMS Module (Pro)
 
-> You must have an ABP Team or a higher license to use this module.
+> You must have an [ABP Team or a higher license](https://abp.io/pricing) to use this module.
 
 [Twilio](https://www.twilio.com) is a cloud communication provider that makes it easy to send and receive SMS. ABP Twilio SMS module implements the SMS sending feature of `ISmsSender` interface with Twilio.
 

--- a/docs/en/solution-templates/layered-web-application/mobile-applications.md
+++ b/docs/en/solution-templates/layered-web-application/mobile-applications.md
@@ -21,7 +21,7 @@
 }
 ```
 
-> You must have an ABP Team or a higher license to be able to create a mobile application project with ABP Studio.
+> You must have an [ABP Team or a higher license](https://abp.io/pricing) to be able to create a mobile application project with ABP Studio.
 
 Mobile applications are an essential part of modern software solutions. They provide a user-friendly interface to the end-users and allow them to access the system from anywhere. ABP Studio allows you to create mobile applications for your layered solution. You can create a new mobile application project, configure it, and run it on your device.
 

--- a/docs/en/suite/index.md
+++ b/docs/en/suite/index.md
@@ -17,7 +17,7 @@
 }
 ````
 
-> You must have an ABP Team or a higher license to use the ABP Suite.
+> You must have an [ABP Team or a higher license](https://abp.io/pricing) to use the ABP Suite.
 
 ABP Suite is a complementary tool to the ABP Platform. ABP Suite allows you to build web pages in a matter of minutes. 
 

--- a/docs/en/tutorials/mobile/index.md
+++ b/docs/en/tutorials/mobile/index.md
@@ -7,7 +7,7 @@
 
 # Mobile Application Development Tutorial: Book Store Application
 
-> You must have an ABP Team or a higher license to be able to create a mobile application.
+> You must have an [ABP Team or a higher license](https://abp.io/pricing) to be able to create a mobile application.
 
 Mobile application development tutorials are designed for developers who have completed [the web development part of the tutorial](../book-store/index.md) and wish to continue building the mobile version of the application. 
 

--- a/docs/en/tutorials/mobile/maui/index.md
+++ b/docs/en/tutorials/mobile/maui/index.md
@@ -9,7 +9,7 @@
 
 ## About This Tutorial
 
-> You must have an ABP Team or a higher license to be able to create a mobile application.
+> You must have an [ABP Team or a higher license](https://abp.io/pricing) to be able to create a mobile application.
 
 This tutorial assumes that you have completed the [Web Application Development tutorial](../../book-store/part-01.md) and built an ABP based application named `Acme.BookStore` with [MAUI](../../../get-started/maui.md) as the mobile option. Therefore, if you haven't completed the [Web Application Development tutorial](../../book-store/part-01.md), you either need to complete it or download the source code from down below and follow this tutorial. 
 

--- a/docs/en/tutorials/mobile/react-native/index.md
+++ b/docs/en/tutorials/mobile/react-native/index.md
@@ -11,7 +11,7 @@ React Native mobile option is *available for* ***Team*** *or higher licenses*. T
 
 ## About This Tutorial
 
-> You must have an ABP Team or a higher license to be able to create a mobile application.
+> You must have an [ABP Team or a higher license](https://abp.io/pricing) to be able to create a mobile application.
 
 - This tutorial assumes that you have completed the [Web Application Development tutorial](../../book-store/part-01.md) and built an ABP based application named `Acme.BookStore` with [React Native](../../../framework/ui/react-native) as the mobile option.. Therefore, if you haven't completed the [Web Application Development tutorial](../../book-store/part-01.md), you either need to complete it or download the source code from down below and follow this tutorial.
 - In this tutorial, we will only focus on the UI side of the `Acme.BookStore` application and will implement the CRUD operations.

--- a/docs/en/ui-themes/lepton-x/index.md
+++ b/docs/en/ui-themes/lepton-x/index.md
@@ -7,7 +7,7 @@
 
 # LeptonX Theme Module
 
-> You must have an ABP Team or a higher license to use this theme.
+> You must have an [ABP Team or a higher license](https://abp.io/pricing) to use this theme.
 
 The LeptonX Theme is a professional theme for the ABP. 
 

--- a/docs/en/ui-themes/lepton/index.md
+++ b/docs/en/ui-themes/lepton/index.md
@@ -7,7 +7,7 @@
 
 # Lepton Theme Module
 
-> You must have an ABP Team or a higher license to use this theme.
+> You must have an [ABP Team or a higher license](https://abp.io/pricing) to use this theme.
 
 The Lepton Theme is a professional theme for the ABP.
 


### PR DESCRIPTION
Updated all documentation files to include a direct link to the ABP pricing page in license requirement notices. This improves clarity for users regarding licensing requirements for Pro modules and features.

Resolves[ #7428](https://github.com/volosoft/vs-internal/issues/7428)
