### PR TITLE
Do not short-circuit tenant resolver chain when query string tenant value is blank

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.MultiTenancy/Volo/Abp/AspNetCore/MultiTenancy/QueryStringTenantResolveContributor.cs
+++ b/framework/src/Volo.Abp.AspNetCore.MultiTenancy/Volo/Abp/AspNetCore/MultiTenancy/QueryStringTenantResolveContributor.cs
@@ -21,7 +21,7 @@ public class QueryStringTenantResolveContributor : HttpTenantResolveContributorB
                 var tenantValue = httpContext.Request.Query[tenantKey].ToString();
                 if (!tenantValue.IsNullOrWhiteSpace())
                 {
-                    return Task.FromResult(tenantValue)!;
+                    return Task.FromResult<string?>(tenantValue);
                 }
             }
         }

--- a/framework/src/Volo.Abp.AspNetCore.MultiTenancy/Volo/Abp/AspNetCore/MultiTenancy/QueryStringTenantResolveContributor.cs
+++ b/framework/src/Volo.Abp.AspNetCore.MultiTenancy/Volo/Abp/AspNetCore/MultiTenancy/QueryStringTenantResolveContributor.cs
@@ -19,13 +19,10 @@ public class QueryStringTenantResolveContributor : HttpTenantResolveContributorB
             if (httpContext.Request.Query.ContainsKey(tenantKey))
             {
                 var tenantValue = httpContext.Request.Query[tenantKey].ToString();
-                if (tenantValue.IsNullOrWhiteSpace())
+                if (!tenantValue.IsNullOrWhiteSpace())
                 {
-                    context.Handled = true;
-                    return Task.FromResult<string?>(null);
+                    return Task.FromResult(tenantValue)!;
                 }
-
-                return Task.FromResult(tenantValue)!;
             }
         }
 

--- a/framework/test/Volo.Abp.AspNetCore.MultiTenancy.Tests/Volo/Abp/AspNetCore/MultiTenancy/AspNetCoreMultiTenancy_Without_DomainResolver_Tests.cs
+++ b/framework/test/Volo.Abp.AspNetCore.MultiTenancy.Tests/Volo/Abp/AspNetCore/MultiTenancy/AspNetCoreMultiTenancy_Without_DomainResolver_Tests.cs
@@ -70,4 +70,20 @@ public class AspNetCoreMultiTenancy_Without_DomainResolver_Tests : AspNetCoreMul
         var result = await GetResponseAsObjectAsync<Dictionary<string, string>>("http://abp.io");
         result["TenantId"].ShouldBe(_testTenantId.ToString());
     }
+
+    [Fact]
+    public async Task Should_Use_Header_Tenant_Id_When_QueryString_Tenant_Is_Empty()
+    {
+        Client.DefaultRequestHeaders.Add(_options.TenantKey, _testTenantId.ToString());
+
+        var result = await GetResponseAsObjectAsync<Dictionary<string, string>>($"http://abp.io?{_options.TenantKey}=");
+        result["TenantId"].ShouldBe(_testTenantId.ToString());
+    }
+
+    [Fact]
+    public async Task Should_Fallback_To_Host_When_QueryString_Tenant_Is_Empty_And_No_Other_Resolver()
+    {
+        var result = await GetResponseAsObjectAsync<Dictionary<string, string>>($"http://abp.io?{_options.TenantKey}=");
+        result["TenantId"].ShouldBe("");
+    }
 }

--- a/framework/test/Volo.Abp.AspNetCore.MultiTenancy.Tests/Volo/Abp/AspNetCore/MultiTenancy/AspNetCoreMultiTenancy_Without_DomainResolver_Tests.cs
+++ b/framework/test/Volo.Abp.AspNetCore.MultiTenancy.Tests/Volo/Abp/AspNetCore/MultiTenancy/AspNetCoreMultiTenancy_Without_DomainResolver_Tests.cs
@@ -86,4 +86,20 @@ public class AspNetCoreMultiTenancy_Without_DomainResolver_Tests : AspNetCoreMul
         var result = await GetResponseAsObjectAsync<Dictionary<string, string>>($"http://abp.io?{_options.TenantKey}=");
         result["TenantId"].ShouldBe("");
     }
+
+    [Fact]
+    public async Task Should_Use_Header_Tenant_Id_When_QueryString_Tenant_Is_Whitespace()
+    {
+        Client.DefaultRequestHeaders.Add(_options.TenantKey, _testTenantId.ToString());
+
+        var result = await GetResponseAsObjectAsync<Dictionary<string, string>>($"http://abp.io?{_options.TenantKey}=%20");
+        result["TenantId"].ShouldBe(_testTenantId.ToString());
+    }
+
+    [Fact]
+    public async Task Should_Fallback_To_Host_When_QueryString_Tenant_Is_Whitespace_And_No_Other_Resolver()
+    {
+        var result = await GetResponseAsObjectAsync<Dictionary<string, string>>($"http://abp.io?{_options.TenantKey}=%20");
+        result["TenantId"].ShouldBe("");
+    }
 }


### PR DESCRIPTION
Previously, `QueryStringTenantResolveContributor` set `context.Handled = true` when the `__tenant` query string parameter was present but its value was empty or whitespace. This caused the tenant resolver chain to stop early, preventing subsequent resolvers (e.g. header, cookie) from being evaluated.

While this is not a real security vulnerability since user credentials are still validated regardless of the resolved tenant context, it is an unexpected behavior: a blank query string value should not suppress a valid tenant header.

This change removes the `Handled = true` for blank values, allowing the resolver chain to continue to later resolvers. Unit tests have been added to cover this scenario.

Related: volosoft/volo#22072