### PR TITLE
Angular - Fixing incorrect proxy generation for `IRemoteStreamContent` type

### DIFF
--- a/npm/ng-packs/packages/schematics/src/utils/methods.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/methods.ts
@@ -20,3 +20,8 @@ export function isDictionaryType(type?: string, typeSimple?: string): boolean {
   const haystacks = [type || '', typeSimple || ''];
   return haystacks.some(t => /(^|\b)(System\.Collections\.Generic\.)?(I)?Dictionary\s*</.test(t));
 }
+
+export function isCollectionType(type?: string, typeSimple?: string): boolean {
+  const haystacks = [type || '', typeSimple || ''];
+  return haystacks.some(t => /(^|\b)(System\.Collections\.Generic\.)?(I)?(List|Enumerable|Collection)\s*</.test(t));
+}

--- a/npm/ng-packs/packages/schematics/src/utils/service.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/service.ts
@@ -14,6 +14,8 @@ import {
 import { sortImports } from './import';
 import { parseNamespace } from './namespace';
 import { parseGenerics } from './tree';
+import { extractGenerics } from './generics';
+import { isCollectionType } from './methods';
 import {
   createTypeAdapter,
   createTypeParser,
@@ -144,7 +146,21 @@ export function isRemoteStreamContent(type: string) {
 }
 
 export function isRemoteStreamContentArray(type: string) {
-  return VOLO_REMOTE_STREAM_CONTENT.map(x => `${x}[]`).some(x => x === type);
+  // Check for array types like Volo.Abp.Content.IRemoteStreamContent[]
+  if (VOLO_REMOTE_STREAM_CONTENT.map(x => `${x}[]`).some(x => x === type)) {
+    return true;
+  }
+
+  // Check for collection types like List<T>, IEnumerable<T>, ICollection<T>, Collection<T>, IList<T>
+  // This matches any generic type from System.Collections.Generic that implements IEnumerable<T>
+  if (isCollectionType(type)) {
+    const { generics } = extractGenerics(type);
+    if (generics.length > 0 && VOLO_REMOTE_STREAM_CONTENT.includes(generics[0])) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 function getMethodNameFromAction(action: Action): string {


### PR DESCRIPTION
### Description

Resolves #24588 

### Checklist

- [X] I fully tested it as developer / designer and created unit / integration tests
- [X] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

- Create an application through ABP Studio
- Run `yarn build:schematics` under `ng-packs` directory
- Open up a terminal under `dist/packages/schematics` and run `yarn link`
- Get the link command and paste & run it under the angular directory of your application
- Follow this guide to prepare the application https://gist.github.com/sumeyyeKurtulus/3e8b8b87cd1e7dc2e98244d8e7f47507
- Run this command under angular directory `abp generate-proxy -t ng`
