### PR TITLE
Implement single active token providers for email change, email confirmation, and password reset

### DIFF
--- a/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpChangeEmailTokenProvider.cs
+++ b/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpChangeEmailTokenProvider.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Volo.Abp.Identity;
+using Volo.Abp.Threading;
 
 namespace Volo.Abp.Identity.AspNetCore;
 
@@ -18,8 +19,9 @@ public class AbpChangeEmailTokenProvider : AbpSingleActiveTokenProvider
         IDataProtectionProvider dataProtectionProvider,
         IOptions<AbpChangeEmailTokenProviderOptions> options,
         ILogger<DataProtectorTokenProvider<IdentityUser>> logger,
-        IIdentityUserRepository userRepository)
-        : base(dataProtectionProvider, options, logger, userRepository)
+        IIdentityUserRepository userRepository,
+        ICancellationTokenProvider cancellationTokenProvider)
+        : base(dataProtectionProvider, options, logger, userRepository, cancellationTokenProvider)
     {
     }
 }

--- a/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpChangeEmailTokenProvider.cs
+++ b/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpChangeEmailTokenProvider.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Volo.Abp.Identity;
+
+namespace Volo.Abp.Identity.AspNetCore;
+
+/// <summary>
+/// Change email token provider that enforces only the most recently issued
+/// token to be valid, with a configurable expiration period.
+/// </summary>
+public class AbpChangeEmailTokenProvider : AbpSingleActiveTokenProvider
+{
+    public const string ProviderName = "AbpChangeEmail";
+
+    public AbpChangeEmailTokenProvider(
+        IDataProtectionProvider dataProtectionProvider,
+        IOptions<AbpChangeEmailTokenProviderOptions> options,
+        ILogger<DataProtectorTokenProvider<IdentityUser>> logger,
+        IIdentityUserRepository userRepository)
+        : base(dataProtectionProvider, options, logger, userRepository)
+    {
+    }
+}

--- a/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpChangeEmailTokenProviderOptions.cs
+++ b/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpChangeEmailTokenProviderOptions.cs
@@ -1,0 +1,13 @@
+using System;
+using Microsoft.AspNetCore.Identity;
+
+namespace Volo.Abp.Identity.AspNetCore;
+
+public class AbpChangeEmailTokenProviderOptions : DataProtectionTokenProviderOptions
+{
+    public AbpChangeEmailTokenProviderOptions()
+    {
+        Name = AbpChangeEmailTokenProvider.ProviderName;
+        TokenLifespan = TimeSpan.FromHours(2);
+    }
+}

--- a/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpEmailConfirmationTokenProvider.cs
+++ b/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpEmailConfirmationTokenProvider.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Volo.Abp.Identity;
+using Volo.Abp.Threading;
 
 namespace Volo.Abp.Identity.AspNetCore;
 
@@ -31,8 +32,9 @@ public class AbpEmailConfirmationTokenProvider : AbpSingleActiveTokenProvider
         IDataProtectionProvider dataProtectionProvider,
         IOptions<AbpEmailConfirmationTokenProviderOptions> options,
         ILogger<DataProtectorTokenProvider<IdentityUser>> logger,
-        IIdentityUserRepository userRepository)
-        : base(dataProtectionProvider, options, logger, userRepository)
+        IIdentityUserRepository userRepository,
+        ICancellationTokenProvider cancellationTokenProvider)
+        : base(dataProtectionProvider, options, logger, userRepository, cancellationTokenProvider)
     {
     }
 }

--- a/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpEmailConfirmationTokenProvider.cs
+++ b/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpEmailConfirmationTokenProvider.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Volo.Abp.Identity;
+
+namespace Volo.Abp.Identity.AspNetCore;
+
+/// <summary>
+/// Email confirmation token provider that enforces only the most recently issued
+/// token to be valid, with a configurable expiration period.
+/// Token reuse is bounded by the token expiry and the single-active policy:
+/// generating a new token overwrites the stored hash, invalidating all previous tokens.
+/// <para>
+/// Unlike password-reset and change-email flows, <see cref="Microsoft.AspNetCore.Identity.UserManager{TUser}.ConfirmEmailAsync"/>
+/// does <b>not</b> update the security stamp, so the token hash is NOT automatically
+/// invalidated after a successful confirmation. Callers that require single-use semantics
+/// must explicitly revoke the hash after confirmation:
+/// <code>
+/// var result = await userManager.ConfirmEmailAsync(user, token);
+/// if (result.Succeeded)
+///     await userManager.RemoveEmailConfirmationTokenAsync(user);
+/// </code>
+/// </para>
+/// </summary>
+public class AbpEmailConfirmationTokenProvider : AbpSingleActiveTokenProvider
+{
+    public const string ProviderName = "AbpEmailConfirmation";
+
+    public AbpEmailConfirmationTokenProvider(
+        IDataProtectionProvider dataProtectionProvider,
+        IOptions<AbpEmailConfirmationTokenProviderOptions> options,
+        ILogger<DataProtectorTokenProvider<IdentityUser>> logger,
+        IIdentityUserRepository userRepository)
+        : base(dataProtectionProvider, options, logger, userRepository)
+    {
+    }
+}

--- a/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpEmailConfirmationTokenProviderOptions.cs
+++ b/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpEmailConfirmationTokenProviderOptions.cs
@@ -1,0 +1,13 @@
+using System;
+using Microsoft.AspNetCore.Identity;
+
+namespace Volo.Abp.Identity.AspNetCore;
+
+public class AbpEmailConfirmationTokenProviderOptions : DataProtectionTokenProviderOptions
+{
+    public AbpEmailConfirmationTokenProviderOptions()
+    {
+        Name = AbpEmailConfirmationTokenProvider.ProviderName;
+        TokenLifespan = TimeSpan.FromHours(2);
+    }
+}

--- a/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpIdentityAspNetCoreModule.cs
+++ b/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpIdentityAspNetCoreModule.cs
@@ -20,6 +20,9 @@ public class AbpIdentityAspNetCoreModule : AbpModule
             builder
                 .AddDefaultTokenProviders()
                 .AddTokenProvider<LinkUserTokenProvider>(LinkUserTokenProviderConsts.LinkUserTokenProviderName)
+                .AddTokenProvider<AbpPasswordResetTokenProvider>(AbpPasswordResetTokenProvider.ProviderName)
+                .AddTokenProvider<AbpEmailConfirmationTokenProvider>(AbpEmailConfirmationTokenProvider.ProviderName)
+                .AddTokenProvider<AbpChangeEmailTokenProvider>(AbpChangeEmailTokenProvider.ProviderName)
                 .AddSignInManager<AbpSignInManager>()
                 .AddUserValidator<AbpIdentityUserValidator>();
         });
@@ -27,6 +30,13 @@ public class AbpIdentityAspNetCoreModule : AbpModule
 
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
+        Configure<IdentityOptions>(options =>
+        {
+            options.Tokens.PasswordResetTokenProvider = AbpPasswordResetTokenProvider.ProviderName;
+            options.Tokens.EmailConfirmationTokenProvider = AbpEmailConfirmationTokenProvider.ProviderName;
+            options.Tokens.ChangeEmailTokenProvider = AbpChangeEmailTokenProvider.ProviderName;
+        });
+
         //(TODO: Extract an extension method like IdentityBuilder.AddAbpSecurityStampValidator())
         context.Services.AddScoped<AbpSecurityStampValidator>();
         context.Services.AddScoped(typeof(SecurityStampValidator<IdentityUser>), provider => provider.GetService(typeof(AbpSecurityStampValidator)));

--- a/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpPasswordResetTokenProvider.cs
+++ b/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpPasswordResetTokenProvider.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Volo.Abp.Identity;
+
+namespace Volo.Abp.Identity.AspNetCore;
+
+/// <summary>
+/// Password reset token provider that enforces only the most recently issued
+/// token to be valid, with a configurable expiration period.
+/// </summary>
+public class AbpPasswordResetTokenProvider : AbpSingleActiveTokenProvider
+{
+    public const string ProviderName = "AbpPasswordReset";
+
+    public AbpPasswordResetTokenProvider(
+        IDataProtectionProvider dataProtectionProvider,
+        IOptions<AbpPasswordResetTokenProviderOptions> options,
+        ILogger<DataProtectorTokenProvider<IdentityUser>> logger,
+        IIdentityUserRepository userRepository)
+        : base(dataProtectionProvider, options, logger, userRepository)
+    {
+    }
+}

--- a/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpPasswordResetTokenProvider.cs
+++ b/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpPasswordResetTokenProvider.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Volo.Abp.Identity;
+using Volo.Abp.Threading;
 
 namespace Volo.Abp.Identity.AspNetCore;
 
@@ -18,8 +19,9 @@ public class AbpPasswordResetTokenProvider : AbpSingleActiveTokenProvider
         IDataProtectionProvider dataProtectionProvider,
         IOptions<AbpPasswordResetTokenProviderOptions> options,
         ILogger<DataProtectorTokenProvider<IdentityUser>> logger,
-        IIdentityUserRepository userRepository)
-        : base(dataProtectionProvider, options, logger, userRepository)
+        IIdentityUserRepository userRepository,
+        ICancellationTokenProvider cancellationTokenProvider)
+        : base(dataProtectionProvider, options, logger, userRepository, cancellationTokenProvider)
     {
     }
 }

--- a/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpPasswordResetTokenProviderOptions.cs
+++ b/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpPasswordResetTokenProviderOptions.cs
@@ -1,0 +1,13 @@
+using System;
+using Microsoft.AspNetCore.Identity;
+
+namespace Volo.Abp.Identity.AspNetCore;
+
+public class AbpPasswordResetTokenProviderOptions : DataProtectionTokenProviderOptions
+{
+    public AbpPasswordResetTokenProviderOptions()
+    {
+        Name = AbpPasswordResetTokenProvider.ProviderName;
+        TokenLifespan = TimeSpan.FromHours(2);
+    }
+}

