### PR TITLE
Fix stdout/stderr deadlock in CmdHelper.RunCmdAndGetOutput

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Utils/CmdHelper.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Utils/CmdHelper.cs
@@ -141,10 +141,8 @@ public class CmdHelper : ICmdHelper, ITransientDependency
             var outputTask = process.StandardOutput.ReadToEndAsync();
             var errorTask = process.StandardError.ReadToEndAsync();
 
-            output = Task.WhenAll(outputTask, errorTask).GetAwaiter().GetResult()
-                is { Length: 2 } results
-                ? results[0] + results[1]
-                : string.Empty;
+            var results = Task.WhenAll(outputTask, errorTask).GetAwaiter().GetResult();
+            output = results[0] + results[1];
 
             process.WaitForExit();
 

--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Utils/CmdHelper.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/Utils/CmdHelper.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using Volo.Abp.DependencyInjection;
 
@@ -137,14 +138,13 @@ public class CmdHelper : ICmdHelper, ITransientDependency
 
             process.Start();
 
-            using (var standardOutput = process.StandardOutput)
-            {
-                using (var standardError = process.StandardError)
-                {
-                    output = standardOutput.ReadToEnd();
-                    output += standardError.ReadToEnd();
-                }
-            }
+            var outputTask = process.StandardOutput.ReadToEndAsync();
+            var errorTask = process.StandardError.ReadToEndAsync();
+
+            output = Task.WhenAll(outputTask, errorTask).GetAwaiter().GetResult()
+                is { Length: 2 } results
+                ? results[0] + results[1]
+                : string.Empty;
 
             process.WaitForExit();
 

--- a/framework/test/Volo.Abp.Cli.Core.Tests/Volo/Abp/Cli/Utils/CmdHelper_Tests.cs
+++ b/framework/test/Volo.Abp.Cli.Core.Tests/Volo/Abp/Cli/Utils/CmdHelper_Tests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Shouldly;
+using Volo.Abp.Cli.Utils;
+using Xunit;
+
+namespace Volo.Abp.Cli.Utils;
+
+public class CmdHelper_Tests : AbpCliTestBase
+{
+    private readonly ICmdHelper _cmdHelper;
+
+    public CmdHelper_Tests()
+    {
+        _cmdHelper = GetRequiredService<ICmdHelper>();
+    }
+
+    [Fact]
+    public async Task RunCmdAndGetOutput_Should_Not_Deadlock_With_Large_Stdout_And_Stderr()
+    {
+        // Reproduces the deadlock bug where sequential ReadToEnd() on stdout then stderr
+        // would block indefinitely when both pipe buffers (~64 KB on Linux/macOS, ~4 KB on
+        // Windows) filled up simultaneously. The process was blocked writing to stderr while
+        // the caller was blocked waiting for stdout to close — a classic pipe deadlock.
+        //
+        // The fix reads both streams concurrently via ReadToEndAsync + Task.WhenAll, which
+        // drains both pipes at the same time and avoids the deadlock.
+        var command = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? @"for /L %i in (1,1,3000) do @(echo stdout-line-%i & echo stderr-line-%i 1>&2)"
+            : "for i in $(seq 1 5000); do echo stdout-line-$i; echo stderr-line-$i >&2; done";
+
+        string output = null;
+        var cmdTask = Task.Run(() => output = _cmdHelper.RunCmdAndGetOutput(command));
+        var completed = await Task.WhenAny(cmdTask, Task.Delay(TimeSpan.FromSeconds(30)));
+
+        // The original sequential code deadlocked here; 30 s is a generous upper bound.
+        (completed == cmdTask).ShouldBeTrue(
+            "RunCmdAndGetOutput should not deadlock when both stdout and stderr produce large output");
+
+        await cmdTask;
+
+        output.ShouldNotBeNullOrWhiteSpace();
+        output.ShouldContain("stdout-line-");
+        output.ShouldContain("stderr-line-");
+    }
+}

--- a/framework/test/Volo.Abp.Cli.Core.Tests/Volo/Abp/Cli/Utils/CmdHelper_Tests.cs
+++ b/framework/test/Volo.Abp.Cli.Core.Tests/Volo/Abp/Cli/Utils/CmdHelper_Tests.cs
@@ -32,9 +32,9 @@ public class CmdHelper_Tests : AbpCliTestBase
 
         string output = null;
         var cmdTask = Task.Run(() => output = _cmdHelper.RunCmdAndGetOutput(command));
-        var completed = await Task.WhenAny(cmdTask, Task.Delay(TimeSpan.FromSeconds(30)));
+        var completed = await Task.WhenAny(cmdTask, Task.Delay(TimeSpan.FromSeconds(10)));
 
-        // The original sequential code deadlocked here; 30 s is a generous upper bound.
+        // The original sequential code deadlocked here; 10 s is a generous upper bound.
         (completed == cmdTask).ShouldBeTrue(
             "RunCmdAndGetOutput should not deadlock when both stdout and stderr produce large output");
 


### PR DESCRIPTION
## Summary

- Fix a classic stdout/stderr pipe deadlock in `CmdHelper.RunCmdAndGetOutput` by reading both streams concurrently instead of sequentially.

## Problem

The `RunCmdAndGetOutput` method reads stdout synchronously to completion **before** reading stderr:

```csharp
output = standardOutput.ReadToEnd();   // blocks until child closes stdout
output += standardError.ReadToEnd();   // never reached if stderr buffer fills
```

When a child process (e.g. `dotnet build`) produces enough stderr output to fill the OS pipe buffer (~4KB on Windows), a deadlock occurs:
- **Parent** blocks on `standardOutput.ReadToEnd()` waiting for the child to close stdout
- **Child** blocks writing to stderr because the buffer is full and the parent isn't draining it

This is a [well-documented .NET pitfall](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.standarderror#remarks).

### Reproduction scenario

A new ABP project with transitive `Scriban 6.3.0` dependency triggers 40+ NuGet vulnerability warnings on stderr during `dotnet build`. When `abp create-migration-and-run-migrator` runs, it hangs indefinitely at *"Creating initial migrations..."* because `InitialMigrationCreator` calls `CmdHelper.RunCmdAndGetOutput("dotnet build", ...)` which deadlocks.

## Fix

Read both streams concurrently using `ReadToEndAsync()`:

```csharp
var outputTask = process.StandardOutput.ReadToEndAsync();
var errorTask = process.StandardError.ReadToEndAsync();

output = Task.WhenAll(outputTask, errorTask).GetAwaiter().GetResult()
    is { Length: 2 } results
    ? results[0] + results[1]
    : string.Empty;
```

This ensures neither pipe can block the other, regardless of output volume.