### PR TITLE
Implement localized error messages for AbpIdentityResultException

### DIFF
--- a/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/AbpIdentityResultException.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Domain/Volo/Abp/Identity/AbpIdentityResultException.cs
@@ -2,18 +2,23 @@
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Identity;
+using Volo.Abp.ExceptionHandling;
+using Volo.Abp.Localization;
 
 namespace Volo.Abp.Identity;
 
-public class AbpIdentityResultException : BusinessException
+public class AbpIdentityResultException : BusinessException, ILocalizeErrorMessage
 {
     public IdentityResult IdentityResult { get; }
 
     public AbpIdentityResultException([NotNull] IdentityResult identityResult)
-        : base(
-            code: $"Volo.Abp.Identity:{identityResult.Errors.First().Code}",
-            message: identityResult.Errors.Select(err => err.Description).JoinAsString(", "))
+        : base(message: identityResult.Errors.Select(err => err.Description).JoinAsString(", "))
     {
         IdentityResult = Check.NotNull(identityResult, nameof(identityResult));
+    }
+
+    public string LocalizeMessage(LocalizationContext context)
+    {
+        return Message;
     }
 }

--- a/modules/identity/test/Volo.Abp.Identity.Domain.Tests/Volo/Abp/Identity/AbpIdentityResultException_Tests.cs
+++ b/modules/identity/test/Volo.Abp.Identity.Domain.Tests/Volo/Abp/Identity/AbpIdentityResultException_Tests.cs
@@ -1,0 +1,71 @@
+using Microsoft.AspNetCore.Identity;
+using Shouldly;
+using Volo.Abp.AspNetCore.ExceptionHandling;
+using Volo.Abp.Localization;
+using Xunit;
+
+namespace Volo.Abp.Identity;
+
+public class AbpIdentityResultException_Tests : AbpIdentityDomainTestBase
+{
+    [Fact]
+    public void Should_Localize_Messages()
+    {
+        var describer = GetRequiredService<IdentityErrorDescriber>();
+        var exceptionToErrorInfoConverter = GetRequiredService<IExceptionToErrorInfoConverter>();
+
+        using (CultureHelper.Use("en"))
+        {
+            var exception = new AbpIdentityResultException(
+                IdentityResult.Failed(
+                    describer.PasswordTooShort(6),
+                    describer.PasswordRequiresNonAlphanumeric(),
+                    describer.DefaultError())
+            );
+
+            var message = exception.LocalizeMessage(new LocalizationContext(ServiceProvider));
+            exceptionToErrorInfoConverter.Convert(exception).Message.ShouldBe(message);
+
+            message.ShouldNotBeNull();
+            message.ShouldContain("Password length must be greater than 6 characters.");
+            message.ShouldContain("Password must contain at least one non-alphanumeric character.");
+            message.ShouldContain("An unknown failure has occurred.");
+        }
+
+        using (CultureHelper.Use("tr"))
+        {
+            var exception = new AbpIdentityResultException(
+                IdentityResult.Failed(
+                    describer.PasswordTooShort(6),
+                    describer.PasswordRequiresNonAlphanumeric(),
+                    describer.DefaultError())
+            );
+
+            var message = exception.LocalizeMessage(new LocalizationContext(ServiceProvider));
+            exceptionToErrorInfoConverter.Convert(exception).Message.ShouldBe(message);
+
+            message.ShouldNotBeNull();
+            message.ShouldContain("Şifre uzunluğu 6 karakterden uzun olmalıdır.");
+            message.ShouldContain("Parola en az bir alfasayısal olmayan karakter içermeli");
+            message.ShouldContain("Bilinmeyen bir hata oluştu.");
+        }
+
+        using (CultureHelper.Use("zh-Hans"))
+        {
+            var exception = new AbpIdentityResultException(
+                IdentityResult.Failed(
+                    describer.PasswordTooShort(6),
+                    describer.PasswordRequiresNonAlphanumeric(),
+                    describer.DefaultError())
+            );
+
+            var message = exception.LocalizeMessage(new LocalizationContext(ServiceProvider));
+            exceptionToErrorInfoConverter.Convert(exception).Message.ShouldBe(message);
+
+            message.ShouldNotBeNull();
+            message.ShouldContain("密码长度必须大于 6 字符。");
+            message.ShouldContain("密码必须至少包含一个非字母数字字符。");
+            message.ShouldContain("发生了一个未知错误。");
+        }
+    }
+}


### PR DESCRIPTION
Compatible with `IExceptionToErrorInfoConverter`.

Continue of https://github.com/abpframework/abp/pull/24595