### PR TITLE
Require delete permission for deleting posts

### DIFF
--- a/modules/blogging/src/Volo.Blogging.Web/Pages/Blogs/Posts/Detail.cshtml
+++ b/modules/blogging/src/Volo.Blogging.Web/Pages/Blogs/Posts/Detail.cshtml
@@ -95,7 +95,7 @@
                                                 <i class="fa fa-pencil"></i> @L["Edit"]
                                             </a>
                                         }
-                                        @if (await Authorization.IsGrantedAsync(BloggingPermissions.Posts.Delete) || (CurrentUser.Id.HasValue && CurrentUser.Id == Model.Post.CreatorId))
+                                        @if (await Authorization.IsGrantedAsync(BloggingPermissions.Posts.Delete))
                                         {
                                             <span class="seperator">|</span>
                                             <a href="#" id="DeletePostLink" data-postid="@Model.Post.Id" data-blogShortName="@Model.BlogShortName">


### PR DESCRIPTION
Remove the special-case that allowed a post's creator to delete it without the Posts.Delete permission. The Razor view (Detail.cshtml) now only shows the delete link when the user is granted BloggingPermissions.Posts.Delete, enforcing permission-based deletion for consistency and tighter access control.

### Description

Resolves [vs-internal-issue-#8299](https://github.com/volosoft/vs-internal/issues/8299)

### Checklist

- [ ] I fully tested it as developer
- [ ] no need to document
