### PR TITLE
Fix Grant All checkbox not showing indeterminate state in permission modal

### DIFF
--- a/modules/permission-management/src/Volo.Abp.PermissionManagement.Blazor/Components/PermissionManagementModal.razor.cs
+++ b/modules/permission-management/src/Volo.Abp.PermissionManagement.Blazor/Components/PermissionManagementModal.razor.cs
@@ -62,8 +62,8 @@ public partial class PermissionManagementModal
 
             NormalizePermissionGroup();
 
-            GrantAll = _groups.SelectMany(x => x.Permissions).All(p => p.IsGranted);
-            GrantAny = !GrantAll && _groups.SelectMany(x => x.Permissions).Any(p => p.IsGranted);
+            GrantAll = _allGroups.SelectMany(x => x.Permissions).All(p => p.IsGranted);
+            GrantAny = !GrantAll && _allGroups.SelectMany(x => x.Permissions).Any(p => p.IsGranted);
 
             await InvokeAsync(_modal.Show);
         }

--- a/modules/permission-management/src/Volo.Abp.PermissionManagement.Blazor/Components/PermissionManagementModal.razor.cs
+++ b/modules/permission-management/src/Volo.Abp.PermissionManagement.Blazor/Components/PermissionManagementModal.razor.cs
@@ -203,8 +203,8 @@ public partial class PermissionManagementModal
             }
         }
 
-        GrantAll = _groups.SelectMany(x => x.Permissions).All(p => p.IsGranted);
-        GrantAny = !GrantAll && _groups.SelectMany(x => x.Permissions).Any(p => p.IsGranted);
+        GrantAll = _allGroups.SelectMany(x => x.Permissions).All(p => p.IsGranted);
+        GrantAny = !GrantAll && _allGroups.SelectMany(x => x.Permissions).Any(p => p.IsGranted);
         await InvokeAsync(StateHasChanged);
     }
 
@@ -226,8 +226,8 @@ public partial class PermissionManagementModal
             }
         }
 
-        GrantAll = _groups.SelectMany(x => x.Permissions).All(p => p.IsGranted);
-        GrantAny = !GrantAll && _groups.SelectMany(x => x.Permissions).Any(p => p.IsGranted);
+        GrantAll = _allGroups.SelectMany(x => x.Permissions).All(p => p.IsGranted);
+        GrantAny = !GrantAll && _allGroups.SelectMany(x => x.Permissions).Any(p => p.IsGranted);
         await InvokeAsync(StateHasChanged);
     }
 
@@ -339,8 +339,8 @@ public partial class PermissionManagementModal
         _permissionGroupSearchText = value;
         _groups = _permissionGroupSearchText.IsNullOrWhiteSpace() ? _allGroups.ToList() : _allGroups.Where(x => x.DisplayName.Contains(_permissionGroupSearchText, StringComparison.OrdinalIgnoreCase) || x.Permissions.Any(permission => permission.DisplayName.Contains(_permissionGroupSearchText, StringComparison.OrdinalIgnoreCase))).ToList();
 
-        GrantAll = _groups.SelectMany(x => x.Permissions).All(p => p.IsGranted);
-        GrantAny = !GrantAll && _groups.SelectMany(x => x.Permissions).Any(p => p.IsGranted);
+        GrantAll = _allGroups.SelectMany(x => x.Permissions).All(p => p.IsGranted);
+        GrantAny = !GrantAll && _allGroups.SelectMany(x => x.Permissions).Any(p => p.IsGranted);
 
         NormalizePermissionGroup(false);
 


### PR DESCRIPTION
## Summary
- Fixed the "Grant All Permissions" checkbox not displaying indeterminate state when only some permission groups are fully selected
- Changed `GrantAll` and `GrantAny` calculation to use `_allGroups` instead of `_groups` (filtered list)
- Affected methods: `GroupGrantAllChanged`, `PermissionChanged`, and `OnPermissionGroupSearchTextChangedAsync`

## Problem
When selecting "Select All" for a specific permission group in the Blazor permission modal, the top-level "Grant All Permissions" checkbox appeared as if all permissions were granted, instead of showing the indeterminate ("-") state.

## Root Cause
The `GrantAll` and `GrantAny` properties were calculated based on `_groups` (the filtered/visible list) instead of `_allGroups` (all permission groups). This caused incorrect state when:
- Groups were filtered via search
- Only some groups had all permissions selected

## Test plan
- [ ] Open permission management modal with multiple permission groups
- [ ] Click "Select All in This Tab" for one group only
- [ ] Verify the top "Grant All Permissions" checkbox shows indeterminate state (-)
- [ ] Filter groups using search, then select all in a filtered group
- [ ] Verify the top checkbox still shows correct indeterminate state

🤖 Generated with [Claude Code](https://claude.ai/code)