### PR TITLE
Update `Vulnerability` packages to latest.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -53,7 +53,7 @@
     <PackageVersion Include="JetBrains.Annotations" Version="2025.2.2" />
     <PackageVersion Include="LdapForNet" Version="2.7.15" />
     <PackageVersion Include="LibGit2Sharp" Version="0.31.0" />
-    <PackageVersion Include="Magick.NET-Q16-AnyCPU" Version="14.8.2" />
+    <PackageVersion Include="Magick.NET-Q16-AnyCPU" Version="14.9.1" />
     <PackageVersion Include="MailKit" Version="4.13.0" />
     <PackageVersion Include="Markdig.Signed" Version="0.42.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
@@ -174,6 +174,7 @@
     <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.6.7" />
     <PackageVersion Include="System.Linq.Queryable" Version="4.3.0" />
     <PackageVersion Include="System.Runtime.Loader" Version="4.3.0" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.0" />
     <PackageVersion Include="System.Security.Permissions" Version="10.0.0" />
     <PackageVersion Include="System.Security.Principal.Windows" Version="5.0.0" />
     <PackageVersion Include="System.Text.Encoding.CodePages" Version="10.0.0" />

--- a/framework/src/Volo.Abp.BlobStoring.Bunny/Volo.Abp.BlobStoring.Bunny.csproj
+++ b/framework/src/Volo.Abp.BlobStoring.Bunny/Volo.Abp.BlobStoring.Bunny.csproj
@@ -21,6 +21,7 @@
     <ItemGroup>
       <PackageReference Include="BunnyCDN.Net.Storage" />
       <PackageReference Include="Microsoft.Extensions.Http" />
+      <PackageReference Include="Newtonsoft.Json" />
     </ItemGroup>
 
 </Project>

--- a/framework/src/Volo.Abp.HangFire/Volo.Abp.HangFire.csproj
+++ b/framework/src/Volo.Abp.HangFire/Volo.Abp.HangFire.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Hangfire.AspNetCore" />
+    <PackageReference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/framework/src/Volo.Abp.HangFire/Volo.Abp.HangFire.csproj
+++ b/framework/src/Volo.Abp.HangFire/Volo.Abp.HangFire.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Hangfire.AspNetCore" />
+    <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 


### PR DESCRIPTION
`dotnet list package --vulnerable --include-transitive` command shows `framework` has no vulnerability problem.