### PR TITLE
fix: blazor `<AbpStyles>`/`<AbpScripts>` ignore PathBase

### DIFF
--- a/framework/Volo.Abp.slnx
+++ b/framework/Volo.Abp.slnx
@@ -179,6 +179,7 @@
     <Project Path="test/Volo.Abp.AspNetCore.Mvc.PlugIn/Volo.Abp.AspNetCore.Mvc.PlugIn.csproj" />
     <Project Path="test/Volo.Abp.AspNetCore.Mvc.Tests/Volo.Abp.AspNetCore.Mvc.Tests.csproj" />
     <Project Path="test/Volo.Abp.AspNetCore.Mvc.UI.Tests/Volo.Abp.AspNetCore.Mvc.UI.Tests.csproj" />
+    <Project Path="test/Volo.Abp.AspNetCore.Components.Web.Theming.Tests/Volo.Abp.AspNetCore.Components.Web.Theming.Tests.csproj" />
     <Project Path="test/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared.Tests/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared.Tests.csproj" />
     <Project Path="test/Volo.Abp.AspNetCore.Mvc.Versioning.Tests/Volo.Abp.AspNetCore.Mvc.Versioning.Tests.csproj" />
     <Project Path="test/Volo.Abp.AspNetCore.Mvc.Client.Tests/Volo.Abp.AspNetCore.Mvc.Client.Tests.csproj" />

--- a/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Bundling/AbpScripts.razor
+++ b/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Bundling/AbpScripts.razor
@@ -1,16 +1,14 @@
+@using Microsoft.AspNetCore.Components
 @implements IDisposable
 @inject IComponentBundleManager BundleManager
 @inject PersistentComponentState ApplicationState
+@inject NavigationManager NavigationManager
+@inject IComponentBundleUrlBuilder BundleUrlBuilder
 @if (ScriptFiles != null)
 {
     foreach (var file in ScriptFiles)
     {
-        var src = file;
-        if (!AppBasePath.IsNullOrWhiteSpace())
-        {
-            src = AppBasePath.EnsureEndsWith('/') + file.RemovePreFix("/");
-        }
-        <script src="@src"></script>
+        <script src="@file"></script>
     }
 }
 
@@ -39,7 +37,8 @@
             // We are in prerendering mode
             if (!BundleName.IsNullOrWhiteSpace())
             {
-                ScriptFiles = (await BundleManager.GetScriptBundleFilesAsync(BundleName!)).ToList();
+                var rawFiles = await BundleManager.GetScriptBundleFilesAsync(BundleName!);
+                ScriptFiles = await ResolveAsync(rawFiles);
             }
         }
         else
@@ -49,6 +48,16 @@
                 ScriptFiles = WebAssemblyScriptFiles;
             }
         }
+    }
+
+    private async Task<List<string>> ResolveAsync(IReadOnlyList<string> files)
+    {
+        var resolved = new List<string>(files.Count);
+        foreach (var file in files)
+        {
+            resolved.Add(await BundleUrlBuilder.BuildAsync(file, AppBasePath, NavigationManager.BaseUri));
+        }
+        return resolved;
     }
 
     private Task Callback()

--- a/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Bundling/AbpStyles.razor
+++ b/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Bundling/AbpStyles.razor
@@ -1,16 +1,14 @@
+@using Microsoft.AspNetCore.Components
 @implements IDisposable
 @inject IComponentBundleManager BundleManager
 @inject PersistentComponentState ApplicationState
+@inject NavigationManager NavigationManager
+@inject IComponentBundleUrlBuilder BundleUrlBuilder
 @if (StyleFiles != null)
 {
     foreach (var file in StyleFiles)
     {
-        var href = file;
-        if (!AppBasePath.IsNullOrWhiteSpace())
-        {
-            href = AppBasePath.EnsureEndsWith('/') + file.RemovePreFix("/");
-        }
-        <link rel="stylesheet" href="@href" />
+        <link rel="stylesheet" href="@file" />
     }
 }
 
