### PR TITLE
Add `AbpEmailLoginTokenProvider` for passwordless email login

### DIFF
--- a/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpEmailLoginTokenProvider.cs
+++ b/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpEmailLoginTokenProvider.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Volo.Abp.Identity;
 using Volo.Abp.Threading;
 
 namespace Volo.Abp.Identity.AspNetCore;

--- a/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpEmailLoginTokenProvider.cs
+++ b/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpEmailLoginTokenProvider.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Volo.Abp.Threading;
+
+namespace Volo.Abp.Identity.AspNetCore;
+
+/// <summary>
+/// Email login token provider that enforces only the most recently issued
+/// token to be valid, with a configurable expiration period.
+/// </summary>
+public class AbpEmailLoginTokenProvider : AbpSingleActiveTokenProvider
+{
+    public const string ProviderName = "AbpEmailLogin";
+
+    public AbpEmailLoginTokenProvider(
+        IDataProtectionProvider dataProtectionProvider,
+        IOptions<AbpEmailLoginTokenProviderOptions> options,
+        ILogger<DataProtectorTokenProvider<IdentityUser>> logger,
+        IIdentityUserRepository userRepository,
+        ICancellationTokenProvider cancellationTokenProvider)
+        : base(dataProtectionProvider, options, logger, userRepository, cancellationTokenProvider)
+    {
+    }
+}

--- a/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpEmailLoginTokenProviderOptions.cs
+++ b/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpEmailLoginTokenProviderOptions.cs
@@ -1,0 +1,13 @@
+using System;
+using Microsoft.AspNetCore.Identity;
+
+namespace Volo.Abp.Identity.AspNetCore;
+
+public class AbpEmailLoginTokenProviderOptions : DataProtectionTokenProviderOptions
+{
+    public AbpEmailLoginTokenProviderOptions()
+    {
+        Name = AbpEmailLoginTokenProvider.ProviderName;
+        TokenLifespan = TimeSpan.FromSeconds(90);
+    }
+}

--- a/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpEmailLoginTokenPurposes.cs
+++ b/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpEmailLoginTokenPurposes.cs
@@ -1,0 +1,8 @@
+namespace Volo.Abp.Identity.AspNetCore;
+
+public static class AbpEmailLoginTokenPurposes
+{
+    public const string EmailLogin = "EmailLogin";
+
+    public const string OtpCode = "OTP";
+}

--- a/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpEmailLoginTokenPurposes.cs
+++ b/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpEmailLoginTokenPurposes.cs
@@ -3,6 +3,4 @@ namespace Volo.Abp.Identity.AspNetCore;
 public static class AbpEmailLoginTokenPurposes
 {
     public const string EmailLogin = "EmailLogin";
-
-    public const string OtpCode = "OTP";
 }

--- a/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpIdentityAspNetCoreModule.cs
+++ b/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpIdentityAspNetCoreModule.cs
@@ -23,6 +23,7 @@ public class AbpIdentityAspNetCoreModule : AbpModule
                 .AddTokenProvider<AbpPasswordResetTokenProvider>(AbpPasswordResetTokenProvider.ProviderName)
                 .AddTokenProvider<AbpEmailConfirmationTokenProvider>(AbpEmailConfirmationTokenProvider.ProviderName)
                 .AddTokenProvider<AbpChangeEmailTokenProvider>(AbpChangeEmailTokenProvider.ProviderName)
+                .AddTokenProvider<AbpEmailLoginTokenProvider>(AbpEmailLoginTokenProvider.ProviderName)
                 .AddSignInManager<AbpSignInManager>()
                 .AddUserValidator<AbpIdentityUserValidator>();
         });

--- a/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/IdentityUserManagerSingleActiveTokenExtensions.cs
+++ b/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/IdentityUserManagerSingleActiveTokenExtensions.cs
@@ -40,4 +40,21 @@ public static class IdentityUserManagerSingleActiveTokenExtensions
         var name = manager.Options.Tokens.ChangeEmailTokenProvider + ":" + UserManager<IdentityUser>.GetChangeEmailTokenPurpose(newEmail);
         return manager.RemoveAuthenticationTokenAsync(user, AbpSingleActiveTokenProvider.InternalLoginProvider, name);
     }
+
+    public static Task<string> GenerateEmailLoginTokenAsync(this IdentityUserManager manager, IdentityUser user)
+    {
+        return manager.GenerateUserTokenAsync(user, AbpEmailLoginTokenProvider.ProviderName, AbpEmailLoginTokenPurposes.EmailLogin);
+    }
+
+    public static Task<bool> VerifyEmailLoginTokenAsync(this IdentityUserManager manager, IdentityUser user, string token)
+    {
+        return manager.VerifyUserTokenAsync(user, AbpEmailLoginTokenProvider.ProviderName, AbpEmailLoginTokenPurposes.EmailLogin, token);
+    }
+
+    public static Task<IdentityResult> RemoveEmailLoginTokenAsync(this IdentityUserManager manager, IdentityUser user)
+    {
+        var name = AbpEmailLoginTokenProvider.ProviderName + ":" + AbpEmailLoginTokenPurposes.EmailLogin;
+        return manager.RemoveAuthenticationTokenAsync(user, AbpSingleActiveTokenProvider.InternalLoginProvider, name);
+    }
+
 }

--- a/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/IdentityUserManagerSingleActiveTokenExtensions.cs
+++ b/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/IdentityUserManagerSingleActiveTokenExtensions.cs
@@ -4,10 +4,10 @@ using Microsoft.AspNetCore.Identity;
 namespace Volo.Abp.Identity.AspNetCore;
 
 /// <summary>
