### PR TITLE
Add ABP 10.3 availability note to dynamic features articles

### DIFF
--- a/docs/en/Community-Articles/2026-03-21-Dynamic-Background-Jobs-and-Workers-in-ABP/POST.md
+++ b/docs/en/Community-Articles/2026-03-21-Dynamic-Background-Jobs-and-Workers-in-ABP/POST.md
@@ -1,5 +1,7 @@
 # Dynamic Background Jobs and Workers in ABP
 
+> This feature is available since ABP 10.3.
+
 ABP's Background Jobs and Background Workers are two well-established infrastructure pieces. Background jobs handle fire-and-forget async tasks — sending emails, generating reports, processing orders. Background workers handle continuously running periodic tasks — syncing inventory, cleaning up expired data, pushing scheduled notifications.
 
 This works great, but it has one assumption: **you know all your job and worker types at compile time**.

--- a/docs/en/Community-Articles/2026-03-23-Dynamic-Events-in-ABP/POST.md
+++ b/docs/en/Community-Articles/2026-03-23-Dynamic-Events-in-ABP/POST.md
@@ -1,5 +1,7 @@
 # Dynamic Events in ABP
 
+> This feature is available since ABP 10.3.
+
 ABP's Event Bus is a core infrastructure piece. The **Local Event Bus** handles in-process communication between services. The **Distributed Event Bus** handles cross-service communication over message brokers like RabbitMQ, Kafka, Azure Service Bus, and Rebus.
 
 Both are fully type-safe — you define event types at compile time, register handlers via DI, and everything is wired up automatically. This works great, but it has one assumption: **you know all your event types at compile time**.


### PR DESCRIPTION
Added a note to the Dynamic Background Jobs/Workers and Dynamic Events community articles indicating that these features are available since ABP 10.3.

Affected articles:
- `docs/en/Community-Articles/2026-03-21-Dynamic-Background-Jobs-and-Workers-in-ABP/POST.md`
- `docs/en/Community-Articles/2026-03-23-Dynamic-Events-in-ABP/POST.md`