### PR TITLE
fix(Settings): resolve deadlock in SettingValueProviderManager by eager initialization

### DIFF
--- a/framework/src/Volo.Abp.Settings/Volo/Abp/Settings/SettingValueProviderManager.cs
+++ b/framework/src/Volo.Abp.Settings/Volo/Abp/Settings/SettingValueProviderManager.cs
@@ -9,32 +9,31 @@ namespace Volo.Abp.Settings;
 
 public class SettingValueProviderManager : ISettingValueProviderManager, ISingletonDependency
 {
-    public List<ISettingValueProvider> Providers => _lazyProviders.Value;
+    public List<ISettingValueProvider> Providers { get; }
 
     protected AbpSettingOptions Options { get; }
+
     protected IServiceProvider ServiceProvider { get; }
-    private readonly Lazy<List<ISettingValueProvider>> _lazyProviders;
 
     public SettingValueProviderManager(
         IServiceProvider serviceProvider,
         IOptions<AbpSettingOptions> options)
     {
-
         Options = options.Value;
         ServiceProvider = serviceProvider;
 
-        _lazyProviders = new Lazy<List<ISettingValueProvider>>(GetProviders, true);
+        Providers = GetProviders();
     }
-    
+
     protected virtual List<ISettingValueProvider> GetProviders()
     {
         var providers = Options
             .ValueProviders
             .Select(type => (ServiceProvider.GetRequiredService(type) as ISettingValueProvider)!)
             .ToList();
-        
+
         var multipleProviders = providers.GroupBy(p => p.Name).FirstOrDefault(x => x.Count() > 1);
-        if(multipleProviders != null)
+        if (multipleProviders != null)
         {
             throw new AbpException($"Duplicate setting value provider name detected: {multipleProviders.Key}. Providers:{Environment.NewLine}{multipleProviders.Select(p => p.GetType().FullName!).JoinAsString(Environment.NewLine)}");
         }


### PR DESCRIPTION
## Problem

In ABP v10.0.0, concurrent access to `ISettingProvider` (e.g., in xUnit tests) causes a permanent hang due to deadlock in `SettingValueProviderManager`.

The root cause is the use of `Lazy<List<ISettingValueProvider>>` with `isThreadSafe = true`, which performs synchronous initialization. During initialization, it resolves `ISettingValueProvider` instances via `IServiceProvider`, which triggers Castle DynamicProxy type generation — not fully async-safe under xUnit's synchronization context.

This leads to:
- Thread A: holds Lazy internal lock, waiting for proxy generation
- Thread B: waits for Lazy lock to be released
→ Deadlock.

## Solution

Replace lazy initialization with **eager initialization in the constructor**. Since setting value providers are static configuration registered at startup, there is no benefit to lazy loading, but significant risk in concurrent scenarios.

## Changes

- Remove `Lazy<T>` field
- Initialize `Providers` directly in constructor
- Keep interface contract (`List<ISettingValueProvider>`) unchanged → **fully backward compatible**

## Validation

- All existing unit/integration tests pass
- Concurrent xUnit tests that previously deadlocked now pass
- Startup-time validation of duplicate providers still works

Fixes #24247