### PR TITLE
Add `AbpNoContentApiDescriptionProvider` to handle NoContent responses

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/ApiExploring/AbpNoContentApiDescriptionProvider.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/ApiExploring/AbpNoContentApiDescriptionProvider.cs
@@ -1,0 +1,48 @@
+﻿using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.Reflection;
+
+namespace Volo.Abp.AspNetCore.Mvc.ApiExploring;
+
+public class AbpNoContentApiDescriptionProvider : IApiDescriptionProvider, ITransientDependency
+{
+    public void OnProvidersExecuted(ApiDescriptionProviderContext context)
+    {
+    }
+
+    /// <summary>
+    /// The order -999 ensures that this provider is executed right after the
+    /// Microsoft.AspNetCore.Mvc.ApiExplorer.DefaultApiDescriptionProvider.
+    /// </summary>
+    public int Order => -999;
+
+    public void OnProvidersExecuting(ApiDescriptionProviderContext context)
+    {
+        foreach (var result in context.Results.Where(x => x.IsRemoteService()))
+        {
+            var actionProducesResponseTypeAttributes =
+                ReflectionHelper.GetAttributesOfMemberOrDeclaringType<ProducesResponseTypeAttribute>(
+                    result.ActionDescriptor.GetMethodInfo());
+            if (actionProducesResponseTypeAttributes.Any(x => x.StatusCode == (int) HttpStatusCode.NoContent))
+            {
+                continue;
+            }
+
+            var returnType = result.ActionDescriptor.GetReturnType();
+            if (returnType == typeof(Task) || returnType == typeof(void))
+            {
+                result.SupportedResponseTypes.Add(new ApiResponseType
+                {
+                    // If the return type is Task, then we should treat it as a void return type since we can't infer anything without additional metadata or requiring unreferenced code.
+                    Type = typeof(void),
+                    StatusCode = (int) HttpStatusCode.NoContent
+                });
+            }
+        }
+    }
+}

--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/ApiExploring/AbpNoContentApiDescriptionProvider.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/ApiExploring/AbpNoContentApiDescriptionProvider.cs
@@ -11,7 +11,7 @@ namespace Volo.Abp.AspNetCore.Mvc.ApiExploring;
 
 public class AbpNoContentApiDescriptionProvider : IApiDescriptionProvider, ITransientDependency
 {
-    public void OnProvidersExecuted(ApiDescriptionProviderContext context)
+    public virtual void OnProvidersExecuted(ApiDescriptionProviderContext context)
     {
     }
 
@@ -21,7 +21,7 @@ public class AbpNoContentApiDescriptionProvider : IApiDescriptionProvider, ITran
     /// </summary>
     public int Order => -999;
 
-    public void OnProvidersExecuting(ApiDescriptionProviderContext context)
+    public virtual void OnProvidersExecuting(ApiDescriptionProviderContext context)
     {
         foreach (var result in context.Results.Where(x => x.IsRemoteService()))
         {


### PR DESCRIPTION
Introduces a custom API description provider to automatically add 204 No Content response types for remote service actions returning Task or void, improving API documentation accuracy.

Resolve #24647

<img width="1154" height="1370" alt="screenshot-2026-01-10 T15-16-16@2x" src="https://github.com/user-attachments/assets/3ae2036a-e441-4857-b2de-64dc39c0aa63" />
