### PR TITLE
Add support for JS frameworks in InstallLibsService

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/LIbs/InstallLibsService.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/LIbs/InstallLibsService.cs
@@ -93,25 +93,19 @@ public class InstallLibsService : IInstallLibsService, ITransientDependency
             if (projectPath.EndsWith("package.json"))
             {
                 var frameworkType = DetectFrameworkTypeFromPackageJson(projectPath);
-                
-                if (frameworkType == JavaScriptFrameworkType.ReactNative)
+
+                if (frameworkType != JavaScriptFrameworkType.None)
                 {
-                    Logger.LogInformation($"Installing dependencies for React Native project: {projectDirectory}");
-                    NpmHelper.RunYarn(projectDirectory);
-                }
-                else if (frameworkType == JavaScriptFrameworkType.React)
-                {
-                    Logger.LogInformation($"Installing dependencies for React project: {projectDirectory}");
-                    NpmHelper.RunYarn(projectDirectory);
-                }
-                else if (frameworkType == JavaScriptFrameworkType.Vue)
-                {
-                    Logger.LogInformation($"Installing dependencies for Vue.js project: {projectDirectory}");
-                    NpmHelper.RunYarn(projectDirectory);
-                }
-                else if (frameworkType == JavaScriptFrameworkType.NextJs)
-                {
-                    Logger.LogInformation($"Installing dependencies for Next.js project: {projectDirectory}");
+                    var frameworkName = frameworkType switch
+                    {
+                        JavaScriptFrameworkType.ReactNative => "React Native",
+                        JavaScriptFrameworkType.React => "React",
+                        JavaScriptFrameworkType.Vue => "Vue.js",
+                        JavaScriptFrameworkType.NextJs => "Next.js",
+                        _ => "JavaScript"
+                    };
+
+                    Logger.LogInformation($"Installing dependencies for {frameworkName} project: {projectDirectory}");
                     NpmHelper.RunYarn(projectDirectory);
                 }
             }

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/LIbs/InstallLibsService.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/LIbs/InstallLibsService.cs
@@ -170,7 +170,7 @@ public class InstallLibsService : IInstallLibsService, ITransientDependency
         }
         catch (Exception ex)
         {
-            Logger.LogWarning($"Failed to parse package.json at {packageJsonFilePath}: {ex.Message}");
+            Logger.LogWarning(ex, "Failed to parse package.json at {PackageJsonFilePath}", packageJsonFilePath);
             return JavaScriptFrameworkType.None;
         }
     }

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/LIbs/InstallLibsService.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/LIbs/InstallLibsService.cs
@@ -6,10 +6,20 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
 using Volo.Abp.Cli.Utils;
 using Volo.Abp.DependencyInjection;
 
 namespace Volo.Abp.Cli.LIbs;
+
+public enum JavaScriptFrameworkType
+{
+    None,
+    ReactNative,
+    React,
+    Vue,
+    NextJs
+}
 
 public class InstallLibsService : IInstallLibsService, ITransientDependency
 {
@@ -78,36 +88,161 @@ public class InstallLibsService : IInstallLibsService, ITransientDependency
 
                 await CleanAndCopyResources(projectDirectory);
             }
