### PR TITLE
Fix condition check in ResourcePermissionManager to ensure provider match before returning

### DIFF
--- a/modules/permission-management/src/Volo.Abp.PermissionManagement.Domain/Volo/Abp/PermissionManagement/ResourcePermissionManager.cs
+++ b/modules/permission-management/src/Volo.Abp.PermissionManagement.Domain/Volo/Abp/PermissionManagement/ResourcePermissionManager.cs
@@ -270,7 +270,7 @@ public class ResourcePermissionManager : IResourcePermissionManager, ISingletonD
         }
 
         var currentGrantInfo = await GetInternalAsync(permission, resourceName, resourceKey, providerName, providerKey);
-        if (currentGrantInfo.IsGranted == isGranted)
+        if (currentGrantInfo.IsGranted == isGranted && currentGrantInfo.Providers.Any(x => x.Name == providerName && x.Key == providerKey))
         {
             return;
         }


### PR DESCRIPTION
This is different from the modal in permissions. We should be able to continue setting resource permissions for roles and the users under the roles.