### PR TITLE
Bump MongoDB.Driver to version 3.5.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -122,7 +122,7 @@
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.14.0" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.14.0" />
     <PackageVersion Include="Minio" Version="6.0.5" />
-    <PackageVersion Include="MongoDB.Driver" Version="3.5.1" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.5.2" />
     <PackageVersion Include="NEST" Version="7.17.5" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="Nito.AsyncEx.Context" Version="5.1.2" />


### PR DESCRIPTION
> If you are targeting .NET 10 or using C# 14 in your project you should upgrade to this release as soon as possible as it contains important compatibilty fixes.

https://github.com/mongodb/mongo-csharp-driver/releases/tag/v3.5.2
