### PR TITLE
Update TickerQ package versions and refactor background job management

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -183,10 +183,10 @@
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
     <PackageVersion Include="TencentCloudSDK.Sms" Version="3.0.1273" />
     <PackageVersion Include="TimeZoneConverter" Version="7.2.0" />
-    <PackageVersion Include="TickerQ" Version="2.5.3" />
-    <PackageVersion Include="TickerQ.Dashboard" Version="2.5.3" />
-    <PackageVersion Include="TickerQ.Utilities" Version="2.5.3" />
-    <PackageVersion Include="TickerQ.EntityFrameworkCore" Version="2.5.3" />
+    <PackageVersion Include="TickerQ" Version="10.1.1" />
+    <PackageVersion Include="TickerQ.Dashboard" Version="10.1.1" />
+    <PackageVersion Include="TickerQ.Utilities" Version="10.1.1" />
+    <PackageVersion Include="TickerQ.EntityFrameworkCore" Version="10.1.1" />
     <PackageVersion Include="Unidecode.NET" Version="2.1.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.extensibility.execution" Version="2.9.3" />

--- a/docs/en/framework/infrastructure/background-jobs/tickerq.md
+++ b/docs/en/framework/infrastructure/background-jobs/tickerq.md
@@ -44,7 +44,7 @@ You need to call the `UseAbpTickerQ` extension method in the `OnApplicationIniti
 public override async Task OnApplicationInitializationAsync(ApplicationInitializationContext context)
 {
     // (default: TickerQStartMode.Immediate)
-    context.GetHost().UseAbpTickerQ(startMode: ...);
+    context.GetHost().UseAbpTickerQ(qStartMode: ...);
 }
 ```
 

--- a/docs/en/framework/infrastructure/background-jobs/tickerq.md
+++ b/docs/en/framework/infrastructure/background-jobs/tickerq.md
@@ -38,16 +38,20 @@ public override void ConfigureServices(ServiceConfigurationContext context)
 
 ### UseAbpTickerQ
 
-You need to call the `UseAbpTickerQ` extension method instead of `AddTickerQ` in the `OnApplicationInitialization` method of your module:
+You need to call the `UseAbpTickerQ` extension method in the `OnApplicationInitialization` method of your module. The method is an extension on `IHost`, so cast the application builder accordingly:
 
 ```csharp
-// (default: TickerQStartMode.Immediate)
-app.UseAbpTickerQ(startMode: ...);
+public override async Task OnApplicationInitializationAsync(ApplicationInitializationContext context)
+{
+    var app = context.GetApplicationBuilder();
+    // (default: TickerQStartMode.Immediate)
+    (app as IHost)?.UseAbpTickerQ(startMode: ...);
+}
 ```
 
 ### AbpBackgroundJobsTickerQOptions
 
-You can configure the `TimeTicker` properties for specific jobs. For example, you can change `Priority`, `Retries` and `RetryIntervals` properties as shown below:
+You can configure the `TimeTickerEntity` properties for specific jobs. For example, you can change `Priority`, `Retries` and `RetryIntervals` properties as shown below:
 
 ```csharp
 Configure<AbpBackgroundJobsTickerQOptions>(options =>
@@ -56,11 +60,10 @@ Configure<AbpBackgroundJobsTickerQOptions>(options =>
 	{
 		Retries = 3,
 		RetryIntervals = new[] {30, 60, 120}, // Retry after 30s, 60s, then 2min
-		Priority = TickerTaskPriority.High
+		Priority = TickerTaskPriority.High,
 
-		// Optional batching
-		//BatchParent = Guid.Parse("...."),
-		//BatchRunCondition = BatchRunCondition.OnSuccess
+		// Optional: run condition for chained jobs
+		//RunCondition = RunCondition.OnSuccess
 	});
 
 	options.AddJobConfiguration<MyBackgroundJob2>(new AbpBackgroundJobsTimeTickerConfiguration()
@@ -74,7 +77,7 @@ Configure<AbpBackgroundJobsTickerQOptions>(options =>
 
 ### Add your own TickerQ Background Jobs Definitions
 
-ABP will handle the TickerQ job definitions by `AbpTickerQFunctionProvider` service. You shouldn't use `TickerFunction` to add your own job definitions. You can inject and use the `AbpTickerQFunctionProvider` to add your own definitions and use `ITimeTickerManager<TimeTicker>` or `ICronTickerManager<CronTicker>` to manage the jobs.
+ABP will handle the TickerQ job definitions by `AbpTickerQFunctionProvider` service. You shouldn't use `TickerFunction` to add your own job definitions. You can inject and use the `AbpTickerQFunctionProvider` to add your own definitions and use `ITimeTickerManager<TimeTickerEntity>` or `ICronTickerManager<CronTickerEntity>` to manage the jobs.
 
 For example, you can add a `CleanupJobs` job definition in the `OnPreApplicationInitializationAsync` method of your module:
 
@@ -96,7 +99,7 @@ public override Task OnPreApplicationInitializationAsync(ApplicationInitializati
 	abpTickerQFunctionProvider.Functions.TryAdd(nameof(CleanupJobs), (string.Empty, TickerTaskPriority.Normal, new TickerFunctionDelegate(async (cancellationToken, serviceProvider, tickerFunctionContext) =>
 	{
 		var service = new CleanupJobs(); // Or get it from the serviceProvider
-		var request = await TickerRequestProvider.GetRequestAsync<string>(serviceProvider,  tickerFunctionContext.Id, tickerFunctionContext.Type);
+		var request = await TickerRequestProvider.GetRequestAsync<string>(tickerFunctionContext, cancellationToken);
 		var genericContext = new TickerFunctionContext<string>(tickerFunctionContext, request);
 		await service.CleanupLogsAsync(genericContext, cancellationToken);
 	})));
@@ -105,11 +108,11 @@ public override Task OnPreApplicationInitializationAsync(ApplicationInitializati
 }
 ```
 
