### PR TITLE
Set default MaxDepth for all AutoMapper maps to mitigate GHSA-rvv3-g6hj-g44x

### DIFF
--- a/framework/src/Volo.Abp.AutoMapper/Volo/Abp/AutoMapper/AbpAutoMapperModule.cs
+++ b/framework/src/Volo.Abp.AutoMapper/Volo/Abp/AutoMapper/AbpAutoMapperModule.cs
@@ -40,6 +40,14 @@ public class AbpAutoMapperModule : AbpModule
                     configurator(autoMapperConfigurationContext);
                 }
 
+                mapperConfigurationExpression.Internal().ForAllMaps((typeMap, _) =>
+                {
+                    if (typeMap.MaxDepth == 0)
+                    {
+                        typeMap.MaxDepth = 64;
+                    }
+                });
+
                 var mapperConfiguration = new MapperConfiguration(mapperConfigurationExpression);
 
                 foreach (var profileType in options.ValidatingProfiles)

--- a/framework/src/Volo.Abp.AutoMapper/Volo/Abp/AutoMapper/AbpAutoMapperModule.cs
+++ b/framework/src/Volo.Abp.AutoMapper/Volo/Abp/AutoMapper/AbpAutoMapperModule.cs
@@ -40,13 +40,16 @@ public class AbpAutoMapperModule : AbpModule
                     configurator(autoMapperConfigurationContext);
                 }
 
-                mapperConfigurationExpression.Internal().ForAllMaps((typeMap, _) =>
+                if (options.DefaultMaxDepth.HasValue)
                 {
-                    if (typeMap.MaxDepth == 0)
+                    mapperConfigurationExpression.Internal().ForAllMaps((typeMap, _) =>
                     {
-                        typeMap.MaxDepth = 64;
-                    }
-                });
+                        if (typeMap.MaxDepth == 0)
+                        {
+                            typeMap.MaxDepth = options.DefaultMaxDepth.Value;
+                        }
+                    });
+                }
 
                 var mapperConfiguration = new MapperConfiguration(mapperConfigurationExpression);
 

--- a/framework/src/Volo.Abp.AutoMapper/Volo/Abp/AutoMapper/AbpAutoMapperOptions.cs
+++ b/framework/src/Volo.Abp.AutoMapper/Volo/Abp/AutoMapper/AbpAutoMapperOptions.cs
@@ -12,6 +12,13 @@ public class AbpAutoMapperOptions
 
     public ITypeList<Profile> ValidatingProfiles { get; set; }
 
