### PR TITLE
fix: refresh Angular permissions after resource updates

### DIFF
--- a/npm/ng-packs/packages/permission-management/src/lib/components/resource-permission-management/resource-permission-management.component.ts
+++ b/npm/ng-packs/packages/permission-management/src/lib/components/resource-permission-management/resource-permission-management.component.ts
@@ -1,4 +1,4 @@
-import { ListService, LocalizationPipe } from '@abp/ng.core';
+import { ConfigStateService, CurrentUserDto, ListService, LocalizationPipe } from '@abp/ng.core';
 import {
   ButtonComponent,
   Confirmation,
@@ -43,6 +43,7 @@ export class ResourcePermissionManagementComponent implements OnInit {
   protected readonly confirmationService = inject(ConfirmationService);
   protected readonly state = inject(ResourcePermissionStateService);
   private readonly list = inject(ListService);
+  private readonly configState = inject(ConfigStateService);
 
   readonly resourceName = input.required<string>();
   readonly resourceKey = input.required<string>();
@@ -169,6 +170,9 @@ export class ResourcePermissionManagementComponent implements OnInit {
               grant.providerKey || '',
             )
             .pipe(
+              switchMap(() =>
+                this.refreshAppConfigIfNeeded(grant.providerName || '', grant.providerKey || ''),
+              ),
               switchMap(() => this.service.getResource(this.resourceName(), this.resourceKey())),
               finalize(() => this.state.modalBusy.set(false)),
             )
@@ -201,6 +205,7 @@ export class ResourcePermissionManagementComponent implements OnInit {
         permissions: this.state.selectedPermissions(),
       })
       .pipe(
+        switchMap(() => this.refreshAppConfigIfNeeded(providerName, providerKey)),
         switchMap(() => this.service.getResource(this.resourceName(), this.resourceKey())),
         finalize(() => this.state.modalBusy.set(false)),
       )
@@ -212,5 +217,25 @@ export class ResourcePermissionManagementComponent implements OnInit {
           this.state.goToListMode();
         },
       });
+  }
+
+  private refreshAppConfigIfNeeded(providerName: string, providerKey: string) {
+    return this.shouldFetchAppConfig(providerName, providerKey)
+      ? this.configState.refreshAppState()
+      : of(null);
+  }
+
+  private shouldFetchAppConfig(providerName: string, providerKey: string) {
+    const currentUser = (this.configState.getOne('currentUser') || {}) as CurrentUserDto;
+
+    if (providerName === 'R') {
+      return (currentUser.roles || []).some(role => role === providerKey);
+    }
+
+    if (providerName === 'U') {
+      return currentUser.id === providerKey;
+    }
+
+    return false;
   }
 }


### PR DESCRIPTION
## Summary
- refresh Angular app configuration after resource permission changes for the current user or one of the current user's roles
- let `abpPermission`-based UI react immediately after save/delete instead of waiting for a full reload
- support the permission visibility part of volosoft/volo#21899 and other resource-permission screens using the same component

## Testing
1. Open a page that uses resource permission management, such as AI Management workspaces.
2. Change a resource permission for your current user or one of your current roles.
3. Save or delete the permission and confirm the related Angular buttons update without a full page reload.