### PR TITLE
Replace `ajaxSubmit` with `abp.ajax` in CmsKit Pages and BlogPosts

### DIFF
--- a/modules/cms-kit/src/Volo.CmsKit.Admin.Web/Pages/CmsKit/BlogPosts/create.js
+++ b/modules/cms-kit/src/Volo.CmsKit.Admin.Web/Pages/CmsKit/BlogPosts/create.js
@@ -67,7 +67,7 @@ $(function () {
                             else {
                                 finishSaving();
                             }
-                        }).always(function () {
+                        }).fail(function () {
                             abp.ui.clearBusy();
                         });
                     }

--- a/modules/cms-kit/src/Volo.CmsKit.Admin.Web/Pages/CmsKit/BlogPosts/create.js
+++ b/modules/cms-kit/src/Volo.CmsKit.Admin.Web/Pages/CmsKit/BlogPosts/create.js
@@ -55,19 +55,20 @@ $(function () {
 
                         await submitCoverImage();
 
-                        $formCreate.ajaxSubmit({
-                            success: function (result) {
-                                if (isTagsEnabled) {
-                                    submitEntityTags(result.id);
-                                }
-                                else {
-                                    finishSaving();
-                                }
-                            },
-                            error: function (result) {
-                                abp.notify.error(result.responseJSON.error.message);
-                                abp.ui.clearBusy();
+                        abp.ajax({
+                            url: $formCreate.attr("action"),
+                            data: new FormData($formCreate[0]),
+                            processData: false,
+                            contentType: false
+                        }).done(function (result) {
+                            if (isTagsEnabled) {
+                                submitEntityTags(result.id);
                             }
+                            else {
+                                finishSaving();
+                            }
+                        }).always(function () {
+                            abp.ui.clearBusy();
                         });
                     }
                 }

--- a/modules/cms-kit/src/Volo.CmsKit.Admin.Web/Pages/CmsKit/BlogPosts/update.js
+++ b/modules/cms-kit/src/Volo.CmsKit.Admin.Web/Pages/CmsKit/BlogPosts/update.js
@@ -42,19 +42,20 @@ $(function () {
 
             await submitCoverImage();
 
-            $formUpdate.ajaxSubmit({
-                success: function (result) {
-                    if (isTagsEnabled) {
-                        submitEntityTags($blogPostIdInput.val());
-                    }
-                    else {
-                        finishSaving(result);
-                    }
-                },
-                error: function (result) {
-                    abp.ui.clearBusy();
-                    abp.notify.error(result.responseJSON.error.message);
+            abp.ajax({
+                url: $formUpdate.attr("action"),
+                data: new FormData($formUpdate[0]),
+                processData: false,
+                contentType: false
+            }).done(function (result) {
+                if (isTagsEnabled) {
+                    submitEntityTags($blogPostIdInput.val());
                 }
+                else {
+                    finishSaving(result);
+                }
+            }).always(function () {
+                abp.ui.clearBusy();
             });
         }
         else {

--- a/modules/cms-kit/src/Volo.CmsKit.Admin.Web/Pages/CmsKit/BlogPosts/update.js
+++ b/modules/cms-kit/src/Volo.CmsKit.Admin.Web/Pages/CmsKit/BlogPosts/update.js
@@ -54,7 +54,7 @@ $(function () {
                 else {
                     finishSaving(result);
                 }
-            }).always(function () {
+            }).fail(function () {
                 abp.ui.clearBusy();
             });
         }

--- a/modules/cms-kit/src/Volo.CmsKit.Admin.Web/Pages/CmsKit/Pages/create.js
+++ b/modules/cms-kit/src/Volo.CmsKit.Admin.Web/Pages/CmsKit/Pages/create.js
@@ -36,16 +36,16 @@ $(function () {
             $("#ViewModel_Style").val(styleEditor.getValue());
             $("#ViewModel_Script").val(scriptEditor.getValue());
 
-            $createForm.ajaxSubmit({
-                success: function (result) {
-                    abp.notify.success(l('SavedSuccessfully'));
-                    abp.ui.clearBusy();
-                    location.href = "../Pages";
-                },
-                error: function (result) {
-                    abp.ui.clearBusy();
-                    abp.notify.error(result.responseJSON.error.message);
-                }
+            abp.ajax({
+                url: $createForm.attr("action"),
+                data: new FormData($createForm[0]),
+                processData: false,
+                contentType: false
+            }).done(function () {
+                abp.notify.success(l('SavedSuccessfully'));
+                location.href = "../Pages";
+            }).always(function () {
+                abp.ui.clearBusy();
             });
         }
     });

--- a/modules/cms-kit/src/Volo.CmsKit.Admin.Web/Pages/CmsKit/Pages/update.js
+++ b/modules/cms-kit/src/Volo.CmsKit.Admin.Web/Pages/CmsKit/Pages/update.js
@@ -34,12 +34,16 @@ $(function () {
             $("#ViewModel_Style").val(styleEditor.getValue());
             $("#ViewModel_Script").val(scriptEditor.getValue());
 
-            $formUpdate.ajaxSubmit({
-                success: function (result) {
-                    abp.notify.success(l('SavedSuccessfully'));
-                    abp.ui.clearBusy();
-                    location.href = "../../Pages";
-                }
+            abp.ajax({
+                url: $formUpdate.attr("action"),
+                data: new FormData($formUpdate[0]),
+                processData: false,
+                contentType: false
+            }).done(function () {
+                abp.notify.success(l('SavedSuccessfully'));
+                location.href = "../../Pages";
+            }).always(function () {
+                abp.ui.clearBusy();
             });
         }
     });


### PR DESCRIPTION
The `jquery-form` package was removed in #24703, but CmsKit's Pages and BlogPosts JS files still used `ajaxSubmit()`, causing `TypeError: n.ajaxSubmit is not a function`.

Replace all `ajaxSubmit()` calls with `abp.ajax()` + `FormData` in 4 files:
- `Pages/create.js`
- `Pages/update.js`
- `BlogPosts/create.js`
- `BlogPosts/update.js`

Fixes https://abp.io/support/questions/10584