+    /// <summary>
+    /// Default MaxDepth applied to all maps that don't have an explicit MaxDepth configured.
+    /// Set to null to disable the default MaxDepth behavior.
+    /// Default: 64.
+    /// </summary>
+    public int? DefaultMaxDepth { get; set; } = 64;
+
     public AbpAutoMapperOptions()
     {
         Configurators = new List<Action<IAbpAutoMapperConfigurationContext>>();

--- a/framework/test/Volo.Abp.AutoMapper.Tests/Volo/Abp/AutoMapper/AbpAutoMapperModule_MaxDepth_Tests.cs
+++ b/framework/test/Volo.Abp.AutoMapper.Tests/Volo/Abp/AutoMapper/AbpAutoMapperModule_MaxDepth_Tests.cs
@@ -1,0 +1,65 @@
+using AutoMapper;
+using AutoMapper.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Volo.Abp.AutoMapper.SampleClasses;
+using Volo.Abp.Modularity;
+using Volo.Abp.ObjectExtending;
+using Volo.Abp.Testing;
+using Xunit;
+
+namespace Volo.Abp.AutoMapper;
+
+public class AbpAutoMapperModule_MaxDepth_Tests : AbpIntegratedTest<AutoMapperTestModule>
+{
+    private readonly IConfigurationProvider _configurationProvider;
+
+    public AbpAutoMapperModule_MaxDepth_Tests()
+    {
+        _configurationProvider = ServiceProvider.GetRequiredService<IConfigurationProvider>();
+    }
+
+    [Fact]
+    public void Should_Set_Default_MaxDepth_For_All_Maps()
+    {
+        var typeMap = _configurationProvider.Internal().FindTypeMapFor<MyEntity, MyEntityDto>();
+        typeMap.ShouldNotBeNull();
+        typeMap.MaxDepth.ShouldBe(64);
+    }
+}
+
+public class AbpAutoMapperModule_CustomMaxDepth_Tests : AbpIntegratedTest<AbpAutoMapperModule_CustomMaxDepth_Tests.TestModule>
+{
+    private readonly IConfigurationProvider _configurationProvider;
+
+    public AbpAutoMapperModule_CustomMaxDepth_Tests()
+    {
+        _configurationProvider = ServiceProvider.GetRequiredService<IConfigurationProvider>();
+    }
+
+    [Fact]
+    public void Should_Not_Override_Custom_MaxDepth()
+    {
+        var typeMap = _configurationProvider.Internal().FindTypeMapFor<MyEntity, MyEntityDto>();
+        typeMap.ShouldNotBeNull();
+        typeMap.MaxDepth.ShouldBe(10);
+    }
+
+    [DependsOn(
+        typeof(AbpAutoMapperModule),
+        typeof(AbpObjectExtendingTestModule)
+    )]
+    public class TestModule : AbpModule
+    {
+        public override void ConfigureServices(ServiceConfigurationContext context)
+        {
+            Configure<AbpAutoMapperOptions>(options =>
+            {
+                options.Configurators.Add(ctx =>
+                {
+                    ctx.MapperConfiguration.CreateMap<MyEntity, MyEntityDto>().MaxDepth(10);
+                });
+            });
+        }
+    }
+}

--- a/framework/test/Volo.Abp.AutoMapper.Tests/Volo/Abp/AutoMapper/AbpAutoMapperModule_MaxDepth_Tests.cs
+++ b/framework/test/Volo.Abp.AutoMapper.Tests/Volo/Abp/AutoMapper/AbpAutoMapperModule_MaxDepth_Tests.cs
@@ -63,3 +63,40 @@ public class AbpAutoMapperModule_CustomMaxDepth_Tests : AbpIntegratedTest<AbpAut
         }
     }
 }
+
+public class AbpAutoMapperModule_DisabledMaxDepth_Tests : AbpIntegratedTest<AbpAutoMapperModule_DisabledMaxDepth_Tests.TestModule>
+{
+    private readonly IConfigurationProvider _configurationProvider;
+
+    public AbpAutoMapperModule_DisabledMaxDepth_Tests()
+    {
+        _configurationProvider = ServiceProvider.GetRequiredService<IConfigurationProvider>();
+    }
+
+    [Fact]
+    public void Should_Not_Set_MaxDepth_When_Disabled()
+    {
+        var typeMap = _configurationProvider.Internal().FindTypeMapFor<MyEntity, MyEntityDto>();
+        typeMap.ShouldNotBeNull();
+        typeMap.MaxDepth.ShouldBe(0);
+    }
+
+    [DependsOn(
+        typeof(AbpAutoMapperModule),
+        typeof(AbpObjectExtendingTestModule)
+    )]
+    public class TestModule : AbpModule
+    {
+        public override void ConfigureServices(ServiceConfigurationContext context)
+        {
+            Configure<AbpAutoMapperOptions>(options =>
+            {
+                options.DefaultMaxDepth = null;
+                options.Configurators.Add(ctx =>
+                {
+                    ctx.MapperConfiguration.CreateMap<MyEntity, MyEntityDto>();
+                });
+            });
+        }
+    }
+}


### PR DESCRIPTION
AutoMapper 14.0.0 has a known DoS vulnerability (GHSA-rvv3-g6hj-g44x) caused by deeply nested object graphs leading to StackOverflow. The AutoMapper maintainer has confirmed that no patch will be released for version 14.x (see https://github.com/LuckyPennySoftware/AutoMapper/issues/4618), only commercial versions (15.x/16.x) have been patched.

This PR adds a code-level mitigation in `AbpAutoMapperModule` by setting `MaxDepth = 64` for all maps that don't have an explicit `MaxDepth` configured. This prevents the StackOverflow DoS while preserving any custom `MaxDepth` values set by users.

Resolves #25137