### PR TITLE
Upgrade Blazorise packages to version 2.0.4

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,10 +19,10 @@
     <PackageVersion Include="Azure.Identity" Version="1.14.2" />
     <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.25.0" />
-    <PackageVersion Include="Blazorise" Version="2.0.0" />
-    <PackageVersion Include="Blazorise.Components" Version="2.0.0" />
-    <PackageVersion Include="Blazorise.DataGrid" Version="2.0.0" />
-    <PackageVersion Include="Blazorise.Snackbar" Version="2.0.0" />
+    <PackageVersion Include="Blazorise" Version="2.0.4" />
+    <PackageVersion Include="Blazorise.Components" Version="2.0.4" />
+    <PackageVersion Include="Blazorise.DataGrid" Version="2.0.4" />
+    <PackageVersion Include="Blazorise.Snackbar" Version="2.0.4" />
     <PackageVersion Include="Castle.Core" Version="5.2.1" />
     <PackageVersion Include="Castle.Core.AsyncInterceptor" Version="2.1.0" />
     <PackageVersion Include="CommonMark.NET" Version="0.15.1" />

--- a/docs/en/package-version-changes.md
+++ b/docs/en/package-version-changes.md
@@ -1,5 +1,14 @@
 # Package Version Changes
 
+## 10.2.1
+
+| Package | Old Version | New Version | PR |
+|---------|-------------|-------------|-----|
+| Blazorise | 2.0.0 | 2.0.4 | #25264 |
+| Blazorise.Components | 2.0.0 | 2.0.4 | #25264 |
+| Blazorise.DataGrid | 2.0.0 | 2.0.4 | #25264 |
+| Blazorise.Snackbar | 2.0.0 | 2.0.4 | #25264 |
+
 ## 10.2.0-rc.4
 
 | Package | Old Version | New Version | PR |

--- a/templates/app-nolayers/aspnet-core/MyCompanyName.MyProjectName.Blazor.Server.Mongo/MyCompanyName.MyProjectName.Blazor.Server.Mongo.csproj
+++ b/templates/app-nolayers/aspnet-core/MyCompanyName.MyProjectName.Blazor.Server.Mongo/MyCompanyName.MyProjectName.Blazor.Server.Mongo.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Blazorise.Bootstrap5" Version="2.0.0" />
-    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="2.0.0" />
+    <PackageReference Include="Blazorise.Bootstrap5" Version="2.0.4" />
+    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="2.0.4" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
   </ItemGroup>

--- a/templates/app-nolayers/aspnet-core/MyCompanyName.MyProjectName.Blazor.Server/MyCompanyName.MyProjectName.Blazor.Server.csproj
+++ b/templates/app-nolayers/aspnet-core/MyCompanyName.MyProjectName.Blazor.Server/MyCompanyName.MyProjectName.Blazor.Server.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Blazorise.Bootstrap5" Version="2.0.0" />
-    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="2.0.0" />
+    <PackageReference Include="Blazorise.Bootstrap5" Version="2.0.4" />
+    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="2.0.4" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
   </ItemGroup>

