### PR TITLE
Revise ABP v10.0 migration guide for clarity

### DIFF
--- a/docs/en/release-info/migration-guides/abp-10-0.md
+++ b/docs/en/release-info/migration-guides/abp-10-0.md
@@ -1,18 +1,18 @@
 # ABP Version 10.0 Migration Guide
 
-This document is a guide for upgrading ABP v9.x solutions to ABP v10.0. There are some changes in this version that may affect your applications, please read it carefully and apply the necessary changes to your application.
+This document is a guide for upgrading ABP v9.x solutions to ABP v10.0. There are some changes in this version that may affect your applications. Please read them carefully and apply the necessary changes to your application.
 
 ## Open-Source (Framework)
 
-### Upgraded to .NET 10.0
+### Upgrade to .NET 10.0
 
-We've upgraded ABP to .NET 10.0, so you need to move your solutions to .NET 10.0 if you want to use ABP 10.0. You can check Microsoft’s [Migrate from ASP.NET Core 9.0 to 10.0](https://learn.microsoft.com/en-us/aspnet/core/migration/90-to-100) documentation, to see how to update an existing ASP.NET Core 9.0 project to ASP.NET Core 10.0.
+We've upgraded ABP to .NET 10.0, so you need to move your solutions to .NET 10.0 if you want to use ABP 10.0. You can check Microsoft’s [Migrate from ASP.NET Core 9.0 to 10.0](https://learn.microsoft.com/en-us/aspnet/core/migration/90-to-100) documentation to see how to update an existing ASP.NET Core 9.0 project to ASP.NET Core 10.0.
 
-### Add new EF Core Migrations
+### Add New EF Core Migrations
 
 Some entities in certain modules have been modified. If you are using Entity Framework Core, please create a new EF Core migration in your project after upgrading to ABP 10.0.
 
-> If the migration file is empty, you can remove it by `dotnet ef migrations remove` command.
+> If the migration file is empty, you can remove it by using the `dotnet ef migrations remove` command.
 
 ### Razor Runtime Compilation Obsolete
 
@@ -46,31 +46,25 @@ For more information, you can check the [Razor Runtime Compilation Obsolete](htt
 
 ### IActionContextAccessor Obsolete
 
-We removed the `IActionContextAccessor` from dependency injection.
-
-> We are not using `IActionContextAccessor` in ABP core framework and modules.
+We removed the `IActionContextAccessor` from dependency injection and are not using the `IActionContextAccessor` in ABP's core framework and modules.
 
 See [IActionContextAccessor Obsolete](https://learn.microsoft.com/en-us/dotnet/core/compatibility/aspnet-core/10/iactioncontextaccessor-obsolete) for more information.
 
 ### Add `BLOB Storing Memory Provider` module.
 
-In this version, we added the `BLOB Storing Memory Provider` module for unit testing purposes.
+In this version, we have added the `BLOB Storing Memory Provider` module for unit testing purposes.
 
 See the [BLOB Storing Memory Provider](https://github.com/abpframework/abp/blob/dev/docs/en/framework/infrastructure/blob-storing/memory.md) document for more information.
 
 ### Always use `MapStaticAssets`
 
-Provious, the `MapStaticAssets` has performance problems if there are too many static files. and we will use `StaticFileMiddleware` to serve the static files in development mode. NET 10.0 has fixed this problem. We will always use `MapStaticAssets` to serve the static files.
+Previously, the `MapStaticAssets` had performance problems if there were too many static files. NET 10.0 has fixed this problem. We will always use `MapStaticAssets` to serve the static files.
 
 See [Static file serving performance issues](https://github.com/dotnet/aspnetcore/issues/59673) for more information.
 
 ### C# 14 overload resolution with span parameters
 
-NET Core will redirect `array.Contains` extension method to `MemoryExtensions.Contains`, This will cause `MongoDB.Driver` to be unable to translate `IQueryable<T>`, If you are using `array.Contains` in your code, you should use following code to avoid this problem.
-
-> Only array has this problem, other types are not affected. eg List<T>, HashSet<T>, etc.
-
-> MongoDB.Driver will be fixed in the future.
+NET Core will redirect the `array.Contains` extension method to `MemoryExtensions.Contains`. This will cause `MongoDB.Driver` to be unable to translate `IQueryable<T>`. If you are using `array.Contains` in your code, you should use the following code to avoid this problem:
 
 ```csharp
 M((array, num) => array.Contains(num)); // fails, binds to MemoryExtensions.Contains
@@ -79,13 +73,15 @@ M((array, num) => array.AsEnumerable().Contains(num)); // ok, binds to Enumerabl
 M((array, num) => Enumerable.Contains(array, num)); // ok, binds to Enumerable.Contains
 ```
 
+> Please note that only the `array` type has this problem. Other types are not affected (e.g. `List<T>`, `HashSet<T>`, etc). **MongoDB.Driver** provider will be fixed in future versions, and we will immediately apply the changes if needed.
+
 See the [C# 14 overload resolution with span parameters](https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/10.0/csharp-overload-resolution#recommended-action) for more information.
 
-###  OpenIddict 7.X
+###  OpenIddict Upgrade to 7.X
 
-We upgraded OpenIddict to 7.X. See the [OpenIddict 6.x to 7.x Migration Guide](https://documentation.openiddict.com/guides/migration/60-to-70.html) for more information.
+We have upgraded **OpenIddict** to **v7.x**. For detailed information about the changes introduced in this release, refer to the [OpenIddict 6.x to 7.x Migration Guide](https://documentation.openiddict.com/guides/migration/60-to-70.html).
 
-OpenIddict 7.X changed the `OpenIddictToken` entity, you must create a new database migration if you use Entity Framework Core.
+As a developer, you typically only need to **create a new Entity Framework Core migration** and **apply it to your database**, since **OpenIddict v7.x** introduces a modification in the `OpenIddictToken` entity.
 
 ### Migrating from AutoMapper to Mapperly
 
@@ -111,6 +107,3 @@ Starting from **ABP 10.0**, the [`HideErrors`](../../framework/fundamentals/cach
 
 By default, ABP hides and logs cache server errors to keep the application running even when the cache is unavailable.  
 However, in the **development environment**, errors are no longer hidden so that developers can immediately detect and fix **any cache server issues** (such as connection, configuration, or runtime errors).  
-
-## PRO
-


### PR DESCRIPTION
Updated migration guide for ABP v10.0 to improve clarity and fix grammatical issues.
