### PR TITLE
feat(core): use environment defaultResourceName as fallback for localization - Issue 24402

### DIFF
--- a/docs/en/framework/ui/angular/localization.md
+++ b/docs/en/framework/ui/angular/localization.md
@@ -12,7 +12,7 @@ Before exploring _the localization pipe_ and _the localization service_, you sho
 The localization key format consists of two sections which are **Resource Name** and **Key**.
 `ResourceName::Key`
 
-> If you do not specify the resource name, the `defaultResourceName` which is declared in `environment.ts` will be considered as default.
+> If you do not specify the resource name, the `defaultResourceName` will be used. The value is first retrieved from the backend API response. If the backend does not provide a `defaultResourceName`, the value declared in `environment.ts` will be used as a fallback.
 
 ```ts
 const environment = {

--- a/npm/ng-packs/packages/core/src/lib/services/config-state.service.ts
+++ b/npm/ng-packs/packages/core/src/lib/services/config-state.service.ts
@@ -10,6 +10,7 @@ import {
 } from '../proxy/volo/abp/asp-net-core/mvc/application-configurations/models';
 import { INCUDE_LOCALIZATION_RESOURCES_TOKEN } from '../tokens/include-localization-resources.token';
 import { InternalStore } from '../utils/internal-store-utils';
+import { EnvironmentService } from './environment.service';
 
 @Injectable({
   providedIn: 'root',
@@ -17,6 +18,7 @@ import { InternalStore } from '../utils/internal-store-utils';
 export class ConfigStateService {
   private abpConfigService = inject(AbpApplicationConfigurationService);
   private abpApplicationLocalizationService = inject(AbpApplicationLocalizationService);
+  private environmentService = inject(EnvironmentService);
   private readonly includeLocalizationResources = inject(INCUDE_LOCALIZATION_RESOURCES_TOKEN, { optional: true });
 
   private updateSubject = new Subject<void>();
@@ -59,7 +61,18 @@ export class ConfigStateService {
       this.uiCultureFromAuthCodeFlow ?? appState.localization.currentCulture.cultureName;
 
     return this.getlocalizationResource(cultureName).pipe(
-      map(result => ({ ...appState, localization: { ...appState.localization, ...result } })),
+      map(result => {
+        const envLocalization = this.environmentService.getEnvironment()?.localization;
+        return {
+          ...appState,
+          localization: {
+            ...appState.localization,
+            ...result,
+            defaultResourceName:
+              appState.localization?.defaultResourceName ?? envLocalization?.defaultResourceName,
+          },
+        };
+      }),
       tap(() => (this.uiCultureFromAuthCodeFlow = undefined)),
     );
   }
@@ -83,9 +96,18 @@ export class ConfigStateService {
 
     return this.getlocalizationResource(lang)
       .pipe(
-        tap(result =>
-          this.store.patch({ localization: { ...this.store.state.localization, ...result } }),
-        ),
+        tap(result => {
+          const envLocalization = this.environmentService.getEnvironment()?.localization;
+          this.store.patch({
+            localization: {
+              ...this.store.state.localization,
+              ...result,
+              defaultResourceName:
+                this.store.state.localization?.defaultResourceName ??
+                envLocalization?.defaultResourceName,
+            },
+          });
+        }),
       )
       .pipe(map(() => null));
   }


### PR DESCRIPTION
### Description

Resolves #24402 (write the related issue number if available)

### Changes

- **ConfigStateService**: Added `EnvironmentService` dependency and implemented fallback logic for `defaultResourceName`
  - In `getLocalizationAndCombineWithAppState`: Uses environment value when API response doesn't provide `defaultResourceName`
  - In `refreshLocalization`: Same fallback logic applied for consistency

### Behavior

| Source | Priority |
|--------|----------|
| Backend API response | Primary |
| `environment.ts` | Fallback |

### Example

// environment.ts
export const environment = {
  localization: {
    defaultResourceName: 'MyProjectName',
  },
} as Environment;


### Checklist
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?
1. Remove the `[LocalizationResourceName("MyProjectName")]` attribute from:  `abp\templates\app\aspnet-core\src\MyCompanyName.MyProjectName.Domain.Shared\Localization\MyProjectNameResource.cs`

2. Run the DbMigrator:
   cd `abp\templates\app\aspnet-core\src\MyCompanyName.MyProjectName.DbMigrator`   `dotnet run`

3. Ensure `environment.ts` has `defaultResourceName` configured:
`   localization: {     defaultResourceName: 'MyProjectName',   },`

4. Start the Angular dev-app:
   cd `abp\npm\ng-packs   yarn start`
   
Verify that {{ '::Welcome' | abpLocalization }} correctly resolves using the environment fallback.
Expected: Localization keys with :: prefix should resolve to the resource name defined in environment.ts when the backend doesn't provide defaultResourceName.
