### PR TITLE
Upgrade TickerQ packages to 10.2.0 and add  helper to 

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -183,10 +183,10 @@
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
     <PackageVersion Include="TencentCloudSDK.Sms" Version="3.0.1273" />
     <PackageVersion Include="TimeZoneConverter" Version="7.2.0" />
-    <PackageVersion Include="TickerQ" Version="10.1.1" />
-    <PackageVersion Include="TickerQ.Dashboard" Version="10.1.1" />
-    <PackageVersion Include="TickerQ.Utilities" Version="10.1.1" />
-    <PackageVersion Include="TickerQ.EntityFrameworkCore" Version="10.1.1" />
+    <PackageVersion Include="TickerQ" Version="10.2.0" />
+    <PackageVersion Include="TickerQ.Dashboard" Version="10.2.0" />
+    <PackageVersion Include="TickerQ.Utilities" Version="10.2.0" />
+    <PackageVersion Include="TickerQ.EntityFrameworkCore" Version="10.2.0" />
     <PackageVersion Include="Unidecode.NET" Version="2.1.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.extensibility.execution" Version="2.9.3" />

--- a/docs/en/framework/infrastructure/background-jobs/tickerq.md
+++ b/docs/en/framework/infrastructure/background-jobs/tickerq.md
@@ -95,13 +95,13 @@ public class CleanupJobs
 public override Task OnPreApplicationInitializationAsync(ApplicationInitializationContext context)
 {
 	var abpTickerQFunctionProvider = context.ServiceProvider.GetRequiredService<AbpTickerQFunctionProvider>();
-	abpTickerQFunctionProvider.Functions.TryAdd(nameof(CleanupJobs), (string.Empty, TickerTaskPriority.Normal, new TickerFunctionDelegate(async (cancellationToken, serviceProvider, tickerFunctionContext) =>
+	abpTickerQFunctionProvider.AddFunction(nameof(CleanupJobs), async (cancellationToken, serviceProvider, tickerFunctionContext) =>
 	{
 		var service = new CleanupJobs(); // Or get it from the serviceProvider
 		var request = await TickerRequestProvider.GetRequestAsync<string>(tickerFunctionContext, cancellationToken);
 		var genericContext = new TickerFunctionContext<string>(tickerFunctionContext, request);
 		await service.CleanupLogsAsync(genericContext, cancellationToken);
-	}), 0));
+	}, TickerTaskPriority.Normal);
 	abpTickerQFunctionProvider.RequestTypes.TryAdd(nameof(CleanupJobs), (typeof(string).FullName, typeof(string)));
 	return Task.CompletedTask;
 }

--- a/docs/en/framework/infrastructure/background-jobs/tickerq.md
+++ b/docs/en/framework/infrastructure/background-jobs/tickerq.md
@@ -101,7 +101,7 @@ public override Task OnPreApplicationInitializationAsync(ApplicationInitializati
 		var request = await TickerRequestProvider.GetRequestAsync<string>(tickerFunctionContext, cancellationToken);
 		var genericContext = new TickerFunctionContext<string>(tickerFunctionContext, request);
 		await service.CleanupLogsAsync(genericContext, cancellationToken);
-	})));
+	}), 0));
 	abpTickerQFunctionProvider.RequestTypes.TryAdd(nameof(CleanupJobs), (typeof(string).FullName, typeof(string)));
 	return Task.CompletedTask;
 }

--- a/docs/en/framework/infrastructure/background-workers/tickerq.md
+++ b/docs/en/framework/infrastructure/background-workers/tickerq.md
@@ -89,7 +89,7 @@ public override Task OnPreApplicationInitializationAsync(ApplicationInitializati
 		var request = await TickerRequestProvider.GetRequestAsync<string>(tickerFunctionContext, cancellationToken);
 		var genericContext = new TickerFunctionContext<string>(tickerFunctionContext, request);
 		await service.CleanupLogsAsync(genericContext, cancellationToken);
-	})));
+	}), 0));
 	abpTickerQFunctionProvider.RequestTypes.TryAdd(nameof(CleanupJobs), (typeof(string).FullName, typeof(string)));
 	return Task.CompletedTask;
 }