@@ -39,7 +37,8 @@
             // We are in prerendering mode
             if (!BundleName.IsNullOrWhiteSpace())
             {
-                StyleFiles = (await BundleManager.GetStyleBundleFilesAsync(BundleName!)).ToList();
+                var rawFiles = await BundleManager.GetStyleBundleFilesAsync(BundleName!);
+                StyleFiles = await ResolveAsync(rawFiles);
             }
         }
         else
@@ -63,6 +62,16 @@
             StyleFiles = WebAssemblyStyleFiles;
             StateHasChanged();
         }
+    }
+
+    private async Task<List<string>> ResolveAsync(IReadOnlyList<string> files)
+    {
+        var resolved = new List<string>(files.Count);
+        foreach (var file in files)
+        {
+            resolved.Add(await BundleUrlBuilder.BuildAsync(file, AppBasePath, NavigationManager.BaseUri));
+        }
+        return resolved;
     }
 
     private Task Callback()

--- a/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Bundling/ComponentBundleUrlBuilder.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Bundling/ComponentBundleUrlBuilder.cs
@@ -14,11 +14,16 @@ public class ComponentBundleUrlBuilder : IComponentBundleUrlBuilder, ITransientD
     {
         Check.NotNull(fileName, nameof(fileName));
 
-        var pathBase = !string.IsNullOrEmpty(appBasePath)
+        if (IsExternalUrl(fileName))
+        {
+            return Task.FromResult(fileName);
+        }
+
+        var pathBase = !string.IsNullOrWhiteSpace(appBasePath)
             ? appBasePath
             : ExtractPathBaseFromNavigationBaseUri(navigationBaseUri);
 
-        if (string.IsNullOrEmpty(pathBase))
+        if (string.IsNullOrWhiteSpace(pathBase))
         {
             return Task.FromResult(fileName);
         }
@@ -32,9 +37,15 @@ public class ComponentBundleUrlBuilder : IComponentBundleUrlBuilder, ITransientD
         return Task.FromResult(normalized + fileName.RemovePreFix("/"));
     }
 
