### PR TITLE
Update template syntax in custom command examples

### DIFF
--- a/docs/en/studio/custom-commands.md
+++ b/docs/en/studio/custom-commands.md
@@ -115,11 +115,11 @@ Here's an example command that builds a Docker image for Helm charts:
 **Command Properties:**
 - **Command Name:** `buildDockerImage`
 - **Display Name:** `Build Docker Image`
-- **Terminal Command:** `./build-image.ps1 -ProjectPath {{metadata.projectPath}} -ImageName {{metadata.imageName}}`
+- **Terminal Command:** `./build-image.ps1 -ProjectPath {%{{{metadata.projectPath}}}%} -ImageName {%{{{metadata.imageName}}}%}`
 - **Working Directory:** `etc/helm`
 - **Trigger Targets:** Helm Charts Root, Helm Main Chart, Helm Sub Chart
 - **Execution Targets:** Helm Main Chart, Helm Sub Chart
-- **Condition:** `{{metadata.projectPath}}`
+- **Condition:** `{%{{{metadata.projectPath}}}%}`
 
 This command:
 1. Appears in the context menu of Helm charts root and all chart nodes

--- a/docs/en/studio/custom-commands.md
+++ b/docs/en/studio/custom-commands.md
@@ -70,7 +70,7 @@ Execution targets define where the command actually runs. This enables cascading
 
 ## Template Variables
 
-Commands support [Scriban](https://github.com/scriban/scriban/blob/master/doc/language.md) template syntax for dynamic values. Use `{{variable}}` to insert context-specific data.
+Commands support [Scriban](https://github.com/scriban/scriban/blob/master/doc/language.md) template syntax for dynamic values. Use `{%{{{variable}}}%}` to insert context-specific data.
 
 ### Available Variables by Context
 


### PR DESCRIPTION
Replaces double curly braces with the new template syntax `{%{{{...}}}%}` in the 'Terminal Command' and 'Condition' fields for custom commands documentation.

