### PR TITLE
Upgrade `System.Security.Cryptography.Xml` to 10.0.6

### DIFF
--- a/.github/scripts/test_update_dependency_changes.py
+++ b/.github/scripts/test_update_dependency_changes.py
@@ -14,7 +14,7 @@ import sys
 import os
 sys.path.insert(0, os.path.dirname(__file__))
 
-from update_dependency_changes import merge_changes, render_section, normalize_version, extract_preamble
+from update_dependency_changes import merge_changes, render_section, normalize_version, extract_preamble, bump_patch_if_released
 
 
 def test_update_then_revert():
@@ -438,6 +438,55 @@ def test_normalize_version_stable():
     print("✓ Passed: stable versions unchanged\n")
 
 
+def test_bump_patch_no_tag():
+    """Test: version tag does not exist, should return as-is."""
+    print("Test 23: bump_patch_if_released - no tag exists")
+    tag_exists = lambda t: False
+    assert bump_patch_if_released("10.3.0", tag_exists) == "10.3.0"
+    assert bump_patch_if_released("10.2.0", tag_exists) == "10.2.0"
+    print("✓ Passed: version unchanged when tag does not exist\n")
+
+
+def test_bump_patch_tag_exists():
+    """Test: version tag exists, should bump patch."""
+    print("Test 24: bump_patch_if_released - tag exists")
+    existing_tags = {"10.3.0"}
+    tag_exists = lambda t: t in existing_tags
+    assert bump_patch_if_released("10.3.0", tag_exists) == "10.3.1", \
+        f"Expected '10.3.1', got: {bump_patch_if_released('10.3.0', tag_exists)}"
+    print("✓ Passed: version bumped to 10.3.1\n")
+
+
+def test_bump_patch_multiple_tags():
+    """Test: multiple consecutive tags exist, should bump past all."""
+    print("Test 25: bump_patch_if_released - multiple tags exist")
+    existing_tags = {"10.3.0", "10.3.1", "10.3.2"}
+    tag_exists = lambda t: t in existing_tags
+    assert bump_patch_if_released("10.3.0", tag_exists) == "10.3.3", \
+        f"Expected '10.3.3', got: {bump_patch_if_released('10.3.0', tag_exists)}"
+    print("✓ Passed: version bumped past all existing tags\n")
+
+
+def test_bump_patch_prerelease_skipped():
+    """Test: pre-release versions should not be bumped."""
+    print("Test 26: bump_patch_if_released - pre-release skipped")
+    tag_exists = lambda t: True  # all tags "exist"
+    assert bump_patch_if_released("10.3.0-rc.1", tag_exists) == "10.3.0-rc.1"
+    assert bump_patch_if_released("10.3.0-rc.2", tag_exists) == "10.3.0-rc.2"
+    assert bump_patch_if_released("10.3.0-preview", tag_exists) == "10.3.0-preview"
+    print("✓ Passed: pre-release versions not bumped\n")
+
+
+def test_bump_patch_non_zero_patch():
+    """Test: version with non-zero patch, tag exists, should bump."""
+    print("Test 27: bump_patch_if_released - non-zero patch version")
+    existing_tags = {"10.3.1"}
+    tag_exists = lambda t: t in existing_tags
+    assert bump_patch_if_released("10.3.1", tag_exists) == "10.3.2", \
+        f"Expected '10.3.2', got: {bump_patch_if_released('10.3.1', tag_exists)}"
+    print("✓ Passed: non-zero patch correctly bumped\n")
+
+
 def run_all_tests():
     """Run all test cases."""
     print("=" * 70)
@@ -466,9 +515,14 @@ def run_all_tests():
     test_normalize_version_preview()
     test_normalize_version_rc()
     test_normalize_version_stable()
+    test_bump_patch_no_tag()
+    test_bump_patch_tag_exists()
+    test_bump_patch_multiple_tags()
+    test_bump_patch_prerelease_skipped()
+    test_bump_patch_non_zero_patch()
 
     print("=" * 70)
-    print("All 22 tests passed! ✓")
+    print("All 27 tests passed! ✓")
     print("=" * 70)
     print("\nTest coverage summary:")
     print("  ✓ Basic scenarios (update, add, remove)")
@@ -478,6 +532,7 @@ def run_all_tests():
     print("  ✓ Document format validation")
     print("  ✓ Preamble extraction (SEO block, no preamble, no heading)")
     print("  ✓ Version normalization (preview -> rc.1)")
+    print("  ✓ Patch version bump when tag already released")
     print("=" * 70)
 
 

--- a/.github/scripts/update_dependency_changes.py
+++ b/.github/scripts/update_dependency_changes.py
@@ -25,6 +25,46 @@ def normalize_version(version):
     return version
 
 
