### PR TITLE
Fix NRE in batch state checker on fresh `ExecutionContext`

### DIFF
--- a/framework/src/Volo.Abp.Authorization/Volo/Abp/Authorization/Permissions/RequirePermissionsSimpleBatchStateChecker.cs
+++ b/framework/src/Volo.Abp.Authorization/Volo/Abp/Authorization/Permissions/RequirePermissionsSimpleBatchStateChecker.cs
@@ -11,15 +11,21 @@ namespace Volo.Abp.Authorization.Permissions;
 public class RequirePermissionsSimpleBatchStateChecker<TState> : SimpleBatchStateCheckerBase<TState>
     where TState : IHasSimpleStateCheckers<TState>
 {
-    public static RequirePermissionsSimpleBatchStateChecker<TState> Current => _current.Value!;
-    private static readonly AsyncLocal<RequirePermissionsSimpleBatchStateChecker<TState>> _current = new AsyncLocal<RequirePermissionsSimpleBatchStateChecker<TState>>();
+    public static RequirePermissionsSimpleBatchStateChecker<TState> Current
+    {
+        get
+        {
+            if (_current.Value == null)
+            {
+                _current.Value = new RequirePermissionsSimpleBatchStateChecker<TState>();
+            }
+
+            return _current.Value;
+        }
+    }
+    private static readonly AsyncLocal<RequirePermissionsSimpleBatchStateChecker<TState>?> _current = new AsyncLocal<RequirePermissionsSimpleBatchStateChecker<TState>?>();
 
     private readonly List<RequirePermissionsSimpleBatchStateCheckerModel<TState>> _models;
-
-    static RequirePermissionsSimpleBatchStateChecker()
-    {
-        _current.Value = new RequirePermissionsSimpleBatchStateChecker<TState>();
-    }
 
     public RequirePermissionsSimpleBatchStateChecker()
     {

--- a/framework/src/Volo.Abp.Features/Volo/Abp/Features/RequireFeaturesSimpleBatchStateChecker.cs
+++ b/framework/src/Volo.Abp.Features/Volo/Abp/Features/RequireFeaturesSimpleBatchStateChecker.cs
@@ -11,15 +11,21 @@ namespace Volo.Abp.Features;
 public class RequireFeaturesSimpleBatchStateChecker<TState> : SimpleBatchStateCheckerBase<TState>
     where TState : IHasSimpleStateCheckers<TState>
 {
-    public static RequireFeaturesSimpleBatchStateChecker<TState> Current => _current.Value!;
-    private static readonly AsyncLocal<RequireFeaturesSimpleBatchStateChecker<TState>> _current = new();
+    public static RequireFeaturesSimpleBatchStateChecker<TState> Current
+    {
+        get
+        {
+            if (_current.Value == null)
+            {
+                _current.Value = new RequireFeaturesSimpleBatchStateChecker<TState>();
+            }
+
+            return _current.Value;
+        }
+    }
+    private static readonly AsyncLocal<RequireFeaturesSimpleBatchStateChecker<TState>?> _current = new();
 
     private readonly List<RequireFeaturesSimpleBatchStateCheckerModel<TState>> _models;
-
-    static RequireFeaturesSimpleBatchStateChecker()
-    {
-        _current.Value = new RequireFeaturesSimpleBatchStateChecker<TState>();
-    }
 
     public RequireFeaturesSimpleBatchStateChecker()
     {

--- a/framework/test/Volo.Abp.Authorization.Tests/Volo.Abp.Authorization.Tests.csproj
+++ b/framework/test/Volo.Abp.Authorization.Tests/Volo.Abp.Authorization.Tests.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Volo.Abp.Autofac\Volo.Abp.Autofac.csproj" />
     <ProjectReference Include="..\..\src\Volo.Abp.ExceptionHandling\Volo.Abp.ExceptionHandling.csproj" />
+    <ProjectReference Include="..\..\src\Volo.Abp.Features\Volo.Abp.Features.csproj" />
     <ProjectReference Include="..\AbpTestBase\AbpTestBase.csproj" />
     <ProjectReference Include="..\..\src\Volo.Abp.Authorization\Volo.Abp.Authorization.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/framework/test/Volo.Abp.Authorization.Tests/Volo/Abp/Authorization/AbpAuthorizationTestModule.cs
+++ b/framework/test/Volo.Abp.Authorization.Tests/Volo/Abp/Authorization/AbpAuthorizationTestModule.cs
@@ -5,6 +5,7 @@ using Volo.Abp.Authorization.TestServices.Resources;
 using Volo.Abp.Autofac;
 using Volo.Abp.DynamicProxy;
 using Volo.Abp.ExceptionHandling;
+using Volo.Abp.Features;
 using Volo.Abp.Modularity;
 
 namespace Volo.Abp.Authorization;
@@ -12,6 +13,7 @@ namespace Volo.Abp.Authorization;
 [DependsOn(typeof(AbpAutofacModule))]
 [DependsOn(typeof(AbpAuthorizationModule))]
 [DependsOn(typeof(AbpExceptionHandlingModule))]
+[DependsOn(typeof(AbpFeaturesModule))]
 public class AbpAuthorizationTestModule : AbpModule
 {
     public override void PreConfigureServices(ServiceConfigurationContext context)

--- a/framework/test/Volo.Abp.Authorization.Tests/Volo/Abp/Authorization/Authorization_Tests.cs
+++ b/framework/test/Volo.Abp.Authorization.Tests/Volo/Abp/Authorization/Authorization_Tests.cs
@@ -69,7 +69,8 @@ public class Authorization_Tests : AuthorizationTestBase
     [Fact]
     public async Task Should_Permission_Definition_GetGroup()
     {
-        (await _permissionDefinitionManager.GetGroupsAsync()).Count.ShouldBe(1);
+        var groups = await _permissionDefinitionManager.GetGroupsAsync();
+        groups.ShouldContain(g => g.Name == "TestGroup");
     }
 
     [Fact]

--- a/framework/test/Volo.Abp.Authorization.Tests/Volo/Abp/Authorization/RequirePermissionsSimpleBatchStateChecker_Tests.cs
+++ b/framework/test/Volo.Abp.Authorization.Tests/Volo/Abp/Authorization/RequirePermissionsSimpleBatchStateChecker_Tests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Shouldly;
 using Volo.Abp.Authorization.Permissions;
@@ -56,6 +57,21 @@ public class RequirePermissionsSimpleBatchStateChecker_Tests : AuthorizationTest
         result[myStateEntities[3]].ShouldBeTrue();
     }
 
+    [Fact]
+    public async Task Current_Should_Not_Be_Null_In_Fresh_ExecutionContext()
+    {
+        _ = RequirePermissionsSimpleBatchStateChecker<MyStateEntity3>.Current;
+
+        Task<RequirePermissionsSimpleBatchStateChecker<MyStateEntity3>> task;
+        using (ExecutionContext.SuppressFlow())
+        {
+            task = Task.Run(() => RequirePermissionsSimpleBatchStateChecker<MyStateEntity3>.Current);
+        }
+
+        var current = await task;
+        current.ShouldNotBeNull();
+    }
+
     class MyStateEntity : IHasSimpleStateCheckers<MyStateEntity>
     {
         public List<ISimpleStateChecker<MyStateEntity>> StateCheckers { get; }
@@ -73,6 +89,16 @@ public class RequirePermissionsSimpleBatchStateChecker_Tests : AuthorizationTest
         public MyStateEntity2()
         {
             StateCheckers = new List<ISimpleStateChecker<MyStateEntity2>>();
+        }
+    }
+
+    class MyStateEntity3 : IHasSimpleStateCheckers<MyStateEntity3>
+    {
+        public List<ISimpleStateChecker<MyStateEntity3>> StateCheckers { get; }
+
+        public MyStateEntity3()
+        {
+            StateCheckers = new List<ISimpleStateChecker<MyStateEntity3>>();
         }
     }
 }

--- a/framework/test/Volo.Abp.Authorization.Tests/Volo/Abp/Authorization/StaticPermissionDefinitionStore_Tests.cs
+++ b/framework/test/Volo.Abp.Authorization.Tests/Volo/Abp/Authorization/StaticPermissionDefinitionStore_Tests.cs
@@ -1,7 +1,10 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Shouldly;
 using Volo.Abp.Authorization.Permissions;
 using Volo.Abp.Authorization.TestServices.Resources;
+using Volo.Abp.StaticDefinitions;
 using Xunit;
 
 namespace Volo.Abp.Authorization;
@@ -83,5 +86,38 @@ public class StaticPermissionDefinitionStore_Tests : AuthorizationTestBase
             x.Name == "MyResourcePermission7" && x.ResourceName == TestEntityResource.ResourceName);
         permissions.ShouldContain(x =>
             x.Name == "MyResourcePermission7" && x.ResourceName == TestEntityResource2.ResourceName);
+    }
+
+    [Fact]
+    public async Task Should_Rebuild_Definitions_In_Fresh_ExecutionContext_After_Cache_Clear()
+    {
+        var groupCache = GetRequiredService<IStaticDefinitionCache<PermissionGroupDefinition,
+            (Dictionary<string, PermissionGroupDefinition>, List<PermissionDefinition>)>>();
+        var definitionCache = GetRequiredService<IStaticDefinitionCache<PermissionDefinition,
+            Dictionary<string, PermissionDefinition>>>();
+
+        await groupCache.ClearAsync();
+        await definitionCache.ClearAsync();
+
+        // Touch the type initializer (if any) on the test ExecutionContext first, mirroring
+        // the production scenario where startup pre-warms it on a different ExecutionContext.
+        _ = await _store.GetOrNullAsync("FeatureGatedPermission");
+
+        await groupCache.ClearAsync();
+        await definitionCache.ClearAsync();
+
+        PermissionDefinition permission = null;
+        Task task;
+        using (ExecutionContext.SuppressFlow())
+        {
+            task = Task.Run(async () =>
+            {
+                permission = await _store.GetOrNullAsync("FeatureGatedPermission");
+            });
+        }
+        await task;
+
+        permission.ShouldNotBeNull();
+        permission.Name.ShouldBe("FeatureGatedPermission");
     }
 }

