### PR TITLE
Upgrade OpenIddict to 7.5.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -132,11 +132,11 @@
     <PackageVersion Include="NUglify" Version="1.21.17" />
     <PackageVersion Include="Nullable" Version="1.3.1" />
     <PackageVersion Include="Octokit" Version="14.0.0" />
-    <PackageVersion Include="OpenIddict.Abstractions" Version="7.3.0" />
-    <PackageVersion Include="OpenIddict.Core" Version="7.3.0" />
-    <PackageVersion Include="OpenIddict.Server.AspNetCore" Version="7.3.0" />
-    <PackageVersion Include="OpenIddict.Validation.AspNetCore" Version="7.3.0" />
-    <PackageVersion Include="OpenIddict.Validation.ServerIntegration" Version="7.3.0" />
+    <PackageVersion Include="OpenIddict.Abstractions" Version="7.5.0" />
+    <PackageVersion Include="OpenIddict.Core" Version="7.5.0" />
+    <PackageVersion Include="OpenIddict.Server.AspNetCore" Version="7.5.0" />
+    <PackageVersion Include="OpenIddict.Validation.AspNetCore" Version="7.5.0" />
+    <PackageVersion Include="OpenIddict.Validation.ServerIntegration" Version="7.5.0" />
     <PackageVersion Include="Oracle.EntityFrameworkCore" Version="10.23.26000" />
     <PackageVersion Include="Polly" Version="8.6.3" />
     <PackageVersion Include="Polly.Extensions.Http" Version="3.0.0" />

--- a/docs/en/package-version-changes.md
+++ b/docs/en/package-version-changes.md
@@ -7,6 +7,16 @@
 
 # Package Version Changes
 
+## 10.4.0-rc.1
+
+| Package | Old Version | New Version | PR |
+|---------|-------------|-------------|-----|
+| OpenIddict.Abstractions | 7.3.0 | 7.5.0 | #25306 |
+| OpenIddict.Core | 7.3.0 | 7.5.0 | #25306 |
+| OpenIddict.Server.AspNetCore | 7.3.0 | 7.5.0 | #25306 |
+| OpenIddict.Validation.AspNetCore | 7.3.0 | 7.5.0 | #25306 |
+| OpenIddict.Validation.ServerIntegration | 7.3.0 | 7.5.0 | #25306 |
+
 ## 10.3.1
 
 | Package | Old Version | New Version | PR |


### PR DESCRIPTION
Upgrade OpenIddict packages from 7.3.0 to 7.5.0, following the out-of-band ASP.NET Core 10.0.7 update that addresses CVE-2026-40372 in `Microsoft.AspNetCore.DataProtection`.

7.5.0 contains no breaking changes affecting the packages ABP consumes (`OpenIddict.Abstractions`, `OpenIddict.Core`, `OpenIddict.Server.AspNetCore`, `OpenIddict.Validation.AspNetCore`, `OpenIddict.Validation.ServerIntegration`).

Release notes: https://github.com/openiddict/openiddict-core/releases/tag/7.5.0