+    protected virtual bool IsExternalUrl([NotNull] string fileName)
+    {
+        return fileName.StartsWith("//", StringComparison.Ordinal) ||
+               (fileName.Contains(':') && Uri.TryCreate(fileName, UriKind.Absolute, out _));
+    }
+
     protected virtual string? ExtractPathBaseFromNavigationBaseUri([CanBeNull] string? navigationBaseUri)
     {
-        if (string.IsNullOrEmpty(navigationBaseUri))
+        if (string.IsNullOrWhiteSpace(navigationBaseUri))
         {
             return null;
         }

--- a/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Bundling/ComponentBundleUrlBuilder.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Bundling/ComponentBundleUrlBuilder.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Volo.Abp.DependencyInjection;
+
+namespace Volo.Abp.AspNetCore.Components.Web.Theming.Bundling;
+
+public class ComponentBundleUrlBuilder : IComponentBundleUrlBuilder, ITransientDependency
+{
+    public virtual Task<string> BuildAsync(
+        [NotNull] string fileName,
+        [CanBeNull] string? appBasePath,
+        [CanBeNull] string? navigationBaseUri)
+    {
+        Check.NotNull(fileName, nameof(fileName));
+
+        var pathBase = !string.IsNullOrEmpty(appBasePath)
+            ? appBasePath
+            : ExtractPathBaseFromNavigationBaseUri(navigationBaseUri);
+
+        if (string.IsNullOrEmpty(pathBase))
+        {
+            return Task.FromResult(fileName);
+        }
+
+        var normalized = pathBase.EnsureEndsWith('/');
+        if (normalized == "/")
+        {
+            return Task.FromResult(fileName);
+        }
+
+        return Task.FromResult(normalized + fileName.RemovePreFix("/"));
+    }
+
+    protected virtual string? ExtractPathBaseFromNavigationBaseUri([CanBeNull] string? navigationBaseUri)
+    {
+        if (string.IsNullOrEmpty(navigationBaseUri))
+        {
+            return null;
+        }
+
+        return Uri.TryCreate(navigationBaseUri, UriKind.Absolute, out var uri)
+            ? uri.AbsolutePath
+            : null;
+    }
+}

--- a/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Bundling/IComponentBundleUrlBuilder.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Bundling/IComponentBundleUrlBuilder.cs
@@ -1,0 +1,8 @@
+using System.Threading.Tasks;
+
+namespace Volo.Abp.AspNetCore.Components.Web.Theming.Bundling;
+
+public interface IComponentBundleUrlBuilder
+{
+    Task<string> BuildAsync(string fileName, string? appBasePath, string? navigationBaseUri);
+}

--- a/framework/test/Volo.Abp.AspNetCore.Components.Web.Theming.Tests/Volo.Abp.AspNetCore.Components.Web.Theming.Tests.abppkg
+++ b/framework/test/Volo.Abp.AspNetCore.Components.Web.Theming.Tests/Volo.Abp.AspNetCore.Components.Web.Theming.Tests.abppkg
@@ -1,0 +1,3 @@
+{
+  "role": "lib.test"
+}

--- a/framework/test/Volo.Abp.AspNetCore.Components.Web.Theming.Tests/Volo.Abp.AspNetCore.Components.Web.Theming.Tests.csproj
+++ b/framework/test/Volo.Abp.AspNetCore.Components.Web.Theming.Tests/Volo.Abp.AspNetCore.Components.Web.Theming.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\..\..\common.test.props" />
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace />
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AbpTestBase\AbpTestBase.csproj" />
+    <ProjectReference Include="..\..\src\Volo.Abp.AspNetCore.Components.Web.Theming\Volo.Abp.AspNetCore.Components.Web.Theming.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+  </ItemGroup>
+
+</Project>

--- a/framework/test/Volo.Abp.AspNetCore.Components.Web.Theming.Tests/Volo/Abp/AspNetCore/Components/Web/Theming/Bundling/ComponentBundleUrlBuilder_Tests.cs
+++ b/framework/test/Volo.Abp.AspNetCore.Components.Web.Theming.Tests/Volo/Abp/AspNetCore/Components/Web/Theming/Bundling/ComponentBundleUrlBuilder_Tests.cs
@@ -84,4 +84,22 @@ public class ComponentBundleUrlBuilder_Tests
         await Should.ThrowAsync<System.ArgumentNullException>(async () =>
             await _builder.BuildAsync(null!, appBasePath: "/foo", navigationBaseUri: null));
     }
+
+    [Theory]
+    [InlineData("https://cdn.example.com/foo.css")]
+    [InlineData("http://cdn.example.com/foo.css")]
+    [InlineData("//cdn.example.com/foo.css")]
+    [InlineData("data:text/css;base64,Zm9vIA==")]
+    public async Task Should_Not_Prefix_External_Urls(string externalUrl)
+    {
+        (await _builder.BuildAsync(externalUrl, appBasePath: "/foo", navigationBaseUri: "https://localhost/foo/"))
+            .ShouldBe(externalUrl);
+    }
+
+    [Fact]
+    public async Task Should_Treat_Whitespace_AppBasePath_As_Not_Provided()
+    {
+        (await _builder.BuildAsync("/__bundles/Global.css", appBasePath: "   ", navigationBaseUri: "https://localhost/foo/"))
+            .ShouldBe("/foo/__bundles/Global.css");
+    }
 }