--- a/framework/test/Volo.Abp.Authorization.Tests/Volo/Abp/Authorization/TestServices/FeatureGatedTestPermissionDefinitionProvider.cs
+++ b/framework/test/Volo.Abp.Authorization.Tests/Volo/Abp/Authorization/TestServices/FeatureGatedTestPermissionDefinitionProvider.cs
@@ -1,0 +1,15 @@
+using Volo.Abp.Authorization.Permissions;
+using Volo.Abp.Features;
+
+namespace Volo.Abp.Authorization.TestServices;
+
+public class FeatureGatedTestPermissionDefinitionProvider : PermissionDefinitionProvider
+{
+    public override void Define(IPermissionDefinitionContext context)
+    {
+        var group = context.AddGroup("FeatureGatedTestGroup");
+
+        group.AddPermission("FeatureGatedPermission")
+            .RequireFeatures("FeatureGatedTestFeature");
+    }
+}

--- a/framework/test/Volo.Abp.Features.Tests/Volo/Abp/Features/RequireFeaturesSimpleBatchStateChecker_Tests.cs
+++ b/framework/test/Volo.Abp.Features.Tests/Volo/Abp/Features/RequireFeaturesSimpleBatchStateChecker_Tests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Shouldly;
 using Volo.Abp.MultiTenancy;
