### PR TITLE
fix: avoid spacing for hidden MVC inputs

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpInputTagHelperService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpInputTagHelperService.cs
@@ -28,19 +28,21 @@ public class AbpInputTagHelperService : AbpTagHelperService<AbpInputTagHelper>
 
     public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
     {
-        var (innerHtml, isCheckBox, isHidden) = await GetFormInputGroupAsHtmlAsync(context, output);
+        var (innerHtml, isCheckBox) = await GetFormInputGroupAsHtmlAsync(context, output);
 
         if (isCheckBox && TagHelper.CheckBoxHiddenInputRenderMode.HasValue)
         {
             TagHelper.ViewContext.CheckBoxHiddenInputRenderMode = TagHelper.CheckBoxHiddenInputRenderMode.Value;
         }
 
+        var isHidden = await IsFormInputGroupHiddenAsync(context, output);
+
         var order = TagHelper.AspFor.ModelExplorer.GetDisplayOrder();
 
         AddGroupToFormGroupContents(
             context,
             TagHelper.AspFor.Name,
-            SurroundInnerHtmlAndGet(context, output, innerHtml, isCheckBox, isHidden),
+            GetWrappedInnerHtml(context, output, innerHtml, isCheckBox, isHidden),
             order,
             out var suppress
         );
@@ -83,17 +85,23 @@ public class AbpInputTagHelperService : AbpTagHelperService<AbpInputTagHelper>
         }
     }
 
-    protected virtual async Task<(string, bool, bool)> GetFormInputGroupAsHtmlAsync(TagHelperContext context, TagHelperOutput output)
+    protected virtual async Task<(string, bool)> GetFormInputGroupAsHtmlAsync(TagHelperContext context, TagHelperOutput output)
     {
         var (inputTag, isCheckBox) = await GetInputTagHelperOutputAsync(context, output);
-        var isHidden = IsOutputHidden(inputTag);
 
         var inputHtml = inputTag.Render(_encoder);
         var label = await GetLabelAsHtmlAsync(context, output, inputTag, isCheckBox);
         var info = GetInfoAsHtml(context, output, inputTag, isCheckBox);
         var validation = isCheckBox ? "" : await GetValidationAsHtmlAsync(context, output, inputTag);
 
-        return (GetContent(context, output, label, inputHtml, validation, info, isCheckBox), isCheckBox, isHidden);
+        return (GetContent(context, output, label, inputHtml, validation, info, isCheckBox), isCheckBox);
+    }
+
+    protected virtual async Task<bool> IsFormInputGroupHiddenAsync(TagHelperContext context, TagHelperOutput output)
+    {
+        var (inputTag, _) = await GetInputTagHelperOutputAsync(context, output);
+
+        return IsOutputHidden(inputTag);
     }
 
     protected virtual async Task<string> GetValidationAsHtmlAsync(TagHelperContext context, TagHelperOutput output, TagHelperOutput inputTag)
@@ -123,31 +131,57 @@ public class AbpInputTagHelperService : AbpTagHelperService<AbpInputTagHelper>
         return innerContent + validation + infoHtml;
     }
 
-    protected virtual string SurroundInnerHtmlAndGet(TagHelperContext context, TagHelperOutput output, string innerHtml, bool isCheckbox, bool isHidden)
+    protected virtual string GetWrappedInnerHtml(TagHelperContext context, TagHelperOutput output, string innerHtml, bool isCheckbox, bool isHidden)
     {
-        var classNames = new List<string>();
+        var html = SurroundInnerHtmlAndGet(context, output, innerHtml, isCheckbox);
 
-        if (isCheckbox)
-        {
-            classNames.Add("custom-checkbox");
-            classNames.Add("custom-control");
-        }
+        return isHidden ? RemoveMarginBottomClass(html) : html;
+    }
 
