### PR TITLE
Clarify Blazor Server entity history limitation in audit logging docs

### DIFF
--- a/docs/en/framework/infrastructure/audit-logging.md
+++ b/docs/en/framework/infrastructure/audit-logging.md
@@ -169,6 +169,17 @@ public class HomeController : AbpController
 
 [Application service](../architecture/domain-driven-design/application-services.md) method calls also included into the audit log by default. You can use the `[DisableAuditing]` in service or method level.
 
+> ### Blazor Server Limitation (Entity History)
+>
+> In `Blazor Server` applications, entity change history is currently not guaranteed to be complete for every UI interaction.
+>
+> Blazor Server uses SignalR-based event handling, and under some flows the audit scope/action tracking may not align with `DbContext.SaveChanges`, which can cause missing or partial entity change records.
+>
+> This is a known platform-level limitation and not a regular configuration issue.
+>
+> Related discussions:
+> - https://github.com/abpframework/abp/issues/11682
+
 #### Enable/Disable for Other Services
 
 Action audit logging can be enabled for any type of class (registered to and resolved from the [dependency injection](../fundamentals/dependency-injection.md)) while it is only enabled for the controllers and the application services by default.

--- a/docs/en/framework/infrastructure/audit-logging.md
+++ b/docs/en/framework/infrastructure/audit-logging.md
@@ -169,16 +169,7 @@ public class HomeController : AbpController
 
 [Application service](../architecture/domain-driven-design/application-services.md) method calls also included into the audit log by default. You can use the `[DisableAuditing]` in service or method level.
 
-> ### Blazor Server Limitation (Entity History)
->
-> In `Blazor Server` applications, entity change history is currently not guaranteed to be complete for every UI interaction.
->
-> Blazor Server uses SignalR-based event handling, and under some flows the audit scope/action tracking may not align with `DbContext.SaveChanges`, which can cause missing or partial entity change records.
->
-> This is a known platform-level limitation and not a regular configuration issue.
->
-> Related discussions:
-> - https://github.com/abpframework/abp/issues/11682
+> **Blazor Server limitation (Entity history):** In `Blazor Server` applications, entity change history is currently not guaranteed to be complete for every UI interaction. Blazor Server uses SignalR-based event handling, and under some flows the audit scope/action tracking may not align with `DbContext.SaveChanges`, which can cause missing or partial entity change records. This is a known platform-level limitation and not a regular configuration issue. See [#11682](https://github.com/abpframework/abp/issues/11682) for related discussions.
 
 #### Enable/Disable for Other Services
 

--- a/docs/en/modules/audit-logging-pro.md
+++ b/docs/en/modules/audit-logging-pro.md
@@ -73,7 +73,7 @@ You can export audit logs to Excel by clicking the "Export to Excel" button in t
 
 Entity changes tab is used to list, view and filter entity change logs. 
 
-> **Blazor Server note:** Entity change history can be missing or incomplete in some `Blazor Server` scenarios due to known SignalR/event-pipeline limitations. See [Audit Logging](../framework/infrastructure/audit-logging.md) and https://github.com/abpframework/abp/issues/11682.
+> **Blazor Server note:** Entity change history can be missing or incomplete in some `Blazor Server` scenarios due to known SignalR/event-pipeline limitations. See [Audit Logging](../framework/infrastructure/audit-logging.md) and [#11682](https://github.com/abpframework/abp/issues/11682).
 
 ![audit-logging-module-entity-changes-list-page](../images/audit-logging-module-entity-changes-list-page.png)
 

--- a/docs/en/modules/audit-logging-pro.md
+++ b/docs/en/modules/audit-logging-pro.md
@@ -73,6 +73,8 @@ You can export audit logs to Excel by clicking the "Export to Excel" button in t
 
 Entity changes tab is used to list, view and filter entity change logs. 
 
+> **Blazor Server note:** Entity change history can be missing or incomplete in some `Blazor Server` scenarios due to known SignalR/event-pipeline limitations. See [Audit Logging](../framework/infrastructure/audit-logging.md) and https://github.com/abpframework/abp/issues/11682.
+
 ![audit-logging-module-entity-changes-list-page](../images/audit-logging-module-entity-changes-list-page.png)
 
 


### PR DESCRIPTION
## Summary
- add an explicit Blazor Server limitation note to the framework audit logging doc for entity history behavior
- add a matching note in the Audit Logging Pro module docs where the Entity Changes tab is described
- reference the public tracking issue in `abpframework/abp` to provide context for the limitation

Related to https://github.com/volosoft/volo/issues/21357 and https://github.com/abpframework/abp/issues/11682