--- a/templates/app-nolayers/aspnet-core/MyCompanyName.MyProjectName.Blazor.WebAssembly/Client/MyCompanyName.MyProjectName.Blazor.WebAssembly.Client.csproj
+++ b/templates/app-nolayers/aspnet-core/MyCompanyName.MyProjectName.Blazor.WebAssembly/Client/MyCompanyName.MyProjectName.Blazor.WebAssembly.Client.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Blazorise.Bootstrap5" Version="2.0.0" />
-    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="2.0.0" />
+    <PackageReference Include="Blazorise.Bootstrap5" Version="2.0.4" />
+    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="2.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.2" />
   </ItemGroup>

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.Client/MyCompanyName.MyProjectName.Blazor.Client.csproj
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.Client/MyCompanyName.MyProjectName.Blazor.Client.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Blazorise.Bootstrap5" Version="2.0.0" />
-    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="2.0.0" />
+    <PackageReference Include="Blazorise.Bootstrap5" Version="2.0.4" />
+    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="2.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.2" />
   </ItemGroup>

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.Server.Tiered/MyCompanyName.MyProjectName.Blazor.Server.Tiered.csproj
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.Server.Tiered/MyCompanyName.MyProjectName.Blazor.Server.Tiered.csproj
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Blazorise.Bootstrap5" Version="2.0.0" />
-    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="2.0.0" />
+    <PackageReference Include="Blazorise.Bootstrap5" Version="2.0.4" />
+    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="2.0.4" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="10.0.2" />

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.Server/MyCompanyName.MyProjectName.Blazor.Server.csproj
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.Server/MyCompanyName.MyProjectName.Blazor.Server.csproj
@@ -15,8 +15,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.2" />
-    <PackageReference Include="Blazorise.Bootstrap5" Version="2.0.0" />
-    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="2.0.0" />
+    <PackageReference Include="Blazorise.Bootstrap5" Version="2.0.4" />
+    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="2.0.4" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
   </ItemGroup>

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.WebApp.Client/MyCompanyName.MyProjectName.Blazor.WebApp.Client.csproj
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.WebApp.Client/MyCompanyName.MyProjectName.Blazor.WebApp.Client.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Blazorise.Bootstrap5" Version="2.0.0" />
-    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="2.0.0" />
+    <PackageReference Include="Blazorise.Bootstrap5" Version="2.0.4" />
+    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="2.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.2" />
   </ItemGroup>

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.WebApp.Tiered.Client/MyCompanyName.MyProjectName.Blazor.WebApp.Tiered.Client.csproj
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.WebApp.Tiered.Client/MyCompanyName.MyProjectName.Blazor.WebApp.Tiered.Client.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Blazorise.Bootstrap5" Version="2.0.0" />
-    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="2.0.0" />
+    <PackageReference Include="Blazorise.Bootstrap5" Version="2.0.4" />
+    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="2.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.2" />
   </ItemGroup>

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.WebApp.Tiered/MyCompanyName.MyProjectName.Blazor.WebApp.Tiered.csproj
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.WebApp.Tiered/MyCompanyName.MyProjectName.Blazor.WebApp.Tiered.csproj
@@ -16,8 +16,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.2" />
-    <PackageReference Include="Blazorise.Bootstrap5" Version="2.0.0" />
-    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="2.0.0" />
+    <PackageReference Include="Blazorise.Bootstrap5" Version="2.0.4" />
+    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="2.0.4" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="10.0.2" />

--- a/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.WebApp/MyCompanyName.MyProjectName.Blazor.WebApp.csproj
+++ b/templates/app/aspnet-core/src/MyCompanyName.MyProjectName.Blazor.WebApp/MyCompanyName.MyProjectName.Blazor.WebApp.csproj
@@ -16,8 +16,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.2" />
-    <PackageReference Include="Blazorise.Bootstrap5" Version="2.0.0" />
-    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="2.0.0" />
+    <PackageReference Include="Blazorise.Bootstrap5" Version="2.0.4" />
+    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="2.0.4" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
   </ItemGroup>

--- a/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.Blazor.Host.Client/MyCompanyName.MyProjectName.Blazor.Host.Client.csproj
+++ b/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.Blazor.Host.Client/MyCompanyName.MyProjectName.Blazor.Host.Client.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Blazorise.Bootstrap5" Version="2.0.0" />
-    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="2.0.0" />
+    <PackageReference Include="Blazorise.Bootstrap5" Version="2.0.4" />
+    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="2.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.2" />
   </ItemGroup>

--- a/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.Blazor.Server.Host/MyCompanyName.MyProjectName.Blazor.Server.Host.csproj
+++ b/templates/module/aspnet-core/host/MyCompanyName.MyProjectName.Blazor.Server.Host/MyCompanyName.MyProjectName.Blazor.Server.Host.csproj
@@ -13,8 +13,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Blazorise.Bootstrap5" Version="2.0.0" />
-        <PackageReference Include="Blazorise.Icons.FontAwesome" Version="2.0.0" />
+        <PackageReference Include="Blazorise.Bootstrap5" Version="2.0.4" />
+        <PackageReference Include="Blazorise.Icons.FontAwesome" Version="2.0.4" />
         <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
         <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.2" />


### PR DESCRIPTION
Blazorise 2.0.4 introduced two new enum members (`Minus` and `Plus`) into the middle of the `IconName` enum (which has no explicit integer values). This caused all subsequent enum values to shift, breaking icon rendering in ABP components compiled against Blazorise 2.0.0.

For example, `IconName.Times` (error icon) resolved to `IconName.Ticket`, and `IconName.QuestionCircle` (confirmation icon) resolved to `IconName.Print`.

This PR upgrades all Blazorise packages from 2.0.0 to 2.0.4 to fix the enum mismatch.

Related: https://abp.io/support/questions/10593