### PR TITLE
Require delete permission for blog posts

### DIFF
--- a/modules/blogging/src/Volo.Blogging.Web/Pages/Blogs/Posts/Detail.cshtml
+++ b/modules/blogging/src/Volo.Blogging.Web/Pages/Blogs/Posts/Detail.cshtml
@@ -95,7 +95,7 @@
                                                 <i class="fa fa-pencil"></i> @L["Edit"]
                                             </a>
                                         }
-                                        @if (await Authorization.IsGrantedAsync(BloggingPermissions.Posts.Delete) || (CurrentUser.Id.HasValue && CurrentUser.Id == Model.Post.CreatorId))
+                                        @if (await Authorization.IsGrantedAsync(BloggingPermissions.Posts.Delete))
                                         {
                                             <span class="seperator">|</span>
                                             <a href="#" id="DeletePostLink" data-postid="@Model.Post.Id" data-blogShortName="@Model.BlogShortName">


### PR DESCRIPTION
### Description

Remove the ownership-based fallback that allowed post creators to delete their own posts in Detail.cshtml. Deletion now strictly requires BloggingPermissions.Posts.Delete, centralizing authorization on explicit permissions to enforce consistent access control.

Resolves [vs-internal-issue-#8299](https://github.com/volosoft/vs-internal/issues/8299)

### Checklist

- [ ] I fully tested it as developer
- [ ] no need to document
