### PR TITLE
Pass ExclusionFilters to ReplaceEmbeddedByPhysical for letting developers define which files should be included or excluded

### DIFF
--- a/framework/src/Volo.Abp.VirtualFileSystem/Volo/Abp/VirtualFileSystem/VirtualFileSetListExtensions.cs
+++ b/framework/src/Volo.Abp.VirtualFileSystem/Volo/Abp/VirtualFileSystem/VirtualFileSetListExtensions.cs
@@ -64,8 +64,15 @@ public static class VirtualFileSetListExtensions
 
     public static void ReplaceEmbeddedByPhysical<T>(
         [NotNull] this VirtualFileSetList fileSets,
+        [NotNull] string physicalPath)
+    {
+        ReplaceEmbeddedByPhysical<T>(fileSets, physicalPath, ExclusionFilters.Sensitive);
+    }
+
+    public static void ReplaceEmbeddedByPhysical<T>(
+        [NotNull] this VirtualFileSetList fileSets,
         [NotNull] string physicalPath,
-        ExclusionFilters exclusionFilters = ExclusionFilters.Sensitive)
+        ExclusionFilters exclusionFilters)
     {
         Check.NotNull(fileSets, nameof(fileSets));
         Check.NotNullOrWhiteSpace(physicalPath, nameof(physicalPath));

--- a/framework/src/Volo.Abp.VirtualFileSystem/Volo/Abp/VirtualFileSystem/VirtualFileSetListExtensions.cs
+++ b/framework/src/Volo.Abp.VirtualFileSystem/Volo/Abp/VirtualFileSystem/VirtualFileSetListExtensions.cs
@@ -64,7 +64,8 @@ public static class VirtualFileSetListExtensions
 
     public static void ReplaceEmbeddedByPhysical<T>(
         [NotNull] this VirtualFileSetList fileSets,
-        [NotNull] string physicalPath)
+        [NotNull] string physicalPath,
+        ExclusionFilters exclusionFilters = ExclusionFilters.Sensitive)
     {
         Check.NotNull(fileSets, nameof(fileSets));
         Check.NotNullOrWhiteSpace(physicalPath, nameof(physicalPath));
@@ -83,7 +84,7 @@ public static class VirtualFileSetListExtensions
                     thisPath = Path.Combine(thisPath, embeddedVirtualFileSet.BaseFolder!);
                 }
 
-                fileSets[i] = new PhysicalVirtualFileSetInfo(new PhysicalFileProvider(thisPath), thisPath);
+                fileSets[i] = new PhysicalVirtualFileSetInfo(new PhysicalFileProvider(thisPath, exclusionFilters), thisPath);
             }
         }
     }


### PR DESCRIPTION
While building an ABP application, i needed this option to include the hidden files (`.file-name`) and directly use the file in debug mode.