-And then you can add a job by using the `ITimeTickerManager<TimeTicker>`:
+And then you can add a job by using the `ITimeTickerManager<TimeTickerEntity>`:
 
 ```csharp
-var timeTickerManager = context.ServiceProvider.GetRequiredService<ITimeTickerManager<TimeTicker>>();
-await timeTickerManager.AddAsync(new TimeTicker
+var timeTickerManager = context.ServiceProvider.GetRequiredService<ITimeTickerManager<TimeTickerEntity>>();
+await timeTickerManager.AddAsync(new TimeTickerEntity
 {
 	Function = nameof(CleanupJobs),
 	ExecutionTime = DateTime.UtcNow.AddSeconds(5),

--- a/docs/en/framework/infrastructure/background-jobs/tickerq.md
+++ b/docs/en/framework/infrastructure/background-jobs/tickerq.md
@@ -38,14 +38,13 @@ public override void ConfigureServices(ServiceConfigurationContext context)
 
 ### UseAbpTickerQ
 
-You need to call the `UseAbpTickerQ` extension method in the `OnApplicationInitialization` method of your module. The method is an extension on `IHost`, so cast the application builder accordingly:
+You need to call the `UseAbpTickerQ` extension method in the `OnApplicationInitialization` method of your module:
 
 ```csharp
 public override async Task OnApplicationInitializationAsync(ApplicationInitializationContext context)
 {
-    var app = context.GetApplicationBuilder();
     // (default: TickerQStartMode.Immediate)
-    (app as IHost)?.UseAbpTickerQ(startMode: ...);
+    context.GetHost().UseAbpTickerQ(startMode: ...);
 }
 ```
 

--- a/docs/en/framework/infrastructure/background-workers/tickerq.md
+++ b/docs/en/framework/infrastructure/background-workers/tickerq.md
@@ -36,11 +36,15 @@ public override void ConfigureServices(ServiceConfigurationContext context)
 
 ### UseAbpTickerQ
 
-You need to call the `UseAbpTickerQ` extension method instead of `AddTickerQ` in the `OnApplicationInitialization` method of your module:
+You need to call the `UseAbpTickerQ` extension method in the `OnApplicationInitialization` method of your module. The method is an extension on `IHost`, so cast the application builder accordingly:
 
 ```csharp
-// (default: TickerQStartMode.Immediate)
-app.UseAbpTickerQ(startMode: ...);
+public override async Task OnApplicationInitializationAsync(ApplicationInitializationContext context)
+{
+    var app = context.GetApplicationBuilder();
+    // (default: TickerQStartMode.Immediate)
+    (app as IHost)?.UseAbpTickerQ(startMode: ...);
+}
 ```
 
 ### AbpBackgroundWorkersTickerQOptions
@@ -61,7 +65,7 @@ Configure<AbpBackgroundWorkersTickerQOptions>(options =>
 
 ### Add your own TickerQ Background Worker Definitions
 
-ABP will handle the TickerQ job definitions by `AbpTickerQFunctionProvider` service. You shouldn't use `TickerFunction` to add your own job definitions. You can inject and use the `AbpTickerQFunctionProvider` to add your own definitions and use `ITimeTickerManager<TimeTicker>` or `ICronTickerManager<CronTicker>` to manage the jobs.
+ABP will handle the TickerQ job definitions by `AbpTickerQFunctionProvider` service. You shouldn't use `TickerFunction` to add your own job definitions. You can inject and use the `AbpTickerQFunctionProvider` to add your own definitions and use `ITimeTickerManager<TimeTickerEntity>` or `ICronTickerManager<CronTickerEntity>` to manage the jobs.
 
 For example, you can add a `CleanupJobs` job definition in the `OnPreApplicationInitializationAsync` method of your module:
 
@@ -83,7 +87,7 @@ public override Task OnPreApplicationInitializationAsync(ApplicationInitializati
 	abpTickerQFunctionProvider.Functions.TryAdd(nameof(CleanupJobs), (string.Empty, TickerTaskPriority.Normal, new TickerFunctionDelegate(async (cancellationToken, serviceProvider, tickerFunctionContext) =>
 	{
 		var service = new CleanupJobs(); // Or get it from the serviceProvider
-		var request = await TickerRequestProvider.GetRequestAsync<string>(serviceProvider,  tickerFunctionContext.Id, tickerFunctionContext.Type);
+		var request = await TickerRequestProvider.GetRequestAsync<string>(tickerFunctionContext, cancellationToken);
 		var genericContext = new TickerFunctionContext<string>(tickerFunctionContext, request);
 		await service.CleanupLogsAsync(genericContext, cancellationToken);
 	})));
@@ -92,11 +96,11 @@ public override Task OnPreApplicationInitializationAsync(ApplicationInitializati
 }
 ```
 
