### PR TITLE
fix(cli): use ToUpperInvariant for snake case replacement in SolutionRenamer

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/CliService.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/CliService.cs
@@ -165,7 +165,7 @@ public class CliService : ITransientDependency
 
             promptInput = GetPromptInput();
 
-        } while (promptInput?.ToLower() != "exit");
+        } while (promptInput?.ToLowerInvariant() != "exit");
     }
 
     private async Task RunBatchAsync(CommandLineArgs commandLineArgs)

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/BundleCommand.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/BundleCommand.cs
@@ -75,7 +75,7 @@ public class BundleCommand : IConsoleCommand, ITransientDependency
         var projectType = commandLineArgs.Options.GetOrNull(Options.ProjectType.Short, Options.ProjectType.Long);
         projectType ??= BundlingConsts.WebAssembly;
 
-        return projectType.ToLower() switch {
+        return projectType.ToLowerInvariant() switch {
             "webassembly" => BundlingConsts.WebAssembly,
             "maui-blazor" => BundlingConsts.MauiBlazor,
             _ => throw new CliUsageException(ExceptionMessageHelper.GetInvalidOptionExceptionMessage("Project Type"))

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/ProjectCreationCommandBase.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/ProjectCreationCommandBase.cs
@@ -687,7 +687,7 @@ public abstract class ProjectCreationCommandBase
 
     protected virtual Theme? GetThemeByTemplateOrNull(CommandLineArgs commandLineArgs, string template = "app")
     {
-        var theme = commandLineArgs.Options.GetOrNull(Options.Theme.Long)?.ToLower();
+        var theme = commandLineArgs.Options.GetOrNull(Options.Theme.Long)?.ToLowerInvariant();
 
         return template switch
         {
@@ -725,7 +725,7 @@ public abstract class ProjectCreationCommandBase
             return null;
         }
 
-        var themeStyle = commandLineArgs.Options.GetOrNull(Options.ThemeStyle.Long)?.ToLower();
+        var themeStyle = commandLineArgs.Options.GetOrNull(Options.ThemeStyle.Long)?.ToLowerInvariant();
 
         return themeStyle switch
         {
@@ -803,9 +803,9 @@ public abstract class ProjectCreationCommandBase
 
         var commandBuilder = new StringBuilder($"npx ng g @abp/ng.schematics:create-lib --package-name {libraryName}");
 
-        commandBuilder.Append($" --is-secondary-entrypoint {isSecondaryEndpoint.ToString().ToLower()}");
-        commandBuilder.Append($" --is-module-template {isModuleTemplate.ToString().ToLower()}");
-        commandBuilder.Append($" --override {isOverride.ToString().ToLower()}");
+        commandBuilder.Append($" --is-secondary-entrypoint {isSecondaryEndpoint.ToString().ToLowerInvariant()}");
+        commandBuilder.Append($" --is-module-template {isModuleTemplate.ToString().ToLowerInvariant()}");
+        commandBuilder.Append($" --override {isOverride.ToString().ToLowerInvariant()}");
 
         var result = CmdHelper.RunCmdAndGetOutput(commandBuilder.ToString(), workingDirectory);
         return await Task.FromResult(result);

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/ProxyCommandBase.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/ProxyCommandBase.cs
@@ -33,7 +33,7 @@ public abstract class ProxyCommandBase<T> : IConsoleCommand, ITransientDependenc
 
     public async Task ExecuteAsync(CommandLineArgs commandLineArgs)
     {
-        var generateType = commandLineArgs.Options.GetOrNull(Options.GenerateType.Short, Options.GenerateType.Long)?.ToUpper();
+        var generateType = commandLineArgs.Options.GetOrNull(Options.GenerateType.Short, Options.GenerateType.Long)?.ToUpperInvariant();
 
         if (string.IsNullOrWhiteSpace(generateType))
         {
@@ -75,9 +75,9 @@ public abstract class ProxyCommandBase<T> : IConsoleCommand, ITransientDependenc
         ServiceType? serviceType = null;
         if (!serviceTypeArg.IsNullOrWhiteSpace())
         {
-            serviceType = serviceTypeArg.ToLower() == "application"
+            serviceType = serviceTypeArg.ToLowerInvariant() == "application"
                 ? ServiceType.Application
-                : serviceTypeArg.ToLower() == "integration"
+                : serviceTypeArg.ToLowerInvariant() == "integration"
                     ? ServiceType.Integration
                     : ServiceType.All;
         }

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/Services/SuiteAppSettingsService.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/Services/SuiteAppSettingsService.cs
@@ -110,7 +110,7 @@ public class SuiteAppSettingsService : ITransientDependency
         var dotnetToolList = CmdHelper.RunCmdAndGetOutput("dotnet tool list -g", out int exitCode);
 
         var suiteLine = dotnetToolList.Split(Environment.NewLine)
-            .FirstOrDefault(l => l.ToLower().StartsWith("volo.abp.suite "));
+            .FirstOrDefault(l => l.ToLowerInvariant().StartsWith("volo.abp.suite "));
 
         if (string.IsNullOrEmpty(suiteLine))
         {

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/SuiteCommand.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Commands/SuiteCommand.cs
@@ -252,7 +252,7 @@ public class SuiteCommand : IConsoleCommand, ITransientDependency
         var dotnetToolList = CmdHelper.RunCmdAndGetOutput("dotnet tool list -g", out int exitCode);
 
         var suiteLine = dotnetToolList.Split(Environment.NewLine)
-            .FirstOrDefault(l => l.ToLower().StartsWith("volo.abp.suite "));
+            .FirstOrDefault(l => l.ToLowerInvariant().StartsWith("volo.abp.suite "));
 
         if (string.IsNullOrEmpty(suiteLine))
         {
@@ -542,7 +542,7 @@ public class SuiteCommand : IConsoleCommand, ITransientDependency
     private IEnumerable<Process> GetProcessesRelatedWithSuite()
     {
         return (from p in Process.GetProcesses()
-            where p.ProcessName.ToLower().Contains("abp-suite")
+            where p.ProcessName.ToLowerInvariant().Contains("abp-suite")
             select p);
     }
 

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectBuilding/AbpIoSourceCodeStore.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectBuilding/AbpIoSourceCodeStore.cs
@@ -356,7 +356,7 @@ public class AbpIoSourceCodeStore : ISourceCodeStore, ITransientDependency
 
     private static bool IsNetworkSource(string source)
     {
-        return source.ToLower().StartsWith("http");
+        return source.ToLowerInvariant().StartsWith("http");
     }
 
     private List<(string TemplateName, string Version)> GetLocalTemplates()

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectBuilding/Building/Steps/SolutionRenamer.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectBuilding/Building/Steps/SolutionRenamer.cs
@@ -59,7 +59,7 @@ public class SolutionRenamer
         RenameHelper.RenameAll(_entries, _projectNamePlaceHolder.ToCamelCase(), ToCamelCaseWithNamespace(_projectName));
         RenameHelper.RenameAll(_entries, _projectNamePlaceHolder.ToKebabCase(), _projectName.ToKebabCase());
         RenameHelper.RenameAll(_entries, _projectNamePlaceHolder.ToLowerInvariant(), _projectName.ToLowerInvariant());
-        RenameHelper.RenameAll(_entries, _projectNamePlaceHolder.ToSnakeCase().ToUpper(), _projectName.ToSnakeCase().ToUpper());
+        RenameHelper.RenameAll(_entries, _projectNamePlaceHolder.ToSnakeCase().ToUpperInvariant(), _projectName.ToSnakeCase().ToUpperInvariant());
     }
 
     private static string ToCamelCaseWithNamespace(string name)

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectBuilding/Templates/App/AppNoLayersTemplateBase.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectBuilding/Templates/App/AppNoLayersTemplateBase.cs
@@ -241,7 +241,7 @@ public abstract class AppNoLayersTemplateBase : TemplateInfo
 
         if (context.BuildArgs.Theme != Theme.NotSpecified)
         {
-            context.Symbols.Add(context.BuildArgs.Theme.Value.ToString().ToUpper());
+            context.Symbols.Add(context.BuildArgs.Theme.Value.ToString().ToUpperInvariant());
         }
 
         if (context.BuildArgs.Theme == Theme.LeptonX)

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectBuilding/Templates/App/AppTemplateBase.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectBuilding/Templates/App/AppTemplateBase.cs
@@ -228,7 +228,7 @@ public abstract class AppTemplateBase : TemplateInfo
 
         if (context.BuildArgs.Theme != Theme.NotSpecified)
         {
-            context.Symbols.Add(context.BuildArgs.Theme.Value.ToString().ToUpper());
+            context.Symbols.Add(context.BuildArgs.Theme.Value.ToString().ToUpperInvariant());
         }
 
         if (context.BuildArgs.Theme == Theme.LeptonX)

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectBuilding/Templates/Microservice/MicroserviceTemplateBase.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectBuilding/Templates/Microservice/MicroserviceTemplateBase.cs
@@ -41,7 +41,7 @@ public abstract class MicroserviceTemplateBase : TemplateInfo
 
         if (context.BuildArgs.Theme != Theme.NotSpecified)
         {
-            context.Symbols.Add(context.BuildArgs.Theme.Value.ToString().ToUpper());
+            context.Symbols.Add(context.BuildArgs.Theme.Value.ToString().ToUpperInvariant());
         }
 
         if (context.BuildArgs.Theme == Theme.LeptonX)

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ServiceProxying/Angular/AngularServiceProxyGenerator.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ServiceProxying/Angular/AngularServiceProxyGenerator.cs
@@ -85,7 +85,7 @@ public class AngularServiceProxyGenerator : ServiceProxyGeneratorBase<AngularSer
         }
 
         var serviceType = GetServiceType(args) ?? Volo.Abp.Cli.ServiceProxying.ServiceType.Application;
-        commandBuilder.Append($" --service-type {serviceType.ToString().ToLower()}");
+        commandBuilder.Append($" --service-type {serviceType.ToString().ToLowerInvariant()}");
 
 
         _cmdhelper.RunCmd(commandBuilder.ToString());


### PR DESCRIPTION
## Summary

This PR replaces `ToUpper()` with `ToUpperInvariant()` in `SolutionRenamer` to avoid culture-sensitive casing issues during project/module name replacement.

## Why

Issue #24988 reports incorrect Angular route name generation when the module name contains the letter `i`, for example `FinancialOperations`.

Using `ToUpper()` can produce culture-specific results on some systems, while `ToUpperInvariant()` ensures consistent behavior across environments.

## Change

- Replaced:
  - `_projectNamePlaceHolder.ToSnakeCase().ToUpper()`
  - `_projectName.ToSnakeCase().ToUpper()`

- With:
  - `_projectNamePlaceHolder.ToSnakeCase().ToUpperInvariant()`
  - `_projectName.ToSnakeCase().ToUpperInvariant()`

## Notes

The change is isolated and minimal.