### PR TITLE
Angular - Fixing the merger conflict on extensible form prop component

### DIFF
--- a/npm/ng-packs/packages/components/extensible/src/lib/components/extensible-form/extensible-form-prop.component.ts
+++ b/npm/ng-packs/packages/components/extensible/src/lib/components/extensible-form/extensible-form-prop.component.ts
@@ -101,9 +101,6 @@ export class ExtensibleFormPropComponent implements OnChanges, AfterViewInit {
   @Input() isFirstGroup?: boolean;
   @ViewChild('field') private fieldRef!: ElementRef<HTMLElement>;
 
-  private shouldFocus = signal(false);
-  private isViewReady = signal(false);
-
   injectorForCustomComponent?: Injector;
   asterisk = '';
   containerClassName = 'mb-2';
@@ -118,15 +115,6 @@ export class ExtensibleFormPropComponent implements OnChanges, AfterViewInit {
 
   get disabled() {
     return this.disabledFn(this.data);
-  }
-
-  constructor() {
-    // Effect to handle focus when both conditions are met
-    effect(() => {
-      if (this.shouldFocus() && this.isViewReady() && this.fieldRef?.nativeElement) {
-        this.focusElement();
-      }
-    });
   }
 
   setTypeaheadValue(selectedOption: ABP.Option<string>) {


### PR DESCRIPTION
### Description

Resolves this build error 
```bash
×  nx run components:build:production
      Building Angular Package

      ------------------------------------------------------------------------------
      Building entry point '@abp/ng.components'
      ------------------------------------------------------------------------------
      - Compiling with Angular sources in partial compilation mode.
      ✔ Compiling with Angular sources in partial compilation mode.
      - Writing FESM and DTS bundles
      ✔ Writing FESM and DTS bundles
      - Copying assets
      ✔ Copying assets
      - Writing package manifest
      ✔ Writing package manifest
      ✔ Built @abp/ng.components

      ------------------------------------------------------------------------------
      Building entry point '@abp/ng.components/chart.js'
      ------------------------------------------------------------------------------
      - Compiling with Angular sources in partial compilation mode.
      ✔ Compiling with Angular sources in partial compilation mode.
      - Writing FESM and DTS bundles
      ✔ Writing FESM and DTS bundles
      ✔ Built @abp/ng.components/chart.js

      ------------------------------------------------------------------------------
      Building entry point '@abp/ng.components/extensible'
      ------------------------------------------------------------------------------
      - Compiling with Angular sources in partial compilation mode.
      ✖ Compiling with Angular sources in partial compilation mode.

       NX   packages/components/extensible/src/lib/components/extensible-form/extensible-form-prop.component.ts:127:14 -





      Pass --verbose to see the stacktrace.
```