-And then you can add a job by using the `ICronTickerManager<CronTicker>`:
+And then you can add a job by using the `ICronTickerManager<CronTickerEntity>`:
 
 ```csharp
-var cronTickerManager = context.ServiceProvider.GetRequiredService<ICronTickerManager<CronTicker>>();
-await cronTickerManager.AddAsync(new CronTicker
+var cronTickerManager = context.ServiceProvider.GetRequiredService<ICronTickerManager<CronTickerEntity>>();
+await cronTickerManager.AddAsync(new CronTickerEntity
 {
 	Function = nameof(CleanupJobs),
 	Expression = "0 */6 * * *", // Every 6 hours
@@ -106,13 +110,13 @@ await cronTickerManager.AddAsync(new CronTicker
 });
 ```
 
-You can specify a cron expression instead of use `ICronTickerManager<CronTicker>` to add a worker:
+You can specify a cron expression instead of using `ICronTickerManager<CronTickerEntity>` to add a worker:
 
 ```csharp
 abpTickerQFunctionProvider.Functions.TryAdd(nameof(CleanupJobs), (string.Empty, TickerTaskPriority.Normal, new TickerFunctionDelegate(async (cancellationToken, serviceProvider, tickerFunctionContext) =>
 {
 	var service = new CleanupJobs();
-	var request = await TickerRequestProvider.GetRequestAsync<string>(serviceProvider,  tickerFunctionContext.Id, tickerFunctionContext.Type);
+	var request = await TickerRequestProvider.GetRequestAsync<string>(tickerFunctionContext, cancellationToken);
 	var genericContext = new TickerFunctionContext<string>(tickerFunctionContext, request);
 	await service.CleanupLogsAsync(genericContext, cancellationToken);
 })));

--- a/docs/en/framework/infrastructure/background-workers/tickerq.md
+++ b/docs/en/framework/infrastructure/background-workers/tickerq.md
@@ -36,14 +36,13 @@ public override void ConfigureServices(ServiceConfigurationContext context)
 
 ### UseAbpTickerQ
 
-You need to call the `UseAbpTickerQ` extension method in the `OnApplicationInitialization` method of your module. The method is an extension on `IHost`, so cast the application builder accordingly:
+You need to call the `UseAbpTickerQ` extension method in the `OnApplicationInitialization` method of your module:
 
 ```csharp
 public override async Task OnApplicationInitializationAsync(ApplicationInitializationContext context)
 {
-    var app = context.GetApplicationBuilder();
     // (default: TickerQStartMode.Immediate)
-    (app as IHost)?.UseAbpTickerQ(startMode: ...);
+    context.GetHost().UseAbpTickerQ(startMode: ...);
 }
 ```
 

--- a/docs/en/framework/infrastructure/background-workers/tickerq.md
+++ b/docs/en/framework/infrastructure/background-workers/tickerq.md
@@ -42,7 +42,7 @@ You need to call the `UseAbpTickerQ` extension method in the `OnApplicationIniti
 public override async Task OnApplicationInitializationAsync(ApplicationInitializationContext context)
 {
     // (default: TickerQStartMode.Immediate)
-    context.GetHost().UseAbpTickerQ(startMode: ...);
+    context.GetHost().UseAbpTickerQ(qStartMode: ...);
 }
 ```
 

--- a/docs/en/package-version-changes.md
+++ b/docs/en/package-version-changes.md
@@ -1,5 +1,14 @@
 # Package Version Changes
 
+## 10.2.0-preview
+
+| Package | Old Version | New Version | PR |
+|---------|-------------|-------------|-----|
+| TickerQ | 2.5.3 | 10.1.1 | #24916 |
+| TickerQ.Dashboard | 2.5.3 | 10.1.1 | #24916 |
+| TickerQ.EntityFrameworkCore | 2.5.3 | 10.1.1 | #24916 |
+| TickerQ.Utilities | 2.5.3 | 10.1.1 | #24916 |
+
 ## 10.1.0
 
 | Package | Old Version | New Version | PR |

--- a/framework/src/Volo.Abp.AspNetCore/Microsoft/AspNetCore/Builder/AbpApplicationBuilderExtensions.cs
+++ b/framework/src/Volo.Abp.AspNetCore/Microsoft/AspNetCore/Builder/AbpApplicationBuilderExtensions.cs
@@ -38,6 +38,18 @@ public static class AbpApplicationBuilderExtensions
         Check.NotNull(app, nameof(app));
 
         app.ApplicationServices.GetRequiredService<ObjectAccessor<IApplicationBuilder>>().Value = app;
+        if (app is WebApplication webApplication)
+        {
+            app.ApplicationServices.GetRequiredService<ObjectAccessor<WebApplication>>().Value = webApplication;
+        }
+        if (app is IHost host)
+        {
+            app.ApplicationServices.GetRequiredService<ObjectAccessor<IHost>>().Value = host;
+        }
+        if (app is IEndpointRouteBuilder endpointRouteBuilder)
+        {
+            app.ApplicationServices.GetRequiredService<ObjectAccessor<IEndpointRouteBuilder>>().Value = endpointRouteBuilder;
+        }
         var application = app.ApplicationServices.GetRequiredService<IAbpApplicationWithExternalServiceProvider>();
         var applicationLifetime = app.ApplicationServices.GetRequiredService<IHostApplicationLifetime>();
 
@@ -59,6 +71,18 @@ public static class AbpApplicationBuilderExtensions
         Check.NotNull(app, nameof(app));
 
         app.ApplicationServices.GetRequiredService<ObjectAccessor<IApplicationBuilder>>().Value = app;
+        if (app is WebApplication webApplication)
+        {
+            app.ApplicationServices.GetRequiredService<ObjectAccessor<WebApplication>>().Value = webApplication;
+        }
+        if (app is IHost host)
+        {
+            app.ApplicationServices.GetRequiredService<ObjectAccessor<IHost>>().Value = host;
+        }
+        if (app is IEndpointRouteBuilder endpointRouteBuilder)
+        {
+            app.ApplicationServices.GetRequiredService<ObjectAccessor<IEndpointRouteBuilder>>().Value = endpointRouteBuilder;
+        }
         var application = app.ApplicationServices.GetRequiredService<IAbpApplicationWithExternalServiceProvider>();
         var applicationLifetime = app.ApplicationServices.GetRequiredService<IHostApplicationLifetime>();
 

--- a/framework/src/Volo.Abp.AspNetCore/Volo/Abp/ApplicationInitializationContextExtensions.cs
+++ b/framework/src/Volo.Abp.AspNetCore/Volo/Abp/ApplicationInitializationContextExtensions.cs
@@ -1,7 +1,9 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Volo.Abp.DependencyInjection;
 
@@ -19,6 +21,42 @@ public static class ApplicationInitializationContextExtensions
     public static IApplicationBuilder? GetApplicationBuilderOrNull(this ApplicationInitializationContext context)
     {
         return context.ServiceProvider.GetRequiredService<IObjectAccessor<IApplicationBuilder>>().Value;
+    }
+
+    public static IHost GetHost(this ApplicationInitializationContext context)
+    {
+        var host = context.ServiceProvider.GetRequiredService<IObjectAccessor<IHost>>().Value;
+        Check.NotNull(host, nameof(host));
+        return host;
+    }
+
+    public static IHost? GetHostOrNull(this ApplicationInitializationContext context)
+    {
+        return context.ServiceProvider.GetRequiredService<IObjectAccessor<IHost>>().Value;
+    }
+
+    public static IEndpointRouteBuilder GetEndpointRouteBuilder(this ApplicationInitializationContext context)
+    {
+        var endpointRouteBuilder = context.ServiceProvider.GetRequiredService<IObjectAccessor<IEndpointRouteBuilder>>().Value;
+        Check.NotNull(endpointRouteBuilder, nameof(endpointRouteBuilder));
+        return endpointRouteBuilder;
+    }
+
+    public static IEndpointRouteBuilder? GetEndpointRouteBuilderOrNull(this ApplicationInitializationContext context)
+    {
+        return context.ServiceProvider.GetRequiredService<IObjectAccessor<IEndpointRouteBuilder>>().Value;
+    }
+
+    public static WebApplication GetWebApplication(this ApplicationInitializationContext context)
+    {
+        var webApplication = context.ServiceProvider.GetRequiredService<IObjectAccessor<WebApplication>>().Value;
+        Check.NotNull(webApplication, nameof(webApplication));
+        return webApplication;
+    }
+
+    public static WebApplication? GetWebApplicationOrNull(this ApplicationInitializationContext context)
+    {
+        return context.ServiceProvider.GetRequiredService<IObjectAccessor<WebApplication>>().Value;
     }
 
     public static IWebHostEnvironment GetEnvironment(this ApplicationInitializationContext context)

--- a/framework/src/Volo.Abp.AspNetCore/Volo/Abp/AspNetCore/AbpAspNetCoreModule.cs
+++ b/framework/src/Volo.Abp.AspNetCore/Volo/Abp/AspNetCore/AbpAspNetCoreModule.cs
@@ -2,7 +2,9 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting.StaticWebAssets;
 using Microsoft.AspNetCore.RequestLocalization;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.FileProviders;
 using MyCSharp.HttpUserAgentParser.DependencyInjection;
 using Volo.Abp.AspNetCore.Auditing;
@@ -57,6 +59,9 @@ public class AbpAspNetCoreModule : AbpModule
 
         AddAspNetServices(context.Services);
         context.Services.AddObjectAccessor<IApplicationBuilder>();
+        context.Services.AddObjectAccessor<WebApplication>();
+        context.Services.AddObjectAccessor<IHost>();
+        context.Services.AddObjectAccessor<IEndpointRouteBuilder>();
         context.Services.AddAbpDynamicOptions<RequestLocalizationOptions, AbpRequestLocalizationOptionsManager>();
 
         StaticWebAssetsLoader.UseStaticWebAssets(context.Services.GetHostingEnvironment(), context.Services.GetConfiguration());

--- a/framework/src/Volo.Abp.BackgroundJobs.TickerQ/Volo.Abp.BackgroundJobs.TickerQ.csproj
+++ b/framework/src/Volo.Abp.BackgroundJobs.TickerQ/Volo.Abp.BackgroundJobs.TickerQ.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\common.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.1;net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>Nullable</WarningsAsErrors>
         <AssemblyName>Volo.Abp.BackgroundJobs.TickerQ</AssemblyName>

--- a/framework/src/Volo.Abp.BackgroundJobs.TickerQ/Volo/Abp/BackgroundJobs/TickerQ/AbpBackgroundJobsTickerQModule.cs
+++ b/framework/src/Volo.Abp.BackgroundJobs.TickerQ/Volo/Abp/BackgroundJobs/TickerQ/AbpBackgroundJobsTickerQModule.cs
@@ -65,7 +65,7 @@ public class AbpBackgroundJobsTickerQModule : AbpModule
             using (var scope = serviceProvider.CreateScope())
             {
                 var jobExecuter = serviceProvider.GetRequiredService<IBackgroundJobExecuter>();
-                var args = await TickerRequestProvider.GetRequestAsync<TArgs>(serviceProvider, context.Id, context.Type);
+                var args = await TickerRequestProvider.GetRequestAsync<TArgs>(context, cancellationToken);
                 var jobType = options.GetJob(typeof(TArgs)).JobType;
                 var jobExecutionContext = new JobExecutionContext(scope.ServiceProvider, jobType, args!, cancellationToken: cancellationToken);
                 await jobExecuter.ExecuteAsync(jobExecutionContext);

--- a/framework/src/Volo.Abp.BackgroundJobs.TickerQ/Volo/Abp/BackgroundJobs/TickerQ/AbpBackgroundJobsTimeTickerConfiguration.cs
+++ b/framework/src/Volo.Abp.BackgroundJobs.TickerQ/Volo/Abp/BackgroundJobs/TickerQ/AbpBackgroundJobsTimeTickerConfiguration.cs
@@ -1,4 +1,3 @@
-using System;
 using TickerQ.Utilities.Enums;
 
 namespace Volo.Abp.BackgroundJobs.TickerQ;
@@ -11,7 +10,5 @@ public class AbpBackgroundJobsTimeTickerConfiguration
 
     public TickerTaskPriority? Priority { get; set; }
 
-    public Guid? BatchParent { get; set; }
-
-    public BatchRunCondition? BatchRunCondition { get; set; }
+    public RunCondition? RunCondition { get; set; }
 }

--- a/framework/src/Volo.Abp.BackgroundJobs.TickerQ/Volo/Abp/BackgroundJobs/TickerQ/AbpTickerQBackgroundJobManager.cs
+++ b/framework/src/Volo.Abp.BackgroundJobs.TickerQ/Volo/Abp/BackgroundJobs/TickerQ/AbpTickerQBackgroundJobManager.cs
@@ -2,8 +2,8 @@
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using TickerQ.Utilities;
+using TickerQ.Utilities.Entities;
 using TickerQ.Utilities.Interfaces.Managers;
-using TickerQ.Utilities.Models.Ticker;
 using Volo.Abp.DependencyInjection;
 
 namespace Volo.Abp.BackgroundJobs.TickerQ;
@@ -11,12 +11,12 @@ namespace Volo.Abp.BackgroundJobs.TickerQ;
 [Dependency(ReplaceServices = true)]
 public class AbpTickerQBackgroundJobManager : IBackgroundJobManager, ITransientDependency
 {
-    protected ITimeTickerManager<TimeTicker> TimeTickerManager { get; }
+    protected ITimeTickerManager<TimeTickerEntity> TimeTickerManager { get; }
     protected AbpBackgroundJobOptions Options { get; }
     protected AbpBackgroundJobsTickerQOptions TickerQOptions { get; }
 
     public AbpTickerQBackgroundJobManager(
-        ITimeTickerManager<TimeTicker> timeTickerManager,
+        ITimeTickerManager<TimeTickerEntity> timeTickerManager,
         IOptions<AbpBackgroundJobOptions> options,
         IOptions<AbpBackgroundJobsTickerQOptions> tickerQOptions)
     {
@@ -28,7 +28,7 @@ public class AbpTickerQBackgroundJobManager : IBackgroundJobManager, ITransientD
     public virtual async Task<string> EnqueueAsync<TArgs>(TArgs args, BackgroundJobPriority priority = BackgroundJobPriority.Normal, TimeSpan? delay = null)
     {
         var job = Options.GetJob(typeof(TArgs));
-        var timeTicker = new TimeTicker
+        var timeTicker = new TimeTickerEntity
         {
             Id = Guid.NewGuid(),
             Function = job.JobName,
@@ -41,11 +41,10 @@ public class AbpTickerQBackgroundJobManager : IBackgroundJobManager, ITransientD
         {
             timeTicker.Retries = config.Retries ?? timeTicker.Retries;
             timeTicker.RetryIntervals = config.RetryIntervals ?? timeTicker.RetryIntervals;
-            timeTicker.BatchParent = config.BatchParent ?? timeTicker.BatchParent;
-            timeTicker.BatchRunCondition = config.BatchRunCondition ?? timeTicker.BatchRunCondition;
+            timeTicker.RunCondition = config.RunCondition ?? timeTicker.RunCondition;
         }
 
         var result = await TimeTickerManager.AddAsync(timeTicker);
-        return !result.IsSucceded ? timeTicker.Id.ToString() : result.Result.Id.ToString();
+        return !result.IsSucceeded ? timeTicker.Id.ToString() : result.Result.Id.ToString();
     }
 }

--- a/framework/src/Volo.Abp.BackgroundWorkers.TickerQ/Volo.Abp.BackgroundWorkers.TickerQ.csproj
+++ b/framework/src/Volo.Abp.BackgroundWorkers.TickerQ/Volo.Abp.BackgroundWorkers.TickerQ.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\common.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.1;net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>Nullable</WarningsAsErrors>
         <AssemblyName>Volo.Abp.BackgroundWorkers.TickerQ</AssemblyName>

--- a/framework/src/Volo.Abp.BackgroundWorkers.TickerQ/Volo/Abp/BackgroundWorkers/TickerQ/AbpBackgroundWorkersTickerQModule.cs
+++ b/framework/src/Volo.Abp.BackgroundWorkers.TickerQ/Volo/Abp/BackgroundWorkers/TickerQ/AbpBackgroundWorkersTickerQModule.cs
@@ -1,8 +1,8 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using TickerQ.Utilities.Entities;
 using TickerQ.Utilities.Interfaces.Managers;
-using TickerQ.Utilities.Models.Ticker;
 using Volo.Abp.Modularity;
 using Volo.Abp.TickerQ;
 
@@ -14,11 +14,11 @@ public class AbpBackgroundWorkersTickerQModule : AbpModule
     public override async Task OnPostApplicationInitializationAsync(ApplicationInitializationContext context)
     {
         var abpTickerQBackgroundWorkersProvider = context.ServiceProvider.GetRequiredService<AbpTickerQBackgroundWorkersProvider>();
-        var cronTickerManager = context.ServiceProvider.GetRequiredService<ICronTickerManager<CronTicker>>();
+        var cronTickerManager = context.ServiceProvider.GetRequiredService<ICronTickerManager<CronTickerEntity>>();
         var abpBackgroundWorkersTickerQOptions = context.ServiceProvider.GetRequiredService<IOptions<AbpBackgroundWorkersTickerQOptions>>().Value;
         foreach (var backgroundWorker in abpTickerQBackgroundWorkersProvider.BackgroundWorkers)
         {
-            var cronTicker = new CronTicker
+            var cronTicker = new CronTickerEntity
             {
                 Function = backgroundWorker.Value.Function,
                 Expression = backgroundWorker.Value.CronExpression

--- a/framework/src/Volo.Abp.BackgroundWorkers.TickerQ/Volo/Abp/BackgroundWorkers/TickerQ/AbpTickerQPeriodicBackgroundWorkerInvoker.cs
+++ b/framework/src/Volo.Abp.BackgroundWorkers.TickerQ/Volo/Abp/BackgroundWorkers/TickerQ/AbpTickerQPeriodicBackgroundWorkerInvoker.cs
@@ -3,7 +3,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using TickerQ.Utilities.Models;
+using TickerQ.Utilities.Base;
 
 namespace Volo.Abp.BackgroundWorkers.TickerQ;
 

--- a/framework/src/Volo.Abp.TickerQ/Microsoft/Extensions/Hosting/AbpTickerQApplicationBuilderExtensions.cs
+++ b/framework/src/Volo.Abp.TickerQ/Microsoft/Extensions/Hosting/AbpTickerQApplicationBuilderExtensions.cs
@@ -1,16 +1,17 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using TickerQ.DependencyInjection;
 using TickerQ.Utilities;
 using TickerQ.Utilities.Enums;
 using Volo.Abp.TickerQ;
 
-namespace Microsoft.AspNetCore.Builder;
+namespace Microsoft.Extensions.Hosting;
 
 public static class AbpTickerQApplicationBuilderExtensions
 {
-    public static IApplicationBuilder UseAbpTickerQ(this IApplicationBuilder app, TickerQStartMode qStartMode = TickerQStartMode.Immediate)
+    public static IHost UseAbpTickerQ(this IHost app, TickerQStartMode qStartMode = TickerQStartMode.Immediate)
     {
-        var abpTickerQFunctionProvider = app.ApplicationServices.GetRequiredService<AbpTickerQFunctionProvider>();
+        var abpTickerQFunctionProvider = app.Services.GetRequiredService<AbpTickerQFunctionProvider>();
         TickerFunctionProvider.RegisterFunctions(abpTickerQFunctionProvider.Functions);
         TickerFunctionProvider.RegisterRequestType(abpTickerQFunctionProvider.RequestTypes);
 

--- a/framework/src/Volo.Abp.TickerQ/Volo.Abp.TickerQ.csproj
+++ b/framework/src/Volo.Abp.TickerQ/Volo.Abp.TickerQ.csproj
@@ -4,7 +4,7 @@
 <Import Project="..\..\..\common.props" />
 
 <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>Nullable</WarningsAsErrors>
     <AssemblyName>Volo.Abp.TickerQ</AssemblyName>

--- a/framework/src/Volo.Abp.TickerQ/Volo/Abp/TickerQ/AbpTickerQModule.cs
+++ b/framework/src/Volo.Abp.TickerQ/Volo/Abp/TickerQ/AbpTickerQModule.cs
@@ -10,7 +10,10 @@ public class AbpTickerQModule : AbpModule
     {
         context.Services.AddTickerQ(options =>
         {
-            options.SetInstanceIdentifier(context.Services.GetApplicationName());
+            options.ConfigureScheduler(scheduler =>
+            {
+                scheduler.NodeIdentifier = context.Services.GetApplicationName();
+            });
         });
     }
 }

--- a/modules/background-jobs/app/Volo.Abp.BackgroundJobs.DemoApp.TickerQ/CleanupJobs.cs
+++ b/modules/background-jobs/app/Volo.Abp.BackgroundJobs.DemoApp.TickerQ/CleanupJobs.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using TickerQ.Utilities.Models;
+using TickerQ.Utilities.Base;
 
 namespace Volo.Abp.BackgroundJobs.DemoApp.TickerQ;
 

--- a/modules/background-jobs/app/Volo.Abp.BackgroundJobs.DemoApp.TickerQ/DemoAppTickerQModule.cs
+++ b/modules/background-jobs/app/Volo.Abp.BackgroundJobs.DemoApp.TickerQ/DemoAppTickerQModule.cs
@@ -3,13 +3,14 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using TickerQ.Dashboard.DependencyInjection;
 using TickerQ.DependencyInjection;
 using TickerQ.Utilities;
 using TickerQ.Utilities.Enums;
 using TickerQ.Utilities.Interfaces.Managers;
-using TickerQ.Utilities.Models;
-using TickerQ.Utilities.Models.Ticker;
+using TickerQ.Utilities.Base;
+using TickerQ.Utilities.Entities;
 using Volo.Abp.AspNetCore;
 using Volo.Abp.Autofac;
 using Volo.Abp.BackgroundJobs.DemoApp.Shared;
@@ -35,13 +36,14 @@ public class DemoAppTickerQModule : AbpModule
     {
         context.Services.AddTickerQ(options =>
         {
-            options.UpdateMissedJobCheckDelay(TimeSpan.FromSeconds(30));
+            options.ConfigureScheduler(scheduler =>
+            {
+                scheduler.FallbackIntervalChecker = TimeSpan.FromSeconds(30);
+            });
 
             options.AddDashboard(x =>
             {
-                x.BasePath = "/tickerq-dashboard";
-
-                x.UseHostAuthentication = true;
+                x.SetBasePath("/tickerq-dashboard");
             });
         });
 
@@ -78,7 +80,7 @@ public class DemoAppTickerQModule : AbpModule
         abpTickerQFunctionProvider.Functions.TryAdd(nameof(CleanupJobs), (string.Empty, TickerTaskPriority.Normal, new TickerFunctionDelegate(async (cancellationToken, serviceProvider, tickerFunctionContext) =>
         {
             var service = new CleanupJobs();
-            var request = await TickerRequestProvider.GetRequestAsync<string>(serviceProvider,  tickerFunctionContext.Id, tickerFunctionContext.Type);
+            var request = await TickerRequestProvider.GetRequestAsync<string>(tickerFunctionContext, cancellationToken);
             var genericContext = new TickerFunctionContext<string>(tickerFunctionContext, request);
             await service.CleanupLogsAsync(genericContext, cancellationToken);
         })));
@@ -92,10 +94,10 @@ public class DemoAppTickerQModule : AbpModule
         await backgroundWorkerManager.AddAsync(context.ServiceProvider.GetRequiredService<MyBackgroundWorker>());
 
         var app = context.GetApplicationBuilder();
-        app.UseAbpTickerQ();
+        (app as IHost)?.UseAbpTickerQ();
 
-        var timeTickerManager = context.ServiceProvider.GetRequiredService<ITimeTickerManager<TimeTicker>>();
-        await timeTickerManager.AddAsync(new TimeTicker
+        var timeTickerManager = context.ServiceProvider.GetRequiredService<ITimeTickerManager<TimeTickerEntity>>();
+        await timeTickerManager.AddAsync(new TimeTickerEntity
         {
             Function = nameof(CleanupJobs),
             ExecutionTime = DateTime.UtcNow.AddSeconds(5),
@@ -104,8 +106,8 @@ public class DemoAppTickerQModule : AbpModule
             RetryIntervals = new[] { 30, 60, 120 }, // Retry after 30s, 60s, then 2min
         });
 
-        var cronTickerManager = context.ServiceProvider.GetRequiredService<ICronTickerManager<CronTicker>>();
-        await cronTickerManager.AddAsync(new CronTicker
+        var cronTickerManager = context.ServiceProvider.GetRequiredService<ICronTickerManager<CronTickerEntity>>();
+        await cronTickerManager.AddAsync(new CronTickerEntity
         {
             Function = nameof(CleanupJobs),
             Expression = "* * * * *", // Every minute
@@ -134,7 +136,7 @@ public class DemoAppTickerQModule : AbpModule
 
         await Task.Delay(1000);
 
-        var timeTickerManager = serviceProvider.GetRequiredService<ITimeTickerManager<TimeTicker>>();
+        var timeTickerManager = serviceProvider.GetRequiredService<ITimeTickerManager<TimeTickerEntity>>();
         var result = await timeTickerManager.DeleteAsync(Guid.Parse(jobId));
     }
 }

--- a/modules/background-jobs/app/Volo.Abp.BackgroundJobs.DemoApp.TickerQ/DemoAppTickerQModule.cs
+++ b/modules/background-jobs/app/Volo.Abp.BackgroundJobs.DemoApp.TickerQ/DemoAppTickerQModule.cs
@@ -94,7 +94,8 @@ public class DemoAppTickerQModule : AbpModule
         await backgroundWorkerManager.AddAsync(context.ServiceProvider.GetRequiredService<MyBackgroundWorker>());
 
         var app = context.GetApplicationBuilder();
-        (app as IHost)?.UseAbpTickerQ();
+
+        context.GetHost().UseAbpTickerQ();
 
         var timeTickerManager = context.ServiceProvider.GetRequiredService<ITimeTickerManager<TimeTickerEntity>>();
         await timeTickerManager.AddAsync(new TimeTickerEntity


### PR DESCRIPTION
Resolves #24910

## Upgrade TickerQ integration from 2.5.3 to 10.1.1

TickerQ 10.1.1 only targets `net10.0` and contains several breaking API changes. This PR adapts all ABP TickerQ integration packages and the demo app accordingly, and updates the documentation.

### Breaking changes addressed

**Entity types renamed** (`TickerQ.Utilities.Models.Ticker` → `TickerQ.Utilities.Entities`)
- `TimeTicker` → `TimeTickerEntity`
- `CronTicker` → `CronTickerEntity`

**`TickerFunctionContext<T>` namespace moved**
- `TickerQ.Utilities.Models` → `TickerQ.Utilities.Base`

**`TickerRequestProvider.GetRequestAsync<T>` signature changed**
- Before: `GetRequestAsync<T>(serviceProvider, context.Id, context.Type)`
- After: `GetRequestAsync<T>(context, cancellationToken)`

**`UseTickerQ` moved from `IApplicationBuilder` to `IHost`**
- `UseAbpTickerQ` is now an extension on `IHost` (namespace `Microsoft.Extensions.Hosting`)
- In ABP modules, use `context.GetHost().UseAbpTickerQ()` — `GetHost()` is a new helper added to `ApplicationInitializationContext` (see below)

**Scheduler configuration API changed**
- `options.SetInstanceIdentifier(name)` → `options.ConfigureScheduler(s => s.NodeIdentifier = name)`
- `options.UpdateMissedJobCheckDelay(ts)` → `options.ConfigureScheduler(s => s.FallbackIntervalChecker = ts)`

**Dashboard configuration API changed**
- `x.BasePath = "/path"` → `x.SetBasePath("/path")`
- `x.UseHostAuthentication = true` → `x.WithHostAuthentication()`

**Typo fix in `TickerResult<T>`**
- `result.IsSucceded` → `result.IsSucceeded`

**`BatchParent` removed from `AbpBackgroundJobsTimeTickerConfiguration`**
- `TimeTickerEntity.ParentId` now has a private setter; it can only be set via TickerQ's `FluentChainTickerBuilder` fluent API. Users who need job chaining must use that API directly.

**`BatchRunCondition` renamed to `RunCondition`**
- `BatchRunCondition? BatchRunCondition` → `RunCondition? RunCondition`

### New ABP helpers in `ApplicationInitializationContext`

To support the new `IHost`-based TickerQ API (and for general convenience), the following extension methods were added to `ApplicationInitializationContext`:

- `context.GetHost()` / `context.GetHostOrNull()`
- `context.GetWebApplication()` / `context.GetWebApplicationOrNull()`
- `context.GetEndpointRouteBuilder()` / `context.GetEndpointRouteBuilderOrNull()`

These are backed by `ObjectAccessor<T>` and populated automatically during `InitializeApplicationAsync`.

> **Note:** Do **not** resolve `IHost` from `context.ServiceProvider.GetRequiredService<IHost>()`. That returns the internal generic host whose `Services` does not include `IApplicationBuilder`, which will cause a runtime exception from the TickerQ Dashboard. Always use `context.GetHost()`.

### Target framework

All three packages (`Volo.Abp.TickerQ`, `Volo.Abp.BackgroundJobs.TickerQ`, `Volo.Abp.BackgroundWorkers.TickerQ`) now target `net10.0` only, since TickerQ 10.1.1 itself only publishes a `net10.0` target.


<img width="2850" height="2270" alt="screenshot-2026-02-4 T22-57-06@2x" src="https://github.com/user-attachments/assets/374df259-c5bd-4a23-978d-375c9db272b0" />

<img width="2994" height="3086" alt="screenshot-2026-02-4 T22-57-27@2x" src="https://github.com/user-attachments/assets/ba292d6a-dc77-4fd7-a1a4-f93d56b63a7f" />

<img width="2956" height="2076" alt="screenshot-2026-02-4 T22-57-34@2x" src="https://github.com/user-attachments/assets/e0397505-ae1f-4676-a871-85ad6a8465b0" />
