### PR TITLE
Fix OIDC security requirement in AddAbpSwaggerGenWithOidc

### DIFF
--- a/framework/src/Volo.Abp.Swashbuckle/Microsoft/Extensions/DependencyInjection/AbpSwaggerGenServiceCollectionExtensions.cs
+++ b/framework/src/Volo.Abp.Swashbuckle/Microsoft/Extensions/DependencyInjection/AbpSwaggerGenServiceCollectionExtensions.cs
@@ -77,7 +77,8 @@ public static class AbpSwaggerGenServiceCollectionExtensions
         string[]? scopes = null,
         string[]? flows = null,
         string? discoveryEndpoint = null,
-        Action<SwaggerGenOptions>? setupAction = null)
+        Action<SwaggerGenOptions>? setupAction = null,
+        string oidcAuthenticationScheme = "oidc")
     {
         var discoveryUrl = discoveryEndpoint != null ?
             $"{discoveryEndpoint.TrimEnd('/')}/.well-known/openid-configuration":
@@ -96,7 +97,7 @@ public static class AbpSwaggerGenServiceCollectionExtensions
             .AddSwaggerGen(
                 options =>
                 {
-                    options.AddSecurityDefinition("oidc", new OpenApiSecurityScheme
+                    options.AddSecurityDefinition(oidcAuthenticationScheme, new OpenApiSecurityScheme
                     {
                         Type = SecuritySchemeType.OpenIdConnect,
                         OpenIdConnectUrl = new Uri(RemoveTenantPlaceholders(discoveryUrl))
@@ -104,7 +105,7 @@ public static class AbpSwaggerGenServiceCollectionExtensions
 
                     options.AddSecurityRequirement(document => new OpenApiSecurityRequirement()
                     {
-                        [new OpenApiSecuritySchemeReference("oidc", document)] = []
+                        [new OpenApiSecuritySchemeReference(oidcAuthenticationScheme, document)] = []
                     });
 
                     setupAction?.Invoke(options);

--- a/framework/src/Volo.Abp.Swashbuckle/Microsoft/Extensions/DependencyInjection/AbpSwaggerGenServiceCollectionExtensions.cs
+++ b/framework/src/Volo.Abp.Swashbuckle/Microsoft/Extensions/DependencyInjection/AbpSwaggerGenServiceCollectionExtensions.cs
@@ -104,7 +104,7 @@ public static class AbpSwaggerGenServiceCollectionExtensions
 
                     options.AddSecurityRequirement(document => new OpenApiSecurityRequirement()
                     {
-                        [new OpenApiSecuritySchemeReference("oauth2", document)] = []
+                        [new OpenApiSecuritySchemeReference("oidc", document)] = []
                     });
 
                     setupAction?.Invoke(options);


### PR DESCRIPTION

Current Bug:
Generated OpenAPI ended up with anonymous security entries`[{}]` instead of a concrete OIDC requirement, so Swagger UI treated operations as optional/anonymous

This PR fixes the scheme mismatch in OIDC Swagger setup