--- a/framework/test/Volo.Abp.AspNetCore.Components.Web.Theming.Tests/Volo/Abp/AspNetCore/Components/Web/Theming/Bundling/ComponentBundleUrlBuilder_Tests.cs
+++ b/framework/test/Volo.Abp.AspNetCore.Components.Web.Theming.Tests/Volo/Abp/AspNetCore/Components/Web/Theming/Bundling/ComponentBundleUrlBuilder_Tests.cs
@@ -1,0 +1,87 @@
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+
+namespace Volo.Abp.AspNetCore.Components.Web.Theming.Bundling;
+
+public class ComponentBundleUrlBuilder_Tests
+{
+    private readonly IComponentBundleUrlBuilder _builder = new ComponentBundleUrlBuilder();
+
+    [Fact]
+    public async Task Should_Return_FileName_When_No_PathBase_Available()
+    {
+        (await _builder.BuildAsync("/__bundles/Global.css", appBasePath: null, navigationBaseUri: null))
+            .ShouldBe("/__bundles/Global.css");
+    }
+
+    [Fact]
+    public async Task Should_Return_FileName_When_NavigationBaseUri_Has_Root_PathBase()
+    {
+        (await _builder.BuildAsync("/__bundles/Global.css", appBasePath: null, navigationBaseUri: "https://localhost/"))
+            .ShouldBe("/__bundles/Global.css");
+    }
+
+    [Fact]
+    public async Task Should_Use_Explicit_AppBasePath_Over_NavigationBaseUri()
+    {
+        (await _builder.BuildAsync("/__bundles/Global.css", appBasePath: "/explicit", navigationBaseUri: "https://localhost/from-nav/"))
+            .ShouldBe("/explicit/__bundles/Global.css");
+    }
+
+    [Fact]
+    public async Task Should_Resolve_PathBase_From_NavigationBaseUri()
+    {
+        (await _builder.BuildAsync("/__bundles/Global.css", appBasePath: null, navigationBaseUri: "https://localhost/foo/"))
+            .ShouldBe("/foo/__bundles/Global.css");
+    }
+
+    [Fact]
+    public async Task Should_Resolve_PathBase_From_NavigationBaseUri_When_AppBasePath_Empty()
+    {
+        (await _builder.BuildAsync("/__bundles/Global.css", appBasePath: "", navigationBaseUri: "https://localhost/foo/"))
+            .ShouldBe("/foo/__bundles/Global.css");
+    }
+
+    [Fact]
+    public async Task Should_Handle_Nested_PathBase()
+    {
+        (await _builder.BuildAsync("/__bundles/Global.css", appBasePath: null, navigationBaseUri: "https://localhost/foo/bar/"))
+            .ShouldBe("/foo/bar/__bundles/Global.css");
+    }
+
+    [Fact]
+    public async Task Should_Normalize_AppBasePath_Without_Trailing_Slash()
+    {
+        (await _builder.BuildAsync("/__bundles/Global.css", appBasePath: "/foo", navigationBaseUri: null))
+            .ShouldBe("/foo/__bundles/Global.css");
+    }
+
+    [Fact]
+    public async Task Should_Not_Duplicate_Leading_Slash()
+    {
+        (await _builder.BuildAsync("/__bundles/Global.css", appBasePath: "/foo/", navigationBaseUri: null))
+            .ShouldBe("/foo/__bundles/Global.css");
+    }
+
+    [Fact]
+    public async Task Should_Handle_FileName_Without_Leading_Slash()
+    {
+        (await _builder.BuildAsync("__bundles/Global.css", appBasePath: "/foo", navigationBaseUri: null))
+            .ShouldBe("/foo/__bundles/Global.css");
+    }
+
+    [Fact]
+    public async Task Should_Return_FileName_When_NavigationBaseUri_Is_Invalid()
+    {
+        (await _builder.BuildAsync("/__bundles/Global.css", appBasePath: null, navigationBaseUri: "not-a-uri"))
+            .ShouldBe("/__bundles/Global.css");
+    }
+
+    [Fact]
+    public async Task Should_Throw_When_FileName_Is_Null()
+    {
+        await Should.ThrowAsync<System.ArgumentNullException>(async () =>
+            await _builder.BuildAsync(null!, appBasePath: "/foo", navigationBaseUri: null));
+    }
+}


### PR DESCRIPTION
Resolves #25335

`<AbpStyles>` / `<AbpScripts>` emit bundle URLs with a leading `/`, which makes browsers ignore `<base href>` per RFC 3986 §5.2.2. Under a virtual application (IIS sub-app, reverse proxy that only forwards `/foo/*`), the `PathBase` is dropped and the request hits the origin root, returning 404.

Introduce `IComponentBundleUrlBuilder` (replaceable via DI) and inject `NavigationManager` so the components automatically prefix the bundle URL with the current `PathBase`, resolved from `NavigationManager.BaseUri`, when `AppBasePath` is not explicitly provided. The `AppBasePath` parameter from #22514 keeps working and takes precedence.