### PR TITLE
fix: rabbitmq jobQueue expiration parameter format

### DIFF
--- a/framework/src/Volo.Abp.BackgroundJobs.RabbitMQ/Volo/Abp/BackgroundJobs/RabbitMQ/JobQueue.cs
+++ b/framework/src/Volo.Abp.BackgroundJobs.RabbitMQ/Volo/Abp/BackgroundJobs/RabbitMQ/JobQueue.cs
@@ -176,10 +176,10 @@ public class JobQueue<TArgs> : IJobQueue<TArgs>
             CorrelationId = CorrelationIdProvider.Get()
         };
 
-        if (delay.HasValue)
+        if (delay.HasValue && delay.Value > TimeSpan.Zero)
         {
             routingKey = QueueConfiguration.DelayedQueueName;
-            basicProperties.Expiration = Math.Max(0, (long)Math.Ceiling(delay.Value.TotalMilliseconds)).ToString(CultureInfo.InvariantCulture);
+            basicProperties.Expiration = ((long)Math.Ceiling(delay.Value.TotalMilliseconds)).ToString(CultureInfo.InvariantCulture);
         }
 
         if (ChannelAccessor != null)

--- a/framework/src/Volo.Abp.BackgroundJobs.RabbitMQ/Volo/Abp/BackgroundJobs/RabbitMQ/JobQueue.cs
+++ b/framework/src/Volo.Abp.BackgroundJobs.RabbitMQ/Volo/Abp/BackgroundJobs/RabbitMQ/JobQueue.cs
@@ -179,7 +179,7 @@ public class JobQueue<TArgs> : IJobQueue<TArgs>
         if (delay.HasValue)
         {
             routingKey = QueueConfiguration.DelayedQueueName;
-            basicProperties.Expiration = delay.Value.TotalMilliseconds.ToString(CultureInfo.InvariantCulture);
+            basicProperties.Expiration = ((long)delay.Value.TotalMilliseconds).ToString(CultureInfo.InvariantCulture);
         }
 
         if (ChannelAccessor != null)

--- a/framework/src/Volo.Abp.BackgroundJobs.RabbitMQ/Volo/Abp/BackgroundJobs/RabbitMQ/JobQueue.cs
+++ b/framework/src/Volo.Abp.BackgroundJobs.RabbitMQ/Volo/Abp/BackgroundJobs/RabbitMQ/JobQueue.cs
@@ -179,7 +179,7 @@ public class JobQueue<TArgs> : IJobQueue<TArgs>
         if (delay.HasValue)
         {
             routingKey = QueueConfiguration.DelayedQueueName;
-            basicProperties.Expiration = Math.Max(1, (long)Math.Ceiling(delay.Value.TotalMilliseconds)).ToString(CultureInfo.InvariantCulture);
+            basicProperties.Expiration = Math.Max(0, (long)Math.Ceiling(delay.Value.TotalMilliseconds)).ToString(CultureInfo.InvariantCulture);
         }
 
         if (ChannelAccessor != null)

--- a/framework/src/Volo.Abp.BackgroundJobs.RabbitMQ/Volo/Abp/BackgroundJobs/RabbitMQ/JobQueue.cs
+++ b/framework/src/Volo.Abp.BackgroundJobs.RabbitMQ/Volo/Abp/BackgroundJobs/RabbitMQ/JobQueue.cs
@@ -179,7 +179,7 @@ public class JobQueue<TArgs> : IJobQueue<TArgs>
         if (delay.HasValue)
         {
             routingKey = QueueConfiguration.DelayedQueueName;
-            basicProperties.Expiration = ((long)delay.Value.TotalMilliseconds).ToString(CultureInfo.InvariantCulture);
+            basicProperties.Expiration = Math.Max(1, (long)Math.Ceiling(delay.Value.TotalMilliseconds)).ToString(CultureInfo.InvariantCulture);
         }
 
         if (ChannelAccessor != null)


### PR DESCRIPTION
## Problem
TimeSpan.TotalMilliseconds is a double (e.g., 1.23), while the Expiration parameter of RabbitMQ requires a non-negative integer.

This may cause the message to not be published as expected.

https://www.rabbitmq.com/docs/3.13/ttl#per-message-ttl-in-publishers

## Fix
Convert TimeSpan.TotalMilliseconds to a long value.
