### PR TITLE
Add fallback to default chat client for unconfigured workspaces

### DIFF
--- a/framework/src/Volo.Abp.AI/Volo/Abp/AI/ChatClientAccessor.cs
+++ b/framework/src/Volo.Abp.AI/Volo/Abp/AI/ChatClientAccessor.cs
@@ -29,5 +29,13 @@ public class ChatClientAccessor<TWorkSpace> : IChatClientAccessor<TWorkSpace>
         ChatClient = serviceProvider.GetKeyedService<IChatClient>(
             AbpAIWorkspaceOptions.GetChatClientServiceKeyName(
                 WorkspaceNameAttribute.GetWorkspaceName<TWorkSpace>()));
+
+        // Fallback to default chat client if not configured for the workspace.
+        if (ChatClient is null)
+        {
+            ChatClient = serviceProvider.GetKeyedService<IChatClient>(
+                AbpAIWorkspaceOptions.GetChatClientServiceKeyName(
+                    AbpAIModule.DefaultWorkspaceName));
+        }
     }
 }

--- a/framework/src/Volo.Abp.AI/Volo/Abp/AI/TypedChatClient.cs
+++ b/framework/src/Volo.Abp.AI/Volo/Abp/AI/TypedChatClient.cs
@@ -9,9 +9,13 @@ public class TypedChatClient<TWorkSpace> : DelegatingChatClient, IChatClient<TWo
 {
     public TypedChatClient(IServiceProvider serviceProvider)
         : base(
-            serviceProvider.GetRequiredKeyedService<IChatClient>(
+            serviceProvider.GetKeyedService<IChatClient>(
                 AbpAIWorkspaceOptions.GetChatClientServiceKeyName(
                     WorkspaceNameAttribute.GetWorkspaceName<TWorkSpace>()))
+                ??
+            serviceProvider.GetRequiredKeyedService<IChatClient>(
+                AbpAIWorkspaceOptions.GetChatClientServiceKeyName(
+                    AbpAIModule.DefaultWorkspaceName))
         )
     {
     }

--- a/framework/test/Volo.Abp.AI.Tests/Volo/Abp/AI/ChatClientAccessor_Tests.cs
+++ b/framework/test/Volo.Abp.AI.Tests/Volo/Abp/AI/ChatClientAccessor_Tests.cs
@@ -31,14 +31,24 @@ public class ChatClientAccessor_Tests : AbpIntegratedTest<AbpAITestModule>
     }
 
     [Fact]
-    public void Should_Resolve_ChatClientAccessor_For_NonConfigured_Workspace()
+    public void Should_Resolve_Default_ChatClient_From_NonConfigured_Workspace_Accessor()
     {
         // Arrange & Act
         var chatClientAccessor = GetRequiredService<IChatClientAccessor<NonConfiguredWorkspace>>();
 
         // Assert
         chatClientAccessor.ShouldNotBeNull();
-        chatClientAccessor.ChatClient.ShouldBeNull();
+        chatClientAccessor.ChatClient.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void Should_Resolve_Default_ChatClient_For_NonConfigured_Workspace()
+    {
+        // Arrange & Act
+        var chatClientAccessor = GetRequiredService<IChatClient<NonConfiguredWorkspace>>();
+
+        // Assert
+        chatClientAccessor.ShouldNotBeNull();
     }
 
     public class NonConfiguredWorkspace

--- a/framework/test/Volo.Abp.AI.Tests/Volo/Abp/AI/ChatClientAccessor_Tests.cs
+++ b/framework/test/Volo.Abp.AI.Tests/Volo/Abp/AI/ChatClientAccessor_Tests.cs
@@ -45,10 +45,10 @@ public class ChatClientAccessor_Tests : AbpIntegratedTest<AbpAITestModule>
     public void Should_Resolve_Default_ChatClient_For_NonConfigured_Workspace()
     {
         // Arrange & Act
-        var chatClientAccessor = GetRequiredService<IChatClient<NonConfiguredWorkspace>>();
+        var chatClient = GetRequiredService<IChatClient<NonConfiguredWorkspace>>();
 
         // Assert
-        chatClientAccessor.ShouldNotBeNull();
+        chatClient.ShouldNotBeNull();
     }
 
     public class NonConfiguredWorkspace


### PR DESCRIPTION
Updated ChatClientAccessor and TypedChatClient to fallback to the default chat client if a workspace-specific client is not configured. Adjusted tests to verify that the default chat client is resolved for non-configured workspaces.

With this PR, the following code will not throw dependency resolution exception, and resolve the default configuration if done:
```
var chatClient = serviceProvider.GetRequiredService<IChatClient<NonConfiguredWorkspace>>();
```

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

- Tests are added, just execute unit tests