### PR TITLE
Cleaned up LocalAbpDistributedLock

### DIFF
--- a/framework/src/Volo.Abp.DistributedLocking.Abstractions/Volo/Abp/DistributedLocking/LocalAbpDistributedLock.cs
+++ b/framework/src/Volo.Abp.DistributedLocking.Abstractions/Volo/Abp/DistributedLocking/LocalAbpDistributedLock.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using AsyncKeyedLock;
@@ -9,11 +8,7 @@ namespace Volo.Abp.DistributedLocking;
 
 public class LocalAbpDistributedLock : IAbpDistributedLock, ISingletonDependency
 {
-    private readonly AsyncKeyedLocker<string> _localSyncObjects = new(o =>
-    {
-        o.PoolSize = 20;
-        o.PoolInitialFill = 1;
-    });
+    private readonly AsyncKeyedLocker<string> _localSyncObjects = new();
     protected IDistributedLockKeyNormalizer DistributedLockKeyNormalizer { get; }
 
     public LocalAbpDistributedLock(IDistributedLockKeyNormalizer distributedLockKeyNormalizer)
@@ -21,7 +16,6 @@ public class LocalAbpDistributedLock : IAbpDistributedLock, ISingletonDependency
         DistributedLockKeyNormalizer = distributedLockKeyNormalizer;
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public async Task<IAbpDistributedLockHandle?> TryAcquireAsync(
         string name,
         TimeSpan timeout = default,


### PR DESCRIPTION
Alternative to #24425

Still uses pooled SemaphoreSlim objects and cleans up the dictionary after use to prevent a slow memory leak, but cleaner than the existing version and removes the AggressiveInlining which in this case would not be beneficial.