### PR TITLE
Fix localization for `SavedSuccessfully` in feature management MVC notification

### DIFF
--- a/modules/feature-management/src/Volo.Abp.FeatureManagement.Web/AbpFeatureManagementWebModule.cs
+++ b/modules/feature-management/src/Volo.Abp.FeatureManagement.Web/AbpFeatureManagementWebModule.cs
@@ -1,10 +1,12 @@
-﻿using Microsoft.AspNetCore.Mvc.RazorPages;
+﻿using Localization.Resources.AbpUi;
+using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.DependencyInjection;
 using Volo.Abp.AspNetCore.Mvc.Localization;
 using Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared;
 using Volo.Abp.FeatureManagement.Localization;
 using Volo.Abp.FeatureManagement.Settings;
 using Volo.Abp.Http.ProxyScripting.Generators.JQuery;
+using Volo.Abp.Localization;
 using Volo.Abp.Modularity;
 using Volo.Abp.SettingManagement.Web;
 using Volo.Abp.SettingManagement.Web.Pages.SettingManagement;
@@ -38,6 +40,13 @@ public class AbpFeatureManagementWebModule : AbpModule
 
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
+        Configure<AbpLocalizationOptions>(options =>
+        {
+            options.Resources
+                .Get<AbpFeatureManagementResource>()
+                .AddBaseTypes(typeof(AbpUiResource));
+        });
+
         Configure<AbpVirtualFileSystemOptions>(options =>
         {
             options.FileSets.AddEmbedded<AbpFeatureManagementWebModule>();


### PR DESCRIPTION
After saving the "Manage host features" modal in the MVC UI, the success notification shows the raw key `SavedSuccessfully` instead of the translated text.

`SavedSuccessfully` is defined in `AbpUiResource`, not in `AbpFeatureManagementResource`. The `HttpApi` and `Blazor` modules already register `AbpUiResource` as a base type, but the MVC `Web` module does not. In microservice setups where the web gateway only references `HttpApi.Client` (not `HttpApi`), the base type is missing and the lookup falls back to the key name.

Add `AddBaseTypes(typeof(AbpUiResource))` in `AbpFeatureManagementWebModule`, matching how `AbpPermissionManagementWebModule`, `AbpAuditLoggingWebModule`, `AbpOpenIddictProWebModule` and other Web modules do it.

Resolves https://github.com/volosoft/volo/issues/22171