### PR TITLE
Remove permissions header in permission form

### DIFF
--- a/npm/ng-packs/packages/permission-management/src/lib/components/resource-permission-management/resource-permission-form/resource-permission-form.component.html
+++ b/npm/ng-packs/packages/permission-management/src/lib/components/resource-permission-management/resource-permission-form/resource-permission-form.component.html
@@ -27,7 +27,6 @@
   <abp-permission-checkbox-list [permissions]="state.permissionDefinitions()" idPrefix="add" />
 } @else {
   <div class="mb-3" id="permissionList">
-    <h4>{{ 'AbpPermissionManagement::Permissions' | abpLocalization }}</h4>
     <abp-permission-checkbox-list
       [permissions]="state.permissionsWithProvider()"
       idPrefix="edit"


### PR DESCRIPTION
Remove a duplicated 'Permissions' <h4> localization header from the resource-permission-form template. This eliminates a redundant heading above the permission checkbox list in the edit branch to improve the form layout.

<img width="654" height="522" alt="image" src="https://github.com/user-attachments/assets/3999a2d6-7bff-4813-9397-125b654bbacf" />


### Description

Resolves https://github.com/volosoft/volo/issues/21786 (write the related issue number if available)

### How to test it?
Remove from the comment line on `volo\abp\npm\ng-packs\tsconfig.dev.json`
you have to run test-app on ng-packs folder (`yarn start:test-app`)
you have to run `volo\abp\test-app\aspnet-core\src\AbpCommercialTest.HttpApi.Host`
you have to run `volo\abp\test-app\aspnet-core\src\AbpCommercialTest.AuthServer`