--- a/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpSingleActiveTokenProvider.cs
+++ b/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpSingleActiveTokenProvider.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Volo.Abp.Domain.Repositories;
+using Volo.Abp.Identity;
+
+namespace Volo.Abp.Identity.AspNetCore;
+
+/// <summary>
+/// Base class for ABP token providers that enforce a "single active token" policy:
+/// generating a new token automatically invalidates all previously issued tokens.
+/// Token validity is enforced by SecurityStamp verification (via the base class) and
+/// by the stored hash, which is overwritten each time a new token is generated.
+/// </summary>
+public abstract class AbpSingleActiveTokenProvider : DataProtectorTokenProvider<IdentityUser>
+{
+    public const string TokenHashSuffix = "_TokenHash";
+
+    protected IIdentityUserRepository UserRepository { get; }
+
+    protected AbpSingleActiveTokenProvider(
+        IDataProtectionProvider dataProtectionProvider,
+        IOptions<DataProtectionTokenProviderOptions> options,
+        ILogger<DataProtectorTokenProvider<IdentityUser>> logger,
+        IIdentityUserRepository userRepository)
+        : base(dataProtectionProvider, options, logger)
+    {
+        UserRepository = userRepository;
+    }
+
+    public override async Task<string> GenerateAsync(string purpose, UserManager<IdentityUser> manager, IdentityUser user)
+    {
+        var token = await base.GenerateAsync(purpose, manager, user);
+
+        await UserRepository.EnsureCollectionLoadedAsync(user, u => u.Tokens);
+        var tokenHash = ComputeSha256Hash(token);
+        user.SetToken(Options.Name, purpose + TokenHashSuffix, tokenHash);
+
+        await manager.UpdateAsync(user);
+
+        return token;
+    }
+
+    public override async Task<bool> ValidateAsync(string purpose, string token, UserManager<IdentityUser> manager, IdentityUser user)
+    {
+        if (!await base.ValidateAsync(purpose, token, manager, user))
+        {
+            return false;
+        }
+
+        await UserRepository.EnsureCollectionLoadedAsync(user, u => u.Tokens);
+
+        var storedHash = user.FindToken(Options.Name, purpose + TokenHashSuffix)?.Value;
+        if (storedHash == null)
+        {
+            return false;
+        }
+
+        var inputHash = ComputeSha256Hash(token);
+        return string.Equals(storedHash, inputHash, StringComparison.Ordinal);
+    }
+
+    protected virtual string ComputeSha256Hash(string input)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(input));
+        return Convert.ToHexString(bytes);
+    }
+}

--- a/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpSingleActiveTokenProvider.cs
+++ b/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpSingleActiveTokenProvider.cs
@@ -62,7 +62,18 @@ public abstract class AbpSingleActiveTokenProvider : DataProtectorTokenProvider<
         }
 
         var inputHash = ComputeSha256Hash(token);
-        return string.Equals(storedHash, inputHash, StringComparison.Ordinal);
+        try
+        {
+            var storedHashBytes = Convert.FromHexString(storedHash);
+            var inputHashBytes = Convert.FromHexString(inputHash);
+            return CryptographicOperations.FixedTimeEquals(storedHashBytes, inputHashBytes);
+        }
+        catch (FormatException)
+        {
+            // In case the stored hash is corrupted or not a valid hex string,
+            // treat the token as invalid rather than throwing.
+            return false;
+        }
     }
 
     protected virtual string ComputeSha256Hash(string input)

--- a/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpSingleActiveTokenProvider.cs
+++ b/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpSingleActiveTokenProvider.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Volo.Abp.Domain.Repositories;
 using Volo.Abp.Identity;
+using Volo.Abp.Threading;
 
 namespace Volo.Abp.Identity.AspNetCore;
 
@@ -19,27 +20,36 @@ namespace Volo.Abp.Identity.AspNetCore;
 /// </summary>
 public abstract class AbpSingleActiveTokenProvider : DataProtectorTokenProvider<IdentityUser>
 {
-    public const string TokenHashSuffix = "_TokenHash";
+    /// <summary>
+    /// The internal login provider name used to store token hashes in the user token table.
+    /// Using a bracketed name clearly distinguishes these internal entries from real external
+    /// login providers (e.g. Google, GitHub) stored in the same table.
+    /// </summary>
+    public const string InternalLoginProvider = "[AbpSingleActiveToken]";
 
     protected IIdentityUserRepository UserRepository { get; }
+
+    protected ICancellationTokenProvider CancellationTokenProvider { get; }
 
     protected AbpSingleActiveTokenProvider(
         IDataProtectionProvider dataProtectionProvider,
         IOptions<DataProtectionTokenProviderOptions> options,
         ILogger<DataProtectorTokenProvider<IdentityUser>> logger,
-        IIdentityUserRepository userRepository)
+        IIdentityUserRepository userRepository,
+        ICancellationTokenProvider cancellationTokenProvider)
         : base(dataProtectionProvider, options, logger)
     {
         UserRepository = userRepository;
+        CancellationTokenProvider = cancellationTokenProvider;
     }
 
     public override async Task<string> GenerateAsync(string purpose, UserManager<IdentityUser> manager, IdentityUser user)
     {
         var token = await base.GenerateAsync(purpose, manager, user);
 
-        await UserRepository.EnsureCollectionLoadedAsync(user, u => u.Tokens);
+        await UserRepository.EnsureCollectionLoadedAsync(user, u => u.Tokens, CancellationTokenProvider.Token);
         var tokenHash = ComputeSha256Hash(token);
-        user.SetToken(Options.Name, purpose + TokenHashSuffix, tokenHash);
+        user.SetToken(InternalLoginProvider, Options.Name + ":" + purpose, tokenHash);
 
         await manager.UpdateAsync(user);
 
@@ -53,9 +63,9 @@ public abstract class AbpSingleActiveTokenProvider : DataProtectorTokenProvider<
             return false;
         }
 
-        await UserRepository.EnsureCollectionLoadedAsync(user, u => u.Tokens);
+        await UserRepository.EnsureCollectionLoadedAsync(user, u => u.Tokens, CancellationTokenProvider.Token);
 
