### PR TITLE
fix: blazor `<AbpStyles>`/`<AbpScripts>` lose `PathBase` for WebAssembly files

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Bundling/AbpScripts.razor
+++ b/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Bundling/AbpScripts.razor
@@ -45,7 +45,7 @@
         {
             if (OperatingSystem.IsBrowser() && WebAssemblyScriptFiles != null)
             {
-                ScriptFiles = WebAssemblyScriptFiles;
+                ScriptFiles = await ResolveAsync(WebAssemblyScriptFiles);
             }
         }
     }

--- a/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Bundling/AbpStyles.razor
+++ b/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Bundling/AbpStyles.razor
@@ -46,7 +46,7 @@
             StyleFiles = scriptFiles;
             if (OperatingSystem.IsBrowser() && StyleFiles != null && WebAssemblyStyleFiles != null)
             {
-                StyleFiles.AddIfNotContains(WebAssemblyStyleFiles);
+                StyleFiles.AddIfNotContains(await ResolveAsync(WebAssemblyStyleFiles));
             }
         }
     }
@@ -59,7 +59,7 @@
         {
             _hasRemoveServerStyle = true;
             await Task.Delay(3000);
-            StyleFiles = WebAssemblyStyleFiles;
+            StyleFiles = await ResolveAsync(WebAssemblyStyleFiles);
             StateHasChanged();
         }
     }

--- a/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Bundling/ComponentBundleUrlBuilder.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Components.Web.Theming/Bundling/ComponentBundleUrlBuilder.cs
@@ -34,6 +34,11 @@ public class ComponentBundleUrlBuilder : IComponentBundleUrlBuilder, ITransientD
             return Task.FromResult(fileName);
         }
 
+        if (fileName.StartsWith(normalized, StringComparison.Ordinal))
+        {
+            return Task.FromResult(fileName);
+        }
+
         return Task.FromResult(normalized + fileName.RemovePreFix("/"));
     }
 

--- a/framework/test/Volo.Abp.AspNetCore.Components.Web.Theming.Tests/Volo/Abp/AspNetCore/Components/Web/Theming/Bundling/ComponentBundleUrlBuilder_Tests.cs
+++ b/framework/test/Volo.Abp.AspNetCore.Components.Web.Theming.Tests/Volo/Abp/AspNetCore/Components/Web/Theming/Bundling/ComponentBundleUrlBuilder_Tests.cs
@@ -102,4 +102,18 @@ public class ComponentBundleUrlBuilder_Tests
         (await _builder.BuildAsync("/__bundles/Global.css", appBasePath: "   ", navigationBaseUri: "https://localhost/foo/"))
             .ShouldBe("/foo/__bundles/Global.css");
     }
+
+    [Fact]
+    public async Task Should_Be_Idempotent_For_Already_Prefixed_FileName()
+    {
+        (await _builder.BuildAsync("/foo/__bundles/Global.css", appBasePath: "/foo", navigationBaseUri: null))
+            .ShouldBe("/foo/__bundles/Global.css");
+    }
+
+    [Fact]
+    public async Task Should_Be_Idempotent_When_PathBase_Resolved_From_NavigationBaseUri()
+    {
+        (await _builder.BuildAsync("/foo/__bundles/Global.css", appBasePath: null, navigationBaseUri: "https://localhost/foo/"))
+            .ShouldBe("/foo/__bundles/Global.css");
+    }
 }


### PR DESCRIPTION
Follow-up to #25336.

`WebAssemblyStyleFiles` / `WebAssemblyScriptFiles` (the WebAssembly switch / append branches) skipped `IComponentBundleUrlBuilder`, so leading-`/` URLs were rendered as-is and dropped the `PathBase` under a virtual application. Resolve them through the builder, same as the prerender bundle files.