### PR TITLE
fix: use  for semaphore wait in 

### DIFF
--- a/framework/src/Volo.Abp.BackgroundWorkers/Volo/Abp/BackgroundWorkers/DefaultDynamicBackgroundWorkerManager.cs
+++ b/framework/src/Volo.Abp.BackgroundWorkers/Volo/Abp/BackgroundWorkers/DefaultDynamicBackgroundWorkerManager.cs
@@ -144,7 +144,7 @@ public class DefaultDynamicBackgroundWorkerManager : IDynamicBackgroundWorkerMan
             return;
         }
 
-        await _semaphore.WaitAsync(cancellationToken);
+        await _semaphore.WaitAsync(CancellationToken.None);
         try
         {
             if (_isDisposed)


### PR DESCRIPTION
When the app shuts down, the `ApplicationStopping` token is already cancelled, causing `_semaphore.WaitAsync(cancellationToken)` in `StopAllAsync` to immediately throw a `TaskCanceledException`. Changed to `CancellationToken.None` so the cleanup always completes.