### PR TITLE
Add redirectUrl support to PermissionGuard - issue-24272

### DIFF
--- a/npm/ng-packs/packages/core/src/lib/guards/permission.guard.ts
+++ b/npm/ng-packs/packages/core/src/lib/guards/permission.guard.ts
@@ -4,10 +4,11 @@ import {
   CanActivateFn,
   Router,
   RouterStateSnapshot,
+  UrlTree,
 } from '@angular/router';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Observable, of } from 'rxjs';
-import { filter, take, tap } from 'rxjs/operators';
+import { map, take } from 'rxjs/operators';
 import { AuthService, IAbpGuard } from '../abstracts';
 import { findRoute, getRoutePath } from '../utils/route-utils';
 import { RoutesService, PermissionService, HttpErrorReporterService } from '../services';
@@ -25,7 +26,7 @@ export class PermissionGuard implements IAbpGuard {
   protected readonly permissionService = inject(PermissionService);
   protected readonly httpErrorReporter = inject(HttpErrorReporterService);
 
-  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
+  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean | UrlTree> {
     let { requiredPolicy } = route.data || {};
 
     if (!requiredPolicy) {
@@ -38,12 +39,19 @@ export class PermissionGuard implements IAbpGuard {
     }
 
     return this.permissionService.getGrantedPolicy$(requiredPolicy).pipe(
-      filter(Boolean),
       take(1),
-      tap(access => {
-        if (!access && this.authService.isAuthenticated) {
+      map(access => {
+        if (access) return true;
+
+        if (route.data?.['redirectUrl']) {
+          return this.router.parseUrl(route.data['redirectUrl']);
+        }
+
+        if (this.authService.isAuthenticated) {
           this.httpErrorReporter.reportError({ status: 403 } as HttpErrorResponse);
         }
+
+        return false;
       }),
     );
   }
@@ -77,12 +85,19 @@ export const permissionGuard: CanActivateFn = (
   }
 
   return permissionService.getGrantedPolicy$(requiredPolicy).pipe(
-    filter(Boolean),
     take(1),
-    tap(access => {
-      if (!access && authService.isAuthenticated) {
+    map(access => {
+      if (access) return true;
+
+      if (route.data?.['redirectUrl']) {
+        return router.parseUrl(route.data['redirectUrl']);
+      }
+
+      if (authService.isAuthenticated) {
         httpErrorReporter.reportError({ status: 403 } as HttpErrorResponse);
       }
+
+      return false;
     }),
   );
 };

--- a/npm/ng-packs/packages/core/src/lib/tests/permission.guard.spec.ts
+++ b/npm/ng-packs/packages/core/src/lib/tests/permission.guard.spec.ts
@@ -39,6 +39,15 @@ describe('authGuard', () => {
       component: DummyComponent,
       canActivate: [permissionGuard],
     },
+    {
+      path: 'redirect-test',
+      component: DummyComponent,
+      canActivate: [permissionGuard],
+      data: {
+        requiredPolicy: 'TestPolicy',
+        redirectUrl: '/zibzib',
+      },
+    },
   ];
 
   beforeEach(() => {
@@ -102,5 +111,13 @@ describe('authGuard', () => {
   it('should return Observable<true> if RoutesService does not have requiredPolicy for given URL', async () => {
     await RouterTestingHarness.create('/zibzib');
     expect(TestBed.inject(Router).url).toEqual('/zibzib');
+  });
+
+  it('should redirect to redirectUrl when the grantedPolicy is false and redirectUrl is provided', async () => {
+    permissionService.getGrantedPolicy$.andReturn(of(false));
+    await RouterTestingHarness.create('/redirect-test');
+
+    expect(TestBed.inject(Router).url).toEqual('/zibzib');
+    expect(httpErrorReporter.reportError).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
PermissionGuard now supports redirecting to a specified URL when access is denied and a redirectUrl is provided in route data. Updated guard logic to use map instead of filter/tap, and added corresponding unit tests to verify redirect behavior.

### Description

Resolves #24272 (write the related issue number if available)

### How to test it?

you have to change branch issue-24272 on abp
you have to change branch rel-10.0 on volo
you have to change branch rel-5.0 on lepton
you must test it volo demo app on lepton repository. this location => `lepton\aspnet-core\volo\demo`

1.  Open your `app.routes.ts` file. on angular folder
2.  Add the `redirectUrl` property to the `data` object of a route protected by `permissionGuard`.

 ```ts
    {
      path: 'saas',
      loadChildren: () => import('@volo/abp.ng.saas').then(c => c.createRoutes()),
      canActivate: [permissionGuard],
      data: {
        redirectUrl: '/audit-logs' // The URL to redirect to if permission is denied
      }
    },
```

3.  Log in with a user who **does not** have the required permission for the `saas` route (e.g., `Saas.Tenants`).
4.  Navigate to the `/saas/editions` URL.
5.  **Result:** You should be automatically redirected to `/audit-logs` instead of seeing the default 403 error page.