-        if (!isHidden && TagHelper.AddMarginBottomClass)
-        {
-            classNames.Add(isCheckbox ? "mb-2" : "mb-3");
-        }
+    protected virtual string SurroundInnerHtmlAndGet(TagHelperContext context, TagHelperOutput output, string innerHtml, bool isCheckbox)
+    {
+        var mb = TagHelper.AddMarginBottomClass ? (isCheckbox ? "mb-2" : "mb-3") : string.Empty;
 
-        if (isCheckbox)
-        {
-            classNames.Add("form-check");
-        }
-
-        var classAttribute = classNames.Count > 0 ? " class=\"" + string.Join(" ", classNames) + "\"" : string.Empty;
-
-        return "<div" + classAttribute + ">" +
+        return "<div class=\"" + (isCheckbox ? $"custom-checkbox custom-control {mb} form-check" : $"{mb}") + "\">" +
                 Environment.NewLine + innerHtml + Environment.NewLine +
                 "</div>";
+    }
+
+    protected virtual string RemoveMarginBottomClass(string html)
+    {
+        var openingTagEndIndex = html.IndexOf('>');
+        if (openingTagEndIndex < 0)
+        {
+            return html;
+        }
+
+        var openingTag = html.Substring(0, openingTagEndIndex);
+
+        const string classAttributePrefix = " class=\"";
+        var classAttributeIndex = openingTag.IndexOf(classAttributePrefix, StringComparison.Ordinal);
+        if (classAttributeIndex < 0)
+        {
+            return html;
+        }
+
+        var classValueStartIndex = classAttributeIndex + classAttributePrefix.Length;
+        var classValueEndIndex = openingTag.IndexOf('"', classValueStartIndex);
+        if (classValueEndIndex < 0)
+        {
+            return html;
+        }
+
+        var classNames = openingTag
+            .Substring(classValueStartIndex, classValueEndIndex - classValueStartIndex)
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .Where(className => className != "mb-2" && className != "mb-3")
+            .ToList();
+
+        var updatedOpeningTag = classNames.Count > 0
+            ? openingTag.Substring(0, classAttributeIndex) + classAttributePrefix + string.Join(" ", classNames) + "\"" + openingTag.Substring(classValueEndIndex + 1)
+            : openingTag.Remove(classAttributeIndex, classValueEndIndex - classAttributeIndex + 1);
+
+        return updatedOpeningTag + html.Substring(openingTagEndIndex);
     }
 
     protected virtual TagHelper GetInputTagHelper(TagHelperContext context, TagHelperOutput output)

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpInputTagHelperService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpInputTagHelperService.cs
@@ -35,14 +35,12 @@ public class AbpInputTagHelperService : AbpTagHelperService<AbpInputTagHelper>
             TagHelper.ViewContext.CheckBoxHiddenInputRenderMode = TagHelper.CheckBoxHiddenInputRenderMode.Value;
         }
 
-        var isHidden = await IsFormInputGroupHiddenAsync(context, output);
-
         var order = TagHelper.AspFor.ModelExplorer.GetDisplayOrder();
 
         AddGroupToFormGroupContents(
             context,
             TagHelper.AspFor.Name,
-            GetWrappedInnerHtml(context, output, innerHtml, isCheckBox, isHidden),
+            SurroundInnerHtmlAndGet(context, output, innerHtml, isCheckBox),
             order,
             out var suppress
         );
@@ -56,7 +54,7 @@ public class AbpInputTagHelperService : AbpTagHelperService<AbpInputTagHelper>
             output.TagMode = TagMode.StartTagAndEndTag;
             output.TagName = "div";
             LeaveOnlyGroupAttributes(context, output);
