### PR TITLE
Update default background job worker options configuration in docs

### DIFF
--- a/docs/en/framework/infrastructure/background-jobs/index.md
+++ b/docs/en/framework/infrastructure/background-jobs/index.md
@@ -271,9 +271,9 @@ If multiple applications share the same storage for background jobs and workers 
 Set `ApplicationName` property in `AbpBackgroundJobWorkerOptions` to your application's name:
 
 ````csharp
-public override void PreConfigureServices(ServiceConfigurationContext context)
+public override void ConfigureServices(ServiceConfigurationContext context)
 {
-    PreConfigure<AbpBackgroundJobWorkerOptions>(options =>
+    Configure<AbpBackgroundJobWorkerOptions>(options =>
     {
         options.ApplicationName = context.Services.GetApplicationName()!;
     });

--- a/docs/en/framework/infrastructure/background-workers/index.md
+++ b/docs/en/framework/infrastructure/background-workers/index.md
@@ -152,9 +152,9 @@ If multiple applications share the same storage for background jobs and workers 
 Set `ApplicationName` property in `AbpBackgroundJobWorkerOptions` to your application's name:
 
 ````csharp
-public override void PreConfigureServices(ServiceConfigurationContext context)
+public override void ConfigureServices(ServiceConfigurationContext context)
 {
-    PreConfigure<AbpBackgroundJobWorkerOptions>(options =>
+    Configure<AbpBackgroundJobWorkerOptions>(options =>
     {
         options.ApplicationName = context.Services.GetApplicationName()!;
     });


### PR DESCRIPTION
Fix #25291

`PreConfigure<AbpBackgroundJobWorkerOptions>` actions are never applied because neither `AbpBackgroundJobsModule` nor `AbpBackgroundJobsAbstractionsModule` calls `ExecutePreConfiguredActions<AbpBackgroundJobWorkerOptions>()`. Switch the docs to `ConfigureServices` + `Configure<AbpBackgroundJobWorkerOptions>` to match the Hangfire/RabbitMQ samples and the fix in #23977.