### PR TITLE
bump MongoDB.Driver to 3.7.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -122,7 +122,7 @@
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.16.0" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.16.0" />
     <PackageVersion Include="Minio" Version="6.0.5" />
-    <PackageVersion Include="MongoDB.Driver" Version="3.7.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.7.1" />
     <PackageVersion Include="NEST" Version="7.17.5" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="Nito.AsyncEx.Context" Version="5.1.2" />

--- a/docs/en/package-version-changes.md
+++ b/docs/en/package-version-changes.md
@@ -7,6 +7,7 @@
 | Microsoft.IdentityModel.JsonWebTokens | 8.14.0 | 8.16.0 | #25068 |
 | Microsoft.IdentityModel.Protocols.OpenIdConnect | 8.14.0 | 8.16.0 | #25068 |
 | Microsoft.IdentityModel.Tokens | 8.14.0 | 8.16.0 | #25068 |
+| MongoDB.Driver | 3.7.0 | 3.7.1 | #25114 |
 | System.IdentityModel.Tokens.Jwt | 8.14.0 | 8.16.0 | #25068 |
 | TickerQ | 10.1.1 | 10.2.0 | #25091 |
 | TickerQ.Dashboard | 10.1.1 | 10.2.0 | #25091 |


### PR DESCRIPTION
Bumps `MongoDB.Driver` from 3.7.0 to 3.7.1 (patch release).

Release: https://github.com/mongodb/mongo-csharp-driver/releases/tag/v3.7.1