### PR TITLE
Upgrade Scriban to 7.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -150,7 +150,7 @@
     <PackageVersion Include="Rebus" Version="8.8.0" />
     <PackageVersion Include="Rebus.ServiceProvider" Version="10.5.0" />
     <PackageVersion Include="Riok.Mapperly" Version="4.3.1" />
-    <PackageVersion Include="Scriban" Version="6.6.0" />
+    <PackageVersion Include="Scriban" Version="7.0.0" />
     <PackageVersion Include="Serilog" Version="4.3.0" />
     <PackageVersion Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageVersion Include="Serilog.Extensions.Hosting" Version="9.0.0" />

--- a/docs/en/package-version-changes.md
+++ b/docs/en/package-version-changes.md
@@ -1,5 +1,11 @@
 # Package Version Changes
 
+## 10.2.0-rc.4
+
+| Package | Old Version | New Version | PR |
+|---------|-------------|-------------|-----|
+| Scriban | 6.6.0 | 7.0.0 | #25170 |
+
 ## 10.2.0-rc.3
 
 | Package | Old Version | New Version | PR |

--- a/framework/src/Volo.Abp.TextTemplating.Scriban/Volo/Abp/TextTemplating/Scriban/ScribanTemplateLocalizer.cs
+++ b/framework/src/Volo.Abp.TextTemplating.Scriban/Volo/Abp/TextTemplating/Scriban/ScribanTemplateLocalizer.cs
@@ -18,16 +18,16 @@ public class ScribanTemplateLocalizer : IScriptCustomFunction
         _localizer = localizer;
     }
 
-    public object Invoke(TemplateContext context, ScriptNode callerContext, ScriptArray arguments,
-        ScriptBlockStatement blockStatement)
+    public object? Invoke(TemplateContext context, ScriptNode? callerContext, ScriptArray arguments,
+        ScriptBlockStatement? blockStatement)
     {
         return GetString(arguments);
     }
 
-    public ValueTask<object> InvokeAsync(TemplateContext context, ScriptNode callerContext, ScriptArray arguments,
-        ScriptBlockStatement blockStatement)
+    public ValueTask<object?> InvokeAsync(TemplateContext context, ScriptNode? callerContext, ScriptArray arguments,
+        ScriptBlockStatement? blockStatement)
     {
-        return new ValueTask<object>(GetString(arguments));
+        return new ValueTask<object?>(GetString(arguments));
     }
 
     private string GetString(ScriptArray arguments)
@@ -43,7 +43,7 @@ public class ScribanTemplateLocalizer : IScriptCustomFunction
             return string.Empty;
         }
 
-        var args = arguments.Skip(1).Where(x => x != null && !x.ToString().IsNullOrWhiteSpace()).ToArray();
+        var args = arguments.Skip(1).Where(x => x != null && !x.ToString().IsNullOrWhiteSpace()).Cast<object>().ToArray();
         return args.Any() ? _localizer[name.ToString()!, args] : _localizer[name.ToString()!];
     }
 


### PR DESCRIPTION
Upgrade Scriban from 6.6.0 to 7.0.0 to fix security vulnerability GHSA-v66j-x4hw-fv9g (DoS via `string.pad_left`/`string.pad_right` without width validation).

Scriban 7.0.0 changed `ParserOptions` and `LexerOptions` from `struct` to `record`, which also adds nullable annotations to `IScriptCustomFunction` interface. Updated `ScribanTemplateLocalizer` to match the new interface signatures.

Users who previously tried to override Scriban to 7.0.0 encountered a `TypeLoadException` due to the value type mismatch between the ABP NuGet package (compiled against 6.x) and Scriban 7.0.0 at runtime. This upgrade resolves that issue.