### PR TITLE
Fix cache key isolation by user identity in MvcCachedApplicationConfigurationClient

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc.Client/Volo/Abp/AspNetCore/Mvc/Client/MvcCachedApplicationConfigurationClient.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.Client/Volo/Abp/AspNetCore/Mvc/Client/MvcCachedApplicationConfigurationClient.cs
@@ -14,7 +14,7 @@ namespace Volo.Abp.AspNetCore.Mvc.Client;
 
 public class MvcCachedApplicationConfigurationClient : ICachedApplicationConfigurationClient, ITransientDependency
 {
-    private const string ApplicationConfigurationDtoCacheKey = "ApplicationConfigurationDto_CacheKey";
+    private const string ApplicationConfigurationDtoCacheKeyFormat = "ApplicationConfigurationDto_{0}_CacheKey";
 
     protected IHttpContextAccessor HttpContextAccessor { get; }
     protected AbpApplicationConfigurationClientProxy ApplicationConfigurationAppService { get; }
@@ -46,7 +46,8 @@ public class MvcCachedApplicationConfigurationClient : ICachedApplicationConfigu
     {
         string? cacheKey = null;
         var httpContext = HttpContextAccessor?.HttpContext;
-        if (httpContext != null && httpContext.Items[ApplicationConfigurationDtoCacheKey] is string key)
+        var itemsKey = string.Format(ApplicationConfigurationDtoCacheKeyFormat, CurrentUser.Id?.ToString("N") ?? "Anonymous");
+        if (httpContext != null && httpContext.Items[itemsKey] is string key)
         {
             cacheKey = key;
         }
@@ -56,7 +57,7 @@ public class MvcCachedApplicationConfigurationClient : ICachedApplicationConfigu
             cacheKey = await CreateCacheKeyAsync();
             if (httpContext != null)
             {
-                httpContext.Items[ApplicationConfigurationDtoCacheKey] = cacheKey;
+                httpContext.Items[itemsKey] = cacheKey;
             }
         }
 
@@ -107,7 +108,8 @@ public class MvcCachedApplicationConfigurationClient : ICachedApplicationConfigu
     {
         string? cacheKey = null;
         var httpContext = HttpContextAccessor?.HttpContext;
-        if (httpContext != null && httpContext.Items[ApplicationConfigurationDtoCacheKey] is string key)
+        var itemsKey = string.Format(ApplicationConfigurationDtoCacheKeyFormat, CurrentUser.Id?.ToString("N") ?? "Anonymous");
+        if (httpContext != null && httpContext.Items[itemsKey] is string key)
         {
             cacheKey = key;
         }
@@ -117,7 +119,7 @@ public class MvcCachedApplicationConfigurationClient : ICachedApplicationConfigu
             cacheKey = AsyncHelper.RunSync(CreateCacheKeyAsync);
             if (httpContext != null)
             {
-                httpContext.Items[ApplicationConfigurationDtoCacheKey] = cacheKey;
+                httpContext.Items[itemsKey] = cacheKey;
             }
         }
 
@@ -133,4 +135,5 @@ public class MvcCachedApplicationConfigurationClient : ICachedApplicationConfigu
     {
         return await CacheHelper.CreateCacheKeyAsync(CurrentUser.Id);
     }
+
 }

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.Client/Volo/Abp/AspNetCore/Mvc/Client/MvcCachedApplicationConfigurationClient.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.Client/Volo/Abp/AspNetCore/Mvc/Client/MvcCachedApplicationConfigurationClient.cs
@@ -15,7 +15,7 @@ namespace Volo.Abp.AspNetCore.Mvc.Client;
 
 public class MvcCachedApplicationConfigurationClient : ICachedApplicationConfigurationClient, ITransientDependency
 {
-    private const string ApplicationConfigurationDtoCacheKeyFormat = "ApplicationConfigurationDto_{0}_{1}_CacheKey";
+    private const string HttpContextItemsCacheKeyFormat = "ApplicationConfigurationDto_{0}_{1}_CacheKey";
 
     protected IHttpContextAccessor HttpContextAccessor { get; }
     protected AbpApplicationConfigurationClientProxy ApplicationConfigurationAppService { get; }
@@ -139,6 +139,6 @@ public class MvcCachedApplicationConfigurationClient : ICachedApplicationConfigu
 
     protected virtual string GetHttpContextItemsCacheKey()
     {
-        return string.Format(ApplicationConfigurationDtoCacheKeyFormat, CurrentUser.Id?.ToString("N") ?? "Anonymous", CultureInfo.CurrentUICulture.Name);
+        return string.Format(CultureInfo.InvariantCulture, HttpContextItemsCacheKeyFormat, CurrentUser.Id?.ToString("N") ?? "Anonymous", CultureInfo.CurrentUICulture.Name);
     }
 }

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.Client/Volo/Abp/AspNetCore/Mvc/Client/MvcCachedApplicationConfigurationClient.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.Client/Volo/Abp/AspNetCore/Mvc/Client/MvcCachedApplicationConfigurationClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using Microsoft.AspNetCore.Http;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Distributed;
@@ -14,7 +15,7 @@ namespace Volo.Abp.AspNetCore.Mvc.Client;
 
 public class MvcCachedApplicationConfigurationClient : ICachedApplicationConfigurationClient, ITransientDependency
 {
-    private const string ApplicationConfigurationDtoCacheKeyFormat = "ApplicationConfigurationDto_{0}_CacheKey";
+    private const string ApplicationConfigurationDtoCacheKeyFormat = "ApplicationConfigurationDto_{0}_{1}_CacheKey";
 
     protected IHttpContextAccessor HttpContextAccessor { get; }
     protected AbpApplicationConfigurationClientProxy ApplicationConfigurationAppService { get; }
@@ -46,7 +47,7 @@ public class MvcCachedApplicationConfigurationClient : ICachedApplicationConfigu
     {
         string? cacheKey = null;
         var httpContext = HttpContextAccessor?.HttpContext;
-        var itemsKey = string.Format(ApplicationConfigurationDtoCacheKeyFormat, CurrentUser.Id?.ToString("N") ?? "Anonymous");
+        var itemsKey = string.Format(ApplicationConfigurationDtoCacheKeyFormat, CurrentUser.Id?.ToString("N") ?? "Anonymous", CultureInfo.CurrentUICulture.Name);
         if (httpContext != null && httpContext.Items[itemsKey] is string key)
         {
             cacheKey = key;
@@ -108,7 +109,7 @@ public class MvcCachedApplicationConfigurationClient : ICachedApplicationConfigu
     {
         string? cacheKey = null;
         var httpContext = HttpContextAccessor?.HttpContext;
-        var itemsKey = string.Format(ApplicationConfigurationDtoCacheKeyFormat, CurrentUser.Id?.ToString("N") ?? "Anonymous");
+        var itemsKey = string.Format(ApplicationConfigurationDtoCacheKeyFormat, CurrentUser.Id?.ToString("N") ?? "Anonymous", CultureInfo.CurrentUICulture.Name);
         if (httpContext != null && httpContext.Items[itemsKey] is string key)
         {
             cacheKey = key;

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.Client/Volo/Abp/AspNetCore/Mvc/Client/MvcCachedApplicationConfigurationClient.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.Client/Volo/Abp/AspNetCore/Mvc/Client/MvcCachedApplicationConfigurationClient.cs
@@ -47,7 +47,7 @@ public class MvcCachedApplicationConfigurationClient : ICachedApplicationConfigu
     {
         string? cacheKey = null;
         var httpContext = HttpContextAccessor?.HttpContext;
-        var itemsKey = string.Format(ApplicationConfigurationDtoCacheKeyFormat, CurrentUser.Id?.ToString("N") ?? "Anonymous", CultureInfo.CurrentUICulture.Name);
+        var itemsKey = GetHttpContextItemsCacheKey();
         if (httpContext != null && httpContext.Items[itemsKey] is string key)
         {
             cacheKey = key;
@@ -109,7 +109,7 @@ public class MvcCachedApplicationConfigurationClient : ICachedApplicationConfigu
     {
         string? cacheKey = null;
         var httpContext = HttpContextAccessor?.HttpContext;
-        var itemsKey = string.Format(ApplicationConfigurationDtoCacheKeyFormat, CurrentUser.Id?.ToString("N") ?? "Anonymous", CultureInfo.CurrentUICulture.Name);
+        var itemsKey = GetHttpContextItemsCacheKey();
         if (httpContext != null && httpContext.Items[itemsKey] is string key)
         {
             cacheKey = key;
@@ -137,4 +137,8 @@ public class MvcCachedApplicationConfigurationClient : ICachedApplicationConfigu
         return await CacheHelper.CreateCacheKeyAsync(CurrentUser.Id);
     }
 
+    protected virtual string GetHttpContextItemsCacheKey()
+    {
+        return string.Format(ApplicationConfigurationDtoCacheKeyFormat, CurrentUser.Id?.ToString("N") ?? "Anonymous", CultureInfo.CurrentUICulture.Name);
+    }
 }


### PR DESCRIPTION
## Summary
- Include user identity and UI culture in the `httpContext.Items` cache key for `MvcCachedApplicationConfigurationClient`
- Previously, a fixed key (`ApplicationConfigurationDto_CacheKey`) was used to cache the distributed cache key in `httpContext.Items`. If the service was called before authentication middleware, it would cache an anonymous key and reuse it after the user was authenticated, leading to wrong configuration being served
- Now uses `ApplicationConfigurationDto_{userId}_{culture}_CacheKey` format, so different authentication states and cultures naturally use different Items keys and don't interfere with each other
- Extract `GetHttpContextItemsCacheKey` helper method to avoid duplication between `GetAsync` and Get`