### PR TITLE
Blazor - Adding `popper.js` dependency for bootstrap package

### DIFF
--- a/npm/packs/bootstrap/package.json
+++ b/npm/packs/bootstrap/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@abp/core": "~10.2.0-rc.2",
+    "@abp/popper.js": "~10.2.0-rc.2",
     "bootstrap": "^5.3.8"
   },
   "gitHead": "bb4ea17d5996f01889134c138d00b6c8f858a431",


### PR DESCRIPTION
### Description

Hello @enisn, we come accross such problem on a Blazor no-layered template. I suspected that the bootstrap version requires a certain popper.js dependency. That is why, I made such an update to solve the problem. 

<img width="1536" height="804" alt="image" src="https://github.com/user-attachments/assets/39b8d29c-184e-4cd6-9a0f-a95e6f07a884" />


### Checklist

- [ ] I fully tested it as developer / designer and created unit / integration tests

### How to test it?

- You can run `yarn link` under `abp/npm/packs/bootstrap` directory.
- Then run `yarn link "@abp/bootstrap"` under the host application in the template.
- Lastly, you can re-run the initial tasks.
