### PR TITLE
Add AI Token Count Per Developer to en.json

### DIFF
--- a/abp_io/AbpIoLocalization/AbpIoLocalization/Admin/Localization/Resources/en.json
+++ b/abp_io/AbpIoLocalization/AbpIoLocalization/Admin/Localization/Resources/en.json
@@ -672,6 +672,7 @@
     "SupportQuestionCountPerDeveloperOnRenewLicense": "Support Question Count Per Developer for License Renewal",
     "SupportQuestionCountPerDeveloperOnNewLicense": "Support Question Count Per Developer for New License",
     "IncludedDeveloperCount": "Included Developer Count",
+    "AiTokenCountPerDeveloper":  "AI Token Count Per Developer",
     "CanBuyAdditionalDevelopers": "Can Buy Additional Developers",
     "HasEmailSupport": "Has Email Support",
     "IsSupportPrivateQuestion": "Can Open Private Support Question",


### PR DESCRIPTION
Introduced a new localization string 'AiTokenCountPerDeveloper' to support displaying AI token count per developer in the English resource file.

### Description

Resolves [#7685](https://github.com/volosoft/vs-internal/issues/7685)

<img width="1140" height="635" alt="image" src="https://github.com/user-attachments/assets/21e4d9c1-a0b1-4dd5-9667-98a3c3fcd5e3" />


