### PR TITLE
Enable alert blocks in Markdig markdown converter

### DIFF
--- a/modules/docs/src/Volo.Docs.Web/Markdown/MarkDigMarkdownConverter.cs
+++ b/modules/docs/src/Volo.Docs.Web/Markdown/MarkDigMarkdownConverter.cs
@@ -19,6 +19,7 @@ namespace Volo.Docs.Markdown
               .UseGridTables()
               .UsePipeTables()
               .UseHighlightedCodeBlocks()
+              .UseAlertBlocks()
               .Build();
         }
 


### PR DESCRIPTION
<img width="1480" height="256" alt="image" src="https://github.com/user-attachments/assets/a10666a9-c659-4668-bdad-f1d4ef3ec4ea" />
