### PR TITLE
Use GetOrNullAsync for feature definition lookup

### DIFF
--- a/framework/src/Volo.Abp.Features/Volo/Abp/Features/FeatureChecker.cs
+++ b/framework/src/Volo.Abp.Features/Volo/Abp/Features/FeatureChecker.cs
@@ -28,7 +28,12 @@ public class FeatureChecker : FeatureCheckerBase
 
     public override async Task<string?> GetOrNullAsync(string name)
     {
-        var featureDefinition = await FeatureDefinitionManager.GetAsync(name);
+        var featureDefinition = await FeatureDefinitionManager.GetOrNullAsync(name);
+        if (featureDefinition == null)
+        {
+            return null;
+        }
+        
         var providers = FeatureValueProviderManager.ValueProviders
             .Reverse();
 

--- a/framework/src/Volo.Abp.Settings/Volo/Abp/Settings/SettingProvider.cs
+++ b/framework/src/Volo.Abp.Settings/Volo/Abp/Settings/SettingProvider.cs
@@ -23,7 +23,12 @@ public class SettingProvider : ISettingProvider, ITransientDependency
 
     public virtual async Task<string?> GetOrNullAsync(string name)
     {
-        var setting = await SettingDefinitionManager.GetAsync(name);
+        var setting = await SettingDefinitionManager.GetOrNullAsync(name);
+        if (setting == null)
+        {
+            return null;
+        }
+
         var providers = Enumerable
             .Reverse(SettingValueProviderManager.Providers);
 

--- a/modules/setting-management/test/Volo.Abp.SettingManagement.Tests/Volo/Abp/SettingManagement/SettingManager_Basic_Tests.cs
+++ b/modules/setting-management/test/Volo.Abp.SettingManagement.Tests/Volo/Abp/SettingManagement/SettingManager_Basic_Tests.cs
@@ -18,11 +18,10 @@ public class SettingManager_Basic_Tests : SettingsTestBase
     }
 
     [Fact]
-    public async Task Should_Throw_Exception_When_Try_To_Get_An_Undefined_Setting()
+    public async Task Should_Return_Null_When_Try_To_Get_An_Undefined_Setting()
     {
-        await Assert.ThrowsAsync<AbpException>(
-            async () => await _settingProvider.GetOrNullAsync("UndefinedSetting")
-        );
+        var value = await _settingProvider.GetOrNullAsync("UndefinedSetting");
+        value.ShouldBeNull();
     }
 
     [Fact]
@@ -64,7 +63,7 @@ public class SettingManager_Basic_Tests : SettingsTestBase
         (await _settingManager.GetOrNullGlobalAsync("MySetting1")).ShouldBe("43");
         (await _settingProvider.GetOrNullAsync("MySetting1")).ShouldBe("43");
     }
-    
+
     [Fact]
     public async Task Set_Should_Throw_Exception_If_Provider_Not_Found()
     {
@@ -72,7 +71,7 @@ public class SettingManager_Basic_Tests : SettingsTestBase
         {
             await _settingManager.SetAsync("MySetting1", "43", "UndefinedProvider", "Test");
         });
-        
+
         exception.Message.ShouldBe("Unknown setting value provider: UndefinedProvider");
     }
 }


### PR DESCRIPTION
Instead of throwing an exception, just return null if the given feature was not defined.