### PR TITLE
Docs: CMS Kit Pro package requirements

### DIFF
--- a/docs/en/modules/cms-kit-pro/index.md
+++ b/docs/en/modules/cms-kit-pro/index.md
@@ -54,6 +54,11 @@ If you want to add the CMS kit to your existing solution, you can use the ABP CL
 ```bash
 abp add-module Volo.CmsKit.Pro
 ```
+
+> **Important**: CMS Kit Pro requires both the Pro packages **and** the base CMS Kit packages. The `add-module` command handles this automatically, but if you're adding packages manually, you need both:
+> - `Volo.CmsKit.*` packages (base CMS Kit)
+> - `Volo.CmsKit.Pro.*` packages (Pro features)
+
 Open the `GlobalFeatureConfigurator` class in the `Domain.Shared` project and place the following code to the `Configure` method to enable all open-source and commercial features in the CMS Kit module.
 
 ```csharp


### PR DESCRIPTION
Add an Important note to CMS Kit Pro ducmentation clarifying that CMS Kit Pro requires both the base Volo.CmsKit.* packages and the Volo.CmsKit.Pro.* packages. Notes that the `abp add-module Volo.CmsKit.Pro` command will handle this automatically, but if adding packages manually you must include both sets.

Refers to https://abp.io/support/questions/10271/CmsKit-implement-problem

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

