### PR TITLE
Upgrade MongoDB.Driver from 3.6.0 to 3.7.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -122,7 +122,7 @@
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.14.0" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.14.0" />
     <PackageVersion Include="Minio" Version="6.0.5" />
-    <PackageVersion Include="MongoDB.Driver" Version="3.6.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.7.0" />
     <PackageVersion Include="NEST" Version="7.17.5" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="Nito.AsyncEx.Context" Version="5.1.2" />

--- a/docs/en/package-version-changes.md
+++ b/docs/en/package-version-changes.md
@@ -1,5 +1,11 @@
 # Package Version Changes
 
+## 10.2.0-rc.1
+
+| Package | Old Version | New Version | PR |
+|---------|-------------|-------------|-----|
+| MongoDB.Driver | 3.6.0 | 3.7.0 | #25003 |
+
 ## 10.2.0-preview
 
 | Package | Old Version | New Version | PR |


### PR DESCRIPTION
## Summary
- Upgrade MongoDB.Driver from 3.6.0 to 3.7.0

## Test plan
- [x] Build succeeded (0 errors)
- [x] MongoDB tests passed (108 passed, 0 failed, 1 skipped)