### PR TITLE
Change TelemetryActivityEventBuilder to transient dependency

### DIFF
--- a/framework/src/Volo.Abp.Core/Volo/Abp/AbpApplicationBase.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/AbpApplicationBase.cs
@@ -185,8 +185,7 @@ public abstract class AbpApplicationBase : IAbpApplication
         {
             try
             {
-                using var scope = ServiceProvider.CreateScope();
-                var logger = scope.ServiceProvider.GetRequiredService<ILogger<AbpApplicationBase>>();
+                var logger = Services.GetInitLogger<AbpApplicationBase>();
                 logger.LogException(ex, LogLevel.Trace);
             }
             catch

--- a/framework/src/Volo.Abp.Core/Volo/Abp/Internal/Telemetry/Activity/Providers/TelemetryActivityEventBuilder.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/Internal/Telemetry/Activity/Providers/TelemetryActivityEventBuilder.cs
@@ -8,7 +8,7 @@ using Volo.Abp.Internal.Telemetry.Constants;
 
 namespace Volo.Abp.Internal.Telemetry.Activity.Providers;
 
-public class TelemetryActivityEventBuilder : ITelemetryActivityEventBuilder, ISingletonDependency
+public class TelemetryActivityEventBuilder : ITelemetryActivityEventBuilder, ITransientDependency
 {
     private readonly List<ITelemetryActivityEventEnricher> _activityEnrichers;
 
@@ -31,7 +31,7 @@ public class TelemetryActivityEventBuilder : ITelemetryActivityEventBuilder, ISi
             {
                //ignored
             }
-            
+
             if (context.IsTerminated)
             {
                 return null;
@@ -40,10 +40,10 @@ public class TelemetryActivityEventBuilder : ITelemetryActivityEventBuilder, ISi
 
         return context.Current;
     }
-    
+
     private static bool FilterEnricher(ITelemetryActivityEventEnricher enricher)
     {
-        return ProxyHelper.GetUnProxiedType(enricher).Assembly.FullName!.StartsWith(TelemetryConsts.VoloNameSpaceFilter) && 
+        return ProxyHelper.GetUnProxiedType(enricher).Assembly.FullName!.StartsWith(TelemetryConsts.VoloNameSpaceFilter) &&
                enricher is not IHasParentTelemetryActivityEventEnricher<TelemetryActivityEventEnricher>;
     }
 }


### PR DESCRIPTION
Related to https://github.com/abpframework/abp/pull/23343
Resolve #23755

The ASP.NET Core default dependency injection system doesn't allow consuming a scoped service from a singleton service.

This error only happened if we didn't call the `UseAutofac`(Use Autofac to replace default).

```
var builder = WebApplication.CreateBuilder(args);
builder.Host.UseAutofac();
```
