### PR TITLE
Add default scopes fallback for `client_credentials`/`password`/`token_exchange` grants

### DIFF
--- a/docs/en/modules/openiddict.md
+++ b/docs/en/modules/openiddict.md
@@ -303,6 +303,18 @@ PreConfigure<AbpOpenIddictAspNetCoreOptions>(options =>
 
 - `UpdateAbpClaimTypes(default: true)`:  Updates `AbpClaimTypes` to be compatible with the Openiddict claims.
 - `AddDevelopmentEncryptionAndSigningCertificate(default: true)`:  Registers (and generates if necessary) a user-specific development encryption/development signing certificate. This is a certificate used for signing and encrypting the tokens and for **development environment only**. You must set it to **false** for non-development environments.
+- `UseDefaultScopesForClientCredentials(default: false)`: When set to `true`, the access token issued for the `client_credentials` grant automatically grants the scopes configured on the client application (permissions prefixed with `oi_scp:`) when the client does not explicitly request any scope.
+- `UseDefaultScopesForPassword(default: false)`: When set to `true`, the token response for the `password` grant automatically grants the scopes configured on the client application when the client does not explicitly request any scope. If the configured scopes include `openid`/`profile`/`email`/`roles`, the corresponding `id_token` and claim destinations are affected as well.
+- `UseDefaultScopesForTokenExchange(default: false)`: When set to `true`, the token response for the `urn:ietf:params:oauth:grant-type:token-exchange` grant automatically grants the scopes configured on the client application when the client does not explicitly request any scope. If the configured scopes include `openid`/`profile`/`email`/`roles`, the corresponding `id_token` and claim destinations are affected as well.
+
+Example to enable the default-scope fallback for the `client_credentials` grant:
+
+```csharp
+PreConfigure<AbpOpenIddictAspNetCoreOptions>(options =>
+{
+    options.UseDefaultScopesForClientCredentials = true;
+});
+```
 
 > `AddDevelopmentEncryptionAndSigningCertificate` cannot be used in applications deployed on IIS or Azure App Service: trying to use them on IIS or Azure App Service will result in an exception being thrown at runtime (unless the application pool is configured to load a user profile). To avoid that, consider creating self-signed certificates and storing them in the X.509 certificates store of the host machine(s). Please refer to: https://documentation.openiddict.com/configuration/encryption-and-signing-credentials.html#registering-a-development-certificate
 

--- a/modules/openiddict/app/OpenIddict.Demo.Server/OpenIddict.Demo.Server.csproj
+++ b/modules/openiddict/app/OpenIddict.Demo.Server/OpenIddict.Demo.Server.csproj
@@ -68,6 +68,10 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
             <PrivateAssets>compile; contentFiles; build; buildMultitargeting; buildTransitive; analyzers; native</PrivateAssets>
         </PackageReference>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+            <PrivateAssets>compile; contentFiles; build; buildMultitargeting; buildTransitive; analyzers; native</PrivateAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/modules/openiddict/src/Volo.Abp.OpenIddict.AspNetCore/Volo/Abp/OpenIddict/AbpOpenIddictAspNetCoreModule.cs
+++ b/modules/openiddict/src/Volo.Abp.OpenIddict.AspNetCore/Volo/Abp/OpenIddict/AbpOpenIddictAspNetCoreModule.cs
@@ -25,7 +25,14 @@ public class AbpOpenIddictAspNetCoreModule : AbpModule
 
         Configure<AbpOpenIddictClaimsPrincipalOptions>(options =>
         {
+            options.ClaimsPrincipalHandlers.Add<AbpDefaultScopesHandler>();
             options.ClaimsPrincipalHandlers.Add<AbpDefaultOpenIddictClaimsPrincipalHandler>();
+        });
+
+        var preActions = context.Services.GetPreConfigureActions<AbpOpenIddictAspNetCoreOptions>();
+        Configure<AbpOpenIddictAspNetCoreOptions>(options =>
+        {
+            preActions.Configure(options);
         });
 
         Configure<RazorViewEngineOptions>(options =>

--- a/modules/openiddict/src/Volo.Abp.OpenIddict.AspNetCore/Volo/Abp/OpenIddict/AbpOpenIddictOptions.cs
+++ b/modules/openiddict/src/Volo.Abp.OpenIddict.AspNetCore/Volo/Abp/OpenIddict/AbpOpenIddictOptions.cs
@@ -25,4 +25,28 @@ public class AbpOpenIddictAspNetCoreOptions
     /// Set the url of the select account page.
     /// </summary>
     public string SelectAccountPage { get; set; } = "~/Account/SelectAccount";
+
+    /// <summary>
+    /// When set to <c>true</c>, the access token issued for the <c>client_credentials</c> grant
+    /// automatically includes the scopes configured on the client application (permissions
+    /// prefixed with <c>oi_scp:</c>) when the client does not explicitly request any scope.
+    /// Default: false.
+    /// </summary>
+    public bool UseDefaultScopesForClientCredentials { get; set; }
+
+    /// <summary>
+    /// When set to <c>true</c>, the access token issued for the <c>password</c> grant
+    /// automatically includes the scopes configured on the client application (permissions
+    /// prefixed with <c>oi_scp:</c>) when the client does not explicitly request any scope.
+    /// Default: false.
+    /// </summary>
+    public bool UseDefaultScopesForPassword { get; set; }
+
+    /// <summary>
+    /// When set to <c>true</c>, the access token issued for the <c>urn:ietf:params:oauth:grant-type:token-exchange</c>
+    /// grant automatically includes the scopes configured on the client application (permissions
+    /// prefixed with <c>oi_scp:</c>) when the client does not explicitly request any scope.
+    /// Default: false.
+    /// </summary>
+    public bool UseDefaultScopesForTokenExchange { get; set; }
 }

--- a/modules/openiddict/src/Volo.Abp.OpenIddict.AspNetCore/Volo/Abp/OpenIddict/AbpOpenIddictOptions.cs
+++ b/modules/openiddict/src/Volo.Abp.OpenIddict.AspNetCore/Volo/Abp/OpenIddict/AbpOpenIddictOptions.cs
@@ -35,17 +35,22 @@ public class AbpOpenIddictAspNetCoreOptions
     public bool UseDefaultScopesForClientCredentials { get; set; }
 
     /// <summary>
-    /// When set to <c>true</c>, the access token issued for the <c>password</c> grant
-    /// automatically includes the scopes configured on the client application (permissions
-    /// prefixed with <c>oi_scp:</c>) when the client does not explicitly request any scope.
+    /// When set to <c>true</c>, the token response for the <c>password</c> grant automatically
+    /// grants the scopes configured on the client application (permissions prefixed with
+    /// <c>oi_scp:</c>) when the client does not explicitly request any scope. If the configured
+    /// scopes include <c>openid</c>/<c>profile</c>/<c>email</c>/<c>roles</c>, the corresponding
+    /// id_token and claim destinations are affected as well.
     /// Default: false.
     /// </summary>
     public bool UseDefaultScopesForPassword { get; set; }
 
     /// <summary>
-    /// When set to <c>true</c>, the access token issued for the <c>urn:ietf:params:oauth:grant-type:token-exchange</c>
-    /// grant automatically includes the scopes configured on the client application (permissions
-    /// prefixed with <c>oi_scp:</c>) when the client does not explicitly request any scope.
+    /// When set to <c>true</c>, the token response for the
+    /// <c>urn:ietf:params:oauth:grant-type:token-exchange</c> grant automatically grants the
+    /// scopes configured on the client application (permissions prefixed with <c>oi_scp:</c>)
+    /// when the client does not explicitly request any scope. If the configured scopes include
+    /// <c>openid</c>/<c>profile</c>/<c>email</c>/<c>roles</c>, the corresponding id_token and
+    /// claim destinations are affected as well.
     /// Default: false.
     /// </summary>
     public bool UseDefaultScopesForTokenExchange { get; set; }

--- a/modules/openiddict/src/Volo.Abp.OpenIddict.AspNetCore/Volo/Abp/OpenIddict/Claims/AbpDefaultScopesHandler.cs
+++ b/modules/openiddict/src/Volo.Abp.OpenIddict.AspNetCore/Volo/Abp/OpenIddict/Claims/AbpDefaultScopesHandler.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
@@ -68,14 +67,7 @@ public class AbpDefaultScopesHandler : IAbpOpenIddictClaimsPrincipalHandler, ITr
             string.Join(", ", scopes));
 
         context.Principal.SetScopes(scopes);