+def check_tag_exists(tag):
+    """Check if a git tag exists."""
+    result = subprocess.run(
+        ["git", "tag", "-l", tag],
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0 and tag in result.stdout.strip().split("\n")
+
+
+def bump_patch_if_released(version, tag_exists_fn=None):
+    """If the version tag already exists, bump the patch version.
+
+    Only applies to stable versions (no pre-release suffix like -rc.N).
+    """
+    if tag_exists_fn is None:
+        tag_exists_fn = check_tag_exists
+
+    # Only bump stable versions (no pre-release suffix)
+    if "-" in version:
+        return version
+
+    parts = version.split(".")
+    if len(parts) != 3:
+        return version
+
+    major, minor = parts[0], parts[1]
+    try:
+        patch = int(parts[2])
+    except ValueError:
+        return version
+
+    current = version
+    while tag_exists_fn(current):
+        patch += 1
+        current = f"{major}.{minor}.{patch}"
+
+    return current
+
+
 def get_version():
     """Read the current version from common.props."""
     try:
@@ -295,6 +335,9 @@ def main():
     if not version:
         print("Could not read version from common.props.")
         sys.exit(1)
+
+    version = bump_patch_if_released(version)
+    print(f"Resolved version: {version}")
 
     diff = get_diff(base_ref)
     if not diff:

--- a/.github/workflows/nuget-packages-version-change-detector.yml
+++ b/.github/workflows/nuget-packages-version-change-detector.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 1
+          fetch-tags: true
 
       - name: Fetch base branch
         run: git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }} --depth=1

--- a/.github/workflows/nuget-packages-version-change-detector.yml
+++ b/.github/workflows/nuget-packages-version-change-detector.yml
@@ -43,10 +43,11 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 1
-          fetch-tags: true
 
-      - name: Fetch base branch
-        run: git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }} --depth=1
+      - name: Fetch base branch and tags
+        run: |
+          git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }} --depth=1
+          git fetch --tags origin
 
       - uses: actions/setup-python@v5
         with:

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -174,7 +174,7 @@
     <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.6.7" />
     <PackageVersion Include="System.Linq.Queryable" Version="4.3.0" />
     <PackageVersion Include="System.Runtime.Loader" Version="4.3.0" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.2" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.6" />
     <PackageVersion Include="System.Security.Permissions" Version="10.0.2" />
     <PackageVersion Include="System.Security.Principal.Windows" Version="5.0.0" />
     <PackageVersion Include="System.Text.Encoding.CodePages" Version="10.0.2" />

--- a/docs/en/package-version-changes.md
+++ b/docs/en/package-version-changes.md
@@ -7,14 +7,19 @@
 
 # Package Version Changes
 
-## 10.3.1
+## 10.3.0
+
+| Package | Old Version | New Version | PR |
+|---------|-------------|-------------|-----|
+| System.Security.Cryptography.Xml | 10.0.2 | 10.0.6 | #25279 |
+
+## 10.3.0-rc.1
 
 | Package | Old Version | New Version | PR |
 |---------|-------------|-------------|-----|
 | Autofac | 8.4.0 | 9.1.0 | #25190 |
 | Autofac.Extensions.DependencyInjection | 10.0.0 | 11.0.0 | #25190 |
 | Microsoft.Bcl.AsyncInterfaces | 10.0.2 | 10.0.4 | #25190 |
-| System.Security.Cryptography.Xml | 10.0.2 | 10.0.6 | #25279 |
 
 ## 10.2.1
 

--- a/docs/en/package-version-changes.md
+++ b/docs/en/package-version-changes.md
@@ -7,7 +7,7 @@
 
 # Package Version Changes
 
-## 10.3.1
+## 10.3.0
 
 | Package | Old Version | New Version | PR |
 |---------|-------------|-------------|-----|

--- a/docs/en/package-version-changes.md
+++ b/docs/en/package-version-changes.md
@@ -7,6 +7,12 @@
 
 # Package Version Changes
 
+## 10.3.0
+
+| Package | Old Version | New Version | PR |
+|---------|-------------|-------------|-----|
+| System.Security.Cryptography.Xml | 10.0.2 | 10.0.6 | #25279 |
+
 ## 10.3.0-rc.1
 
 | Package | Old Version | New Version | PR |

--- a/docs/en/package-version-changes.md
+++ b/docs/en/package-version-changes.md
@@ -7,19 +7,14 @@
 
 # Package Version Changes
 
-## 10.3.0
-
-| Package | Old Version | New Version | PR |
-|---------|-------------|-------------|-----|
-| System.Security.Cryptography.Xml | 10.0.2 | 10.0.6 | #25279 |
-
-## 10.3.0-rc.1
+## 10.3.1
 
 | Package | Old Version | New Version | PR |
 |---------|-------------|-------------|-----|
 | Autofac | 8.4.0 | 9.1.0 | #25190 |
 | Autofac.Extensions.DependencyInjection | 10.0.0 | 11.0.0 | #25190 |
 | Microsoft.Bcl.AsyncInterfaces | 10.0.2 | 10.0.4 | #25190 |
+| System.Security.Cryptography.Xml | 10.0.2 | 10.0.6 | #25279 |
 
 ## 10.2.1
 

--- a/docs/en/package-version-changes.md
+++ b/docs/en/package-version-changes.md
@@ -7,7 +7,7 @@
 
 # Package Version Changes
 
-## 10.3.0
+## 10.3.1
 
 | Package | Old Version | New Version | PR |
 |---------|-------------|-------------|-----|


### PR DESCRIPTION
Fix CVE-2026-26171 (GHSA-w3x6-4m5h-cxqf) high severity vulnerability in `System.Security.Cryptography.Xml` package, which is a transitive dependency of `Hangfire.AspNetCore` via `Microsoft.AspNetCore.Antiforgery` → `Microsoft.AspNetCore.DataProtection` under netstandard2.0/2.1.

Closes #25278