### PR TITLE
Update release related docs after v10.2

### DIFF
--- a/docs/en/release-info/release-notes.md
+++ b/docs/en/release-info/release-notes.md
@@ -14,9 +14,27 @@ Also see the following notes about ABP releases:
 * [ABP Studio release notes](../studio/release-notes.md)
 * [Change logs for ABP pro packages](https://abp.io/pro-releases)
 
+## 10.2 (2026-02-24)
+
+> This is currently a RC (release-candidate) and you can see the detailed **[blog post / announcement](https://abp.io/community/articles/announcing-abp-10-2-release-candidate-05zatjfq)** for the v10.2 release.
+
+- Multi-Tenant Account Usage: Shared User Accounts
+- Prevent Privilege Escalation: Assignment Restrictions for Roles and Permissions
+- `ClientResourcePermissionValueProvider` for OAuth/OpenIddict
+- Angular: Hybrid Localization Support
+- Angular: Extensible Table Row Detail
+- Angular: CMS Kit Module Features
+- Blazor: Upgrade to Blazorise 2.0
+- Identity: Single Active Token Providers
+- TickerQ Package Upgrade to 10.1.1
+- [AI Management Module](../modules/ai-management/index.md): MCP (Model Context Protocol) Support
+- [AI Management Module](../modules/ai-management/index.md): RAG with File Upload
+- [AI Management Module](../modules/ai-management/index.md): OpenAI-Compatible Chat Endpoint
+- [File Management Module](../modules/file-management.md): Resource-Based Authorization
+
 ## 10.1 (2026-01-06)
 
-> This is currently a RC (release-candidate) and you can see the detailed **[blog post / announcement](https://abp.io/community/announcements/announcing-abp-10-1-release-candidate-cyqui19d)** for the v10.1 release.
+See the detailed **[blog post / announcement](https://abp.io/community/announcements/announcing-abp-10-1-stable-release-z4xfn1me)** for the v10.1 release.
 
 * Resource-Based Authorization
 * Introducing the [TickerQ Background Worker Provider](../framework/infrastructure/background-workers/tickerq.md)

--- a/docs/en/release-info/release-notes.md
+++ b/docs/en/release-info/release-notes.md
@@ -16,21 +16,21 @@ Also see the following notes about ABP releases:
 
 ## 10.2 (2026-02-24)
 
-> This is currently a RC (release-candidate) and you can see the detailed **[blog post / announcement](https://abp.io/community/articles/announcing-abp-10-2-release-candidate-05zatjfq)** for the v10.2 release.
+> This is currently an RC (release-candidate) and you can see the detailed **[blog post / announcement](https://abp.io/community/articles/announcing-abp-10-2-release-candidate-05zatjfq)** for the v10.2 release.
 
-- Multi-Tenant Account Usage: Shared User Accounts
-- Prevent Privilege Escalation: Assignment Restrictions for Roles and Permissions
-- `ClientResourcePermissionValueProvider` for OAuth/OpenIddict
-- Angular: Hybrid Localization Support
-- Angular: Extensible Table Row Detail
-- Angular: CMS Kit Module Features
-- Blazor: Upgrade to Blazorise 2.0
-- Identity: Single Active Token Providers
-- TickerQ Package Upgrade to 10.1.1
-- [AI Management Module](../modules/ai-management/index.md): MCP (Model Context Protocol) Support
-- [AI Management Module](../modules/ai-management/index.md): RAG with File Upload
-- [AI Management Module](../modules/ai-management/index.md): OpenAI-Compatible Chat Endpoint
-- [File Management Module](../modules/file-management.md): Resource-Based Authorization
+* Multi-Tenant Account Usage: Shared User Accounts
+* Prevent Privilege Escalation: Assignment Restrictions for Roles and Permissions
+* `ClientResourcePermissionValueProvider` for OAuth/OpenIddict
+* Angular: Hybrid Localization Support
+* Angular: Extensible Table Row Detail
+* Angular: CMS Kit Module Features
+* Blazor: Upgrade to Blazorise 2.0
+* Identity: Single Active Token Providers
+* TickerQ Package Upgrade to 10.1.1
+* [AI Management Module](../modules/ai-management/index.md): MCP (Model Context Protocol) Support
+* [AI Management Module](../modules/ai-management/index.md): RAG with File Upload
+* [AI Management Module](../modules/ai-management/index.md): OpenAI-Compatible Chat Endpoint
+* [File Management Module](../modules/file-management.md): Resource-Based Authorization
 
 ## 10.1 (2026-01-06)
 

--- a/docs/en/release-info/road-map.md
+++ b/docs/en/release-info/road-map.md
@@ -1,7 +1,7 @@
 ```json
 //[doc-seo]
 {
-    "Description": "Explore the ABP Platform Road Map for insights on upcoming features, release schedules, and improvements in version 10.2, launching January 2026."
+    "Description": "Explore the ABP Platform Road Map for insights on upcoming features, release schedules, and improvements in version 10.3, planned for April 2026."
 }
 ```
 
@@ -13,7 +13,7 @@ This document provides a road map, release schedule, and planned features for th
 
 ### v10.3
 
-The next version will be 10.3 and planned to release the stable 10.3 version in April 2026. We will be mostly working on the following topics:
+The next version will be 10.3 and is planned to be released as a stable version in April 2026. We will be mostly working on the following topics:
 
 * Framework
   * Resource-Based Authorization Improvements
@@ -23,7 +23,7 @@ The next version will be 10.3 and planned to release the stable 10.3 version in 
 
 * ABP Suite
   * Improvements on the generated codes for nullability
-  * Improvements on Master-Detail Page Desing (making it more compact)
+  * Improvements on Master-Detail Page Design (making it more compact)
   * Improvements One-To-Many Scenarios
   * File Upload Modal Enhancements
 

--- a/docs/en/release-info/road-map.md
+++ b/docs/en/release-info/road-map.md
@@ -1,7 +1,7 @@
 ```json
 //[doc-seo]
 {
-    "Description": "Explore the ABP Platform Road Map for insights on upcoming features, release schedules, and improvements in version 10.1, launching January 2026."
+    "Description": "Explore the ABP Platform Road Map for insights on upcoming features, release schedules, and improvements in version 10.2, launching January 2026."
 }
 ```
 
@@ -11,18 +11,17 @@ This document provides a road map, release schedule, and planned features for th
 
 ## Next Versions
 
-### v10.2
+### v10.3
 
-The next version will be 10.2 and planned to release the stable 10.2 version in April 2026. We will be mostly working on the following topics:
+The next version will be 10.3 and planned to release the stable 10.3 version in April 2026. We will be mostly working on the following topics:
 
 * Framework
   * Resource-Based Authorization Improvements
-  * Handle datetime/timezon in `AbpExtensibleDataGrid` Component
+  * Handle datetime/timezone in `AbpExtensibleDataGrid` Component
   * Upgrading 3rd-party Dependencies
   * Enhancements in the Core Points
 
 * ABP Suite
-  * Creating enums on-the-fly (without needing to create manually on the code side)
   * Improvements on the generated codes for nullability
   * Improvements on Master-Detail Page Desing (making it more compact)
   * Improvements One-To-Many Scenarios
@@ -30,16 +29,14 @@ The next version will be 10.2 and planned to release the stable 10.2 version in 
 
 * ABP Studio
   * Allow to Directly Create New Solutions with ABP's RC (Release Candidate) Versions
-  * Integrate AI Management Module with all solution templates and UIs
+  * Integrate AI Management Module with all solution templates and UIs (for Blazor & Angular UIs)
   * Automate More Details on New Service Creation for a Microservice Solution
   * Allow to Download ABP Samples from ABP Studio
-  * Task Panel Documentation
   * Support Multiple Concurrent Kubernetes Deployment/Integration Scenarios
   * Improve the Module Installation Experience / Installation Guides
 
 * Application Modules
-  * AI Management: MCP & RAG Supports
-  * File Management: Using Resource-Based Permission (on file-sharing and more...)
+  * AI Management: Chat History & Visual Improvements on the playground
   * CMS Kit: Enhancements for Some Features (Rating, Dynamic Widgets, FAQ and more...)
   * UI/UX Improvements on Existing Application Modules
 


### PR DESCRIPTION
Once we publish the release post, the URL will be https://abp.io/community/articles/announcing-abp-10-2-release-candidate-05zatjfq, so I used it in the document. (it's not visible yet, fyi @maliming)