+
+            // JavaScript frameworks (React Native, React, Vue, Next.js)
+            if (projectPath.EndsWith("package.json"))
+            {
+                var frameworkType = DetectFrameworkTypeFromPackageJson(projectPath);
+                
+                if (frameworkType == JavaScriptFrameworkType.ReactNative)
+                {
+                    Logger.LogInformation($"Installing dependencies for React Native project: {projectDirectory}");
+                    NpmHelper.RunYarn(projectDirectory);
+                }
+                else if (frameworkType == JavaScriptFrameworkType.React)
+                {
+                    Logger.LogInformation($"Installing dependencies for React project: {projectDirectory}");
+                    NpmHelper.RunYarn(projectDirectory);
+                }
+                else if (frameworkType == JavaScriptFrameworkType.Vue)
+                {
+                    Logger.LogInformation($"Installing dependencies for Vue.js project: {projectDirectory}");
+                    NpmHelper.RunYarn(projectDirectory);
+                }
+                else if (frameworkType == JavaScriptFrameworkType.NextJs)
+                {
+                    Logger.LogInformation($"Installing dependencies for Next.js project: {projectDirectory}");
+                    NpmHelper.RunYarn(projectDirectory);
+                }
+            }
+        }
+    }
+
+    private JavaScriptFrameworkType DetectFrameworkTypeFromPackageJson(string packageJsonFilePath)
+    {
+        if (!File.Exists(packageJsonFilePath))
+        {
+            return JavaScriptFrameworkType.None;
+        }
+
+        try
+        {
+            var packageJsonContent = File.ReadAllText(packageJsonFilePath);
+            var packageJson = JObject.Parse(packageJsonContent);
+
+            var dependencies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            
+            // Check dependencies
+            if (packageJson["dependencies"] is JObject deps)
+            {
+                foreach (var prop in deps.Properties())
+                {
+                    dependencies.Add(prop.Name);
+                }
+            }
+
+            // Check devDependencies
+            if (packageJson["devDependencies"] is JObject devDeps)
+            {
+                foreach (var prop in devDeps.Properties())
+                {
+                    dependencies.Add(prop.Name);
+                }
+            }
+
+            // Check for React Native first (has priority over React)
+            if (dependencies.Contains("react-native"))
+            {
+                return JavaScriptFrameworkType.ReactNative;
+            }
+
+            // Check for other frameworks
+            if (dependencies.Contains("next"))
+            {
+                return JavaScriptFrameworkType.NextJs;
+            }
+
+            if (dependencies.Contains("vue"))
+            {
+                return JavaScriptFrameworkType.Vue;
+            }
+
+            if (dependencies.Contains("react"))
+            {
+                return JavaScriptFrameworkType.React;
+            }
+
+            return JavaScriptFrameworkType.None;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning($"Failed to parse package.json at {packageJsonFilePath}: {ex.Message}");
+            return JavaScriptFrameworkType.None;
         }
     }
 
     private List<string> FindAllProjects(string directory)
     {
-        return Directory.GetFiles(directory, "*.csproj", SearchOption.AllDirectories)
-            .Union(Directory.GetFiles(directory, "angular.json", SearchOption.AllDirectories))
+        var projects = new List<string>();
+
+        // Find .csproj files (existing logic)
+        var csprojFiles = Directory.GetFiles(directory, "*.csproj", SearchOption.AllDirectories)
             .Where(file => ExcludeDirectory.All(x => file.IndexOf(x + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) == -1))
             .Where(file =>
             {
-                if (file.EndsWith(".csproj"))
+                var packageJsonFilePath = Path.Combine(Path.GetDirectoryName(file), "package.json");
+                if (!File.Exists(packageJsonFilePath))
                 {
-                    var packageJsonFilePath = Path.Combine(Path.GetDirectoryName(file), "package.json");
-                    if (!File.Exists(packageJsonFilePath))
-                    {
-                        return false;
-                    }
-
-                    using (var reader = File.OpenText(file))
-                    {
-                        var fileTexts = reader.ReadToEnd();
-                        return fileTexts.Contains("Microsoft.NET.Sdk.Web") ||
-                               fileTexts.Contains("Microsoft.NET.Sdk.Razor") ||
-                               fileTexts.Contains("Microsoft.NET.Sdk.BlazorWebAssembly");
-                    }
+                    return false;
                 }
-                return true;
-            })
-            .OrderBy(x => x)
-            .ToList();
+
+                using (var reader = File.OpenText(file))
+                {
+                    var fileTexts = reader.ReadToEnd();
+                    return fileTexts.Contains("Microsoft.NET.Sdk.Web") ||
+                           fileTexts.Contains("Microsoft.NET.Sdk.Razor") ||
+                           fileTexts.Contains("Microsoft.NET.Sdk.BlazorWebAssembly");
+                }
+            });
+
+        projects.AddRange(csprojFiles);
+
+        // Find angular.json files (existing logic)
+        var angularFiles = Directory.GetFiles(directory, "angular.json", SearchOption.AllDirectories)
+            .Where(file => ExcludeDirectory.All(x => file.IndexOf(x + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) == -1));
+
+        projects.AddRange(angularFiles);
+
+        // Find package.json files for JavaScript frameworks
+        var packageJsonFiles = Directory.GetFiles(directory, "package.json", SearchOption.AllDirectories)
+            .Where(file => ExcludeDirectory.All(x => file.IndexOf(x + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) == -1))
+            .Where(packageJsonFile =>
+            {
+                var packageJsonDirectory = Path.GetDirectoryName(packageJsonFile);
+                if (packageJsonDirectory == null)
+                {
+                    return false;
+                }
+
+                // Skip if already handled by Angular or .NET detection
+                if (File.Exists(Path.Combine(packageJsonDirectory, "angular.json")))
+                {
+                    return false;
+                }
+
+                if (Directory.GetFiles(packageJsonDirectory, "*.csproj", SearchOption.TopDirectoryOnly).Any())
+                {
+                    return false;
+                }
+
+                // Check if it's a JavaScript framework project
+                var frameworkType = DetectFrameworkTypeFromPackageJson(packageJsonFile);
+                return frameworkType != JavaScriptFrameworkType.None;
+            });
+
+        projects.AddRange(packageJsonFiles);
+
+        return projects.OrderBy(x => x).ToList();
     }
 
     private async Task CleanAndCopyResources(string fileDirectory)


### PR DESCRIPTION
Resolves https://github.com/abpframework/abp/issues/24743

Enhanced InstallLibsService to detect and handle JavaScript frameworks (React Native, React, Vue, Next.js) by parsing package.json and running yarn accordingly. Updated project discovery to include these frameworks while avoiding overlap with Angular and .NET projects.

### How to test it?

1) Build Volo.Abp.Cli Project.
2) Create a solution with react-native mobile app. (via ABP Studio)
3) Run `dotnet volo.abp.cli.dll install-libs -wd {your-solution-path}` in `abp\framework\src\Volo.Abp.Cli\bin\Debug\net10.0`  directory.
4) Check if node_modules directory is present in react-naative project.

