### PR TITLE
Clarify chat client resolution behavior in docs

### DIFF
--- a/docs/en/framework/infrastructure/artificial-intelligence/microsoft-extensions-ai.md
+++ b/docs/en/framework/infrastructure/artificial-intelligence/microsoft-extensions-ai.md
@@ -71,7 +71,7 @@ public class CommentSummarization
 > [!NOTE]
 > If you don't specify the workspace name, the full name of the class will be used as the workspace name.
 
-You can resolve generic versions of `IChatClient` and `IChatClientAccessor` services for a specific workspace as generic arguments. If Chat Client is not configured for a workspace, you will get `null` from the accessor services. You should check the accessor before using it. This applies only for specified workspaces. Another workspace may have a configured Chat Client.
+You can resolve generic versions of `IChatClient` and `IChatClientAccessor` services for a specific workspace as generic arguments. If Chat Client is not configured for a workspace, the default workspace's chat client is returned. Only if both the workspace-specific and default chat clients are not configured will you get `null` from the accessor services. You should check the accessor before using it. This applies only for specified workspaces. Another workspace may have a configured Chat Client.
 
 `IChatClient<TWorkSpace>` or `IChatClientAccessor<TWorkSpace>` can be resolved to access a specific workspace's chat client. This is a typed chat client and can be configured separately from the default chat client.
 


### PR DESCRIPTION
Updated documentation to specify that if a chat client is not configured for a workspace, the default workspace's chat client is returned, and null is only returned if neither is configured.

Update docs according to https://github.com/abpframework/abp/pull/24717

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)


