### PR TITLE
fix: Resolve JS proxy namespace mismatch for multi-segment company names

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectBuilding/Building/Steps/SolutionRenamer.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectBuilding/Building/Steps/SolutionRenamer.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using Volo.Abp.Cli.ProjectBuilding.Files;
 
 namespace Volo.Abp.Cli.ProjectBuilding.Building.Steps;
@@ -41,7 +42,7 @@ public class SolutionRenamer
             if (_companyName != null)
             {
                 RenameHelper.RenameAll(_entries, _companyNamePlaceHolder, _companyName);
-                RenameHelper.RenameAll(_entries, _companyNamePlaceHolder.ToCamelCase(), _companyName.ToCamelCase());
+                RenameHelper.RenameAll(_entries, _companyNamePlaceHolder.ToCamelCase(), ToCamelCaseWithNamespace(_companyName));
                 RenameHelper.RenameAll(_entries, _companyNamePlaceHolder.ToKebabCase(), _companyName.ToKebabCase());
                 RenameHelper.RenameAll(_entries, _companyNamePlaceHolder.ToLowerInvariant(), _companyName.ToLowerInvariant());
             }
@@ -55,9 +56,19 @@ public class SolutionRenamer
         }
 
         RenameHelper.RenameAll(_entries, _projectNamePlaceHolder, _projectName);
-        RenameHelper.RenameAll(_entries, _projectNamePlaceHolder.ToCamelCase(), _projectName.ToCamelCase());
+        RenameHelper.RenameAll(_entries, _projectNamePlaceHolder.ToCamelCase(), ToCamelCaseWithNamespace(_projectName));
         RenameHelper.RenameAll(_entries, _projectNamePlaceHolder.ToKebabCase(), _projectName.ToKebabCase());
         RenameHelper.RenameAll(_entries, _projectNamePlaceHolder.ToLowerInvariant(), _projectName.ToLowerInvariant());
         RenameHelper.RenameAll(_entries, _projectNamePlaceHolder.ToSnakeCase().ToUpper(), _projectName.ToSnakeCase().ToUpper());
+    }
+
+    private static string ToCamelCaseWithNamespace(string name)
+    {
+        if (name.Contains('.'))
+        {
+            return name.Split('.').Select(n => n.ToCamelCase()).JoinAsString(".");
+        }
+
+        return name.ToCamelCase();
     }
 }

--- a/framework/test/Volo.Abp.Cli.Core.Tests/Volo/Abp/Cli/ProjectBuilding/Building/Steps/SolutionRenamer_Tests.cs
+++ b/framework/test/Volo.Abp.Cli.Core.Tests/Volo/Abp/Cli/ProjectBuilding/Building/Steps/SolutionRenamer_Tests.cs
@@ -1,0 +1,87 @@
+using Shouldly;
+using System.Collections.Generic;
+using System.Reflection;
+using Volo.Abp.Cli.ProjectBuilding.Files;
+using Xunit;
+
+namespace Volo.Abp.Cli.ProjectBuilding.Building.Steps;
+
+public class SolutionRenamer_Tests
+{
+    [Theory]
+    [InlineData("Demo", "demo")]
+    [InlineData("MyCompany", "myCompany")]
+    [InlineData("Acme", "acme")]
+    [InlineData("ABC", "aBC")]
+    public void ToCamelCaseWithNamespace_Should_Handle_Single_Segment_Names(string input, string expected)
+    {
+        // Act
+        var result = InvokeToCamelCaseWithNamespace(input);
+
+        // Assert
+        result.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("Demo.App", "demo.app")]
+    [InlineData("MyCompany.MyProject", "myCompany.myProject")]
+    [InlineData("Acme.Bookstore", "acme.bookstore")]
+    [InlineData("ABC.XYZ", "aBC.xYZ")]
+    public void ToCamelCaseWithNamespace_Should_Handle_Two_Segment_Names(string input, string expected)
+    {
+        // Act
+        var result = InvokeToCamelCaseWithNamespace(input);
+
+        // Assert
+        result.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("Demo.App.QoL", "demo.app.qoL")]
+    [InlineData("MyCompany.MyProject.Module", "myCompany.myProject.module")]
+    [InlineData("Acme.Bookstore.Application", "acme.bookstore.application")]
+    [InlineData("A.B.C.D", "a.b.c.d")]
+    public void ToCamelCaseWithNamespace_Should_Handle_Multi_Segment_Names(string input, string expected)
+    {
+        // Act
+        var result = InvokeToCamelCaseWithNamespace(input);
+
+        // Assert
+        result.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("", "")]
+    [InlineData("A", "a")]
+    [InlineData(".", ".")]
+    [InlineData("...", "...")]
+    public void ToCamelCaseWithNamespace_Should_Handle_Edge_Cases(string input, string expected)
+    {
+        // Act
+        var result = InvokeToCamelCaseWithNamespace(input);
+
+        // Assert
+        result.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void ToCamelCaseWithNamespace_Should_Throw_On_Null_Input()
+    {
+        // Act & Assert
+        var exception = Should.Throw<System.Reflection.TargetInvocationException>(() => InvokeToCamelCaseWithNamespace(null));
+        exception.InnerException.ShouldBeOfType<System.NullReferenceException>();
+    }
+
+    /// <summary>
+    /// Helper method to invoke the private static ToCamelCaseWithNamespace method using reflection
+    /// </summary>
+    private static string InvokeToCamelCaseWithNamespace(string input)
+    {
+        var type = typeof(SolutionRenamer);
+        var method = type.GetMethod("ToCamelCaseWithNamespace", BindingFlags.NonPublic | BindingFlags.Static);
+        
+        method.ShouldNotBeNull("ToCamelCaseWithNamespace method should exist");
+        
+        return (string)method.Invoke(null, new object[] { input });
+    }
+}


### PR DESCRIPTION
## Summary

When generating a project with a company name containing dots (e.g., `Demo.App.QoL`), the template replacement was incorrectly camelCasing the company name as `demo.App` instead of `demo.app`.

### Root Cause

- **Template replacement** (`SolutionRenamer`): Used `ToCamelCase()` on the entire company/project name string, which only lowercases the first character of the whole string.
  - `"Demo.App".ToCamelCase()` → `"demo.App"`

- **Runtime proxy** (`JQueryProxyScriptGenerator.CamelCaseWithNamespace`): Applies `ToCamelCase()` to each dot-separated segment individually.
  - `"Demo.App"` → `"demo.app"`

This mismatch causes a runtime error: `Cannot read properties of undefined (reading 'someProperty')` when the generated JavaScript tries to access a namespace that doesn't exist.

### Fix

Added `ToCamelCaseWithNamespace()` helper method in `SolutionRenamer.cs` that mirrors the runtime proxy's behavior - splitting by `.` and camelCasing each segment.

### Affected Areas

- `app-nolayers` template (MVC, Blazor, etc.)
- `app` template (Web, Web.Host)
- `microservice` templates
- Any template using dynamic JS proxies with the `.services.` or `.controllers.` pattern

### Files Changed

- `framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectBuilding/Building/Steps/SolutionRenamer.cs`