### PR TITLE
fix: initialize `ProfileManagementPageCreationContext` in `OnPostAsync` of `ManageModel`

### DIFF
--- a/modules/account/src/Volo.Abp.Account.Web/Pages/Account/Manage.cshtml.cs
+++ b/modules/account/src/Volo.Abp.Account.Web/Pages/Account/Manage.cshtml.cs
@@ -47,8 +47,15 @@ public class ManageModel : AccountPageModel
         return Page();
     }
 
-    public virtual Task<IActionResult> OnPostAsync()
+    public virtual async Task<IActionResult> OnPostAsync()
     {
-        return Task.FromResult<IActionResult>(Page());
+        ProfileManagementPageCreationContext = new ProfileManagementPageCreationContext(ServiceProvider);
+
+        foreach (var contributor in Options.Contributors)
+        {
+            await contributor.ConfigureAsync(ProfileManagementPageCreationContext);
+        }
+
+        return Page();
     }
 }


### PR DESCRIPTION
`ManageModel.OnPostAsync` returned `Page()` without initializing `ProfileManagementPageCreationContext`, causing a `NullReferenceException` when the view tried to render `Model.ProfileManagementPageCreationContext.Groups` inside the `<abp-tabs>` tag helper.

Although normal usage relies on JavaScript to intercept form submissions (using AJAX instead of a native HTML POST), a direct POST to `/Account/Manage` — triggered by JS being disabled, a JS load failure, or an automated tool — would hit `OnPostAsync` and crash during view rendering.

The fix mirrors the initialization logic from `OnGetAsync`: creating a new `ProfileManagementPageCreationContext` and running all registered contributors through it before returning `Page()`.