### PR TITLE
remove hardcoded 'en' culture in AbpIdentityErrorDescriber

### DIFF
--- a/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/AbpIdentityErrorDescriber.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/AbpIdentityErrorDescriber.cs
@@ -4,7 +4,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Identity.Localization;
-using Volo.Abp.Localization;
 
 namespace Volo.Abp.Identity;
 
@@ -21,13 +20,10 @@ public class AbpIdentityErrorDescriber : IdentityErrorDescriber
 
     public override IdentityError InvalidUserName([CanBeNull] string userName)
     {
-        using (CultureHelper.Use("en"))
+        return new IdentityError
         {
-            return new IdentityError
-            {
-                Code = nameof(InvalidUserName),
-                Description = Localizer["Volo.Abp.Identity:InvalidUserName", userName ?? ""]
-            };
-        }
+            Code = nameof(InvalidUserName),
+            Description = Localizer["Volo.Abp.Identity:InvalidUserName", userName ?? ""]
+        };
     }
 }


### PR DESCRIPTION
### Description
Hardcoding 'en' culture in AbpIdentityErrorDescriber breaks localization in non-English environments and causes InvalidUserName_Messages_Test to fail because the expected localized string does not match the hardcoded English response.

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)