-        var storedHash = user.FindToken(Options.Name, purpose + TokenHashSuffix)?.Value;
+        var storedHash = user.FindToken(InternalLoginProvider, Options.Name + ":" + purpose)?.Value;
         if (storedHash == null)
         {
             return false;

--- a/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/IdentityUserManagerSingleActiveTokenExtensions.cs
+++ b/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/IdentityUserManagerSingleActiveTokenExtensions.cs
@@ -1,0 +1,43 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+
+namespace Volo.Abp.Identity.AspNetCore;
+
+/// <summary>
+/// Provides extension methods on <see cref="IdentityUserManager"/> for invalidating
+/// single-active tokens managed by <see cref="AbpSingleActiveTokenProvider"/>.
+/// These helpers live in the AspNetCore layer because they depend on
+/// <see cref="AbpSingleActiveTokenProvider.TokenHashSuffix"/>.
+/// </summary>
+public static class IdentityUserManagerSingleActiveTokenExtensions
+{
+    /// <summary>
+    /// Removes the stored password-reset token hash for <paramref name="user"/>,
+    /// immediately invalidating any previously issued password-reset token.
+    /// </summary>
+    public static Task<IdentityResult> RemovePasswordResetTokenAsync(this IdentityUserManager manager, IdentityUser user)
+    {
+        var name = UserManager<IdentityUser>.ResetPasswordTokenPurpose + AbpSingleActiveTokenProvider.TokenHashSuffix;
+        return manager.RemoveAuthenticationTokenAsync(user, manager.Options.Tokens.PasswordResetTokenProvider, name);
+    }
+
+    /// <summary>
+    /// Removes the stored email-confirmation token hash for <paramref name="user"/>,
+    /// immediately invalidating any previously issued email-confirmation token.
+    /// </summary>
+    public static Task<IdentityResult> RemoveEmailConfirmationTokenAsync(this IdentityUserManager manager, IdentityUser user)
+    {
+        var name = UserManager<IdentityUser>.ConfirmEmailTokenPurpose + AbpSingleActiveTokenProvider.TokenHashSuffix;
+        return manager.RemoveAuthenticationTokenAsync(user, manager.Options.Tokens.EmailConfirmationTokenProvider, name);
+    }
+
+    /// <summary>
+    /// Removes the stored change-email token hash for <paramref name="user"/>,
+    /// immediately invalidating any previously issued change-email token for <paramref name="newEmail"/>.
+    /// </summary>
+    public static Task<IdentityResult> RemoveChangeEmailTokenAsync(this IdentityUserManager manager, IdentityUser user, string newEmail)
+    {
+        var name = UserManager<IdentityUser>.GetChangeEmailTokenPurpose(newEmail) + AbpSingleActiveTokenProvider.TokenHashSuffix;
+        return manager.RemoveAuthenticationTokenAsync(user, manager.Options.Tokens.ChangeEmailTokenProvider, name);
+    }
+}

--- a/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/IdentityUserManagerSingleActiveTokenExtensions.cs
+++ b/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/IdentityUserManagerSingleActiveTokenExtensions.cs
@@ -7,7 +7,7 @@ namespace Volo.Abp.Identity.AspNetCore;
 /// Provides extension methods on <see cref="IdentityUserManager"/> for invalidating
 /// single-active tokens managed by <see cref="AbpSingleActiveTokenProvider"/>.
 /// These helpers live in the AspNetCore layer because they depend on
-/// <see cref="AbpSingleActiveTokenProvider.TokenHashSuffix"/>.
+/// <see cref="AbpSingleActiveTokenProvider.InternalLoginProvider"/>.
 /// </summary>
 public static class IdentityUserManagerSingleActiveTokenExtensions
 {
@@ -17,8 +17,8 @@ public static class IdentityUserManagerSingleActiveTokenExtensions
     /// </summary>
     public static Task<IdentityResult> RemovePasswordResetTokenAsync(this IdentityUserManager manager, IdentityUser user)
     {
-        var name = UserManager<IdentityUser>.ResetPasswordTokenPurpose + AbpSingleActiveTokenProvider.TokenHashSuffix;
-        return manager.RemoveAuthenticationTokenAsync(user, manager.Options.Tokens.PasswordResetTokenProvider, name);
+        var name = manager.Options.Tokens.PasswordResetTokenProvider + ":" + UserManager<IdentityUser>.ResetPasswordTokenPurpose;
+        return manager.RemoveAuthenticationTokenAsync(user, AbpSingleActiveTokenProvider.InternalLoginProvider, name);
     }
 
     /// <summary>
@@ -27,8 +27,8 @@ public static class IdentityUserManagerSingleActiveTokenExtensions
     /// </summary>
     public static Task<IdentityResult> RemoveEmailConfirmationTokenAsync(this IdentityUserManager manager, IdentityUser user)
     {
-        var name = UserManager<IdentityUser>.ConfirmEmailTokenPurpose + AbpSingleActiveTokenProvider.TokenHashSuffix;
-        return manager.RemoveAuthenticationTokenAsync(user, manager.Options.Tokens.EmailConfirmationTokenProvider, name);
+        var name = manager.Options.Tokens.EmailConfirmationTokenProvider + ":" + UserManager<IdentityUser>.ConfirmEmailTokenPurpose;
+        return manager.RemoveAuthenticationTokenAsync(user, AbpSingleActiveTokenProvider.InternalLoginProvider, name);
     }
 
     /// <summary>
@@ -37,7 +37,7 @@ public static class IdentityUserManagerSingleActiveTokenExtensions
     /// </summary>
     public static Task<IdentityResult> RemoveChangeEmailTokenAsync(this IdentityUserManager manager, IdentityUser user, string newEmail)
     {
-        var name = UserManager<IdentityUser>.GetChangeEmailTokenPurpose(newEmail) + AbpSingleActiveTokenProvider.TokenHashSuffix;
-        return manager.RemoveAuthenticationTokenAsync(user, manager.Options.Tokens.ChangeEmailTokenProvider, name);
+        var name = manager.Options.Tokens.ChangeEmailTokenProvider + ":" + UserManager<IdentityUser>.GetChangeEmailTokenPurpose(newEmail);
+        return manager.RemoveAuthenticationTokenAsync(user, AbpSingleActiveTokenProvider.InternalLoginProvider, name);
     }
 }

--- a/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/AbpChangeEmailTokenProvider_Tests.cs
+++ b/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/AbpChangeEmailTokenProvider_Tests.cs
@@ -1,0 +1,175 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Volo.Abp.Uow;
+using Xunit;
+
+namespace Volo.Abp.Identity.AspNetCore;
+
+public class AbpChangeEmailTokenProvider_Tests : AbpIdentityAspNetCoreTestBase
+{
+    private const string NewEmail = "newemail@example.com";
+
+    protected IIdentityUserRepository UserRepository { get; }
+    protected IdentityUserManager UserManager { get; }
+    protected IdentityTestData TestData { get; }
+    protected IUnitOfWorkManager UnitOfWorkManager { get; }
+
+    public AbpChangeEmailTokenProvider_Tests()
+    {
+        UserRepository = GetRequiredService<IIdentityUserRepository>();
+        UserManager = GetRequiredService<IdentityUserManager>();
+        TestData = GetRequiredService<IdentityTestData>();
+        UnitOfWorkManager = GetRequiredService<IUnitOfWorkManager>();
+    }
+
+    [Fact]
+    public void AbpChangeEmailTokenProvider_Should_Be_Registered()
+    {
+        var identityOptions = GetRequiredService<IOptions<IdentityOptions>>().Value;
+
+        identityOptions.Tokens.ProviderMap.ShouldContainKey(AbpChangeEmailTokenProvider.ProviderName);
+        identityOptions.Tokens.ProviderMap[AbpChangeEmailTokenProvider.ProviderName].ProviderType
+            .ShouldBe(typeof(AbpChangeEmailTokenProvider));
+    }
+
+    [Fact]
+    public void ChangeEmailTokenProvider_Should_Be_Configured_As_Abp()
+    {
+        var identityOptions = GetRequiredService<IOptions<IdentityOptions>>().Value;
+
+        identityOptions.Tokens.ChangeEmailTokenProvider.ShouldBe(AbpChangeEmailTokenProvider.ProviderName);
+    }
+
+    [Fact]
+    public async Task Generate_And_Verify_Change_Email_Token_Should_Succeed()
+    {
+        using (var uow = UnitOfWorkManager.Begin())
+        {
+            var john = await UserRepository.GetAsync(TestData.UserJohnId);
+
+            var token = await UserManager.GenerateChangeEmailTokenAsync(john, NewEmail);
+            token.ShouldNotBeNullOrEmpty();
+
+            var isValid = await UserManager.VerifyUserTokenAsync(
+                john,
+                UserManager.Options.Tokens.ChangeEmailTokenProvider,
+                UserManager<IdentityUser>.GetChangeEmailTokenPurpose(NewEmail),
+                token);
+
+            isValid.ShouldBeTrue();
+
+            await uow.CompleteAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Invalid_Token_Should_Fail_Verification()
+    {
+        using (var uow = UnitOfWorkManager.Begin())
+        {
+            var john = await UserRepository.GetAsync(TestData.UserJohnId);
+
+            await UserManager.GenerateChangeEmailTokenAsync(john, NewEmail);
+
+            var isValid = await UserManager.VerifyUserTokenAsync(
+                john,
+                UserManager.Options.Tokens.ChangeEmailTokenProvider,
+                UserManager<IdentityUser>.GetChangeEmailTokenPurpose(NewEmail),
+                "invalid-token-value");
+
+            isValid.ShouldBeFalse();
+
+            await uow.CompleteAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Second_Token_Should_Invalidate_First_Token()
+    {
+        using (var uow = UnitOfWorkManager.Begin())
+        {
+            var john = await UserRepository.GetAsync(TestData.UserJohnId);
+
+            var firstToken = await UserManager.GenerateChangeEmailTokenAsync(john, NewEmail);
+
+            john = await UserRepository.GetAsync(TestData.UserJohnId);
+            var secondToken = await UserManager.GenerateChangeEmailTokenAsync(john, NewEmail);
+
+            john = await UserRepository.GetAsync(TestData.UserJohnId);
+
+            var firstTokenValid = await UserManager.VerifyUserTokenAsync(
+                john,
+                UserManager.Options.Tokens.ChangeEmailTokenProvider,
+                UserManager<IdentityUser>.GetChangeEmailTokenPurpose(NewEmail),
+                firstToken);
+
+            var secondTokenValid = await UserManager.VerifyUserTokenAsync(
+                john,
+                UserManager.Options.Tokens.ChangeEmailTokenProvider,
+                UserManager<IdentityUser>.GetChangeEmailTokenPurpose(NewEmail),
+                secondToken);
+
+            firstTokenValid.ShouldBeFalse();
+            secondTokenValid.ShouldBeTrue();
+
+            await uow.CompleteAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Token_Should_Become_Invalid_After_Email_Change()
+    {
+        using (var uow = UnitOfWorkManager.Begin())
+        {
+            var john = await UserRepository.GetAsync(TestData.UserJohnId);
+
+            var token = await UserManager.GenerateChangeEmailTokenAsync(john, NewEmail);
+
+            john = await UserRepository.GetAsync(TestData.UserJohnId);
+            var result = await UserManager.ChangeEmailAsync(john, NewEmail, token);
+            result.Succeeded.ShouldBeTrue();
+
+            // SecurityStamp has changed after the email change, so the old token must be invalid.
+            john = await UserRepository.GetAsync(TestData.UserJohnId);
+            var isValid = await UserManager.VerifyUserTokenAsync(
+                john,
+                UserManager.Options.Tokens.ChangeEmailTokenProvider,
+                UserManager<IdentityUser>.GetChangeEmailTokenPurpose(NewEmail),
+                token);
+
+            isValid.ShouldBeFalse();
+
+            await uow.CompleteAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Token_Hash_Should_Persist_Across_UnitOfWork_Boundaries()
+    {
+        string token;
+
+        // UoW 1: generate the token; UpdateAsync inside GenerateAsync must persist the hash.
+        using (var uow = UnitOfWorkManager.Begin(requiresNew: true))
+        {
+            var john = await UserRepository.GetAsync(TestData.UserJohnId);
+            token = await UserManager.GenerateChangeEmailTokenAsync(john, NewEmail);
+            await uow.CompleteAsync();
+        }
+
+        // UoW 2: validate using a fresh DbContext to confirm the hash was written to the DB.
+        using (var uow = UnitOfWorkManager.Begin(requiresNew: true))
+        {
+            var john = await UserRepository.GetAsync(TestData.UserJohnId);
+            var isValid = await UserManager.VerifyUserTokenAsync(
+                john,
+                UserManager.Options.Tokens.ChangeEmailTokenProvider,
+                UserManager<IdentityUser>.GetChangeEmailTokenPurpose(NewEmail),
+                token);
+
+            isValid.ShouldBeTrue();
+            await uow.CompleteAsync();
+        }
+    }
+}

--- a/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/AbpChangeEmailTokenProvider_Tests.cs
+++ b/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/AbpChangeEmailTokenProvider_Tests.cs
@@ -7,22 +7,25 @@ using Xunit;
 
 namespace Volo.Abp.Identity.AspNetCore;
 
-public class AbpChangeEmailTokenProvider_Tests : AbpIdentityAspNetCoreTestBase
+public class AbpChangeEmailTokenProvider_Tests : AbpSingleActiveTokenProviderTestBase
 {
     private const string NewEmail = "newemail@example.com";
 
-    protected IIdentityUserRepository UserRepository { get; }
-    protected IdentityUserManager UserManager { get; }
-    protected IdentityTestData TestData { get; }
-    protected IUnitOfWorkManager UnitOfWorkManager { get; }
+    protected override Task<string> GenerateTokenAsync(IdentityUser user)
+        => UserManager.GenerateChangeEmailTokenAsync(user, NewEmail);
 
-    public AbpChangeEmailTokenProvider_Tests()
-    {
-        UserRepository = GetRequiredService<IIdentityUserRepository>();
-        UserManager = GetRequiredService<IdentityUserManager>();
-        TestData = GetRequiredService<IdentityTestData>();
-        UnitOfWorkManager = GetRequiredService<IUnitOfWorkManager>();
-    }
+    protected override Task<bool> VerifyTokenAsync(IdentityUser user, string token)
+        => UserManager.VerifyUserTokenAsync(
+            user,
+            UserManager.Options.Tokens.ChangeEmailTokenProvider,
+            UserManager<IdentityUser>.GetChangeEmailTokenPurpose(NewEmail),
+            token);
+
+    protected override string GetProviderName()
+        => UserManager.Options.Tokens.ChangeEmailTokenProvider;
+
+    protected override string GetPurpose()
+        => UserManager<IdentityUser>.GetChangeEmailTokenPurpose(NewEmail);
 
     [Fact]
     public void AbpChangeEmailTokenProvider_Should_Be_Registered()
@@ -43,82 +46,6 @@ public class AbpChangeEmailTokenProvider_Tests : AbpIdentityAspNetCoreTestBase
     }
 
     [Fact]
-    public async Task Generate_And_Verify_Change_Email_Token_Should_Succeed()
-    {
-        using (var uow = UnitOfWorkManager.Begin())
-        {
-            var john = await UserRepository.GetAsync(TestData.UserJohnId);
-
-            var token = await UserManager.GenerateChangeEmailTokenAsync(john, NewEmail);
-            token.ShouldNotBeNullOrEmpty();
-
-            var isValid = await UserManager.VerifyUserTokenAsync(
-                john,
-                UserManager.Options.Tokens.ChangeEmailTokenProvider,
-                UserManager<IdentityUser>.GetChangeEmailTokenPurpose(NewEmail),
-                token);
-
-            isValid.ShouldBeTrue();
-
-            await uow.CompleteAsync();
-        }
-    }
-
-    [Fact]
-    public async Task Invalid_Token_Should_Fail_Verification()
-    {
-        using (var uow = UnitOfWorkManager.Begin())
-        {
-            var john = await UserRepository.GetAsync(TestData.UserJohnId);
-
-            await UserManager.GenerateChangeEmailTokenAsync(john, NewEmail);
-
-            var isValid = await UserManager.VerifyUserTokenAsync(
-                john,
-                UserManager.Options.Tokens.ChangeEmailTokenProvider,
-                UserManager<IdentityUser>.GetChangeEmailTokenPurpose(NewEmail),
-                "invalid-token-value");
-
-            isValid.ShouldBeFalse();
-
-            await uow.CompleteAsync();
-        }
-    }
-
-    [Fact]
-    public async Task Second_Token_Should_Invalidate_First_Token()
-    {
-        using (var uow = UnitOfWorkManager.Begin())
-        {
-            var john = await UserRepository.GetAsync(TestData.UserJohnId);
-
-            var firstToken = await UserManager.GenerateChangeEmailTokenAsync(john, NewEmail);
-
-            john = await UserRepository.GetAsync(TestData.UserJohnId);
-            var secondToken = await UserManager.GenerateChangeEmailTokenAsync(john, NewEmail);
-
-            john = await UserRepository.GetAsync(TestData.UserJohnId);
-
-            var firstTokenValid = await UserManager.VerifyUserTokenAsync(
-                john,
-                UserManager.Options.Tokens.ChangeEmailTokenProvider,
-                UserManager<IdentityUser>.GetChangeEmailTokenPurpose(NewEmail),
-                firstToken);
-
-            var secondTokenValid = await UserManager.VerifyUserTokenAsync(
-                john,
-                UserManager.Options.Tokens.ChangeEmailTokenProvider,
-                UserManager<IdentityUser>.GetChangeEmailTokenPurpose(NewEmail),
-                secondToken);
-
-            firstTokenValid.ShouldBeFalse();
-            secondTokenValid.ShouldBeTrue();
-
-            await uow.CompleteAsync();
-        }
-    }
-
-    [Fact]
     public async Task Token_Should_Become_Invalid_After_Email_Change()
     {
         using (var uow = UnitOfWorkManager.Begin())
@@ -133,42 +60,8 @@ public class AbpChangeEmailTokenProvider_Tests : AbpIdentityAspNetCoreTestBase
 
             // SecurityStamp has changed after the email change, so the old token must be invalid.
             john = await UserRepository.GetAsync(TestData.UserJohnId);
-            var isValid = await UserManager.VerifyUserTokenAsync(
-                john,
-                UserManager.Options.Tokens.ChangeEmailTokenProvider,
-                UserManager<IdentityUser>.GetChangeEmailTokenPurpose(NewEmail),
-                token);
+            (await VerifyTokenAsync(john, token)).ShouldBeFalse();
 
-            isValid.ShouldBeFalse();
-
-            await uow.CompleteAsync();
-        }
-    }
-
-    [Fact]
-    public async Task Token_Hash_Should_Persist_Across_UnitOfWork_Boundaries()
-    {
-        string token;
-
-        // UoW 1: generate the token; UpdateAsync inside GenerateAsync must persist the hash.
-        using (var uow = UnitOfWorkManager.Begin(requiresNew: true))
-        {
-            var john = await UserRepository.GetAsync(TestData.UserJohnId);
-            token = await UserManager.GenerateChangeEmailTokenAsync(john, NewEmail);
-            await uow.CompleteAsync();
-        }
-
-        // UoW 2: validate using a fresh DbContext to confirm the hash was written to the DB.
-        using (var uow = UnitOfWorkManager.Begin(requiresNew: true))
-        {
-            var john = await UserRepository.GetAsync(TestData.UserJohnId);
-            var isValid = await UserManager.VerifyUserTokenAsync(
-                john,
-                UserManager.Options.Tokens.ChangeEmailTokenProvider,
-                UserManager<IdentityUser>.GetChangeEmailTokenPurpose(NewEmail),
-                token);
-
-            isValid.ShouldBeTrue();
             await uow.CompleteAsync();
         }
     }

--- a/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/AbpEmailConfirmationTokenProvider_Tests.cs
+++ b/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/AbpEmailConfirmationTokenProvider_Tests.cs
@@ -1,0 +1,178 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Volo.Abp.Uow;
+using Xunit;
+
+namespace Volo.Abp.Identity.AspNetCore;
+
+public class AbpEmailConfirmationTokenProvider_Tests : AbpIdentityAspNetCoreTestBase
+{
+    protected IIdentityUserRepository UserRepository { get; }
+    protected IdentityUserManager UserManager { get; }
+    protected IdentityTestData TestData { get; }
+    protected IUnitOfWorkManager UnitOfWorkManager { get; }
+
+    public AbpEmailConfirmationTokenProvider_Tests()
+    {
+        UserRepository = GetRequiredService<IIdentityUserRepository>();
+        UserManager = GetRequiredService<IdentityUserManager>();
+        TestData = GetRequiredService<IdentityTestData>();
+        UnitOfWorkManager = GetRequiredService<IUnitOfWorkManager>();
+    }
+
+    [Fact]
+    public void AbpEmailConfirmationTokenProvider_Should_Be_Registered()
+    {
+        var identityOptions = GetRequiredService<IOptions<IdentityOptions>>().Value;
+
+        identityOptions.Tokens.ProviderMap.ShouldContainKey(AbpEmailConfirmationTokenProvider.ProviderName);
+        identityOptions.Tokens.ProviderMap[AbpEmailConfirmationTokenProvider.ProviderName].ProviderType
+            .ShouldBe(typeof(AbpEmailConfirmationTokenProvider));
+    }
+
+    [Fact]
+    public void EmailConfirmationTokenProvider_Should_Be_Configured_As_Abp()
+    {
+        var identityOptions = GetRequiredService<IOptions<IdentityOptions>>().Value;
+
+        identityOptions.Tokens.EmailConfirmationTokenProvider.ShouldBe(AbpEmailConfirmationTokenProvider.ProviderName);
+    }
+
+    [Fact]
+    public async Task Generate_And_Verify_Email_Confirmation_Token_Should_Succeed()
+    {
+        using (var uow = UnitOfWorkManager.Begin())
+        {
+            var john = await UserRepository.GetAsync(TestData.UserJohnId);
+
+            var token = await UserManager.GenerateEmailConfirmationTokenAsync(john);
+            token.ShouldNotBeNullOrEmpty();
+
+            var isValid = await UserManager.VerifyUserTokenAsync(
+                john,
+                UserManager.Options.Tokens.EmailConfirmationTokenProvider,
+                UserManager<IdentityUser>.ConfirmEmailTokenPurpose,
+                token);
+
+            isValid.ShouldBeTrue();
+
+            await uow.CompleteAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Invalid_Token_Should_Fail_Verification()
+    {
+        using (var uow = UnitOfWorkManager.Begin())
+        {
+            var john = await UserRepository.GetAsync(TestData.UserJohnId);
+
+            await UserManager.GenerateEmailConfirmationTokenAsync(john);
+
+            var isValid = await UserManager.VerifyUserTokenAsync(
+                john,
+                UserManager.Options.Tokens.EmailConfirmationTokenProvider,
+                UserManager<IdentityUser>.ConfirmEmailTokenPurpose,
+                "invalid-token-value");
+
+            isValid.ShouldBeFalse();
+
+            await uow.CompleteAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Second_Token_Should_Invalidate_First_Token()
+    {
+        using (var uow = UnitOfWorkManager.Begin())
+        {
+            var john = await UserRepository.GetAsync(TestData.UserJohnId);
+
+            var firstToken = await UserManager.GenerateEmailConfirmationTokenAsync(john);
+
+            john = await UserRepository.GetAsync(TestData.UserJohnId);
+            var secondToken = await UserManager.GenerateEmailConfirmationTokenAsync(john);
+
+            john = await UserRepository.GetAsync(TestData.UserJohnId);
+
+            var firstTokenValid = await UserManager.VerifyUserTokenAsync(
+                john,
+                UserManager.Options.Tokens.EmailConfirmationTokenProvider,
+                UserManager<IdentityUser>.ConfirmEmailTokenPurpose,
+                firstToken);
+
+            var secondTokenValid = await UserManager.VerifyUserTokenAsync(
+                john,
+                UserManager.Options.Tokens.EmailConfirmationTokenProvider,
+                UserManager<IdentityUser>.ConfirmEmailTokenPurpose,
+                secondToken);
+
+            firstTokenValid.ShouldBeFalse();
+            secondTokenValid.ShouldBeTrue();
+
+            await uow.CompleteAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Token_Should_Become_Invalid_After_Email_Confirmation_With_Explicit_Revocation()
+    {
+        using (var uow = UnitOfWorkManager.Begin())
+        {
+            var john = await UserRepository.GetAsync(TestData.UserJohnId);
+
+            var token = await UserManager.GenerateEmailConfirmationTokenAsync(john);
+
+            var result = await UserManager.ConfirmEmailAsync(john, token);
+            result.Succeeded.ShouldBeTrue();
+
+            // ConfirmEmailAsync does NOT update SecurityStamp, so the hash is not
+            // automatically invalidated. Callers that require single-use semantics must
+            // explicitly revoke the stored token hash after a successful confirmation.
+            john = await UserRepository.GetAsync(TestData.UserJohnId);
+            var removeResult = await UserManager.RemoveEmailConfirmationTokenAsync(john);
+            removeResult.Succeeded.ShouldBeTrue();
+
+            john = await UserRepository.GetAsync(TestData.UserJohnId);
+            var isValid = await UserManager.VerifyUserTokenAsync(
+                john,
+                UserManager.Options.Tokens.EmailConfirmationTokenProvider,
+                UserManager<IdentityUser>.ConfirmEmailTokenPurpose,
+                token);
+
+            isValid.ShouldBeFalse();
+
+            await uow.CompleteAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Token_Hash_Should_Persist_Across_UnitOfWork_Boundaries()
+    {
+        string token;
+
+        // UoW 1: generate the token; UpdateAsync inside GenerateAsync must persist the hash.
+        using (var uow = UnitOfWorkManager.Begin(requiresNew: true))
+        {
+            var john = await UserRepository.GetAsync(TestData.UserJohnId);
+            token = await UserManager.GenerateEmailConfirmationTokenAsync(john);
+            await uow.CompleteAsync();
+        }
+
+        // UoW 2: validate using a fresh DbContext to confirm the hash was written to the DB.
+        using (var uow = UnitOfWorkManager.Begin(requiresNew: true))
+        {
+            var john = await UserRepository.GetAsync(TestData.UserJohnId);
+            var isValid = await UserManager.VerifyUserTokenAsync(
+                john,
+                UserManager.Options.Tokens.EmailConfirmationTokenProvider,
+                UserManager<IdentityUser>.ConfirmEmailTokenPurpose,
+                token);
+
+            isValid.ShouldBeTrue();
+            await uow.CompleteAsync();
+        }
+    }
+}

--- a/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/AbpEmailConfirmationTokenProvider_Tests.cs
+++ b/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/AbpEmailConfirmationTokenProvider_Tests.cs
@@ -7,20 +7,23 @@ using Xunit;
 
 namespace Volo.Abp.Identity.AspNetCore;
 
-public class AbpEmailConfirmationTokenProvider_Tests : AbpIdentityAspNetCoreTestBase
+public class AbpEmailConfirmationTokenProvider_Tests : AbpSingleActiveTokenProviderTestBase
 {
-    protected IIdentityUserRepository UserRepository { get; }
-    protected IdentityUserManager UserManager { get; }
-    protected IdentityTestData TestData { get; }
-    protected IUnitOfWorkManager UnitOfWorkManager { get; }
+    protected override Task<string> GenerateTokenAsync(IdentityUser user)
+        => UserManager.GenerateEmailConfirmationTokenAsync(user);
 
-    public AbpEmailConfirmationTokenProvider_Tests()
-    {
-        UserRepository = GetRequiredService<IIdentityUserRepository>();
-        UserManager = GetRequiredService<IdentityUserManager>();
-        TestData = GetRequiredService<IdentityTestData>();
-        UnitOfWorkManager = GetRequiredService<IUnitOfWorkManager>();
-    }
+    protected override Task<bool> VerifyTokenAsync(IdentityUser user, string token)
+        => UserManager.VerifyUserTokenAsync(
+            user,
+            UserManager.Options.Tokens.EmailConfirmationTokenProvider,
+            UserManager<IdentityUser>.ConfirmEmailTokenPurpose,
+            token);
+
+    protected override string GetProviderName()
+        => UserManager.Options.Tokens.EmailConfirmationTokenProvider;
+
+    protected override string GetPurpose()
+        => UserManager<IdentityUser>.ConfirmEmailTokenPurpose;
 
     [Fact]
     public void AbpEmailConfirmationTokenProvider_Should_Be_Registered()
@@ -41,82 +44,6 @@ public class AbpEmailConfirmationTokenProvider_Tests : AbpIdentityAspNetCoreTest
     }
 
     [Fact]
-    public async Task Generate_And_Verify_Email_Confirmation_Token_Should_Succeed()
-    {
-        using (var uow = UnitOfWorkManager.Begin())
-        {
-            var john = await UserRepository.GetAsync(TestData.UserJohnId);
-
-            var token = await UserManager.GenerateEmailConfirmationTokenAsync(john);
-            token.ShouldNotBeNullOrEmpty();
-
-            var isValid = await UserManager.VerifyUserTokenAsync(
-                john,
-                UserManager.Options.Tokens.EmailConfirmationTokenProvider,
-                UserManager<IdentityUser>.ConfirmEmailTokenPurpose,
-                token);
-
-            isValid.ShouldBeTrue();
-
-            await uow.CompleteAsync();
-        }
-    }
-
-    [Fact]
-    public async Task Invalid_Token_Should_Fail_Verification()
-    {
-        using (var uow = UnitOfWorkManager.Begin())
-        {
-            var john = await UserRepository.GetAsync(TestData.UserJohnId);
-
-            await UserManager.GenerateEmailConfirmationTokenAsync(john);
-
-            var isValid = await UserManager.VerifyUserTokenAsync(
-                john,
-                UserManager.Options.Tokens.EmailConfirmationTokenProvider,
-                UserManager<IdentityUser>.ConfirmEmailTokenPurpose,
-                "invalid-token-value");
-
-            isValid.ShouldBeFalse();
-
-            await uow.CompleteAsync();
-        }
-    }
-
-    [Fact]
-    public async Task Second_Token_Should_Invalidate_First_Token()
-    {
-        using (var uow = UnitOfWorkManager.Begin())
-        {
-            var john = await UserRepository.GetAsync(TestData.UserJohnId);
-
-            var firstToken = await UserManager.GenerateEmailConfirmationTokenAsync(john);
-
-            john = await UserRepository.GetAsync(TestData.UserJohnId);
-            var secondToken = await UserManager.GenerateEmailConfirmationTokenAsync(john);
-
-            john = await UserRepository.GetAsync(TestData.UserJohnId);
-
-            var firstTokenValid = await UserManager.VerifyUserTokenAsync(
-                john,
-                UserManager.Options.Tokens.EmailConfirmationTokenProvider,
-                UserManager<IdentityUser>.ConfirmEmailTokenPurpose,
-                firstToken);
-
-            var secondTokenValid = await UserManager.VerifyUserTokenAsync(
-                john,
-                UserManager.Options.Tokens.EmailConfirmationTokenProvider,
-                UserManager<IdentityUser>.ConfirmEmailTokenPurpose,
-                secondToken);
-
-            firstTokenValid.ShouldBeFalse();
-            secondTokenValid.ShouldBeTrue();
-
-            await uow.CompleteAsync();
-        }
-    }
-
-    [Fact]
     public async Task Token_Should_Become_Invalid_After_Email_Confirmation_With_Explicit_Revocation()
     {
         using (var uow = UnitOfWorkManager.Begin())
@@ -129,49 +56,13 @@ public class AbpEmailConfirmationTokenProvider_Tests : AbpIdentityAspNetCoreTest
             result.Succeeded.ShouldBeTrue();
 
             // ConfirmEmailAsync does NOT update SecurityStamp, so the hash is not
-            // automatically invalidated. Callers that require single-use semantics must
-            // explicitly revoke the stored token hash after a successful confirmation.
+            // automatically invalidated. Callers must explicitly revoke the hash.
             john = await UserRepository.GetAsync(TestData.UserJohnId);
-            var removeResult = await UserManager.RemoveEmailConfirmationTokenAsync(john);
-            removeResult.Succeeded.ShouldBeTrue();
+            (await UserManager.RemoveEmailConfirmationTokenAsync(john)).Succeeded.ShouldBeTrue();
 
             john = await UserRepository.GetAsync(TestData.UserJohnId);
-            var isValid = await UserManager.VerifyUserTokenAsync(
-                john,
-                UserManager.Options.Tokens.EmailConfirmationTokenProvider,
-                UserManager<IdentityUser>.ConfirmEmailTokenPurpose,
-                token);
+            (await VerifyTokenAsync(john, token)).ShouldBeFalse();
 
-            isValid.ShouldBeFalse();
-
-            await uow.CompleteAsync();
-        }
-    }
-
-    [Fact]
-    public async Task Token_Hash_Should_Persist_Across_UnitOfWork_Boundaries()
-    {
-        string token;
-
-        // UoW 1: generate the token; UpdateAsync inside GenerateAsync must persist the hash.
-        using (var uow = UnitOfWorkManager.Begin(requiresNew: true))
-        {
-            var john = await UserRepository.GetAsync(TestData.UserJohnId);
-            token = await UserManager.GenerateEmailConfirmationTokenAsync(john);
-            await uow.CompleteAsync();
-        }
-
-        // UoW 2: validate using a fresh DbContext to confirm the hash was written to the DB.
-        using (var uow = UnitOfWorkManager.Begin(requiresNew: true))
-        {
-            var john = await UserRepository.GetAsync(TestData.UserJohnId);
-            var isValid = await UserManager.VerifyUserTokenAsync(
-                john,
-                UserManager.Options.Tokens.EmailConfirmationTokenProvider,
-                UserManager<IdentityUser>.ConfirmEmailTokenPurpose,
-                token);
-
-            isValid.ShouldBeTrue();
             await uow.CompleteAsync();
         }
     }

--- a/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/AbpPasswordResetTokenProvider_Tests.cs
+++ b/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/AbpPasswordResetTokenProvider_Tests.cs
@@ -1,0 +1,173 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Volo.Abp.Uow;
+using Xunit;
+
+namespace Volo.Abp.Identity.AspNetCore;
+
+public class AbpPasswordResetTokenProvider_Tests : AbpIdentityAspNetCoreTestBase
+{
+    protected IIdentityUserRepository UserRepository { get; }
+    protected IdentityUserManager UserManager { get; }
+    protected IdentityTestData TestData { get; }
+    protected IUnitOfWorkManager UnitOfWorkManager { get; }
+
+    public AbpPasswordResetTokenProvider_Tests()
+    {
+        UserRepository = GetRequiredService<IIdentityUserRepository>();
+        UserManager = GetRequiredService<IdentityUserManager>();
+        TestData = GetRequiredService<IdentityTestData>();
+        UnitOfWorkManager = GetRequiredService<IUnitOfWorkManager>();
+    }
+
+    [Fact]
+    public void AbpPasswordResetTokenProvider_Should_Be_Registered()
+    {
+        var identityOptions = GetRequiredService<IOptions<IdentityOptions>>().Value;
+
+        identityOptions.Tokens.ProviderMap.ShouldContainKey(AbpPasswordResetTokenProvider.ProviderName);
+        identityOptions.Tokens.ProviderMap[AbpPasswordResetTokenProvider.ProviderName].ProviderType
+            .ShouldBe(typeof(AbpPasswordResetTokenProvider));
+    }
+
+    [Fact]
+    public void PasswordResetTokenProvider_Should_Be_Configured_As_Abp()
+    {
+        var identityOptions = GetRequiredService<IOptions<IdentityOptions>>().Value;
+
+        identityOptions.Tokens.PasswordResetTokenProvider.ShouldBe(AbpPasswordResetTokenProvider.ProviderName);
+    }
+
+    [Fact]
+    public async Task Generate_And_Verify_Password_Reset_Token_Should_Succeed()
+    {
+        using (var uow = UnitOfWorkManager.Begin())
+        {
+            var john = await UserRepository.GetAsync(TestData.UserJohnId);
+
+            var token = await UserManager.GeneratePasswordResetTokenAsync(john);
+            token.ShouldNotBeNullOrEmpty();
+
+            var isValid = await UserManager.VerifyUserTokenAsync(
+                john,
+                UserManager.Options.Tokens.PasswordResetTokenProvider,
+                UserManager<IdentityUser>.ResetPasswordTokenPurpose,
+                token);
+
+            isValid.ShouldBeTrue();
+
+            await uow.CompleteAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Invalid_Token_Should_Fail_Verification()
+    {
+        using (var uow = UnitOfWorkManager.Begin())
+        {
+            var john = await UserRepository.GetAsync(TestData.UserJohnId);
+
+            await UserManager.GeneratePasswordResetTokenAsync(john);
+
+            var isValid = await UserManager.VerifyUserTokenAsync(
+                john,
+                UserManager.Options.Tokens.PasswordResetTokenProvider,
+                UserManager<IdentityUser>.ResetPasswordTokenPurpose,
+                "invalid-token-value");
+
+            isValid.ShouldBeFalse();
+
+            await uow.CompleteAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Second_Token_Should_Invalidate_First_Token()
+    {
+        using (var uow = UnitOfWorkManager.Begin())
+        {
+            var john = await UserRepository.GetAsync(TestData.UserJohnId);
+
+            var firstToken = await UserManager.GeneratePasswordResetTokenAsync(john);
+
+            john = await UserRepository.GetAsync(TestData.UserJohnId);
+            var secondToken = await UserManager.GeneratePasswordResetTokenAsync(john);
+
+            john = await UserRepository.GetAsync(TestData.UserJohnId);
+
+            var firstTokenValid = await UserManager.VerifyUserTokenAsync(
+                john,
+                UserManager.Options.Tokens.PasswordResetTokenProvider,
+                UserManager<IdentityUser>.ResetPasswordTokenPurpose,
+                firstToken);
+
+            var secondTokenValid = await UserManager.VerifyUserTokenAsync(
+                john,
+                UserManager.Options.Tokens.PasswordResetTokenProvider,
+                UserManager<IdentityUser>.ResetPasswordTokenPurpose,
+                secondToken);
+
+            firstTokenValid.ShouldBeFalse();
+            secondTokenValid.ShouldBeTrue();
+
+            await uow.CompleteAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Token_Should_Become_Invalid_After_Password_Reset()
+    {
+        using (var uow = UnitOfWorkManager.Begin())
+        {
+            var john = await UserRepository.GetAsync(TestData.UserJohnId);
+
+            var token = await UserManager.GeneratePasswordResetTokenAsync(john);
+
+            john = await UserRepository.GetAsync(TestData.UserJohnId);
+            var result = await UserManager.ResetPasswordAsync(john, token, "1q2w3E*NewP@ss!");
+            result.Succeeded.ShouldBeTrue();
+
+            // SecurityStamp has changed after reset, so the old token must be invalid.
+            john = await UserRepository.GetAsync(TestData.UserJohnId);
+            var isValid = await UserManager.VerifyUserTokenAsync(
+                john,
+                UserManager.Options.Tokens.PasswordResetTokenProvider,
+                UserManager<IdentityUser>.ResetPasswordTokenPurpose,
+                token);
+
+            isValid.ShouldBeFalse();
+
+            await uow.CompleteAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Token_Hash_Should_Persist_Across_UnitOfWork_Boundaries()
+    {
+        string token;
+
+        // UoW 1: generate the token; UpdateAsync inside GenerateAsync must persist the hash.
+        using (var uow = UnitOfWorkManager.Begin(requiresNew: true))
+        {
+            var john = await UserRepository.GetAsync(TestData.UserJohnId);
+            token = await UserManager.GeneratePasswordResetTokenAsync(john);
+            await uow.CompleteAsync();
+        }
+
+        // UoW 2: validate using a fresh DbContext to confirm the hash was written to the DB.
+        using (var uow = UnitOfWorkManager.Begin(requiresNew: true))
+        {
+            var john = await UserRepository.GetAsync(TestData.UserJohnId);
+            var isValid = await UserManager.VerifyUserTokenAsync(
+                john,
+                UserManager.Options.Tokens.PasswordResetTokenProvider,
+                UserManager<IdentityUser>.ResetPasswordTokenPurpose,
+                token);
+
+            isValid.ShouldBeTrue();
+            await uow.CompleteAsync();
+        }
+    }
+}

--- a/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/AbpPasswordResetTokenProvider_Tests.cs
+++ b/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/AbpPasswordResetTokenProvider_Tests.cs
@@ -7,20 +7,23 @@ using Xunit;
 
 namespace Volo.Abp.Identity.AspNetCore;
 
-public class AbpPasswordResetTokenProvider_Tests : AbpIdentityAspNetCoreTestBase
+public class AbpPasswordResetTokenProvider_Tests : AbpSingleActiveTokenProviderTestBase
 {
-    protected IIdentityUserRepository UserRepository { get; }
-    protected IdentityUserManager UserManager { get; }
-    protected IdentityTestData TestData { get; }
-    protected IUnitOfWorkManager UnitOfWorkManager { get; }
+    protected override Task<string> GenerateTokenAsync(IdentityUser user)
+        => UserManager.GeneratePasswordResetTokenAsync(user);
 
-    public AbpPasswordResetTokenProvider_Tests()
-    {
-        UserRepository = GetRequiredService<IIdentityUserRepository>();
-        UserManager = GetRequiredService<IdentityUserManager>();
-        TestData = GetRequiredService<IdentityTestData>();
-        UnitOfWorkManager = GetRequiredService<IUnitOfWorkManager>();
-    }
+    protected override Task<bool> VerifyTokenAsync(IdentityUser user, string token)
+        => UserManager.VerifyUserTokenAsync(
+            user,
+            UserManager.Options.Tokens.PasswordResetTokenProvider,
+            UserManager<IdentityUser>.ResetPasswordTokenPurpose,
+            token);
+
+    protected override string GetProviderName()
+        => UserManager.Options.Tokens.PasswordResetTokenProvider;
+
+    protected override string GetPurpose()
+        => UserManager<IdentityUser>.ResetPasswordTokenPurpose;
 
     [Fact]
     public void AbpPasswordResetTokenProvider_Should_Be_Registered()
@@ -41,82 +44,6 @@ public class AbpPasswordResetTokenProvider_Tests : AbpIdentityAspNetCoreTestBase
     }
 
     [Fact]
-    public async Task Generate_And_Verify_Password_Reset_Token_Should_Succeed()
-    {
-        using (var uow = UnitOfWorkManager.Begin())
-        {
-            var john = await UserRepository.GetAsync(TestData.UserJohnId);
-
-            var token = await UserManager.GeneratePasswordResetTokenAsync(john);
-            token.ShouldNotBeNullOrEmpty();
-
-            var isValid = await UserManager.VerifyUserTokenAsync(
-                john,
-                UserManager.Options.Tokens.PasswordResetTokenProvider,
-                UserManager<IdentityUser>.ResetPasswordTokenPurpose,
-                token);
-
-            isValid.ShouldBeTrue();
-
-            await uow.CompleteAsync();
-        }
-    }
-
-    [Fact]
-    public async Task Invalid_Token_Should_Fail_Verification()
-    {
-        using (var uow = UnitOfWorkManager.Begin())
-        {
-            var john = await UserRepository.GetAsync(TestData.UserJohnId);
-
-            await UserManager.GeneratePasswordResetTokenAsync(john);
-
-            var isValid = await UserManager.VerifyUserTokenAsync(
-                john,
-                UserManager.Options.Tokens.PasswordResetTokenProvider,
-                UserManager<IdentityUser>.ResetPasswordTokenPurpose,
-                "invalid-token-value");
-
-            isValid.ShouldBeFalse();
-
-            await uow.CompleteAsync();
-        }
-    }
-
-    [Fact]
-    public async Task Second_Token_Should_Invalidate_First_Token()
-    {
-        using (var uow = UnitOfWorkManager.Begin())
-        {
-            var john = await UserRepository.GetAsync(TestData.UserJohnId);
-
-            var firstToken = await UserManager.GeneratePasswordResetTokenAsync(john);
-
-            john = await UserRepository.GetAsync(TestData.UserJohnId);
-            var secondToken = await UserManager.GeneratePasswordResetTokenAsync(john);
-
-            john = await UserRepository.GetAsync(TestData.UserJohnId);
-
-            var firstTokenValid = await UserManager.VerifyUserTokenAsync(
-                john,
-                UserManager.Options.Tokens.PasswordResetTokenProvider,
-                UserManager<IdentityUser>.ResetPasswordTokenPurpose,
-                firstToken);
-
-            var secondTokenValid = await UserManager.VerifyUserTokenAsync(
-                john,
-                UserManager.Options.Tokens.PasswordResetTokenProvider,
-                UserManager<IdentityUser>.ResetPasswordTokenPurpose,
-                secondToken);
-
-            firstTokenValid.ShouldBeFalse();
-            secondTokenValid.ShouldBeTrue();
-
-            await uow.CompleteAsync();
-        }
-    }
-
-    [Fact]
     public async Task Token_Should_Become_Invalid_After_Password_Reset()
     {
         using (var uow = UnitOfWorkManager.Begin())
@@ -131,42 +58,8 @@ public class AbpPasswordResetTokenProvider_Tests : AbpIdentityAspNetCoreTestBase
 
             // SecurityStamp has changed after reset, so the old token must be invalid.
             john = await UserRepository.GetAsync(TestData.UserJohnId);
-            var isValid = await UserManager.VerifyUserTokenAsync(
-                john,
-                UserManager.Options.Tokens.PasswordResetTokenProvider,
-                UserManager<IdentityUser>.ResetPasswordTokenPurpose,
-                token);
+            (await VerifyTokenAsync(john, token)).ShouldBeFalse();
 
-            isValid.ShouldBeFalse();
-
-            await uow.CompleteAsync();
-        }
-    }
-
-    [Fact]
-    public async Task Token_Hash_Should_Persist_Across_UnitOfWork_Boundaries()
-    {
-        string token;
-
-        // UoW 1: generate the token; UpdateAsync inside GenerateAsync must persist the hash.
-        using (var uow = UnitOfWorkManager.Begin(requiresNew: true))
-        {
-            var john = await UserRepository.GetAsync(TestData.UserJohnId);
-            token = await UserManager.GeneratePasswordResetTokenAsync(john);
-            await uow.CompleteAsync();
-        }
-
-        // UoW 2: validate using a fresh DbContext to confirm the hash was written to the DB.
-        using (var uow = UnitOfWorkManager.Begin(requiresNew: true))
-        {
-            var john = await UserRepository.GetAsync(TestData.UserJohnId);
-            var isValid = await UserManager.VerifyUserTokenAsync(
-                john,
-                UserManager.Options.Tokens.PasswordResetTokenProvider,
-                UserManager<IdentityUser>.ResetPasswordTokenPurpose,
-                token);
-
-            isValid.ShouldBeTrue();
             await uow.CompleteAsync();
         }
     }

--- a/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/AbpSingleActiveTokenProviderTestBase.cs
+++ b/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/AbpSingleActiveTokenProviderTestBase.cs
@@ -39,7 +39,7 @@ public abstract class AbpSingleActiveTokenProviderTestBase : AbpIdentityAspNetCo
     /// <summary>Returns the token purpose used as the hash key prefix.</summary>
     protected abstract string GetPurpose();
 
-    private string GetHashKey() => GetPurpose() + AbpSingleActiveTokenProvider.TokenHashSuffix;
+    private string GetTokenHashName() => GetProviderName() + ":" + GetPurpose();
 
     [Fact]
     public async Task Generate_And_Verify_Token_Should_Succeed()
@@ -103,7 +103,7 @@ public abstract class AbpSingleActiveTokenProviderTestBase : AbpIdentityAspNetCo
 
             // Overwrite with a non-hex string to simulate data corruption.
             user = await UserRepository.GetAsync(TestData.UserJohnId);
-            await UserManager.SetAuthenticationTokenAsync(user, GetProviderName(), GetHashKey(), "not-valid-hex!!!");
+            await UserManager.SetAuthenticationTokenAsync(user, AbpSingleActiveTokenProvider.InternalLoginProvider, GetTokenHashName(), "not-valid-hex!!!");
 
             user = await UserRepository.GetAsync(TestData.UserJohnId);
 

--- a/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/AbpSingleActiveTokenProviderTestBase.cs
+++ b/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/AbpSingleActiveTokenProviderTestBase.cs
@@ -1,0 +1,138 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using Shouldly;
+using Volo.Abp.Uow;
+using Xunit;
+
+namespace Volo.Abp.Identity.AspNetCore;
+
+/// <summary>
+/// Abstract base class that exercises the common behaviour of every
+/// <see cref="AbpSingleActiveTokenProvider"/> subclass.
+/// Concrete subclasses inject their provider-specific generate/verify helpers
+/// so the same test suite runs against each provider.
+/// </summary>
+public abstract class AbpSingleActiveTokenProviderTestBase : AbpIdentityAspNetCoreTestBase
+{
+    protected IIdentityUserRepository UserRepository { get; }
+    protected IdentityUserManager UserManager { get; }
+    protected IdentityTestData TestData { get; }
+    protected IUnitOfWorkManager UnitOfWorkManager { get; }
+
+    protected AbpSingleActiveTokenProviderTestBase()
+    {
+        UserRepository = GetRequiredService<IIdentityUserRepository>();
+        UserManager = GetRequiredService<IdentityUserManager>();
+        TestData = GetRequiredService<IdentityTestData>();
+        UnitOfWorkManager = GetRequiredService<IUnitOfWorkManager>();
+    }
+
+    /// <summary>Generates a token for <paramref name="user"/> via the provider under test.</summary>
+    protected abstract Task<string> GenerateTokenAsync(IdentityUser user);
+
+    /// <summary>Verifies <paramref name="token"/> for <paramref name="user"/> via the provider under test.</summary>
+    protected abstract Task<bool> VerifyTokenAsync(IdentityUser user, string token);
+
+    /// <summary>Returns the provider name used to look up the stored hash.</summary>
+    protected abstract string GetProviderName();
+
+    /// <summary>Returns the token purpose used as the hash key prefix.</summary>
+    protected abstract string GetPurpose();
+
+    private string GetHashKey() => GetPurpose() + AbpSingleActiveTokenProvider.TokenHashSuffix;
+
+    [Fact]
+    public async Task Generate_And_Verify_Token_Should_Succeed()
+    {
+        using (var uow = UnitOfWorkManager.Begin())
+        {
+            var user = await UserRepository.GetAsync(TestData.UserJohnId);
+
+            var token = await GenerateTokenAsync(user);
+            token.ShouldNotBeNullOrEmpty();
+
+            user = await UserRepository.GetAsync(TestData.UserJohnId);
+            (await VerifyTokenAsync(user, token)).ShouldBeTrue();
+
+            await uow.CompleteAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Invalid_Token_Should_Fail_Verification()
+    {
+        using (var uow = UnitOfWorkManager.Begin())
+        {
+            var user = await UserRepository.GetAsync(TestData.UserJohnId);
+            await GenerateTokenAsync(user);
+
+            user = await UserRepository.GetAsync(TestData.UserJohnId);
+            (await VerifyTokenAsync(user, "invalid-token-value")).ShouldBeFalse();
+
+            await uow.CompleteAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Second_Token_Should_Invalidate_First_Token()
+    {
+        using (var uow = UnitOfWorkManager.Begin())
+        {
+            var user = await UserRepository.GetAsync(TestData.UserJohnId);
+            var firstToken = await GenerateTokenAsync(user);
+
+            user = await UserRepository.GetAsync(TestData.UserJohnId);
+            var secondToken = await GenerateTokenAsync(user);
+
+            user = await UserRepository.GetAsync(TestData.UserJohnId);
+
+            (await VerifyTokenAsync(user, firstToken)).ShouldBeFalse();
+            (await VerifyTokenAsync(user, secondToken)).ShouldBeTrue();
+
+            await uow.CompleteAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Corrupted_Hash_Should_Return_False_Instead_Of_Throwing()
+    {
+        using (var uow = UnitOfWorkManager.Begin())
+        {
+            var user = await UserRepository.GetAsync(TestData.UserJohnId);
+            var token = await GenerateTokenAsync(user);
+
+            // Overwrite with a non-hex string to simulate data corruption.
+            user = await UserRepository.GetAsync(TestData.UserJohnId);
+            await UserManager.SetAuthenticationTokenAsync(user, GetProviderName(), GetHashKey(), "not-valid-hex!!!");
+
+            user = await UserRepository.GetAsync(TestData.UserJohnId);
+
+            // ValidateAsync must catch FormatException internally and return false.
+            (await VerifyTokenAsync(user, token)).ShouldBeFalse();
+
+            await uow.CompleteAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Token_Hash_Should_Persist_Across_UnitOfWork_Boundaries()
+    {
+        string token;
+
+        // UoW 1: generate; UpdateAsync inside GenerateAsync must write the hash to the DB.
+        using (var uow = UnitOfWorkManager.Begin(requiresNew: true))
+        {
+            var user = await UserRepository.GetAsync(TestData.UserJohnId);
+            token = await GenerateTokenAsync(user);
+            await uow.CompleteAsync();
+        }
+
+        // UoW 2: validate with a fresh DbContext to confirm the hash was persisted.
+        using (var uow = UnitOfWorkManager.Begin(requiresNew: true))
+        {
+            var user = await UserRepository.GetAsync(TestData.UserJohnId);
+            (await VerifyTokenAsync(user, token)).ShouldBeTrue();
+            await uow.CompleteAsync();
+        }
+    }
+}

--- a/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/IdentityUserManagerSingleActiveTokenExtensions_Tests.cs
+++ b/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/IdentityUserManagerSingleActiveTokenExtensions_Tests.cs
@@ -1,0 +1,89 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using Shouldly;
+using Volo.Abp.Identity;
+using Volo.Abp.Uow;
+using Xunit;
+
+namespace Volo.Abp.Identity.AspNetCore;
+
+public class IdentityUserManagerSingleActiveTokenExtensions_Tests : AbpIdentityAspNetCoreTestBase
+{
+    private const string NewEmail = "newemail@example.com";
+
+    protected IIdentityUserRepository UserRepository { get; }
+    protected IdentityUserManager UserManager { get; }
+    protected IdentityTestData TestData { get; }
+    protected IUnitOfWorkManager UnitOfWorkManager { get; }
+
+    public IdentityUserManagerSingleActiveTokenExtensions_Tests()
+    {
+        UserRepository = GetRequiredService<IIdentityUserRepository>();
+        UserManager = GetRequiredService<IdentityUserManager>();
+        TestData = GetRequiredService<IdentityTestData>();
+        UnitOfWorkManager = GetRequiredService<IUnitOfWorkManager>();
+    }
+
+    [Fact]
+    public async Task Should_Remove_PasswordReset_TokenHash()
+    {
+        using (var uow = UnitOfWorkManager.Begin())
+        {
+            var user = await UserRepository.GetAsync(TestData.UserJohnId);
+            var providerName = UserManager.Options.Tokens.PasswordResetTokenProvider;
+            var tokenKey = UserManager<IdentityUser>.ResetPasswordTokenPurpose + AbpSingleActiveTokenProvider.TokenHashSuffix;
+
+            await UserManager.SetAuthenticationTokenAsync(user, providerName, tokenKey, "hash-value");
+            (await UserManager.GetAuthenticationTokenAsync(user, providerName, tokenKey)).ShouldNotBeNull();
+
+            var result = await UserManager.RemovePasswordResetTokenAsync(user);
+            result.Succeeded.ShouldBeTrue();
+
+            (await UserManager.GetAuthenticationTokenAsync(user, providerName, tokenKey)).ShouldBeNull();
+
+            await uow.CompleteAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Should_Remove_EmailConfirmation_TokenHash()
+    {
+        using (var uow = UnitOfWorkManager.Begin())
+        {
+            var user = await UserRepository.GetAsync(TestData.UserJohnId);
+            var providerName = UserManager.Options.Tokens.EmailConfirmationTokenProvider;
+            var tokenKey = UserManager<IdentityUser>.ConfirmEmailTokenPurpose + AbpSingleActiveTokenProvider.TokenHashSuffix;
+
+            await UserManager.SetAuthenticationTokenAsync(user, providerName, tokenKey, "hash-value");
+            (await UserManager.GetAuthenticationTokenAsync(user, providerName, tokenKey)).ShouldNotBeNull();
+
+            var result = await UserManager.RemoveEmailConfirmationTokenAsync(user);
+            result.Succeeded.ShouldBeTrue();
+
+            (await UserManager.GetAuthenticationTokenAsync(user, providerName, tokenKey)).ShouldBeNull();
+
+            await uow.CompleteAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Should_Remove_ChangeEmail_TokenHash()
+    {
+        using (var uow = UnitOfWorkManager.Begin())
+        {
+            var user = await UserRepository.GetAsync(TestData.UserJohnId);
+            var providerName = UserManager.Options.Tokens.ChangeEmailTokenProvider;
+            var tokenKey = UserManager<IdentityUser>.GetChangeEmailTokenPurpose(NewEmail) + AbpSingleActiveTokenProvider.TokenHashSuffix;
+
+            await UserManager.SetAuthenticationTokenAsync(user, providerName, tokenKey, "hash-value");
+            (await UserManager.GetAuthenticationTokenAsync(user, providerName, tokenKey)).ShouldNotBeNull();
+
+            var result = await UserManager.RemoveChangeEmailTokenAsync(user, NewEmail);
+            result.Succeeded.ShouldBeTrue();
+
+            (await UserManager.GetAuthenticationTokenAsync(user, providerName, tokenKey)).ShouldBeNull();
+
+            await uow.CompleteAsync();
+        }
+    }
+}

--- a/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/IdentityUserManagerSingleActiveTokenExtensions_Tests.cs
+++ b/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/IdentityUserManagerSingleActiveTokenExtensions_Tests.cs
@@ -30,8 +30,8 @@ public class IdentityUserManagerSingleActiveTokenExtensions_Tests : AbpIdentityA
         using (var uow = UnitOfWorkManager.Begin())
         {
             var user = await UserRepository.GetAsync(TestData.UserJohnId);
-            var providerName = UserManager.Options.Tokens.PasswordResetTokenProvider;
-            var tokenKey = UserManager<IdentityUser>.ResetPasswordTokenPurpose + AbpSingleActiveTokenProvider.TokenHashSuffix;
+            var providerName = AbpSingleActiveTokenProvider.InternalLoginProvider;
+            var tokenKey = UserManager.Options.Tokens.PasswordResetTokenProvider + ":" + UserManager<IdentityUser>.ResetPasswordTokenPurpose;
 
             await UserManager.SetAuthenticationTokenAsync(user, providerName, tokenKey, "hash-value");
             (await UserManager.GetAuthenticationTokenAsync(user, providerName, tokenKey)).ShouldNotBeNull();
@@ -51,8 +51,8 @@ public class IdentityUserManagerSingleActiveTokenExtensions_Tests : AbpIdentityA
         using (var uow = UnitOfWorkManager.Begin())
         {
             var user = await UserRepository.GetAsync(TestData.UserJohnId);
-            var providerName = UserManager.Options.Tokens.EmailConfirmationTokenProvider;
-            var tokenKey = UserManager<IdentityUser>.ConfirmEmailTokenPurpose + AbpSingleActiveTokenProvider.TokenHashSuffix;
+            var providerName = AbpSingleActiveTokenProvider.InternalLoginProvider;
+            var tokenKey = UserManager.Options.Tokens.EmailConfirmationTokenProvider + ":" + UserManager<IdentityUser>.ConfirmEmailTokenPurpose;
 
             await UserManager.SetAuthenticationTokenAsync(user, providerName, tokenKey, "hash-value");
             (await UserManager.GetAuthenticationTokenAsync(user, providerName, tokenKey)).ShouldNotBeNull();
@@ -72,8 +72,8 @@ public class IdentityUserManagerSingleActiveTokenExtensions_Tests : AbpIdentityA
         using (var uow = UnitOfWorkManager.Begin())
         {
             var user = await UserRepository.GetAsync(TestData.UserJohnId);
-            var providerName = UserManager.Options.Tokens.ChangeEmailTokenProvider;
-            var tokenKey = UserManager<IdentityUser>.GetChangeEmailTokenPurpose(NewEmail) + AbpSingleActiveTokenProvider.TokenHashSuffix;
+            var providerName = AbpSingleActiveTokenProvider.InternalLoginProvider;
+            var tokenKey = UserManager.Options.Tokens.ChangeEmailTokenProvider + ":" + UserManager<IdentityUser>.GetChangeEmailTokenPurpose(NewEmail);
 
             await UserManager.SetAuthenticationTokenAsync(user, providerName, tokenKey, "hash-value");
             (await UserManager.GetAuthenticationTokenAsync(user, providerName, tokenKey)).ShouldNotBeNull();


### PR DESCRIPTION
## Summary

Introduces a "single active token" policy for password reset, email confirmation, and change-email flows by adding three new token providers backed by `AbpSingleActiveTokenProvider`.

## How it works

Each time a new token is generated, a SHA-256 hash is stored in `user.Tokens` using a fixed internal login provider `[AbpSingleActiveToken]` and a key of `{ProviderName}:{purpose}`. On validation, the incoming token is re-hashed and compared against the stored hash using a constant-time comparison. Issuing a new token overwrites the hash, immediately invalidating all previously issued tokens for that purpose.

The bracketed `[AbpSingleActiveToken]` login provider name clearly distinguishes these internal entries from real external login providers (e.g. Google, GitHub) stored in the same `AbpUserTokens` table — following the same convention used by ASP.NET Core Identity's own `[AspNetUserStore]` internal provider.

**Example rows in `AbpUserTokens`:**

| LoginProvider | Name | Value |
|---|---|---|
| `[AbpSingleActiveToken]` | `AbpPasswordReset:ResetPassword` | `<SHA-256 hex hash>` |
| `[AbpSingleActiveToken]` | `AbpEmailConfirmation:EmailConfirmation` | `<SHA-256 hex hash>` |

**After a successful operation:**
- **Password reset / Change email** – the SecurityStamp is updated by ASP.NET Core Identity, which causes all outstanding tokens for the user to fail base validation. No manual cleanup is needed.
- **Email confirmation** – `ConfirmEmailAsync` does **not** update the SecurityStamp. Callers that require single-use semantics must explicitly revoke the hash:
  ```csharp
  var result = await userManager.ConfirmEmailAsync(user, token);
  if (result.Succeeded)
      await userManager.RemoveEmailConfirmationTokenAsync(user);
  ```

## New providers

| Provider | Default token lifespan | Replaces |
|---|---|---|
| `AbpPasswordResetTokenProvider` | 2 hours | `Default` |
| `AbpEmailConfirmationTokenProvider` | 2 hours | `Default` |
| `AbpChangeEmailTokenProvider` | 2 hours | `Default` |

All three are registered and set as the default providers in `AbpIdentityAspNetCoreModule`.

## Configuration

Token lifespan can be customized via the respective options classes:

```csharp
Configure<AbpPasswordResetTokenProviderOptions>(options =>
{
    options.TokenLifespan = TimeSpan.FromHours(1);
});

Configure<AbpEmailConfirmationTokenProviderOptions>(options =>
{
    options.TokenLifespan = TimeSpan.FromDays(1);
});

Configure<AbpChangeEmailTokenProviderOptions>(options =>
{
    options.TokenLifespan = TimeSpan.FromHours(6);
});
```
