### PR TITLE
docs: address Copilot review feedback on dynamic events PR

### DIFF
--- a/docs/en/Community-Articles/2026-03-23-Dynamic-Events-in-ABP/POST.md
+++ b/docs/en/Community-Articles/2026-03-23-Dynamic-Events-in-ABP/POST.md
@@ -127,6 +127,7 @@ public class PartnerOrderHandler : IDistributedEventHandler<DynamicEventData>
 Typed and dynamic handlers coexist naturally. When both are registered for the same event name, **both are triggered** — the framework automatically converts the data to the appropriate format for each handler.
 
 ```csharp
+var eventBus = context.ServiceProvider.GetRequiredService<IDistributedEventBus>();
 var scopeFactory = context.ServiceProvider.GetRequiredService<IServiceScopeFactory>();
 
 // Typed handler — receives OrderPlacedEto

--- a/docs/en/Community-Articles/2026-03-23-Dynamic-Events-in-ABP/POST.md
+++ b/docs/en/Community-Articles/2026-03-23-Dynamic-Events-in-ABP/POST.md
@@ -120,13 +120,15 @@ public class PartnerOrderHandler : IDistributedEventHandler<DynamicEventData>
 - **`EventName`** — the string name that identifies the event
 - **`Data`** — the raw event data payload (the deserialized `object` from the broker)
 
-> `Subscribe` returns an `IDisposable`. Call `Dispose()` to unsubscribe the handler at runtime. For application-lifetime subscriptions, prefer module initialization (`OnApplicationInitializationAsync`) over subscribing inside an application service.
+> `Subscribe` returns an `IDisposable`. Call `Dispose()` to unsubscribe the handler at runtime. For application-lifetime subscriptions, prefer module initialization (`OnApplicationInitialization` / `OnApplicationInitializationAsync`) over subscribing inside an application service.
 
 ## Mixed Typed and Dynamic Handlers
 
 Typed and dynamic handlers coexist naturally. When both are registered for the same event name, **both are triggered** — the framework automatically converts the data to the appropriate format for each handler.
 
 ```csharp
+var scopeFactory = context.ServiceProvider.GetRequiredService<IServiceScopeFactory>();
+
 // Typed handler — receives OrderPlacedEto
 eventBus.Subscribe<OrderPlacedEto, OrderEmailHandler>();
 

--- a/framework/test/Volo.Abp.EventBus.Tests/Volo/Abp/EventBus/Distributed/LocalDistributedEventBus_Test.cs
+++ b/framework/test/Volo.Abp.EventBus.Tests/Volo/Abp/EventBus/Distributed/LocalDistributedEventBus_Test.cs
@@ -384,7 +384,7 @@ public class LocalDistributedEventBus_Test : LocalDistributedEventBusTestBase
         services.AddSingleton<ITestCounterService>(
             new TestCounterService(() => handleCount++, () => disposeCount++));
         services.AddTransient<DynamicIocEventHandlerWithCounter>();
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
 
         using var subscription = DistributedEventBus.Subscribe(
@@ -410,7 +410,7 @@ public class LocalDistributedEventBus_Test : LocalDistributedEventBusTestBase
         var services = new ServiceCollection();
         services.AddSingleton<ITestCounterService>(new TestCounterService(() => callCount++));
         services.AddTransient<DynamicIocEventHandlerWithService>();
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
         var scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
 
         using var subscription = DistributedEventBus.Subscribe(


### PR DESCRIPTION
Follow-up to #25200.

- Wrap BuildServiceProvider() in using in both tests to ensure the container is disposed after each test.
- Update note in POST.md to reference both OnApplicationInitialization and OnApplicationInitializationAsync.
- Add missing scopeFactory resolution line to the mixed handlers code snippet so the example is self-contained.