-
-        var resources = new List<string>();
-        await foreach (var resource in scopeManager.ListResourcesAsync(scopes))
-        {
-            resources.Add(resource);
-        }
-
-        context.Principal.SetResources(resources);
+        context.Principal.SetResources(await scopeManager.ListResourcesAsync(scopes).ToListAsync());
     }
 
     protected virtual bool IsDefaultScopesEnabled(OpenIddictRequest request, AbpOpenIddictAspNetCoreOptions options)

--- a/modules/openiddict/src/Volo.Abp.OpenIddict.AspNetCore/Volo/Abp/OpenIddict/Claims/AbpDefaultScopesHandler.cs
+++ b/modules/openiddict/src/Volo.Abp.OpenIddict.AspNetCore/Volo/Abp/OpenIddict/Claims/AbpDefaultScopesHandler.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using OpenIddict.Abstractions;
+using Volo.Abp.DependencyInjection;
+
+namespace Volo.Abp.OpenIddict;
+
+public class AbpDefaultScopesHandler : IAbpOpenIddictClaimsPrincipalHandler, ITransientDependency
+{
+    public ILogger<AbpDefaultScopesHandler> Logger { get; set; }
+        = NullLogger<AbpDefaultScopesHandler>.Instance;
+
+    public async Task HandleAsync(AbpOpenIddictClaimsPrincipalHandlerContext context)
+    {
+        var options = context.ScopeServiceProvider
+            .GetRequiredService<IOptions<AbpOpenIddictAspNetCoreOptions>>().Value;
+
+        var request = context.OpenIddictRequest;
+        if (!IsDefaultScopesEnabled(request, options))
+        {
+            return;
+        }
+
+        if (!context.Principal.GetScopes().IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        var clientId = request.ClientId;
+        if (string.IsNullOrEmpty(clientId))
+        {
+            return;
+        }
+
+        var applicationManager = context.ScopeServiceProvider.GetRequiredService<IOpenIddictApplicationManager>();
+        var scopeManager = context.ScopeServiceProvider.GetRequiredService<IOpenIddictScopeManager>();
+
+        var application = await applicationManager.FindByClientIdAsync(clientId);
+        if (application == null)
+        {
+            return;
+        }
+
+        var permissions = await applicationManager.GetPermissionsAsync(application);
+        var prefix = OpenIddictConstants.Permissions.Prefixes.Scope;
+
+        var scopes = permissions
+            .Where(p => p.StartsWith(prefix, StringComparison.Ordinal))
+            .Select(p => p[prefix.Length..])
+            .ToImmutableArray();
+
+        if (scopes.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        Logger.LogDebug(
+            "Injecting default scopes for client {ClientId} (grant_type {GrantType}): {Scopes}",
+            clientId,
+            request.GrantType,
+            string.Join(", ", scopes));
+
+        context.Principal.SetScopes(scopes);
+
+        var resources = new List<string>();
+        await foreach (var resource in scopeManager.ListResourcesAsync(scopes))
+        {
+            resources.Add(resource);
+        }
+
+        context.Principal.SetResources(resources);
+    }
+
+    protected virtual bool IsDefaultScopesEnabled(OpenIddictRequest request, AbpOpenIddictAspNetCoreOptions options)
+    {
+        if (request.IsClientCredentialsGrantType())
+        {
+            return options.UseDefaultScopesForClientCredentials;
+        }
+
+        if (request.IsPasswordGrantType())
+        {
+            return options.UseDefaultScopesForPassword;
+        }
+
+        if (request.IsTokenExchangeGrantType())
+        {
+            return options.UseDefaultScopesForTokenExchange;
+        }
+
+        return false;
+    }
+}

--- a/modules/openiddict/src/Volo.Abp.OpenIddict.AspNetCore/Volo/Abp/OpenIddict/Claims/AbpDefaultScopesHandler.cs
+++ b/modules/openiddict/src/Volo.Abp.OpenIddict.AspNetCore/Volo/Abp/OpenIddict/Claims/AbpDefaultScopesHandler.cs
@@ -16,7 +16,7 @@ public class AbpDefaultScopesHandler : IAbpOpenIddictClaimsPrincipalHandler, ITr
     public ILogger<AbpDefaultScopesHandler> Logger { get; set; }
         = NullLogger<AbpDefaultScopesHandler>.Instance;
 
-    public async Task HandleAsync(AbpOpenIddictClaimsPrincipalHandlerContext context)
+    public virtual async Task HandleAsync(AbpOpenIddictClaimsPrincipalHandlerContext context)
     {
         var options = context.ScopeServiceProvider
             .GetRequiredService<IOptions<AbpOpenIddictAspNetCoreOptions>>().Value;


### PR DESCRIPTION
Adds three opt-in switches on `AbpOpenIddictAspNetCoreOptions` so the access token issued for `client_credentials` / `password` / `urn:ietf:params:oauth:grant-type:token-exchange` grants can fall back to the scopes registered on the client (`oi_scp:` permissions) when the client did not pass a `scope` parameter. All default to `false`.

- `UseDefaultScopesForClientCredentials`
- `UseDefaultScopesForPassword`
- `UseDefaultScopesForTokenExchange`