### PR TITLE
Increase `AbpMemoryPoolHttpResponseStreamWriterFactory` buffer size to 256KB

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/Infrastructure/AbpMemoryPoolHttpResponseStreamWriterFactory.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/Infrastructure/AbpMemoryPoolHttpResponseStreamWriterFactory.cs
@@ -12,7 +12,7 @@ namespace Volo.Abp.AspNetCore.Mvc.Infrastructure;
 /// </summary>
 public class AbpMemoryPoolHttpResponseStreamWriterFactory : IHttpResponseStreamWriterFactory
 {
-    public const int DefaultBufferSize = 32 * 1024;
+    public const int DefaultBufferSize = 256 * 1024;
 
     private readonly ArrayPool<byte> _bytePool;
     private readonly ArrayPool<char> _charPool;


### PR DESCRIPTION
Increase the default buffer size of `AbpMemoryPoolHttpResponseStreamWriterFactory` from 32KB to 256KB.

When rendering large MVC views (e.g. Account settings page with multiple tabs in non-English locales), the 32KB buffer overflows during `ViewBuffer.WriteToAsync`, triggering a synchronous flush to `HttpResponseStream.Write` which throws `InvalidOperationException: Synchronous operations are disallowed`.

Since the buffer is backed by `ArrayPool`, the increased size has negligible memory impact.
