### PR TITLE
Fix `DataGridEntityActionsColumn` field resolution for dynamic types

### DIFF
--- a/framework/src/Volo.Abp.BlazoriseUI/Components/DataGridEntityActionsColumn.razor.cs
+++ b/framework/src/Volo.Abp.BlazoriseUI/Components/DataGridEntityActionsColumn.razor.cs
@@ -23,7 +23,16 @@ public partial class DataGridEntityActionsColumn<TItem> : DataGridColumn<TItem>
         Caption = UiLocalizer["Actions"];
         Width = "150px";
         Sortable = false;
-        Field = typeof(TItem).GetProperties().First().Name;
+        Field = ResolveFieldName();
+        
         return ValueTask.CompletedTask;
+    }
+    
+    protected virtual string ResolveFieldName()
+    {
+        var props = typeof(TItem).GetProperties();
+        return props.Length > 0
+            ? props[0].Name
+            : "Id";
     }
 }


### PR DESCRIPTION
This change improves the default Field resolution logic in
DataGridEntityActionsColumn<TItem> to make it safer and more predictable when
working with strongly typed, dynamic, and property-less items.