### PR TITLE
fix: OIDC schema mismatch in `AddAbpSwaggerGenWithOidc`

### DIFF
--- a/framework/src/Volo.Abp.Swashbuckle/Microsoft/Extensions/DependencyInjection/AbpSwaggerGenServiceCollectionExtensions.cs
+++ b/framework/src/Volo.Abp.Swashbuckle/Microsoft/Extensions/DependencyInjection/AbpSwaggerGenServiceCollectionExtensions.cs
@@ -104,7 +104,7 @@ public static class AbpSwaggerGenServiceCollectionExtensions
 
                     options.AddSecurityRequirement(document => new OpenApiSecurityRequirement()
                     {
-                        [new OpenApiSecuritySchemeReference("oauth2", document)] = []
+                        [new OpenApiSecuritySchemeReference("oidc", document)] = []
                     });
 
                     setupAction?.Invoke(options);


### PR DESCRIPTION
Backport of #24915 to rel-10.1.

During the Swashbuckle v10.0 upgrade (#24255), the `AddAbpSwaggerGenWithOidc` method's `SecurityRequirement` was incorrectly set to reference `"oauth2"` instead of `"oidc"`, while the `SecurityDefinition` uses `"oidc"`. This mismatch causes Swagger UI to not attach the Bearer token to API requests after authorization, resulting in HTTP 401 errors on all authenticated endpoints.

Related: https://abp.io/support/questions/10507