### PR TITLE
Clarify SSR setup instructions in article

### DIFF
--- a/docs/en/Community-Articles/2025-11-15-Announcing-SSR-Support/article.md
+++ b/docs/en/Community-Articles/2025-11-15-Announcing-SSR-Support/article.md
@@ -33,7 +33,7 @@ You can easily add SSR support to your existing ABP Angular application using th
 # Generate SSR configuration for your project
 ng generate @abp/ng.schematics:ssr-add
 
-# Or using the short form
+# Alternatively, you can use the short form
 ng g @abp/ng.schematics:ssr-add
 ```
 


### PR DESCRIPTION
Reworded the SSR setup command instructions for improved clarity, replacing 'Or using the short form' with 'Alternatively, you can use the short form'.