### PR TITLE
Resolve the RemoveProjectFromSolutionStep "file not found" error in the abp CLI new command. 

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectBuilding/Building/Steps/RemoveProjectFromSolutionStep.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectBuilding/Building/Steps/RemoveProjectFromSolutionStep.cs
@@ -29,8 +29,7 @@ public class RemoveProjectFromSolutionStep : ProjectBuildPipelineStep
         {
             _solutionFilePathWithoutFileExtension = solutionFilePathWithoutFileExtension.RemovePostFix(".sln");
         }
-        
-        if (solutionFilePathWithoutFileExtension != null && solutionFilePathWithoutFileExtension.EndsWith(".slnx"))
+        else if (solutionFilePathWithoutFileExtension != null && solutionFilePathWithoutFileExtension.EndsWith(".slnx"))
         {
             _solutionFilePathWithoutFileExtension = solutionFilePathWithoutFileExtension.RemovePostFix(".slnx");
         }


### PR DESCRIPTION
### Description

Resolve the RemoveProjectFromSolutionStep "file not found" error in the abp CLI new command.

#### cli command

`abp new Acme.BookStore -t microservice-pro -d ef -dbms PostgreSQL -m maui --tiered --with-public-website -v 9.3.6 -sib`

#### output

```
Could not find file: /apps/blazor/MyCompanyName.MyProjectName.Blazor.sln.slnx
System.ApplicationException: Could not find file: /apps/blazor/MyCompanyName.MyProjectName.Blazor.sln.slnx
   at Volo.Abp.Cli.ProjectBuilding.Building.ProjectBuildContextExtensions.GetFile(ProjectBuildContext context, String filePath) in abp\framework\src\Volo.Abp.Cli.Core\Vo
lo\Abp\Cli\ProjectBuilding\Building\ProjectBuildContextExtensions.cs:line 14
   at Volo.Abp.Cli.ProjectBuilding.Building.Steps.RemoveProjectFromSolutionStep.Execute(ProjectBuildContext context) in abp\framework\src\Volo.Abp.Cli.Core\Volo\Abp\Cli\
ProjectBuilding\Building\Steps\RemoveProjectFromSolutionStep.cs:line 53
```

TODO: Describe what this PR has changed, add screenshot or animated GIF if available, write if it is a breaking change, and how to fix the breaking changes for existing applications if so.

<img width="2463" height="1038" alt="image" src="https://github.com/user-attachments/assets/5dc1f0a8-baad-4e2c-920a-745306915117" />


### Checklist

- [ √] I fully tested it as developer / designer and created unit / integration tests
- [ √] I documented it (or no need to document or I will create a separate documentation issue)

