### PR TITLE
Update Riok.Mapperly package version to 4.3.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -149,7 +149,7 @@
     <PackageVersion Include="RabbitMQ.Client" Version="7.1.2" />
     <PackageVersion Include="Rebus" Version="8.8.0" />
     <PackageVersion Include="Rebus.ServiceProvider" Version="10.5.0" />
-    <PackageVersion Include="Riok.Mapperly" Version="4.3.0" />
+    <PackageVersion Include="Riok.Mapperly" Version="4.3.1" />
     <PackageVersion Include="Scriban" Version="6.3.0" />
     <PackageVersion Include="Serilog" Version="4.3.0" />
     <PackageVersion Include="Serilog.AspNetCore" Version="9.0.0" />


### PR DESCRIPTION
https://github.com/riok/mapperly/releases/tag/v4.3.1
