### PR TITLE
Use `HttpPost` for `PermissionIntegrationController.IsGrantedAsync`

### DIFF
--- a/modules/permission-management/src/Volo.Abp.PermissionManagement.HttpApi.Client/ClientProxies/permissionManagement-generate-proxy.json
+++ b/modules/permission-management/src/Volo.Abp.PermissionManagement.HttpApi.Client/ClientProxies/permissionManagement-generate-proxy.json
@@ -21,7 +21,7 @@
                   "parametersOnMethod": [
                     {
                       "name": "input",
-                      "typeAsString": "System.Collections.Generic.List`1[[Volo.Abp.PermissionManagement.IsGrantedRequest, Volo.Abp.PermissionManagement.Domain.Shared, Version=10.1.0.0, Culture=neutral, PublicKeyToken=null]], System.Private.CoreLib",
+                      "typeAsString": "System.Collections.Generic.List`1[[Volo.Abp.PermissionManagement.IsGrantedRequest, Volo.Abp.PermissionManagement.Domain.Shared, Version=10.3.0.0, Culture=neutral, PublicKeyToken=null]], System.Private.CoreLib",
                       "type": "System.Collections.Generic.List<Volo.Abp.PermissionManagement.IsGrantedRequest>",
                       "typeSimple": "[Volo.Abp.PermissionManagement.IsGrantedRequest]",
                       "isOptional": false,
@@ -40,13 +40,13 @@
             "IsGrantedAsyncByInput": {
               "uniqueName": "IsGrantedAsyncByInput",
               "name": "IsGrantedAsync",
-              "httpMethod": "GET",
+              "httpMethod": "POST",
               "url": "integration-api/permission-management/permissions/is-granted",
               "supportedVersions": [],
               "parametersOnMethod": [
                 {
                   "name": "input",
-                  "typeAsString": "System.Collections.Generic.List`1[[Volo.Abp.PermissionManagement.IsGrantedRequest, Volo.Abp.PermissionManagement.Domain.Shared, Version=10.1.0.0, Culture=neutral, PublicKeyToken=null]], System.Private.CoreLib",
+                  "typeAsString": "System.Collections.Generic.List`1[[Volo.Abp.PermissionManagement.IsGrantedRequest, Volo.Abp.PermissionManagement.Domain.Shared, Version=10.3.0.0, Culture=neutral, PublicKeyToken=null]], System.Private.CoreLib",
                   "type": "System.Collections.Generic.List<Volo.Abp.PermissionManagement.IsGrantedRequest>",
                   "typeSimple": "[Volo.Abp.PermissionManagement.IsGrantedRequest]",
                   "isOptional": false,
@@ -63,7 +63,7 @@
                   "isOptional": false,
                   "defaultValue": null,
                   "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
+                  "bindingSourceId": "Body",
                   "descriptorName": ""
                 }
               ],

--- a/modules/permission-management/src/Volo.Abp.PermissionManagement.HttpApi/Volo/Abp/PermissionManagement/Integration/PermissionIntegrationController.cs
+++ b/modules/permission-management/src/Volo.Abp.PermissionManagement.HttpApi/Volo/Abp/PermissionManagement/Integration/PermissionIntegrationController.cs
@@ -20,7 +20,7 @@ public class PermissionIntegrationController: AbpControllerBase, IPermissionInte
         PermissionIntegrationService = permissionIntegrationService;
     }
 
-    [HttpGet]
+    [HttpPost]
     [Route("is-granted")]
     public virtual Task<ListResultDto<IsGrantedResponse>> IsGrantedAsync(List<IsGrantedRequest> input)
     {


### PR DESCRIPTION
The `IsGrantedAsync` endpoint was using `[HttpGet]`, which requires passing `List<IsGrantedRequest>` via query string and can easily exceed URL length limits when checking multiple users and permissions.

Changed to `[HttpPost]` so the payload is sent in the request body.

Closes #25175