### PR TITLE
docs(identity): document 2FA verification code mechanics and customization

### DIFF
--- a/docs/en/modules/identity/two-factor-authentication.md
+++ b/docs/en/modules/identity/two-factor-authentication.md
@@ -124,78 +124,58 @@ Configure<CookieAuthenticationOptions>(IdentityConstants.TwoFactorRememberMeSche
 
 ## How the Verification Code Is Generated
 
-The code that is delivered by the **Email** and **SMS** verification providers is produced by ASP.NET Core Identity's built-in `EmailTokenProvider<TUser>` and `PhoneNumberTokenProvider<TUser>`. ABP registers them through `AddDefaultTokenProviders()` in `AbpIdentityAspNetCoreModule` and does not replace them, so the mechanics described below are the stock Identity behavior. The `Authenticator` provider is overridden by `AbpAuthenticatorTokenProvider` to additionally require a registered authenticator device before a code can be generated.
+The codes delivered by the **Email** and **SMS** verification providers are produced by ABP's built-in single-use token providers, registered in `AbpIdentityAspNetCoreModule`:
 
-Both `EmailTokenProvider<TUser>` and `PhoneNumberTokenProvider<TUser>` derive from `TotpSecurityStampBasedTokenProvider<TUser>`, which implements TOTP as described in [RFC 6238](https://datatracker.ietf.org/doc/html/rfc6238). The six-digit value is a pure function of the user's security stamp, the current timestep and a provider-specific modifier:
+- `AbpEmailTwoFactorTokenProvider` is registered under `TokenOptions.DefaultEmailProvider` and replaces ASP.NET Core Identity's TOTP-based `EmailTokenProvider<TUser>`.
+- `AbpPhoneNumberTwoFactorTokenProvider` is registered under `TokenOptions.DefaultPhoneProvider` and replaces ASP.NET Core Identity's TOTP-based `PhoneNumberTokenProvider<TUser>`.
 
-```text
-code     = Truncate(HMAC-SHA1(key = SecurityStamp, message = timestep || modifier))
-timestep = floor(UtcNow.UnixSeconds / 180)     // 3-minute step by default
-modifier = "Email:{purpose}:{email}" or "Phone:{purpose}:{phoneNumber}"
-```
+Both derive from the abstract `AbpTwoFactorTokenProvider`. The `Authenticator` provider is unaffected: it is overridden by `AbpAuthenticatorTokenProvider`, which still relies on TOTP ([RFC 6238](https://datatracker.ietf.org/doc/html/rfc6238)) because authenticator apps require it.
 
-The code itself is **not persisted anywhere**. Verification recomputes the value for the current timestep (and one previous timestep to tolerate clock drift and delivery latency) and compares it against the submitted input. This statelessness has a few behaviors that are worth being explicit about:
+On generation, the provider produces a cryptographically-random numeric code (default 6 digits), encrypts it together with an absolute UTC expiration via `IDataProtector`, and persists the resulting blob in the user tokens table. The plaintext code is sent to the user via email/SMS and is never stored. Validation reloads the persisted entry, verifies it has not expired, decrypts and compares constant-time against the submitted input, and — on success — removes the entry so it cannot be replayed.
 
-1. **Two requests in the same timestep return the same code.** If a user presses "Resend code" several times within a few seconds, all deliveries contain an identical value. Nothing is regenerated because nothing is stored — the formula just produces the same output.
-2. **A generated code is not single-use.** Successful verification does not mark the code as consumed. Within its validity window the same code can be submitted again, for example from a concurrent session.
-3. **Generating a new code does not invalidate the previous one.** Any still-valid code remains valid until the window slides past.
-4. **Effective validity is roughly 3–6 minutes.** The current and previous timesteps are both accepted.
-5. **Security stamp rotation is the only natural invalidation.** Operations such as password change or an explicit `UserManager.UpdateSecurityStampAsync` call change the HMAC key and invalidate any outstanding code. Rotating the stamp mid-login will also invalidate the `RequiresTwoFactor` token produced by `SignInManager`, so avoid doing it between the credential step and the verification step.
+This persisted, single-use design has a few properties worth being explicit about:
 
-These properties match the RFC 6238 design and are consistent with how most TOTP-based authenticator apps behave.
+1. **A generated code is single-use.** Successful verification removes the stored entry. Re-submitting the same code from a concurrent session fails.
+2. **Generating a new code invalidates the previous one.** `SetToken` overwrites the same `(provider, name)` row, so at most one code is valid at any time. Re-issuing a code (e.g. when the user requests a new one) replaces the stored entry and the previously delivered code stops working.
+3. **The validity window is exactly the configured lifespan (3 minutes by default).** Expiration is captured as an absolute Unix-seconds value at generation time and is not extended at validation — in contrast to TOTP-based providers, which accept the previous timestep as well and effectively give a 3–6 minute window.
+4. **Failed verification keeps the stored entry in place** so the user can retry until expiration. Rate-limiting incorrect attempts is delegated to ASP.NET Core Identity's lockout settings.
+5. **Concurrent successful verification returns `false` instead of throwing.** Two requests racing to consume the same code go through the user row's `ConcurrencyStamp`; the loser surfaces as a normal validation failure rather than a 500.
+6. **Expired or undecryptable entries are cleaned up on next access.** A stale entry encountered during validation is removed before returning `false`, so the next `GenerateAsync` starts from a clean slate.
 
-## Customizing the Verification Code Provider
+## Configuring the Default Providers
 
-Applications with stronger single-use or replay-resistance requirements can replace the Email and/or Phone providers with a custom implementation of `IUserTwoFactorTokenProvider<IdentityUser>` that stores the generated code in a cache or database, overwrites the entry on regeneration and removes it on successful validation. Because ABP does not register a custom provider for the `Email` and `Phone` keys, adding one in your own module is enough — `AddTokenProvider` with an existing key replaces the previous descriptor in `TokenOptions.ProviderMap`:
+Both built-in providers expose options classes (`AbpEmailTwoFactorTokenProviderOptions` and `AbpPhoneNumberTwoFactorTokenProviderOptions`) inheriting from `AbpTwoFactorTokenProviderOptions`:
+
+| Option | Default | Notes |
+| --- | --- | --- |
+| `TokenLifespan` | `TimeSpan.FromMinutes(3)` | Absolute lifetime of an issued code. |
+| `CodeLength` | `6` | Number of digits in the generated code. Valid range: `1`–`9`. |
+
+Configure them in your module's `ConfigureServices`:
 
 ```csharp
-public class SingleUseEmailOtpTokenProvider : IUserTwoFactorTokenProvider<IdentityUser>
+Configure<AbpEmailTwoFactorTokenProviderOptions>(options =>
 {
-    private static readonly TimeSpan Ttl = TimeSpan.FromMinutes(3);
-    private readonly IDistributedCache _cache;
+    options.TokenLifespan = TimeSpan.FromMinutes(5);
+    options.CodeLength = 8;
+});
 
-    public SingleUseEmailOtpTokenProvider(IDistributedCache cache)
-    {
-        _cache = cache;
-    }
-
-    public Task<bool> CanGenerateTwoFactorTokenAsync(UserManager<IdentityUser> manager, IdentityUser user)
-        => Task.FromResult(true);
-
-    public async Task<string> GenerateAsync(string purpose, UserManager<IdentityUser> manager, IdentityUser user)
-    {
-        var code = RandomNumberGenerator.GetInt32(0, 1_000_000).ToString("D6");
-        await _cache.SetStringAsync(
-            Key(user.Id, purpose),
-            code,
-            new DistributedCacheEntryOptions { AbsoluteExpirationRelativeToNow = Ttl });
-        return code;
-    }
-
-    public async Task<bool> ValidateAsync(string purpose, string token, UserManager<IdentityUser> manager, IdentityUser user)
-    {
-        var key = Key(user.Id, purpose);
-        var stored = await _cache.GetStringAsync(key);
-        if (stored is null || !CryptographicOperations.FixedTimeEquals(
-                Encoding.UTF8.GetBytes(stored),
-                Encoding.UTF8.GetBytes(token)))
-        {
-            return false;
-        }
-        await _cache.RemoveAsync(key);
-        return true;
-    }
-
-    private static string Key(Guid userId, string purpose) => $"otp:email:{purpose}:{userId:N}";
-}
+Configure<AbpPhoneNumberTwoFactorTokenProviderOptions>(options =>
+{
+    options.TokenLifespan = TimeSpan.FromMinutes(2);
+});
 ```
 
-Register the provider in your module's `ConfigureServices`:
+## Replacing the Verification Code Provider
+
+If the built-in single-use behavior does not match your requirements (e.g. you need alphanumeric codes, a different storage backend or a custom delivery policy), you can replace either provider by registering your own `IUserTwoFactorTokenProvider<IdentityUser>` under the same key. `AddTokenProvider` with an existing key replaces the previous descriptor in `TokenOptions.ProviderMap`:
 
 ```csharp
-context.Services.AddIdentityCore<IdentityUser>()
-    .AddTokenProvider<SingleUseEmailOtpTokenProvider>(TokenOptions.DefaultEmailProvider)
-    .AddTokenProvider<SingleUsePhoneOtpTokenProvider>(TokenOptions.DefaultPhoneProvider);
+PreConfigure<IdentityBuilder>(builder =>
+{
+    builder.AddTokenProvider<MyEmailTokenProvider>(TokenOptions.DefaultEmailProvider);
+    builder.AddTokenProvider<MyPhoneTokenProvider>(TokenOptions.DefaultPhoneProvider);
+});
 ```
 
-`AccountAppService.SendTwoFactorCodeAsync` and `SignInManager.TwoFactorSignInAsync` call through `UserManager.GenerateTwoFactorTokenAsync` and `UserManager.VerifyTwoFactorTokenAsync` respectively, so the new provider is invoked without any further wiring. The `RequiresTwoFactor` sentinel token consumed by `SendTwoFactorCodeAsync` uses a separate provider (`TokenOptions.DefaultProvider`, the `DataProtectorTokenProvider`) and is not affected.
+The most ergonomic starting point is to subclass `AbpTwoFactorTokenProvider` and override only the parts you want to change (for example `GenerateNumericCode`, `CreateProtector`, or the storage helpers). `AccountAppService.SendTwoFactorCodeAsync` and `SignInManager.TwoFactorSignInAsync` call through `UserManager.GenerateTwoFactorTokenAsync` and `UserManager.VerifyTwoFactorTokenAsync` respectively, so a registered replacement is invoked without any further wiring.

--- a/docs/en/modules/identity/two-factor-authentication.md
+++ b/docs/en/modules/identity/two-factor-authentication.md
@@ -121,3 +121,81 @@ Configure<CookieAuthenticationOptions>(IdentityConstants.TwoFactorRememberMeSche
      options.Cookie.Name = "MyRememberMeCookieName"; //override the cookie name
 });
 ```
+
+## How the Verification Code Is Generated
+
+The code that is delivered by the **Email** and **SMS** verification providers is produced by ASP.NET Core Identity's built-in `EmailTokenProvider<TUser>` and `PhoneNumberTokenProvider<TUser>`. ABP registers them through `AddDefaultTokenProviders()` in `AbpIdentityAspNetCoreModule` and does not replace them, so the mechanics described below are the stock Identity behavior. The `Authenticator` provider is overridden by `AbpAuthenticatorTokenProvider` to additionally require a registered authenticator device before a code can be generated.
+
+Both `EmailTokenProvider<TUser>` and `PhoneNumberTokenProvider<TUser>` derive from `TotpSecurityStampBasedTokenProvider<TUser>`, which implements TOTP as described in [RFC 6238](https://datatracker.ietf.org/doc/html/rfc6238). The six-digit value is a pure function of the user's security stamp, the current timestep and a provider-specific modifier:
+
+```text
+code     = Truncate(HMAC-SHA1(key = SecurityStamp, message = timestep || modifier))
+timestep = floor(UtcNow.UnixSeconds / 180)     // 3-minute step by default
+modifier = "Email:{purpose}:{email}" or "Phone:{purpose}:{phoneNumber}"
+```
+
+The code itself is **not persisted anywhere**. Verification recomputes the value for the current timestep (and one previous timestep to tolerate clock drift and delivery latency) and compares it against the submitted input. This statelessness has a few behaviors that are worth being explicit about:
+
+1. **Two requests in the same timestep return the same code.** If a user presses "Resend code" several times within a few seconds, all deliveries contain an identical value. Nothing is regenerated because nothing is stored — the formula just produces the same output.
+2. **A generated code is not single-use.** Successful verification does not mark the code as consumed. Within its validity window the same code can be submitted again, for example from a concurrent session.
+3. **Generating a new code does not invalidate the previous one.** Any still-valid code remains valid until the window slides past.
+4. **Effective validity is roughly 3–6 minutes.** The current and previous timesteps are both accepted.
+5. **Security stamp rotation is the only natural invalidation.** Operations such as password change or an explicit `UserManager.UpdateSecurityStampAsync` call change the HMAC key and invalidate any outstanding code. Rotating the stamp mid-login will also invalidate the `RequiresTwoFactor` token produced by `SignInManager`, so avoid doing it between the credential step and the verification step.
+
+These properties match the RFC 6238 design and are consistent with how most TOTP-based authenticator apps behave.
+
+## Customizing the Verification Code Provider
+
+Applications with stronger single-use or replay-resistance requirements can replace the Email and/or Phone providers with a custom implementation of `IUserTwoFactorTokenProvider<IdentityUser>` that stores the generated code in a cache or database, overwrites the entry on regeneration and removes it on successful validation. Because ABP does not register a custom provider for the `Email` and `Phone` keys, adding one in your own module is enough — `AddTokenProvider` with an existing key replaces the previous descriptor in `TokenOptions.ProviderMap`:
+
+```csharp
+public class SingleUseEmailOtpTokenProvider : IUserTwoFactorTokenProvider<IdentityUser>
+{
+    private static readonly TimeSpan Ttl = TimeSpan.FromMinutes(3);
+    private readonly IDistributedCache _cache;
+
+    public SingleUseEmailOtpTokenProvider(IDistributedCache cache)
+    {
+        _cache = cache;
+    }
+
+    public Task<bool> CanGenerateTwoFactorTokenAsync(UserManager<IdentityUser> manager, IdentityUser user)
+        => Task.FromResult(true);
+
+    public async Task<string> GenerateAsync(string purpose, UserManager<IdentityUser> manager, IdentityUser user)
+    {
+        var code = RandomNumberGenerator.GetInt32(0, 1_000_000).ToString("D6");
+        await _cache.SetStringAsync(
+            Key(user.Id, purpose),
+            code,
+            new DistributedCacheEntryOptions { AbsoluteExpirationRelativeToNow = Ttl });
+        return code;
+    }
+
+    public async Task<bool> ValidateAsync(string purpose, string token, UserManager<IdentityUser> manager, IdentityUser user)
+    {
+        var key = Key(user.Id, purpose);
+        var stored = await _cache.GetStringAsync(key);
+        if (stored is null || !CryptographicOperations.FixedTimeEquals(
+                Encoding.UTF8.GetBytes(stored),
+                Encoding.UTF8.GetBytes(token)))
+        {
+            return false;
+        }
+        await _cache.RemoveAsync(key);
+        return true;
+    }
+
+    private static string Key(Guid userId, string purpose) => $"otp:email:{purpose}:{userId:N}";
+}
+```
+
+Register the provider in your module's `ConfigureServices`:
+
+```csharp
+context.Services.AddIdentityCore<IdentityUser>()
+    .AddTokenProvider<SingleUseEmailOtpTokenProvider>(TokenOptions.DefaultEmailProvider)
+    .AddTokenProvider<SingleUsePhoneOtpTokenProvider>(TokenOptions.DefaultPhoneProvider);
+```
+
+`AccountAppService.SendTwoFactorCodeAsync` and `SignInManager.TwoFactorSignInAsync` call through `UserManager.GenerateTwoFactorTokenAsync` and `UserManager.VerifyTwoFactorTokenAsync` respectively, so the new provider is invoked without any further wiring. The `RequiresTwoFactor` sentinel token consumed by `SendTwoFactorCodeAsync` uses a separate provider (`TokenOptions.DefaultProvider`, the `DataProtectorTokenProvider`) and is not affected.


### PR DESCRIPTION
  ### Description

  Adds two new sections to the Two Factor Authentication guide                                                                        
  (`docs/en/modules/identity/two-factor-authentication.md`) covering an
  area the document did not previously address: **how the Email/SMS                                                                   
  verification codes are actually produced, and how to replace the                                                                    
  provider when the default behaviour is not sufficient**.
                                                                                                                                      
  **New sections (appended after "2FA From the End Users' Perspective"):**                                                            
                                                                                                                                      
  1. **How the Verification Code Is Generated**                                                                                       
     - Clarifies that the Email and Phone providers are ASP.NET Core
       Identity's built-in `EmailTokenProvider<TUser>` /                                                                              
       `PhoneNumberTokenProvider<TUser>`, registered via                                                                              
       `AddDefaultTokenProviders()` in `AbpIdentityAspNetCoreModule` and                                                              
       not replaced by ABP, while `Authenticator` is overridden by                                                                    
       `AbpAuthenticatorTokenProvider`.                                                                                               
     - Documents the RFC 6238 TOTP derivation                                                                                         
       (`HMAC-SHA1(SecurityStamp, timestep || modifier)`, 3-minute step).                                                             
     - Spells out five behavioural consequences of the stateless design                                                               
       that users regularly ask about on the forums / GitHub (same code                                                               
       returned within a timestep, codes not being single-use, a new                                                                  
       request not invalidating the previous code, effective 3–6 minute                                                               
       window, security-stamp rotation as the only natural invalidation                                                               
       — including the caveat that rotating mid-login breaks the
       `RequiresTwoFactor` token produced by `SignInManager`).                                                                        
                                                                                                                                      
  2. **Customizing the Verification Code Provider**                                                                                   
     - Explains that stronger single-use / replay-resistant semantics                                                                 
       can be obtained by implementing                                                                                                
       `IUserTwoFactorTokenProvider<IdentityUser>` and registering it                                                                 
       under the existing `Email` / `Phone` keys, which overrides the                                                                 
       previous descriptor in `TokenOptions.ProviderMap`.                                                                             
     - Provides a self-contained `IDistributedCache`-backed example
       (cryptographically-secure 6-digit code, overwrite on regenerate,                                                               
       removed on successful validation, 3-minute TTL).                                                                               
     - Notes that `AccountAppService.SendTwoFactorCodeAsync` and                                                                      
       `SignInManager.TwoFactorSignInAsync` dispatch through                                                                          
       `UserManager.GenerateTwoFactorTokenAsync` /                                                                                    
       `VerifyTwoFactorTokenAsync`, so no further wiring is required,                                                                 
       and that the `RequiresTwoFactor` sentinel (using                                                                               
       `TokenOptions.DefaultProvider`) is unaffected.                                                                                 
                                                                                                                                      
  **Placement:** the new sections are appended at the end of the document
  so it now flows from administrator configuration → provider overview →                                                              
  end-user experience → developer customization, which is the same                                                                    
  progression the existing `Identity.TwoFactorRememberMe` cookie                                                                      
  override example already establishes on its closing paragraph.                                                                      
                                                                                                                                      
  **Not a breaking change.** Documentation-only; no source code or                                                                    
  public API is touched.                                                                                                              
                                                                                                                                      
  ### Checklist                                             
                                                                                                                                      
  - [x] I fully tested it as developer / designer and created unit / integration tests
        *(documentation-only change; no code paths modified, so no tests apply)*
  - [x] I documented it (or no need to document or I will create a separate documentation issue)                                      
                                                                                                                                      
  ### How to test it?                                                                                                                 
                                                                                                                                      
  - Render `docs/en/modules/identity/two-factor-authentication.md` and
    confirm the two new `##` sections appear after
    **2FA From the End Users' Perspective**, the heading hierarchy is                                                                 
    correct, and the `csharp` / `text` code blocks render.                                                                            
  - Cross-check the technical claims against source:                                                                                  
    - `modules/identity/src/Volo.Abp.Identity.AspNetCore/Volo/Abp/Identity/AspNetCore/AbpIdentityAspNetCoreModule.cs`                 
      → `AddDefaultTokenProviders()` registration.                                                                                    
    - `AbpAuthenticatorTokenProvider` (in the commercial Identity Pro                                                                 
      module) → the only provider ABP overrides out of the default three.                                                             
    - `TokenOptions.ProviderMap` replacement semantics via                                                                            
      `IdentityBuilder.AddTokenProvider(name, type)` in the ASP.NET Core                                                              
      Identity source.                                                                                                                
  - Optional sanity check of the example: drop the two provider classes                                                               
    into any ABP Identity-enabled app, register them as shown, then log                                                               
    in with a 2FA-enabled user — requesting a code twice should yield                                                                 
    two different values, and submitting an already-validated code                                                                    
    should fail on the second attempt.                                                                                                
