### PR TITLE
Remove bottom padding from modal header

### DIFF
--- a/npm/ng-packs/packages/theme-shared/src/lib/components/modal/modal.component.html
+++ b/npm/ng-packs/packages/theme-shared/src/lib/components/modal/modal.component.html
@@ -2,7 +2,7 @@
 
 <ng-template #modalContent let-modal>
   @if (abpHeader()) {
-    <div id="abp-modal-header" class="modal-header abp-modal-header">
+    <div id="abp-modal-header" class="modal-header abp-modal-header pb-0">
       <ng-container *ngTemplateOutlet="abpHeader()"></ng-container>
       ​
       <button


### PR DESCRIPTION
Add the 'pb-0' class to the modal header div in modal.component.html to remove the default bottom padding when abpHeader() is present. This fixes layout/spacing in the theme-shared modal header.
<img width="991" height="787" alt="image" src="https://github.com/user-attachments/assets/fa4ae803-6fa0-4765-9d05-77efa7da1828" />
### Description

Resolves  https://github.com/volosoft/volo/issues/21890 (write the related issue number if available)

### How to test it?
you have to change branch rel-10.2 on abp and lepton (rel-5.2)
you have to change branch issue-21879 on volo.
you have to run symlinks commands.
you have to run dev-app on volo.

