### PR TITLE
Remove extra Select2 dropdown padding in resource permission modal

### DIFF
--- a/modules/permission-management/src/Volo.Abp.PermissionManagement.Web/Pages/AbpPermissionManagement/AddResourcePermissionManagementModal.cshtml
+++ b/modules/permission-management/src/Volo.Abp.PermissionManagement.Web/Pages/AbpPermissionManagement/AddResourcePermissionManagementModal.cshtml
@@ -13,6 +13,7 @@
 
 <script src="/client-proxies/permissionManagement-proxy.js"></script>
 <script src="/Pages/AbpPermissionManagement/add-resource-permission-management-modal.js"></script>
+<abp-style src="/Pages/AbpPermissionManagement/add-resource-permission-management-modal.css" />
 
 <form method="post" asp-page="/AbpPermissionManagement/AddResourcePermissionManagementModal" id="addResourcePermissionManagementForm">
     <abp-modal id="addResourcePermissionManagementModal">

--- a/modules/permission-management/src/Volo.Abp.PermissionManagement.Web/Pages/AbpPermissionManagement/add-resource-permission-management-modal.css
+++ b/modules/permission-management/src/Volo.Abp.PermissionManagement.Web/Pages/AbpPermissionManagement/add-resource-permission-management-modal.css
@@ -1,0 +1,3 @@
+#addResourcePermissionManagementModal .select2-dropdown {
+    padding-bottom: 0 !important;
+}


### PR DESCRIPTION
## Summary
- load a dedicated style for the reusable add resource permission modal
- remove the extra bottom padding from the Select2 dropdown so the provider picker no longer shows an empty gap

## Testing
- dotnet build modules/permission-management/src/Volo.Abp.PermissionManagement.Web/Volo.Abp.PermissionManagement.Web.csproj

Closes volosoft/volo#22073
