### PR TITLE
Upgrade `MongoDB.Driver` to 3.8.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -122,7 +122,7 @@
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.16.0" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.16.0" />
     <PackageVersion Include="Minio" Version="6.0.5" />
-    <PackageVersion Include="MongoDB.Driver" Version="3.7.1" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.8.0" />
     <PackageVersion Include="NEST" Version="7.17.5" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="Nito.AsyncEx.Context" Version="5.1.2" />

--- a/docs/en/package-version-changes.md
+++ b/docs/en/package-version-changes.md
@@ -11,6 +11,7 @@
 
 | Package | Old Version | New Version | PR |
 |---------|-------------|-------------|-----|
+| MongoDB.Driver | 3.7.1 | 3.8.0 | #25302 |
 | System.Security.Cryptography.Xml | 10.0.2 | 10.0.6 | #25279 |
 
 ## 10.3.0-rc.1


### PR DESCRIPTION
Upgrade `MongoDB.Driver` from 3.7.1 to 3.8.0.

Release notes: https://github.com/mongodb/mongo-csharp-driver/releases/tag/v3.8.0