### PR TITLE
fix: only enable browser request streaming over HTTPS in `AbpBlazorClientHttpMessageHandler`

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Components.WebAssembly/Volo/Abp/AspNetCore/Components/WebAssembly/AbpBlazorClientHttpMessageHandler.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Components.WebAssembly/Volo/Abp/AspNetCore/Components/WebAssembly/AbpBlazorClientHttpMessageHandler.cs
@@ -53,7 +53,10 @@ public class AbpBlazorClientHttpMessageHandler : DelegatingHandler, ITransientDe
                 options.Type = UiPageProgressType.Info;
             });
 
-            request.SetBrowserRequestStreamingEnabled(true);
+            if (request.RequestUri?.Scheme == Uri.UriSchemeHttps)
+            {
+                request.SetBrowserRequestStreamingEnabled(true);
+            }
             await SetLanguageAsync(request, cancellationToken);
             await SetAntiForgeryTokenAsync(request);
             await SetTimeZoneAsync(request);


### PR DESCRIPTION
`AbpBlazorClientHttpMessageHandler.SendAsync` unconditionally calls `request.SetBrowserRequestStreamingEnabled(true)` for every outgoing request in Blazor WebAssembly. 

Browser request streaming uses `ReadableStream` body with `duplex: "half"` in the fetch API, which **requires HTTP/2**. Browsers only support HTTP/2 over TLS (via ALPN negotiation). When the target API runs on plain HTTP (common in development), the browser cannot complete the TLS/ALPN handshake and fails with `ERR_ALPN_NEGOTIATION_FAILED` for all POST/PUT requests (GET/OPTIONS are unaffected because they have no request body).

This change conditionally enables streaming only when the request URL scheme is HTTPS, preserving the large file upload capability (the original reason for enabling streaming) while fixing HTTP-only scenarios.

**Symptoms:**
- Blazor WASM POST/PUT requests to HTTP-only backend fail with `net::ERR_ALPN_NEGOTIATION_FAILED`
- GET/OPTIONS requests work fine
- The same POST requests succeed via browser console `fetch()`, curl, or Swagger UI
- No logs appear on the server side (the request never reaches the server)

https://github.com/abpframework/abp/pull/24794