### PR TITLE
Ensure config state is loaded before permission check

### DIFF
--- a/npm/ng-packs/packages/core/src/lib/guards/permission.guard.ts
+++ b/npm/ng-packs/packages/core/src/lib/guards/permission.guard.ts
@@ -8,10 +8,10 @@ import {
 } from '@angular/router';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Observable, of } from 'rxjs';
-import { map, take } from 'rxjs/operators';
+import { filter, map, switchMap, take } from 'rxjs/operators';
 import { AuthService, IAbpGuard } from '../abstracts';
 import { findRoute, getRoutePath } from '../utils/route-utils';
-import { RoutesService, PermissionService, HttpErrorReporterService } from '../services';
+import { RoutesService, PermissionService, HttpErrorReporterService, ConfigStateService } from '../services';
 import { isPlatformServer } from '@angular/common';
 /**
  * @deprecated Use `permissionGuard` *function* instead.
@@ -25,6 +25,7 @@ export class PermissionGuard implements IAbpGuard {
   protected readonly authService = inject(AuthService);
   protected readonly permissionService = inject(PermissionService);
   protected readonly httpErrorReporter = inject(HttpErrorReporterService);
+  protected readonly configStateService = inject(ConfigStateService);
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean | UrlTree> {
     let { requiredPolicy } = route.data || {};
@@ -38,7 +39,10 @@ export class PermissionGuard implements IAbpGuard {
       return of(true);
     }
 
-    return this.permissionService.getGrantedPolicy$(requiredPolicy).pipe(
+    return this.configStateService.getAll$().pipe(
+      filter(config => !!config?.auth?.grantedPolicies),
+      take(1),
+      switchMap(() => this.permissionService.getGrantedPolicy$(requiredPolicy)),
       take(1),
       map(access => {
         if (access) return true;
@@ -50,7 +54,6 @@ export class PermissionGuard implements IAbpGuard {
         if (this.authService.isAuthenticated) {
           this.httpErrorReporter.reportError({ status: 403 } as HttpErrorResponse);
         }
-
         return false;
       }),
     );
@@ -66,6 +69,7 @@ export const permissionGuard: CanActivateFn = (
   const authService = inject(AuthService);
   const permissionService = inject(PermissionService);
   const httpErrorReporter = inject(HttpErrorReporterService);
+  const configStateService = inject(ConfigStateService);
   const platformId = inject(PLATFORM_ID);
 
   let { requiredPolicy } = route.data || {};
@@ -84,7 +88,10 @@ export const permissionGuard: CanActivateFn = (
     return of(true);
   }
 
-  return permissionService.getGrantedPolicy$(requiredPolicy).pipe(
+  return configStateService.getAll$().pipe(
+    filter(config => !!config?.auth?.grantedPolicies),
+    take(1),
+    switchMap(() => permissionService.getGrantedPolicy$(requiredPolicy)),
     take(1),
     map(access => {
       if (access) return true;


### PR DESCRIPTION
## Description
Fixes #24438
This PR fixes the issue where `permissionGuard` returns a 403 error and redirects to the base URL when refreshing a page that uses the new `data: { requiredPolicy: '...' }` format.
### Root Cause
The `permissionGuard` was using `take(1)` which immediately consumed the first value from the `BehaviorSubject` in `ConfigStateService`. On page refresh, this initial value was an empty `{}` object before the application configuration API response arrived, causing the permission check to fail.
### Solution
Added a `filter` operator to wait for `grantedPolicies` to be loaded before performing the permission check:
```typescript
return configStateService.getAll$().pipe(
  filter(config => !!config?.auth?.grantedPolicies),
  take(1),
  switchMap(() => permissionService.getGrantedPolicy$(requiredPolicy)),
  take(1),
  map(access => { ... })
);
```
### How to test it?
you have to change branch issue-24438-test on abp. (because i created test permission and test page)
you have to run dev-app on abp repository

First, try going to localhost:4200/test without assigning yourself the "test" role.
Then, assign yourself the "test" role and try going to the page again.