@@ -84,6 +85,21 @@ public class RequireFeaturesSimpleBatchStateChecker_Tests : FeatureTestBase
         }
     }
 
+    [Fact]
+    public async Task Current_Should_Not_Be_Null_In_Fresh_ExecutionContext()
+    {
+        _ = RequireFeaturesSimpleBatchStateChecker<MyStateEntity3>.Current;
+
+        Task<RequireFeaturesSimpleBatchStateChecker<MyStateEntity3>> task;
+        using (ExecutionContext.SuppressFlow())
+        {
+            task = Task.Run(() => RequireFeaturesSimpleBatchStateChecker<MyStateEntity3>.Current);
+        }
+
+        var current = await task;
+        current.ShouldNotBeNull();
+    }
+
     class MyStateEntity : IHasSimpleStateCheckers<MyStateEntity>
     {
         public List<ISimpleStateChecker<MyStateEntity>> StateCheckers { get; }
@@ -101,6 +117,16 @@ public class RequireFeaturesSimpleBatchStateChecker_Tests : FeatureTestBase
         public MyStateEntity2()
         {
             StateCheckers = new List<ISimpleStateChecker<MyStateEntity2>>();
+        }
+    }
+
+    class MyStateEntity3 : IHasSimpleStateCheckers<MyStateEntity3>
+    {
+        public List<ISimpleStateChecker<MyStateEntity3>> StateCheckers { get; }
+
+        public MyStateEntity3()
+        {
+            StateCheckers = new List<ISimpleStateChecker<MyStateEntity3>>();
         }
     }
 }


### PR DESCRIPTION
`RequireFeaturesSimpleBatchStateChecker<TState>.Current` and `RequirePermissionsSimpleBatchStateChecker<TState>.Current` initialize their `AsyncLocal<>` value from a static type initializer, so the value is only visible on the ExecutionContext that triggered it. Any other ExecutionContext (a new HTTP request, queued event handler, `Task.Run` without flow) sees `null` and crashes `AddCheckModels(...)` with NRE — reproducible by `await _distributedEventBus.PublishAsync(new StaticPermissionDefinitionChangedEvent())`, which clears the static permission caches and forces the next request to rebuild definitions on a fresh ExecutionContext through a provider that uses `RequireFeatures(...)` (e.g. `AbpAuditLoggingPermissionDefinitionProvider`).

Lazy-init `Current` per ExecutionContext.