### PR TITLE
Detect EF Core database provider by keyword match

### DIFF
--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/AbpDbContext.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/AbpDbContext.cs
@@ -197,29 +197,7 @@ public abstract class AbpDbContext<TDbContext> : DbContext, IAbpEfCoreDbContext,
 
     protected virtual EfCoreDatabaseProvider? GetDatabaseProviderOrNull(ModelBuilder modelBuilder)
     {
-        switch (Database.ProviderName)
-        {
-            case "Microsoft.EntityFrameworkCore.SqlServer":
-                return EfCoreDatabaseProvider.SqlServer;
-            case "Npgsql.EntityFrameworkCore.PostgreSQL":
-                return EfCoreDatabaseProvider.PostgreSql;
-            case "Pomelo.EntityFrameworkCore.MySql":
-            case "MySql.Data.MySqlClient":
-                return EfCoreDatabaseProvider.MySql;
-            case "Oracle.EntityFrameworkCore":
-            case "Devart.Data.Oracle.Entity.EFCore":
-                return EfCoreDatabaseProvider.Oracle;
-            case "Microsoft.EntityFrameworkCore.Sqlite":
-                return EfCoreDatabaseProvider.Sqlite;
-            case "Microsoft.EntityFrameworkCore.InMemory":
-                return EfCoreDatabaseProvider.InMemory;
-            case "FirebirdSql.EntityFrameworkCore.Firebird":
-                return EfCoreDatabaseProvider.Firebird;
-            case "Microsoft.EntityFrameworkCore.Cosmos":
-                return EfCoreDatabaseProvider.Cosmos;
-            default:
-                return null;
-        }
+        return EfCoreDatabaseProviderHelper.GetDatabaseProviderOrNull(Database.ProviderName);
     }
 
     public async override Task<int> SaveChangesAsync(bool acceptAllChangesOnSuccess, CancellationToken cancellationToken = default)

--- a/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/EfCoreDatabaseProviderHelper.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore/Volo/Abp/EntityFrameworkCore/EfCoreDatabaseProviderHelper.cs
@@ -1,0 +1,52 @@
+using System;
+
+namespace Volo.Abp.EntityFrameworkCore;
+
+public static class EfCoreDatabaseProviderHelper
+{
+    public static EfCoreDatabaseProvider? GetDatabaseProviderOrNull(string? providerName)
+    {
+        if (providerName.IsNullOrWhiteSpace())
+        {
+            return null;
+        }
+
+        if (providerName.Contains("SqlServer", StringComparison.OrdinalIgnoreCase))
+        {
+            return EfCoreDatabaseProvider.SqlServer;
+        }
+        if (providerName.Contains("Npgsql", StringComparison.OrdinalIgnoreCase) ||
+            providerName.Contains("PostgreSQL", StringComparison.OrdinalIgnoreCase))
+        {
+            return EfCoreDatabaseProvider.PostgreSql;
+        }
+        if (providerName.Contains("MySql", StringComparison.OrdinalIgnoreCase) ||
+            providerName.Contains("Pomelo", StringComparison.OrdinalIgnoreCase))
+        {
+            return EfCoreDatabaseProvider.MySql;
+        }
+        if (providerName.Contains("Oracle", StringComparison.OrdinalIgnoreCase) ||
+            providerName.Contains("Devart", StringComparison.OrdinalIgnoreCase))
+        {
+            return EfCoreDatabaseProvider.Oracle;
+        }
+        if (providerName.Contains("Sqlite", StringComparison.OrdinalIgnoreCase))
+        {
+            return EfCoreDatabaseProvider.Sqlite;
+        }
+        if (providerName.Contains("InMemory", StringComparison.OrdinalIgnoreCase))
+        {
+            return EfCoreDatabaseProvider.InMemory;
+        }
+        if (providerName.Contains("Firebird", StringComparison.OrdinalIgnoreCase))
+        {
+            return EfCoreDatabaseProvider.Firebird;
+        }
+        if (providerName.Contains("Cosmos", StringComparison.OrdinalIgnoreCase))
+        {
+            return EfCoreDatabaseProvider.Cosmos;
+        }
+
+        return null;
+    }
+}

