### PR TITLE
Bump Semantic Kernel packages to 1.71.0

### DIFF
--- a/.github/workflows/nuget-packages-version-change-detector.yml
+++ b/.github/workflows/nuget-packages-version-change-detector.yml
@@ -36,7 +36,7 @@ jobs:
       - run: gh pr edit "$PR_NUMBER" --add-label "dependency-change"
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          GH_TOKEN: ${{ secrets.BOT_SECRET }}
+          GH_TOKEN: ${{ secrets.MLM_Token }}
           GH_REPO: ${{ github.repository }}
 
       - uses: actions/checkout@v4

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -89,8 +89,8 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.2" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.2" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.SemanticKernel" Version="1.67.1" />
-    <PackageVersion Include="Microsoft.SemanticKernel.Abstractions" Version="1.67.1" />
+    <PackageVersion Include="Microsoft.SemanticKernel" Version="1.71.0" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Abstractions" Version="1.71.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="9.9.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.2" />

--- a/docs/en/package-version-changes.md
+++ b/docs/en/package-version-changes.md
@@ -1,0 +1,9 @@
+# Package Version Changes
+
+## 10.1.0
+
+| Package | Old Version | New Version | PR |
+|---------|-------------|-------------|-----|
+| Microsoft.SemanticKernel | 1.67.1 | 1.71.0 | #24891 |
+| Microsoft.SemanticKernel.Abstractions | 1.67.1 | 1.71.0 | #24891 |
+


### PR DESCRIPTION
Update Microsoft.SemanticKernel and Microsoft.SemanticKernel.Abstractions from 1.67.1 to 1.71.0 in Directory.Packages.props to pick up upstream fixes and improvements. No other package versions were changed.

https://abp.io/support/questions/10443/AI-Module-Errors-for-Blazor

