### PR TITLE
Add provider check to SqliteBusyTimeout interceptor

### DIFF
--- a/framework/src/Volo.Abp.EntityFrameworkCore.Sqlite/Volo/Abp/EntityFrameworkCore/Interceptors/SqliteBusyTimeoutSaveChangesInterceptor.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore.Sqlite/Volo/Abp/EntityFrameworkCore/Interceptors/SqliteBusyTimeoutSaveChangesInterceptor.cs
@@ -19,7 +19,7 @@ public class SqliteBusyTimeoutSaveChangesInterceptor : SaveChangesInterceptor
 
     public override InterceptionResult<int> SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)
     {
-        if (eventData.Context != null)
+        if (eventData.Context != null && IsSqlite(eventData.Context))
         {
             eventData.Context.Database.ExecuteSqlRaw(_pragmaCommand);
         }
@@ -29,11 +29,17 @@ public class SqliteBusyTimeoutSaveChangesInterceptor : SaveChangesInterceptor
 
     public override async ValueTask<InterceptionResult<int>> SavingChangesAsync(DbContextEventData eventData, InterceptionResult<int> result, CancellationToken cancellationToken = default)
     {
-        if (eventData.Context != null)
+        if (eventData.Context != null && IsSqlite(eventData.Context))
         {
             await eventData.Context.Database.ExecuteSqlRawAsync(_pragmaCommand, cancellationToken: cancellationToken);
         }
 
         return await base.SavingChangesAsync(eventData, result, cancellationToken);
+    }
+    
+    
+    private bool IsSqlite(DbContext context)
+    {
+        return context.Database.ProviderName != null && context.Database.ProviderName.Contains("Sqlite");
     }
 }

--- a/framework/src/Volo.Abp.EntityFrameworkCore.Sqlite/Volo/Abp/EntityFrameworkCore/Interceptors/SqliteBusyTimeoutSaveChangesInterceptor.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore.Sqlite/Volo/Abp/EntityFrameworkCore/Interceptors/SqliteBusyTimeoutSaveChangesInterceptor.cs
@@ -19,7 +19,7 @@ public class SqliteBusyTimeoutSaveChangesInterceptor : SaveChangesInterceptor
 
     public override InterceptionResult<int> SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)
     {
-        if (eventData.Context != null && IsSqlite(eventData.Context))
+        if (eventData.Context != null)
         {
             eventData.Context.Database.ExecuteSqlRaw(_pragmaCommand);
         }
@@ -29,17 +29,11 @@ public class SqliteBusyTimeoutSaveChangesInterceptor : SaveChangesInterceptor
 
     public override async ValueTask<InterceptionResult<int>> SavingChangesAsync(DbContextEventData eventData, InterceptionResult<int> result, CancellationToken cancellationToken = default)
     {
-        if (eventData.Context != null && IsSqlite(eventData.Context))
+        if (eventData.Context != null)
         {
             await eventData.Context.Database.ExecuteSqlRawAsync(_pragmaCommand, cancellationToken: cancellationToken);
         }
 
         return await base.SavingChangesAsync(eventData, result, cancellationToken);
-    }
-    
-    
-    private bool IsSqlite(DbContext context)
-    {
-        return context.Database.ProviderName != null && context.Database.ProviderName.Contains("Sqlite");
     }
 }

--- a/framework/src/Volo.Abp.EntityFrameworkCore.Sqlite/Volo/Abp/EntityFrameworkCore/Sqlite/AbpEntityFrameworkCoreSqliteModule.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore.Sqlite/Volo/Abp/EntityFrameworkCore/Sqlite/AbpEntityFrameworkCoreSqliteModule.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Sqlite.Infrastructure.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Volo.Abp.EntityFrameworkCore.GlobalFilters;
 using Volo.Abp.EntityFrameworkCore.Interceptors;
@@ -32,7 +34,10 @@ public class AbpEntityFrameworkCoreSqliteModule : AbpModule
             {
                 options.ConfigureDefaultOnConfiguring((dbContext, dbContextOptionsBuilder) =>
                 {
-                    dbContextOptionsBuilder.AddInterceptors(new SqliteBusyTimeoutSaveChangesInterceptor(sqliteOptions.BusyTimeout.Value));
+                    if (dbContextOptionsBuilder.Options.Extensions.Any(extension => extension is SqliteOptionsExtension))
+                    {
+                        dbContextOptionsBuilder.AddInterceptors(new SqliteBusyTimeoutSaveChangesInterceptor(sqliteOptions.BusyTimeout.Value));
+                    }
                 }, overrideExisting: false);
             });
         }


### PR DESCRIPTION
Updated SqliteBusyTimeoutSaveChangesInterceptor to execute the PRAGMA command only if the DbContext is using the Sqlite provider. This prevents unnecessary execution for non-Sqlite databases.