-            if (!isHidden)
+            if (!IsInputHidden(context))
             {
                 if (TagHelper.FloatingLabel && !isCheckBox)
                 {
@@ -88,6 +86,7 @@ public class AbpInputTagHelperService : AbpTagHelperService<AbpInputTagHelper>
     protected virtual async Task<(string, bool)> GetFormInputGroupAsHtmlAsync(TagHelperContext context, TagHelperOutput output)
     {
         var (inputTag, isCheckBox) = await GetInputTagHelperOutputAsync(context, output);
+        context.Items[nameof(IsOutputHidden)] = IsOutputHidden(inputTag);
 
         var inputHtml = inputTag.Render(_encoder);
         var label = await GetLabelAsHtmlAsync(context, output, inputTag, isCheckBox);
@@ -95,13 +94,6 @@ public class AbpInputTagHelperService : AbpTagHelperService<AbpInputTagHelper>
         var validation = isCheckBox ? "" : await GetValidationAsHtmlAsync(context, output, inputTag);
 
         return (GetContent(context, output, label, inputHtml, validation, info, isCheckBox), isCheckBox);
-    }
-
-    protected virtual async Task<bool> IsFormInputGroupHiddenAsync(TagHelperContext context, TagHelperOutput output)
-    {
-        var (inputTag, _) = await GetInputTagHelperOutputAsync(context, output);
-
-        return IsOutputHidden(inputTag);
     }
 
     protected virtual async Task<string> GetValidationAsHtmlAsync(TagHelperContext context, TagHelperOutput output, TagHelperOutput inputTag)
@@ -131,57 +123,13 @@ public class AbpInputTagHelperService : AbpTagHelperService<AbpInputTagHelper>
         return innerContent + validation + infoHtml;
     }
 
-    protected virtual string GetWrappedInnerHtml(TagHelperContext context, TagHelperOutput output, string innerHtml, bool isCheckbox, bool isHidden)
-    {
-        var html = SurroundInnerHtmlAndGet(context, output, innerHtml, isCheckbox);
-
-        return isHidden ? RemoveMarginBottomClass(html) : html;
-    }
-
     protected virtual string SurroundInnerHtmlAndGet(TagHelperContext context, TagHelperOutput output, string innerHtml, bool isCheckbox)
     {
-        var mb = TagHelper.AddMarginBottomClass ? (isCheckbox ? "mb-2" : "mb-3") : string.Empty;
-
+        var isHidden = IsInputHidden(context);
+        var mb = !isHidden && TagHelper.AddMarginBottomClass ? (isCheckbox ? "mb-2" : "mb-3") : string.Empty;
         return "<div class=\"" + (isCheckbox ? $"custom-checkbox custom-control {mb} form-check" : $"{mb}") + "\">" +
                 Environment.NewLine + innerHtml + Environment.NewLine +
                 "</div>";
-    }
-
-    protected virtual string RemoveMarginBottomClass(string html)
-    {
-        var openingTagEndIndex = html.IndexOf('>');
-        if (openingTagEndIndex < 0)
-        {
-            return html;
-        }
-
-        var openingTag = html.Substring(0, openingTagEndIndex);
-
-        const string classAttributePrefix = " class=\"";
-        var classAttributeIndex = openingTag.IndexOf(classAttributePrefix, StringComparison.Ordinal);
-        if (classAttributeIndex < 0)
-        {
-            return html;
-        }
-
-        var classValueStartIndex = classAttributeIndex + classAttributePrefix.Length;
-        var classValueEndIndex = openingTag.IndexOf('"', classValueStartIndex);
-        if (classValueEndIndex < 0)
-        {
-            return html;
-        }
-
-        var classNames = openingTag
-            .Substring(classValueStartIndex, classValueEndIndex - classValueStartIndex)
-            .Split(' ', StringSplitOptions.RemoveEmptyEntries)
-            .Where(className => className != "mb-2" && className != "mb-3")
-            .ToList();
-
-        var updatedOpeningTag = classNames.Count > 0
-            ? openingTag.Substring(0, classAttributeIndex) + classAttributePrefix + string.Join(" ", classNames) + "\"" + openingTag.Substring(classValueEndIndex + 1)
-            : openingTag.Remove(classAttributeIndex, classValueEndIndex - classAttributeIndex + 1);
-
-        return updatedOpeningTag + html.Substring(openingTagEndIndex);
     }
 
     protected virtual TagHelper GetInputTagHelper(TagHelperContext context, TagHelperOutput output)
@@ -568,6 +516,11 @@ public class AbpInputTagHelperService : AbpTagHelperService<AbpInputTagHelper>
     protected virtual bool IsOutputHidden(TagHelperOutput inputTag)
     {
         return inputTag.Attributes.Any(a => a.Name.ToLowerInvariant() == "type" && a.Value.ToString()!.ToLowerInvariant() == "hidden");
+    }
+
+    protected virtual bool IsInputHidden(TagHelperContext context)
+    {
+        return context.Items.TryGetValue(nameof(IsOutputHidden), out var val) && val is true;
     }
 
     protected virtual string GetIdAttributeValue(TagHelperOutput inputTag)

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpInputTagHelperService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpInputTagHelperService.cs
@@ -28,7 +28,7 @@ public class AbpInputTagHelperService : AbpTagHelperService<AbpInputTagHelper>
 
     public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
     {
-        var (innerHtml, isCheckBox) = await GetFormInputGroupAsHtmlAsync(context, output);
+        var (innerHtml, isCheckBox, isHidden) = await GetFormInputGroupAsHtmlAsync(context, output);
 
         if (isCheckBox && TagHelper.CheckBoxHiddenInputRenderMode.HasValue)
         {
@@ -40,7 +40,7 @@ public class AbpInputTagHelperService : AbpTagHelperService<AbpInputTagHelper>
         AddGroupToFormGroupContents(
             context,
             TagHelper.AspFor.Name,
-            SurroundInnerHtmlAndGet(context, output, innerHtml, isCheckBox),
+            SurroundInnerHtmlAndGet(context, output, innerHtml, isCheckBox, isHidden),
             order,
             out var suppress
         );
@@ -54,7 +54,7 @@ public class AbpInputTagHelperService : AbpTagHelperService<AbpInputTagHelper>
             output.TagMode = TagMode.StartTagAndEndTag;
             output.TagName = "div";
             LeaveOnlyGroupAttributes(context, output);
-            if (!IsOutputHidden(output))
+            if (!isHidden)
             {
                 if (TagHelper.FloatingLabel && !isCheckBox)
                 {
@@ -83,16 +83,17 @@ public class AbpInputTagHelperService : AbpTagHelperService<AbpInputTagHelper>
         }
     }
 
-    protected virtual async Task<(string, bool)> GetFormInputGroupAsHtmlAsync(TagHelperContext context, TagHelperOutput output)
+    protected virtual async Task<(string, bool, bool)> GetFormInputGroupAsHtmlAsync(TagHelperContext context, TagHelperOutput output)
     {
         var (inputTag, isCheckBox) = await GetInputTagHelperOutputAsync(context, output);
+        var isHidden = IsOutputHidden(inputTag);
 
         var inputHtml = inputTag.Render(_encoder);
         var label = await GetLabelAsHtmlAsync(context, output, inputTag, isCheckBox);
         var info = GetInfoAsHtml(context, output, inputTag, isCheckBox);
         var validation = isCheckBox ? "" : await GetValidationAsHtmlAsync(context, output, inputTag);
 
-        return (GetContent(context, output, label, inputHtml, validation, info, isCheckBox), isCheckBox);
+        return (GetContent(context, output, label, inputHtml, validation, info, isCheckBox), isCheckBox, isHidden);
     }
 
     protected virtual async Task<string> GetValidationAsHtmlAsync(TagHelperContext context, TagHelperOutput output, TagHelperOutput inputTag)
@@ -122,10 +123,29 @@ public class AbpInputTagHelperService : AbpTagHelperService<AbpInputTagHelper>
         return innerContent + validation + infoHtml;
     }
 
-    protected virtual string SurroundInnerHtmlAndGet(TagHelperContext context, TagHelperOutput output, string innerHtml, bool isCheckbox)
+    protected virtual string SurroundInnerHtmlAndGet(TagHelperContext context, TagHelperOutput output, string innerHtml, bool isCheckbox, bool isHidden)
     {
-        var mb = TagHelper.AddMarginBottomClass ? (isCheckbox ? "mb-2" : "mb-3") : string.Empty;
-        return "<div class=\"" + (isCheckbox ? $"custom-checkbox custom-control {mb} form-check" : $"{mb}") + "\">" +
+        var classNames = new List<string>();
+
+        if (isCheckbox)
+        {
+            classNames.Add("custom-checkbox");
+            classNames.Add("custom-control");
+        }
+
+        if (!isHidden && TagHelper.AddMarginBottomClass)
+        {
+            classNames.Add(isCheckbox ? "mb-2" : "mb-3");
+        }
+
+        if (isCheckbox)
+        {
+            classNames.Add("form-check");
+        }
+
+        var classAttribute = classNames.Count > 0 ? " class=\"" + string.Join(" ", classNames) + "\"" : string.Empty;
+
+        return "<div" + classAttribute + ">" +
                 Environment.NewLine + innerHtml + Environment.NewLine +
                 "</div>";
     }

--- a/framework/test/Volo.Abp.AspNetCore.Mvc.UI.Tests/Volo.Abp.AspNetCore.Mvc.UI.Tests.csproj
+++ b/framework/test/Volo.Abp.AspNetCore.Mvc.UI.Tests/Volo.Abp.AspNetCore.Mvc.UI.Tests.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Volo.Abp.AspNetCore.Mvc.UI.Bootstrap\Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.csproj" />
     <ProjectReference Include="..\..\src\Volo.Abp.AspNetCore.Mvc.UI.Bundling\Volo.Abp.AspNetCore.Mvc.UI.Bundling.csproj" />
     <ProjectReference Include="..\..\src\Volo.Abp.Autofac\Volo.Abp.Autofac.csproj" />
     <ProjectReference Include="..\Volo.Abp.AspNetCore.Tests\Volo.Abp.AspNetCore.Tests.csproj" />

--- a/framework/test/Volo.Abp.AspNetCore.Mvc.UI.Tests/Volo/Abp/AspNetCore/Mvc/UI/Bootstrap/TagHelpers/Form/AbpInputTagHelperService_Tests.cs
+++ b/framework/test/Volo.Abp.AspNetCore.Mvc.UI.Tests/Volo/Abp/AspNetCore/Mvc/UI/Bootstrap/TagHelpers/Form/AbpInputTagHelperService_Tests.cs
@@ -1,0 +1,96 @@
+using System.Collections.Generic;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Shouldly;
+using Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Form;
+using Xunit;
+
+namespace Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Form;
+
+public class AbpInputTagHelperService_Tests
+{
+    [Fact]
+    public async Task Hidden_inputs_should_not_add_margin_bottom_classes()
+    {
+        var service = new TestAbpInputTagHelperService(isHidden: true);
+        var tagHelper = new AbpInputTagHelper(service)
+        {
+            AspFor = CreateModelExpression()
+        };
+
+        var output = CreateOutput();
+
+        await tagHelper.ProcessAsync(CreateContext(), output);
+
+        output.Attributes.ContainsName("class").ShouldBeFalse();
+        service.LastGroupHtml.ShouldNotContain("mb-3");
+    }
+
+    [Fact]
+    public async Task Visible_inputs_should_keep_margin_bottom_classes()
+    {
+        var service = new TestAbpInputTagHelperService(isHidden: false);
+        var tagHelper = new AbpInputTagHelper(service)
+        {
+            AspFor = CreateModelExpression()
+        };
+
+        var output = CreateOutput();
+
+        await tagHelper.ProcessAsync(CreateContext(), output);
+
+        output.Attributes["class"].Value.ShouldBe("mb-3");
+        service.LastGroupHtml.ShouldContain("mb-3");
+    }
+
+    private static TagHelperContext CreateContext()
+    {
+        return new TagHelperContext(
+            new TagHelperAttributeList(),
+            new Dictionary<object, object>(),
+            "test");
+    }
+
+    private static TagHelperOutput CreateOutput()
+    {
+        return new TagHelperOutput(
+            "abp-input",
+            new TagHelperAttributeList(),
+            (_, _) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
+    }
+
+    private static ModelExpression CreateModelExpression()
+    {
+        var metadataProvider = new EmptyModelMetadataProvider();
+        return new ModelExpression(
+            "HiddenInput",
+            metadataProvider.GetModelExplorerForType(typeof(string), null));
+    }
+
+    private sealed class TestAbpInputTagHelperService : AbpInputTagHelperService
+    {
+        private readonly bool _isHidden;
+
+        public string LastGroupHtml { get; private set; } = string.Empty;
+
+        public TestAbpInputTagHelperService(bool isHidden)
+            : base(null!, HtmlEncoder.Default, null!)
+        {
+            _isHidden = isHidden;
+        }
+
+        protected override Task<(string, bool, bool)> GetFormInputGroupAsHtmlAsync(TagHelperContext context, TagHelperOutput output)
+        {
+            return Task.FromResult(("<input />", false, _isHidden));
+        }
+
+        protected override void AddGroupToFormGroupContents(TagHelperContext context, string propertyName, string html, int order, out bool suppress)
+        {
+            LastGroupHtml = html;
+            suppress = false;
+        }
+    }
+}

--- a/framework/test/Volo.Abp.AspNetCore.Mvc.UI.Tests/Volo/Abp/AspNetCore/Mvc/UI/Bootstrap/TagHelpers/Form/AbpInputTagHelperService_Tests.cs
+++ b/framework/test/Volo.Abp.AspNetCore.Mvc.UI.Tests/Volo/Abp/AspNetCore/Mvc/UI/Bootstrap/TagHelpers/Form/AbpInputTagHelperService_Tests.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Shouldly;
-using Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Form;
 using Xunit;
 
 namespace Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Form;
@@ -15,7 +14,7 @@ public class AbpInputTagHelperService_Tests
     [Fact]
     public async Task Hidden_inputs_should_not_add_margin_bottom_classes()
     {
-        var service = new TestAbpInputTagHelperService(isHidden: true);
+        var service = new TestAbpInputTagHelperService("hidden");
         var tagHelper = new AbpInputTagHelper(service)
         {
             AspFor = CreateModelExpression()
@@ -32,7 +31,7 @@ public class AbpInputTagHelperService_Tests
     [Fact]
     public async Task Visible_inputs_should_keep_margin_bottom_classes()
     {
-        var service = new TestAbpInputTagHelperService(isHidden: false);
+        var service = new TestAbpInputTagHelperService("text");
         var tagHelper = new AbpInputTagHelper(service)
         {
             AspFor = CreateModelExpression()
@@ -72,19 +71,46 @@ public class AbpInputTagHelperService_Tests
 
     private sealed class TestAbpInputTagHelperService : AbpInputTagHelperService
     {
-        private readonly bool _isHidden;
+        private readonly string _inputTypeName;
 
         public string LastGroupHtml { get; private set; } = string.Empty;
 
-        public TestAbpInputTagHelperService(bool isHidden)
+        public TestAbpInputTagHelperService(string inputTypeName)
             : base(null!, HtmlEncoder.Default, null!)
         {
-            _isHidden = isHidden;
+            _inputTypeName = inputTypeName;
         }
 
-        protected override Task<(string, bool, bool)> GetFormInputGroupAsHtmlAsync(TagHelperContext context, TagHelperOutput output)
+        protected override Task<(TagHelperOutput, bool)> GetInputTagHelperOutputAsync(TagHelperContext context, TagHelperOutput output)
         {
-            return Task.FromResult(("<input />", false, _isHidden));
+            var inputTagHelperOutput = new TagHelperOutput(
+                "input",
+                new TagHelperAttributeList
+                {
+                    { "type", _inputTypeName },
+                    { "id", "HiddenInput" },
+                    { "class", "form-control" }
+                },
+                (_, _) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
+
+            inputTagHelperOutput.TagMode = TagMode.SelfClosing;
+
+            return Task.FromResult((inputTagHelperOutput, false));
+        }
+
+        protected override Task<string> GetLabelAsHtmlAsync(TagHelperContext context, TagHelperOutput output, TagHelperOutput inputTag, bool isCheckbox)
+        {
+            return Task.FromResult(string.Empty);
+        }
+
+        protected override Task<string> GetValidationAsHtmlAsync(TagHelperContext context, TagHelperOutput output, TagHelperOutput inputTag)
+        {
+            return Task.FromResult(string.Empty);
+        }
+
+        protected override string GetInfoAsHtml(TagHelperContext context, TagHelperOutput output, TagHelperOutput inputTag, bool isCheckbox)
+        {
+            return string.Empty;
         }
 
         protected override void AddGroupToFormGroupContents(TagHelperContext context, string propertyName, string html, int order, out bool suppress)

--- a/modules/basic-theme/test/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.Demo/Pages/Components/DynamicForms.cshtml
+++ b/modules/basic-theme/test/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.Demo/Pages/Components/DynamicForms.cshtml
@@ -317,7 +317,7 @@ public class DynamicFormsModel : PageModel
             <abp-tab title="Rendered">
                 <pre><code>
 &lt;form method=&quot;post&quot;&gt;
-    &lt;div class=&quot;mb-3&quot;&gt;
+    &lt;div&gt;
         &lt;input type=&quot;hidden&quot; id=&quot;MyAttributeExamplesModel_HiddenInput&quot; name=&quot;MyAttributeExamplesModel.HiddenInput&quot; value=&quot;&quot; class=&quot;form-control &quot;&gt;
     &lt;/div&gt;
     &lt;div class=&quot;mb-3&quot;&gt;


### PR DESCRIPTION
## Summary
- prevent `abp-input` wrappers from adding `mb-3` or `mb-2` classes when the generated input is hidden
- add regression tests for hidden and visible input wrapper spacing in MVC UI tag helpers
- update the Bootstrap demo's rendered dynamic-form example to match the hidden input output

Prevents unwanted margin bottom from hidden inputs:
<img width="560" height="120" alt="image" src="https://github.com/user-attachments/assets/c0ccc7b3-8122-41b2-827b-34ca6cb962cb" />


## Testing
- `dotnet test \"framework/test/Volo.Abp.AspNetCore.Mvc.UI.Tests/Volo.Abp.AspNetCore.Mvc.UI.Tests.csproj\" --filter AbpInputTagHelperService_Tests`