@@ -118,5 +118,5 @@ abpTickerQFunctionProvider.Functions.TryAdd(nameof(CleanupJobs), (string.Empty, 
 	var request = await TickerRequestProvider.GetRequestAsync<string>(tickerFunctionContext, cancellationToken);
 	var genericContext = new TickerFunctionContext<string>(tickerFunctionContext, request);
 	await service.CleanupLogsAsync(genericContext, cancellationToken);
-})));
+}), 0));
 ```

--- a/docs/en/framework/infrastructure/background-workers/tickerq.md
+++ b/docs/en/framework/infrastructure/background-workers/tickerq.md
@@ -83,13 +83,13 @@ public class CleanupJobs
 public override Task OnPreApplicationInitializationAsync(ApplicationInitializationContext context)
 {
 	var abpTickerQFunctionProvider = context.ServiceProvider.GetRequiredService<AbpTickerQFunctionProvider>();
-	abpTickerQFunctionProvider.Functions.TryAdd(nameof(CleanupJobs), (string.Empty, TickerTaskPriority.Normal, new TickerFunctionDelegate(async (cancellationToken, serviceProvider, tickerFunctionContext) =>
+	abpTickerQFunctionProvider.AddFunction(nameof(CleanupJobs), async (cancellationToken, serviceProvider, tickerFunctionContext) =>
 	{
 		var service = new CleanupJobs(); // Or get it from the serviceProvider
 		var request = await TickerRequestProvider.GetRequestAsync<string>(tickerFunctionContext, cancellationToken);
 		var genericContext = new TickerFunctionContext<string>(tickerFunctionContext, request);
 		await service.CleanupLogsAsync(genericContext, cancellationToken);
-	}), 0));
+	}, TickerTaskPriority.Normal);
 	abpTickerQFunctionProvider.RequestTypes.TryAdd(nameof(CleanupJobs), (typeof(string).FullName, typeof(string)));
 	return Task.CompletedTask;
 }
@@ -112,11 +112,11 @@ await cronTickerManager.AddAsync(new CronTickerEntity
 You can specify a cron expression instead of using `ICronTickerManager<CronTickerEntity>` to add a worker:
 
 ```csharp