--- a/framework/test/Volo.Abp.EntityFrameworkCore.Tests/Volo.Abp.EntityFrameworkCore.Tests.csproj
+++ b/framework/test/Volo.Abp.EntityFrameworkCore.Tests/Volo.Abp.EntityFrameworkCore.Tests.csproj
@@ -17,6 +17,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" />
+    <PackageReference Include="MySql.EntityFrameworkCore" />
+    <PackageReference Include="Oracle.EntityFrameworkCore" />
   </ItemGroup>
 
 </Project>

--- a/framework/test/Volo.Abp.EntityFrameworkCore.Tests/Volo/Abp/EntityFrameworkCore/EfCoreDatabaseProviderHelper_Tests.cs
+++ b/framework/test/Volo.Abp.EntityFrameworkCore.Tests/Volo/Abp/EntityFrameworkCore/EfCoreDatabaseProviderHelper_Tests.cs
@@ -1,0 +1,111 @@
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Xunit;
+
+namespace Volo.Abp.EntityFrameworkCore;
+
+public class EfCoreDatabaseProviderHelper_Tests
+{
+    [Fact]
+    public void Should_Detect_SqlServer_From_Real_Assembly()
+    {
+        var builder = new DbContextOptionsBuilder<EmptyDbContext>();
+        Microsoft.EntityFrameworkCore.SqlServerDbContextOptionsExtensions.UseSqlServer(builder, "Server=localhost;Database=test");
+        using var context = new EmptyDbContext(builder.Options);
+        EfCoreDatabaseProviderHelper.GetDatabaseProviderOrNull(context.Database.ProviderName)
+            .ShouldBe(EfCoreDatabaseProvider.SqlServer);
+    }
+
+    [Fact]
+    public void Should_Detect_PostgreSql_From_Real_Assembly()
+    {
+        var builder = new DbContextOptionsBuilder<EmptyDbContext>();
+        Microsoft.EntityFrameworkCore.NpgsqlDbContextOptionsBuilderExtensions.UseNpgsql(builder, "Host=localhost;Database=test");
+        using var context = new EmptyDbContext(builder.Options);
+        EfCoreDatabaseProviderHelper.GetDatabaseProviderOrNull(context.Database.ProviderName)
+            .ShouldBe(EfCoreDatabaseProvider.PostgreSql);
+    }
+
+    [Fact]
+    public void Should_Detect_MySql_Pomelo_From_Assembly_Name()
+    {
+        var providerName = typeof(Microsoft.EntityFrameworkCore.MySqlDbContextOptionsBuilderExtensions).Assembly.GetName().Name;
+        EfCoreDatabaseProviderHelper.GetDatabaseProviderOrNull(providerName)
+            .ShouldBe(EfCoreDatabaseProvider.MySql);
+    }
+
+    [Fact]
+    public void Should_Detect_MySql_Oracle_From_Real_Assembly()
+    {
+        var builder = new DbContextOptionsBuilder<EmptyDbContext>();
+        Microsoft.EntityFrameworkCore.MySQLDbContextOptionsExtensions.UseMySQL(builder, "Server=localhost;Database=test");
+        using var context = new EmptyDbContext(builder.Options);
+        EfCoreDatabaseProviderHelper.GetDatabaseProviderOrNull(context.Database.ProviderName)
+            .ShouldBe(EfCoreDatabaseProvider.MySql);
+    }
+
+    [Fact]
+    public void Should_Detect_Oracle_From_Real_Assembly()
+    {
+        var builder = new DbContextOptionsBuilder<EmptyDbContext>();
+        Microsoft.EntityFrameworkCore.OracleDbContextOptionsExtensions.UseOracle(builder, "Data Source=localhost/XE");
+        using var context = new EmptyDbContext(builder.Options);
+        EfCoreDatabaseProviderHelper.GetDatabaseProviderOrNull(context.Database.ProviderName)
+            .ShouldBe(EfCoreDatabaseProvider.Oracle);
+    }
+
+    [Fact]
+    public void Should_Detect_Sqlite_From_Real_Assembly()
+    {
+        var builder = new DbContextOptionsBuilder<EmptyDbContext>();
+        Microsoft.EntityFrameworkCore.SqliteDbContextOptionsBuilderExtensions.UseSqlite(builder, "Data Source=:memory:");
+        using var context = new EmptyDbContext(builder.Options);
+        EfCoreDatabaseProviderHelper.GetDatabaseProviderOrNull(context.Database.ProviderName)
+            .ShouldBe(EfCoreDatabaseProvider.Sqlite);
+    }
+
+    [Fact]
+    public void Should_Detect_InMemory_From_Real_Assembly()
+    {
+        var builder = new DbContextOptionsBuilder<EmptyDbContext>();
+        Microsoft.EntityFrameworkCore.InMemoryDbContextOptionsExtensions.UseInMemoryDatabase(builder, "test");
+        using var context = new EmptyDbContext(builder.Options);
+        EfCoreDatabaseProviderHelper.GetDatabaseProviderOrNull(context.Database.ProviderName)
+            .ShouldBe(EfCoreDatabaseProvider.InMemory);
+    }
+
+    [Theory]
+    [InlineData("Devart.Data.Oracle.Entity.EFCore", EfCoreDatabaseProvider.Oracle)]
+    [InlineData("FirebirdSql.EntityFrameworkCore.Firebird", EfCoreDatabaseProvider.Firebird)]
+    [InlineData("Microsoft.EntityFrameworkCore.Cosmos", EfCoreDatabaseProvider.Cosmos)]
+    public void Should_Detect_Providers_Without_Package_Reference(string providerName, EfCoreDatabaseProvider expected)
+    {
+        EfCoreDatabaseProviderHelper.GetDatabaseProviderOrNull(providerName).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("microsoft.entityframeworkcore.sqlserver", EfCoreDatabaseProvider.SqlServer)]
+    [InlineData("POMELO.ENTITYFRAMEWORKCORE.MYSQL", EfCoreDatabaseProvider.MySql)]
+    [InlineData("npgsql.entityframeworkcore.postgresql", EfCoreDatabaseProvider.PostgreSql)]
+    public void Should_Detect_Providers_Case_Insensitively(string providerName, EfCoreDatabaseProvider expected)
+    {
+        EfCoreDatabaseProviderHelper.GetDatabaseProviderOrNull(providerName).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("Some.Unknown.Provider")]
+    public void Should_Return_Null_For_Unknown_Or_Empty(string? providerName)
+    {
+        EfCoreDatabaseProviderHelper.GetDatabaseProviderOrNull(providerName).ShouldBeNull();
+    }
+
+    private class EmptyDbContext : DbContext
+    {
+        public EmptyDbContext(DbContextOptions<EmptyDbContext> options) : base(options)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Resolve #25293

The previous switch in `AbpDbContext.GetDatabaseProviderOrNull` matched `Database.ProviderName` against a hard-coded set of strings. When the upstream provider assembly got renamed (e.g. Oracle's `MySql.EntityFrameworkCore` vs the old `MySql.Data.MySqlClient`), the switch fell through to `null` and `SetDatabaseProvider` was never called.

Extracted the mapping into `EfCoreDatabaseProviderHelper.GetDatabaseProviderOrNull(string?)` and switched to keyword `Contains` matching, so renamed/forked provider packages are still detected without changes to the framework.

Added unit tests that verify the mapping against the real provider assemblies (SqlServer, PostgreSQL, MySQL (Oracle), Oracle, Sqlite, InMemory) plus string-level tests for the providers not referenced as packages (Pomelo MySQL, Devart Oracle, Firebird, Cosmos).