### PR TITLE
Add AbpAppPath extension method and update appPath handling in Swagger UI scripts

### DIFF
--- a/framework/src/Volo.Abp.Swashbuckle/Microsoft/Extensions/DependencyInjection/AbpSwaggerUIOptionsExtensions.cs
+++ b/framework/src/Volo.Abp.Swashbuckle/Microsoft/Extensions/DependencyInjection/AbpSwaggerUIOptionsExtensions.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Text;
 using System.Text.Json;
+using JetBrains.Annotations;
 using Swashbuckle.AspNetCore.SwaggerUI;
+using Volo.Abp;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -12,19 +14,34 @@ public static class AbpSwaggerUIOptionsExtensions
     /// </summary>
     /// <param name="options">The Swagger UI options.</param>
     /// <param name="appPath">The application base path.</param>
-    public static void AbpAppPath(this SwaggerUIOptions options, string appPath)
+    public static void AbpAppPath([NotNull] this SwaggerUIOptions options, [NotNull] string appPath)
     {
+        Check.NotNull(options, nameof(options));
+        Check.NotNull(appPath, nameof(appPath));
+
         var normalizedAppPath = NormalizeAppPath(appPath);
-        var builder = new StringBuilder(options.HeadContent ?? string.Empty);
-        builder.AppendLine("<script>");
-        builder.AppendLine("    var abp = abp || {};");
-        builder.AppendLine($"    abp.appPath = {JsonSerializer.Serialize(normalizedAppPath)};");
-        builder.AppendLine("</script>");
-        options.HeadContent = builder.ToString();
+        options.HeadContent = BuildAppPathScript(normalizedAppPath, options.HeadContent ?? string.Empty);
     }
 
     private static string NormalizeAppPath(string appPath)
     {
-        return string.IsNullOrWhiteSpace(appPath) ? "/" : appPath.Trim().EnsureStartsWith('/').EnsureEndsWith('/');
+        return string.IsNullOrWhiteSpace(appPath)
+            ? "/"
+            : appPath.Trim().EnsureStartsWith('/').EnsureEndsWith('/');
+    }
+
+    private static string BuildAppPathScript(string normalizedAppPath, string headContent)
+    {
+        var builder = new StringBuilder(headContent);
+        if (builder.Length > 0)
+        {
+            builder.AppendLine();
+        }
+
+        builder.AppendLine("<script>");
+        builder.AppendLine("    var abp = abp || {};");
+        builder.AppendLine($"    abp.appPath = {JsonSerializer.Serialize(normalizedAppPath)};");
+        builder.AppendLine("</script>");
+        return builder.ToString();
     }
 }

--- a/framework/src/Volo.Abp.Swashbuckle/Microsoft/Extensions/DependencyInjection/AbpSwaggerUIOptionsExtensions.cs
+++ b/framework/src/Volo.Abp.Swashbuckle/Microsoft/Extensions/DependencyInjection/AbpSwaggerUIOptionsExtensions.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Text;
+using System.Text.Json;
+using Swashbuckle.AspNetCore.SwaggerUI;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+public static class AbpSwaggerUIOptionsExtensions
+{
+    /// <summary>
+    /// Sets the abp.appPath used by the Swagger UI scripts.
+    /// </summary>
+    /// <param name="options">The Swagger UI options.</param>
+    /// <param name="appPath">The application base path.</param>
+    public static void AbpAppPath(this SwaggerUIOptions options, string appPath)
+    {
+        var normalizedAppPath = NormalizeAppPath(appPath);
+        var builder = new StringBuilder(options.HeadContent ?? string.Empty);
+        builder.AppendLine("<script>");
+        builder.AppendLine("    var abp = abp || {};");
+        builder.AppendLine($"    abp.appPath = {JsonSerializer.Serialize(normalizedAppPath)};");
+        builder.AppendLine("</script>");
+        options.HeadContent = builder.ToString();
+    }
+
+    private static string NormalizeAppPath(string appPath)
+    {
+        return string.IsNullOrWhiteSpace(appPath) ? "/" : appPath.Trim().EnsureStartsWith('/').EnsureEndsWith('/');
+    }
+}

--- a/framework/src/Volo.Abp.Swashbuckle/wwwroot/swagger/ui/abp.js
+++ b/framework/src/Volo.Abp.Swashbuckle/wwwroot/swagger/ui/abp.js
@@ -2,11 +2,7 @@ var abp = abp || {};
 (function () {
 
     /* Application paths *****************************************/
-
-    //Current application root path (including virtual directory if exists).
-    var baseElement = document.querySelector('base');
-    var baseHref = baseElement ? baseElement.getAttribute('href') : null;
-    abp.appPath = baseHref || abp.appPath || '/';
+    abp.appPath = abp.appPath || '/';
 
     /* UTILS ***************************************************/
 

--- a/framework/src/Volo.Abp.Swashbuckle/wwwroot/swagger/ui/abp.swagger.js
+++ b/framework/src/Volo.Abp.Swashbuckle/wwwroot/swagger/ui/abp.swagger.js
@@ -11,7 +11,7 @@ var abp = abp || {};
         var oidcSupportedScopes = configObject.oidcSupportedScopes || [];
         var oidcDiscoveryEndpoint = configObject.oidcDiscoveryEndpoint || [];
         var tenantPlaceHolders = ["{{tenantId}}", "{{tenantName}}", "{0}"]
-        abp.appPath = configObject.baseUrl || abp.appPath;
+        abp.appPath = abp.appPath || "/";
 
         var requestInterceptor = configObject.requestInterceptor;
         var responseInterceptor = configObject.responseInterceptor;


### PR DESCRIPTION
Resolves #24798 

```cs
app.UseAbpSwaggerUI(options =>
{
    options.AbpAppPath("/mysubapp/");
    options.SwaggerEndpoint("/mysubapp/swagger/v1/swagger.json", "Test MyProjectName API");
});
```

https://abp.io/support/questions/10387/We-need-a-meeting-to-take-sample-abp-mvc-layered-project-using-pathbased-routing#answer-3a1f36ce-f635-d283-5b95-a16e8d3e907b