-abpTickerQFunctionProvider.Functions.TryAdd(nameof(CleanupJobs), (string.Empty, TickerTaskPriority.Normal, new TickerFunctionDelegate(async (cancellationToken, serviceProvider, tickerFunctionContext) =>
+abpTickerQFunctionProvider.AddFunction(nameof(CleanupJobs), async (cancellationToken, serviceProvider, tickerFunctionContext) =>
 {
 	var service = new CleanupJobs();
 	var request = await TickerRequestProvider.GetRequestAsync<string>(tickerFunctionContext, cancellationToken);
 	var genericContext = new TickerFunctionContext<string>(tickerFunctionContext, request);
 	await service.CleanupLogsAsync(genericContext, cancellationToken);
-}), 0));
+}, TickerTaskPriority.Normal);
 ```

--- a/docs/en/package-version-changes.md
+++ b/docs/en/package-version-changes.md
@@ -8,10 +8,6 @@
 | Microsoft.IdentityModel.Protocols.OpenIdConnect | 8.14.0 | 8.16.0 | #25068 |
 | Microsoft.IdentityModel.Tokens | 8.14.0 | 8.16.0 | #25068 |
 | System.IdentityModel.Tokens.Jwt | 8.14.0 | 8.16.0 | #25068 |
-| TickerQ | 10.1.1 | 10.2.0 | #25091 |
-| TickerQ.Dashboard | 10.1.1 | 10.2.0 | #25091 |
-| TickerQ.EntityFrameworkCore | 10.1.1 | 10.2.0 | #25091 |
-| TickerQ.Utilities | 10.1.1 | 10.2.0 | #25091 |
 
 ## 10.3.0-preview
 

--- a/docs/en/package-version-changes.md
+++ b/docs/en/package-version-changes.md
@@ -8,6 +8,10 @@
 | Microsoft.IdentityModel.Protocols.OpenIdConnect | 8.14.0 | 8.16.0 | #25068 |
 | Microsoft.IdentityModel.Tokens | 8.14.0 | 8.16.0 | #25068 |
 | System.IdentityModel.Tokens.Jwt | 8.14.0 | 8.16.0 | #25068 |
+| TickerQ | 10.1.1 | 10.2.0 | #PR |
+| TickerQ.Dashboard | 10.1.1 | 10.2.0 | #PR |
+| TickerQ.EntityFrameworkCore | 10.1.1 | 10.2.0 | #PR |
+| TickerQ.Utilities | 10.1.1 | 10.2.0 | #PR |
 
 ## 10.3.0-preview
 

--- a/docs/en/package-version-changes.md
+++ b/docs/en/package-version-changes.md
@@ -8,10 +8,10 @@
 | Microsoft.IdentityModel.Protocols.OpenIdConnect | 8.14.0 | 8.16.0 | #25068 |
 | Microsoft.IdentityModel.Tokens | 8.14.0 | 8.16.0 | #25068 |
 | System.IdentityModel.Tokens.Jwt | 8.14.0 | 8.16.0 | #25068 |
-| TickerQ | 10.1.1 | 10.2.0 | #PR |
-| TickerQ.Dashboard | 10.1.1 | 10.2.0 | #PR |
-| TickerQ.EntityFrameworkCore | 10.1.1 | 10.2.0 | #PR |
-| TickerQ.Utilities | 10.1.1 | 10.2.0 | #PR |
+| TickerQ | 10.1.1 | 10.2.0 | #25091 |
+| TickerQ.Dashboard | 10.1.1 | 10.2.0 | #25091 |
+| TickerQ.EntityFrameworkCore | 10.1.1 | 10.2.0 | #25091 |
+| TickerQ.Utilities | 10.1.1 | 10.2.0 | #25091 |
 
 ## 10.3.0-preview
 

--- a/docs/en/package-version-changes.md
+++ b/docs/en/package-version-changes.md
@@ -8,6 +8,10 @@
 | Microsoft.IdentityModel.Protocols.OpenIdConnect | 8.14.0 | 8.16.0 | #25068 |
 | Microsoft.IdentityModel.Tokens | 8.14.0 | 8.16.0 | #25068 |
 | System.IdentityModel.Tokens.Jwt | 8.14.0 | 8.16.0 | #25068 |
+| TickerQ | 10.1.1 | 10.2.0 | #25091 |
+| TickerQ.Dashboard | 10.1.1 | 10.2.0 | #25091 |
+| TickerQ.EntityFrameworkCore | 10.1.1 | 10.2.0 | #25091 |
+| TickerQ.Utilities | 10.1.1 | 10.2.0 | #25091 |
 
 ## 10.3.0-preview
 

--- a/framework/src/Volo.Abp.BackgroundJobs.TickerQ/Volo/Abp/BackgroundJobs/TickerQ/AbpBackgroundJobsTickerQModule.cs
+++ b/framework/src/Volo.Abp.BackgroundJobs.TickerQ/Volo/Abp/BackgroundJobs/TickerQ/AbpBackgroundJobsTickerQModule.cs
@@ -23,14 +23,14 @@ public class AbpBackgroundJobsTickerQModule : AbpModule
     {
         var abpBackgroundJobOptions = context.ServiceProvider.GetRequiredService<IOptions<AbpBackgroundJobOptions>>();
         var abpBackgroundJobsTickerQOptions = context.ServiceProvider.GetRequiredService<IOptions<AbpBackgroundJobsTickerQOptions>>();
-        var tickerFunctionDelegates = new Dictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate)>();
+        var tickerFunctionDelegates = new Dictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate, int)>();
         var requestTypes = new Dictionary<string, (string, Type)>();
         foreach (var jobConfiguration in abpBackgroundJobOptions.Value.GetJobs())
         {
             var genericMethod = GetTickerFunctionDelegateMethod.MakeGenericMethod(jobConfiguration.ArgsType);
             var tickerFunctionDelegate = (TickerFunctionDelegate)genericMethod.Invoke(null, [jobConfiguration.ArgsType])!;
             var config = abpBackgroundJobsTickerQOptions.Value.GetConfigurationOrNull(jobConfiguration.JobType);
-            tickerFunctionDelegates.TryAdd(jobConfiguration.JobName, (string.Empty, config?.Priority ?? TickerTaskPriority.Normal, tickerFunctionDelegate));
+            tickerFunctionDelegates.TryAdd(jobConfiguration.JobName, (string.Empty, config?.Priority ?? TickerTaskPriority.Normal, tickerFunctionDelegate, config?.MaxConcurrency ?? 0));
             requestTypes.TryAdd(jobConfiguration.JobName, (jobConfiguration.ArgsType.FullName, jobConfiguration.ArgsType)!);
         }
 

--- a/framework/src/Volo.Abp.BackgroundJobs.TickerQ/Volo/Abp/BackgroundJobs/TickerQ/AbpBackgroundJobsTickerQModule.cs
+++ b/framework/src/Volo.Abp.BackgroundJobs.TickerQ/Volo/Abp/BackgroundJobs/TickerQ/AbpBackgroundJobsTickerQModule.cs
@@ -23,26 +23,14 @@ public class AbpBackgroundJobsTickerQModule : AbpModule
     {
         var abpBackgroundJobOptions = context.ServiceProvider.GetRequiredService<IOptions<AbpBackgroundJobOptions>>();
         var abpBackgroundJobsTickerQOptions = context.ServiceProvider.GetRequiredService<IOptions<AbpBackgroundJobsTickerQOptions>>();
-        var tickerFunctionDelegates = new Dictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate, int)>();
-        var requestTypes = new Dictionary<string, (string, Type)>();
+        var abpTickerQFunctionProvider = context.ServiceProvider.GetRequiredService<AbpTickerQFunctionProvider>();
         foreach (var jobConfiguration in abpBackgroundJobOptions.Value.GetJobs())
         {
             var genericMethod = GetTickerFunctionDelegateMethod.MakeGenericMethod(jobConfiguration.ArgsType);
             var tickerFunctionDelegate = (TickerFunctionDelegate)genericMethod.Invoke(null, [jobConfiguration.ArgsType])!;
             var config = abpBackgroundJobsTickerQOptions.Value.GetConfigurationOrNull(jobConfiguration.JobType);
-            tickerFunctionDelegates.TryAdd(jobConfiguration.JobName, (string.Empty, config?.Priority ?? TickerTaskPriority.Normal, tickerFunctionDelegate, config?.MaxConcurrency ?? 0));
-            requestTypes.TryAdd(jobConfiguration.JobName, (jobConfiguration.ArgsType.FullName, jobConfiguration.ArgsType)!);
-        }
-
-        var abpTickerQFunctionProvider = context.ServiceProvider.GetRequiredService<AbpTickerQFunctionProvider>();
-        foreach (var functionDelegate in tickerFunctionDelegates)
-        {
-            abpTickerQFunctionProvider.Functions.TryAdd(functionDelegate.Key, functionDelegate.Value);
-        }
-
-        foreach (var requestType in requestTypes)
-        {
-            abpTickerQFunctionProvider.RequestTypes.TryAdd(requestType.Key, requestType.Value);
+            abpTickerQFunctionProvider.AddFunction(jobConfiguration.JobName, tickerFunctionDelegate, config?.Priority ?? TickerTaskPriority.Normal, config?.MaxConcurrency ?? 0);
+            abpTickerQFunctionProvider.RequestTypes.TryAdd(jobConfiguration.JobName, (jobConfiguration.ArgsType.FullName, jobConfiguration.ArgsType)!);
         }
     }
 

--- a/framework/src/Volo.Abp.BackgroundJobs.TickerQ/Volo/Abp/BackgroundJobs/TickerQ/AbpBackgroundJobsTimeTickerConfiguration.cs
+++ b/framework/src/Volo.Abp.BackgroundJobs.TickerQ/Volo/Abp/BackgroundJobs/TickerQ/AbpBackgroundJobsTimeTickerConfiguration.cs
@@ -10,5 +10,7 @@ public class AbpBackgroundJobsTimeTickerConfiguration
 
     public TickerTaskPriority? Priority { get; set; }
 
+    public int? MaxConcurrency { get; set; }
+
     public RunCondition? RunCondition { get; set; }
 }

--- a/framework/src/Volo.Abp.BackgroundWorkers.TickerQ/Volo/Abp/BackgroundWorkers/TickerQ/AbpBackgroundWorkersCronTickerConfiguration.cs
+++ b/framework/src/Volo.Abp.BackgroundWorkers.TickerQ/Volo/Abp/BackgroundWorkers/TickerQ/AbpBackgroundWorkersCronTickerConfiguration.cs
@@ -9,4 +9,6 @@ public class AbpBackgroundWorkersCronTickerConfiguration
     public int[]? RetryIntervals { get; set; }
 
     public TickerTaskPriority? Priority { get; set; }
+
+    public int? MaxConcurrency { get; set; }
 }

--- a/framework/src/Volo.Abp.BackgroundWorkers.TickerQ/Volo/Abp/BackgroundWorkers/TickerQ/AbpTickerQBackgroundWorkerManager.cs
+++ b/framework/src/Volo.Abp.BackgroundWorkers.TickerQ/Volo/Abp/BackgroundWorkers/TickerQ/AbpTickerQBackgroundWorkerManager.cs
@@ -57,7 +57,7 @@ public class AbpTickerQBackgroundWorkerManager : BackgroundWorkerManager, ISingl
             {
                 var workerInvoker = new AbpTickerQPeriodicBackgroundWorkerInvoker(worker, serviceProvider);
                 await workerInvoker.DoWorkAsync(tickerFunctionContext, tickerQCancellationToken);
-            }));
+            }, config?.MaxConcurrency ?? 0));
 
             AbpTickerQBackgroundWorkersProvider.BackgroundWorkers.Add(name!, new AbpTickerQCronBackgroundWorker
             {

--- a/framework/src/Volo.Abp.BackgroundWorkers.TickerQ/Volo/Abp/BackgroundWorkers/TickerQ/AbpTickerQBackgroundWorkerManager.cs
+++ b/framework/src/Volo.Abp.BackgroundWorkers.TickerQ/Volo/Abp/BackgroundWorkers/TickerQ/AbpTickerQBackgroundWorkerManager.cs
@@ -53,11 +53,11 @@ public class AbpTickerQBackgroundWorkerManager : BackgroundWorkerManager, ISingl
             var name = BackgroundWorkerNameAttribute.GetNameOrNull(worker.GetType()) ?? worker.GetType().FullName;
 
             var config = Options.GetConfigurationOrNull(ProxyHelper.GetUnProxiedType(worker));
-            AbpTickerQFunctionProvider.Functions.TryAdd(name!, (string.Empty, config?.Priority ?? TickerTaskPriority.LongRunning, async (tickerQCancellationToken, serviceProvider, tickerFunctionContext) =>
+            AbpTickerQFunctionProvider.AddFunction(name!, async (tickerQCancellationToken, serviceProvider, tickerFunctionContext) =>
             {
                 var workerInvoker = new AbpTickerQPeriodicBackgroundWorkerInvoker(worker, serviceProvider);
                 await workerInvoker.DoWorkAsync(tickerFunctionContext, tickerQCancellationToken);
-            }, config?.MaxConcurrency ?? 0));
+            }, config?.Priority ?? TickerTaskPriority.LongRunning, config?.MaxConcurrency ?? 0);
 
             AbpTickerQBackgroundWorkersProvider.BackgroundWorkers.Add(name!, new AbpTickerQCronBackgroundWorker
             {

--- a/framework/src/Volo.Abp.TickerQ/Volo/Abp/TickerQ/AbpTickerQFunctionProvider.cs
+++ b/framework/src/Volo.Abp.TickerQ/Volo/Abp/TickerQ/AbpTickerQFunctionProvider.cs
@@ -24,6 +24,17 @@ public class AbpTickerQFunctionProvider : ISingletonDependency
         TickerTaskPriority priority = TickerTaskPriority.Normal,
         int maxConcurrency = 0)
     {
-        Functions.TryAdd(name, (string.Empty, priority, function, maxConcurrency));
+        Check.NotNullOrWhiteSpace(name, nameof(name));
+        Check.NotNull(function, nameof(function));
+
+        if (maxConcurrency < 0)
+        {
+            throw new ArgumentException("maxConcurrency must be greater than or equal to 0.", nameof(maxConcurrency));
+        }
+
+        if (!Functions.TryAdd(name, (string.Empty, priority, function, maxConcurrency)))
+        {
+            throw new AbpException($"A function with the name '{name}' is already registered.");
+        }
     }
 }

--- a/framework/src/Volo.Abp.TickerQ/Volo/Abp/TickerQ/AbpTickerQFunctionProvider.cs
+++ b/framework/src/Volo.Abp.TickerQ/Volo/Abp/TickerQ/AbpTickerQFunctionProvider.cs
@@ -8,13 +8,13 @@ namespace Volo.Abp.TickerQ;
 
 public class AbpTickerQFunctionProvider : ISingletonDependency
 {
-    public Dictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate)> Functions { get;}
+    public Dictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate, int)> Functions { get;}
 
     public Dictionary<string, (string, Type)> RequestTypes { get; }
 
     public AbpTickerQFunctionProvider()
     {
-        Functions = new Dictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate)>();
+        Functions = new Dictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate, int)>();
         RequestTypes = new Dictionary<string, (string, Type)>();
     }
 }

--- a/framework/src/Volo.Abp.TickerQ/Volo/Abp/TickerQ/AbpTickerQFunctionProvider.cs
+++ b/framework/src/Volo.Abp.TickerQ/Volo/Abp/TickerQ/AbpTickerQFunctionProvider.cs
@@ -8,13 +8,22 @@ namespace Volo.Abp.TickerQ;
 
 public class AbpTickerQFunctionProvider : ISingletonDependency
 {
-    public Dictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate, int)> Functions { get;}
+    public Dictionary<string, (string CronExpression, TickerTaskPriority Priority, TickerFunctionDelegate Function, int MaxConcurrency)> Functions { get; }
 
-    public Dictionary<string, (string, Type)> RequestTypes { get; }
+    public Dictionary<string, (string TypeName, Type Type)> RequestTypes { get; }
 
     public AbpTickerQFunctionProvider()
     {
         Functions = new Dictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate, int)>();
         RequestTypes = new Dictionary<string, (string, Type)>();
+    }
+
+    public void AddFunction(
+        string name,
+        TickerFunctionDelegate function,
+        TickerTaskPriority priority = TickerTaskPriority.Normal,
+        int maxConcurrency = 0)
+    {
+        Functions.TryAdd(name, (string.Empty, priority, function, maxConcurrency));
     }
 }

--- a/modules/background-jobs/app/Volo.Abp.BackgroundJobs.DemoApp.TickerQ/DemoAppTickerQModule.cs
+++ b/modules/background-jobs/app/Volo.Abp.BackgroundJobs.DemoApp.TickerQ/DemoAppTickerQModule.cs
@@ -83,7 +83,7 @@ public class DemoAppTickerQModule : AbpModule
             var request = await TickerRequestProvider.GetRequestAsync<string>(tickerFunctionContext, cancellationToken);
             var genericContext = new TickerFunctionContext<string>(tickerFunctionContext, request);
             await service.CleanupLogsAsync(genericContext, cancellationToken);
-        })));
+        }), 0));
         abpTickerQFunctionProvider.RequestTypes.TryAdd(nameof(CleanupJobs), (typeof(string).FullName, typeof(string)));
         return Task.CompletedTask;
     }

--- a/modules/background-jobs/app/Volo.Abp.BackgroundJobs.DemoApp.TickerQ/DemoAppTickerQModule.cs
+++ b/modules/background-jobs/app/Volo.Abp.BackgroundJobs.DemoApp.TickerQ/DemoAppTickerQModule.cs
@@ -77,13 +77,13 @@ public class DemoAppTickerQModule : AbpModule
     public override Task OnPreApplicationInitializationAsync(ApplicationInitializationContext context)
     {
         var abpTickerQFunctionProvider = context.ServiceProvider.GetRequiredService<AbpTickerQFunctionProvider>();
-        abpTickerQFunctionProvider.Functions.TryAdd(nameof(CleanupJobs), (string.Empty, TickerTaskPriority.Normal, new TickerFunctionDelegate(async (cancellationToken, serviceProvider, tickerFunctionContext) =>
+        abpTickerQFunctionProvider.AddFunction(nameof(CleanupJobs), async (cancellationToken, serviceProvider, tickerFunctionContext) =>
         {
             var service = new CleanupJobs();
             var request = await TickerRequestProvider.GetRequestAsync<string>(tickerFunctionContext, cancellationToken);
             var genericContext = new TickerFunctionContext<string>(tickerFunctionContext, request);
             await service.CleanupLogsAsync(genericContext, cancellationToken);
-        }), 0));
+        }, TickerTaskPriority.Normal);
         abpTickerQFunctionProvider.RequestTypes.TryAdd(nameof(CleanupJobs), (typeof(string).FullName, typeof(string)));
         return Task.CompletedTask;
     }


### PR DESCRIPTION
Upgrades all TickerQ-related NuGet packages from `10.1.1` to `10.2.0`.

TickerQ 10.2.0 adds per-function concurrency control via a new `maxConcurrency` parameter, changing the function registration tuple from 3 to 4 elements. This PR follows that change and also adds:

- `AddFunction` helper method on `AbpTickerQFunctionProvider` with input validation and duplicate-registration guard, as a cleaner alternative to `Functions.TryAdd`.
- `MaxConcurrency` property on `AbpBackgroundJobsTimeTickerConfiguration` and `AbpBackgroundWorkersCronTickerConfiguration`.
- Updated all internal call sites and documentation samples.