-/// Provides extension methods on <see cref="IdentityUserManager"/> for invalidating
-/// single-active tokens managed by <see cref="AbpSingleActiveTokenProvider"/>.
-/// These helpers live in the AspNetCore layer because they depend on
-/// <see cref="AbpSingleActiveTokenProvider.InternalLoginProvider"/>.
+/// Provides extension methods on <see cref="IdentityUserManager"/> for generating,
+/// verifying, and invalidating single-active tokens managed by
+/// <see cref="AbpSingleActiveTokenProvider"/>. These helpers live in the AspNetCore
+/// layer because they depend on <see cref="AbpSingleActiveTokenProvider.InternalLoginProvider"/>.
 /// </summary>
 public static class IdentityUserManagerSingleActiveTokenExtensions
 {

--- a/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/IdentityUserManagerSingleActiveTokenExtensions.cs
+++ b/modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/IdentityUserManagerSingleActiveTokenExtensions.cs
@@ -41,16 +41,27 @@ public static class IdentityUserManagerSingleActiveTokenExtensions
         return manager.RemoveAuthenticationTokenAsync(user, AbpSingleActiveTokenProvider.InternalLoginProvider, name);
     }
 
+    /// <summary>
+    /// Generates a new email login token for <paramref name="user"/>.
+    /// Any previously issued email login token is automatically invalidated.
+    /// </summary>
     public static Task<string> GenerateEmailLoginTokenAsync(this IdentityUserManager manager, IdentityUser user)
     {
         return manager.GenerateUserTokenAsync(user, AbpEmailLoginTokenProvider.ProviderName, AbpEmailLoginTokenPurposes.EmailLogin);
     }
 
+    /// <summary>
+    /// Verifies the email login token for <paramref name="user"/>.
+    /// </summary>
     public static Task<bool> VerifyEmailLoginTokenAsync(this IdentityUserManager manager, IdentityUser user, string token)
     {
         return manager.VerifyUserTokenAsync(user, AbpEmailLoginTokenProvider.ProviderName, AbpEmailLoginTokenPurposes.EmailLogin, token);
     }
 
+    /// <summary>
+    /// Removes the stored email login token hash for <paramref name="user"/>,
+    /// immediately invalidating any previously issued email login token.
+    /// </summary>
     public static Task<IdentityResult> RemoveEmailLoginTokenAsync(this IdentityUserManager manager, IdentityUser user)
     {
         var name = AbpEmailLoginTokenProvider.ProviderName + ":" + AbpEmailLoginTokenPurposes.EmailLogin;

--- a/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/AbpEmailLoginTokenProvider_Tests.cs
+++ b/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/AbpEmailLoginTokenProvider_Tests.cs
@@ -1,0 +1,53 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Volo.Abp.Uow;
+using Xunit;
+
+namespace Volo.Abp.Identity.AspNetCore;
+
+public class AbpEmailLoginTokenProvider_Tests : AbpSingleActiveTokenProviderTestBase
+{
+    protected override Task<string> GenerateTokenAsync(IdentityUser user)
+        => UserManager.GenerateEmailLoginTokenAsync(user);
+
+    protected override Task<bool> VerifyTokenAsync(IdentityUser user, string token)
+        => UserManager.VerifyEmailLoginTokenAsync(user, token);
+
+    protected override string GetProviderName()
+        => AbpEmailLoginTokenProvider.ProviderName;
+
+    protected override string GetPurpose()
+        => AbpEmailLoginTokenPurposes.EmailLogin;
+
+    [Fact]
+    public void AbpEmailLoginTokenProvider_Should_Be_Registered()
+    {
+        var identityOptions = GetRequiredService<IOptions<IdentityOptions>>().Value;
+
+        identityOptions.Tokens.ProviderMap.ShouldContainKey(AbpEmailLoginTokenProvider.ProviderName);
+        identityOptions.Tokens.ProviderMap[AbpEmailLoginTokenProvider.ProviderName].ProviderType
+            .ShouldBe(typeof(AbpEmailLoginTokenProvider));
+    }
+
+    [Fact]
+    public async Task RemoveEmailLoginTokenAsync_Should_Invalidate_Token()
+    {
+        using (var uow = UnitOfWorkManager.Begin(new AbpUnitOfWorkOptions()))
+        {
+            var john = await UserRepository.GetAsync(TestData.UserJohnId);
+
+            var token = await UserManager.GenerateEmailLoginTokenAsync(john);
+            (await UserManager.VerifyEmailLoginTokenAsync(john, token)).ShouldBeTrue();
+
+            john = await UserRepository.GetAsync(TestData.UserJohnId);
+            await UserManager.RemoveEmailLoginTokenAsync(john);
+
+            john = await UserRepository.GetAsync(TestData.UserJohnId);
+            (await UserManager.VerifyEmailLoginTokenAsync(john, token)).ShouldBeFalse();
+
+            await uow.CompleteAsync();
+        }
+    }
+}

--- a/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/AbpEmailLoginTokenProvider_Tests.cs
+++ b/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/AbpEmailLoginTokenProvider_Tests.cs
@@ -34,7 +34,7 @@ public class AbpEmailLoginTokenProvider_Tests : AbpSingleActiveTokenProviderTest
     [Fact]
     public async Task RemoveEmailLoginTokenAsync_Should_Invalidate_Token()
     {
-        using (var uow = UnitOfWorkManager.Begin(new AbpUnitOfWorkOptions()))
+        using (var uow = UnitOfWorkManager.Begin())
         {
             var john = await UserRepository.GetAsync(TestData.UserJohnId);
 


### PR DESCRIPTION
Add `AbpEmailLoginTokenProvider` to support passwordless email login feature in Account Pro module.

This token provider is based on `AbpSingleActiveTokenProvider`, ensuring only the most recently issued token is valid. Used for generating and verifying one-time login tokens sent via email.