### PR TITLE
Wrap MudBlazor UI calls with `InvokeAsync` to fix Dispatcher race

### DIFF
--- a/framework/src/Volo.Abp.MudBlazorUI/AbpMudCrudPageBase.cs
+++ b/framework/src/Volo.Abp.MudBlazorUI/AbpMudCrudPageBase.cs
@@ -375,7 +375,7 @@ public abstract class AbpMudCrudPageBase<
 
             if (_createDialog != null)
             {
-                await _createDialog.ShowAsync();
+                await InvokeAsync(() => _createDialog.ShowAsync());
             }
         }
         catch (Exception ex)
@@ -384,13 +384,14 @@ public abstract class AbpMudCrudPageBase<
         }
     }
 
-    protected virtual async Task CloseCreateDialogAsync()
+    protected virtual Task CloseCreateDialogAsync()
     {
         NewEntity = new TCreateViewModel();
         if (_createDialog != null)
         {
-            await _createDialog.CloseAsync();
+            return InvokeAsync(() => _createDialog.CloseAsync());
         }
+        return Task.CompletedTask;
     }
 
     protected virtual async Task OpenEditDialogAsync(TListViewModel entity)
@@ -406,7 +407,7 @@ public abstract class AbpMudCrudPageBase<
 
             if (_editDialog != null)
             {
-                await _editDialog.ShowAsync();
+                await InvokeAsync(() => _editDialog.ShowAsync());
             }
         }
         catch (Exception ex)
@@ -440,12 +441,13 @@ public abstract class AbpMudCrudPageBase<
         return ObjectMapper.Map<TUpdateViewModel, TUpdateInput>(updateViewModel);
     }
 
-    protected virtual async Task CloseEditDialogAsync()
+    protected virtual Task CloseEditDialogAsync()
     {
         if (_editDialog != null)
         {
-            await _editDialog.CloseAsync();
+            return InvokeAsync(() => _editDialog.CloseAsync());
         }
+        return Task.CompletedTask;
     }
 
     protected virtual async Task CreateEntityAsync()

--- a/framework/src/Volo.Abp.MudBlazorUI/Components/AbpMudExtensibleDataGrid.razor.cs
+++ b/framework/src/Volo.Abp.MudBlazorUI/Components/AbpMudExtensibleDataGrid.razor.cs
@@ -61,7 +61,7 @@ public partial class AbpMudExtensibleDataGrid<TItem> : ComponentBase
     {
         if (_dataGrid != null && ServerData != null)
         {
-            await _dataGrid.ReloadServerData();
+            await InvokeAsync(() => _dataGrid.ReloadServerData());
         }
     }
 

--- a/framework/src/Volo.Abp.MudBlazorUI/Components/MudEntityAction.razor.cs
+++ b/framework/src/Volo.Abp.MudBlazorUI/Components/MudEntityAction.razor.cs
@@ -69,7 +69,7 @@ public partial class MudEntityAction<TItem> : ComponentBase
         {
             if (await UiMessageService.Confirm(ConfirmationMessage()))
             {
-                await InvokeAsync(async () => await Clicked.InvokeAsync());
+                await InvokeAsync(Clicked.InvokeAsync);
             }
         }
         else

--- a/framework/src/Volo.Abp.MudBlazorUI/Components/MudEntityAction.razor.cs
+++ b/framework/src/Volo.Abp.MudBlazorUI/Components/MudEntityAction.razor.cs
@@ -69,7 +69,7 @@ public partial class MudEntityAction<TItem> : ComponentBase
         {
             if (await UiMessageService.Confirm(ConfirmationMessage()))
             {
-                await InvokeAsync(Clicked.InvokeAsync);
+                await InvokeAsync(() => Clicked.InvokeAsync());
             }
         }
         else

--- a/framework/src/Volo.Abp.MudBlazorUI/Components/ObjectExtending/MudLookupExtensionProperty.razor.cs
+++ b/framework/src/Volo.Abp.MudBlazorUI/Components/ObjectExtending/MudLookupExtensionProperty.razor.cs
@@ -58,7 +58,7 @@ public partial class MudLookupExtensionProperty<TEntity, TResourceType>
         if (firstRender)
         {
             LookupItems = await GetLookupItemsAsync(string.Empty);
-            StateHasChanged();
+            await InvokeAsync(StateHasChanged);
         }
     }
 


### PR DESCRIPTION
Wrap MudBlazor UI calls (`Show/CloseAsync`, `ReloadServerData`, `StateHasChanged` after `await`) with `InvokeAsync` to fix `InvalidOperationException: The current thread is not associated with the Dispatcher` in Blazor InteractiveServer mode.

Root cause: ABP `configureawait.props` injects `ConfigureAwait(false)` in Release builds, so continuations after `await AppService.XxxAsync(...)` drift off the Renderer Dispatcher; subsequent `MudDialog` / `MudDataGrid` UI calls then trigger `StateHasChanged()` on a non-Dispatcher thread.

Files:
- `AbpMudCrudPageBase`: `OpenCreate/EditDialogAsync`, `CloseCreate/EditDialogAsync`
- `AbpMudExtensibleDataGrid.ReloadServerDataAsync`
- `MudLookupExtensionProperty.OnAfterRenderAsync`

Same approach as MudBlazor/MudBlazor#9261 and MudBlazor/MudBlazor#9306. `Volo.Abp.BlazoriseUI` already does this.