### PR TITLE
fix(mvc): skip `abpAjaxForm` submission when default is already prevented

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/wwwroot/libs/abp/aspnetcore-mvc-ui-theme-shared/jquery-form/jquery-form-extensions.js
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/wwwroot/libs/abp/aspnetcore-mvc-ui-theme-shared/jquery-form/jquery-form-extensions.js
@@ -88,6 +88,10 @@
         };
 
         $form.off("submit.abpAjaxForm").on("submit.abpAjaxForm", function (e) {
+            if (e.isDefaultPrevented()) {
+                return;
+            }
+
             e.preventDefault();
 
             var formEl = $form[0];


### PR DESCRIPTION
When the jquery-form plugin was replaced with a custom `abpAjaxForm` implementation, the `isDefaultPrevented()` check was lost. The old plugin skipped submission if another handler had already called `preventDefault()`, but the new implementation always proceeds unconditionally.

This caused issues for modal forms with custom submit handlers (e.g. `DelegateNewUserForm` in Authority Delegation), where both the custom handler and `abpAjaxForm` would fire, resulting in an unwanted extra POST to `window.location.href`.

This restores the old jquery-form plugin's behavior by checking `e.isDefaultPrevented()` before proceeding.