### PR TITLE
Upgrade Scriban to 6.6.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -150,7 +150,7 @@
     <PackageVersion Include="Rebus" Version="8.8.0" />
     <PackageVersion Include="Rebus.ServiceProvider" Version="10.5.0" />
     <PackageVersion Include="Riok.Mapperly" Version="4.3.1" />
-    <PackageVersion Include="Scriban" Version="6.3.0" />
+    <PackageVersion Include="Scriban" Version="6.6.0" />
     <PackageVersion Include="Serilog" Version="4.3.0" />
     <PackageVersion Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageVersion Include="Serilog.Extensions.Hosting" Version="9.0.0" />

--- a/docs/en/package-version-changes.md
+++ b/docs/en/package-version-changes.md
@@ -1,5 +1,11 @@
 # Package Version Changes
 
+## 10.2.0-rc.3
+
+| Package | Old Version | New Version | PR |
+|---------|-------------|-------------|-----|
+| Scriban | 6.3.0 | 6.6.0 | #25122 |
+
 ## 10.2.0-rc.1
 
 | Package | Old Version | New Version | PR |


### PR DESCRIPTION
Upgrade Scriban NuGet package from 6.3.0 to 6.6.0 to resolve security advisory [GHSA-5rpf-x9jg-8j5p](https://github.com/advisories/GHSA-5rpf-x9jg-8j5p) (Memory Exhaustion / DoS, medium severity).

This fixes the NU1902 NuGet security warning that causes `Add-Migration` and other build commands to fail.

Resolves #25121