### PR TITLE
Update SemanticKernel package versions to 1.67.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -89,8 +89,8 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.0" />   
-    <PackageVersion Include="Microsoft.SemanticKernel" Version="1.61.0" />
-    <PackageVersion Include="Microsoft.SemanticKernel.Abstractions" Version="1.61.0" />
+    <PackageVersion Include="Microsoft.SemanticKernel" Version="1.67.1" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Abstractions" Version="1.67.1" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="9.9.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.0" />


### PR DESCRIPTION
Bumped Microsoft.SemanticKernel and Microsoft.SemanticKernel.Abstractions from version 1.61.0 to 1.67.1 to use the latest features and improvements.
