### PR TITLE
Use `git ls-remote` instead of `git tag -l` for tag check

### DIFF
--- a/.github/scripts/update_dependency_changes.py
+++ b/.github/scripts/update_dependency_changes.py
@@ -26,13 +26,13 @@ def normalize_version(version):
 
 
 def check_tag_exists(tag):
-    """Check if a git tag exists."""
+    """Check if a git tag exists on the remote."""
     result = subprocess.run(
-        ["git", "tag", "-l", tag],
+        ["git", "ls-remote", "--tags", "origin", tag],
         capture_output=True,
         text=True,
     )
-    return result.returncode == 0 and tag in result.stdout.strip().split("\n")
+    return result.returncode == 0 and result.stdout.strip() != ""
 
 
 def bump_patch_if_released(version, tag_exists_fn=None):

--- a/.github/scripts/update_dependency_changes.py
+++ b/.github/scripts/update_dependency_changes.py
@@ -28,11 +28,11 @@ def normalize_version(version):
 def check_tag_exists(tag):
     """Check if a git tag exists on the remote."""
     result = subprocess.run(
-        ["git", "ls-remote", "--tags", "origin", tag],
+        ["git", "ls-remote", "--exit-code", "--tags", "origin", f"refs/tags/{tag}"],
         capture_output=True,
         text=True,
     )
-    return result.returncode == 0 and result.stdout.strip() != ""
+    return result.returncode == 0
 
 
 def bump_patch_if_released(version, tag_exists_fn=None):

--- a/.github/scripts/update_dependency_changes.py
+++ b/.github/scripts/update_dependency_changes.py
@@ -32,7 +32,16 @@ def check_tag_exists(tag):
         capture_output=True,
         text=True,
     )
-    return result.returncode == 0
+    if result.returncode == 0:
+        return True
+    if result.returncode == 2:
+        return False
+
+    stderr = (result.stderr or "").strip()
+    raise RuntimeError(
+        f"Failed to check whether git tag '{tag}' exists on remote 'origin' "
+        f"(exit code {result.returncode}): {stderr or 'No error output provided.'}"
+    )
 
 
 def bump_patch_if_released(version, tag_exists_fn=None):

--- a/.github/workflows/nuget-packages-version-change-detector.yml
+++ b/.github/workflows/nuget-packages-version-change-detector.yml
@@ -44,10 +44,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 1
 
-      - name: Fetch base branch and tags
-        run: |
-          git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }} --depth=1
-          git fetch --tags origin
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }} --depth=1
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Use `git ls-remote --tags origin <tag>` to query the remote directly instead of `git tag -l` which requires fetching all tags locally. This avoids the expensive `git fetch --tags origin` step in the CI workflow.