### PR TITLE
Upgrade MongoDB.Driver to 3.8.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -123,7 +123,7 @@
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.16.0" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.16.0" />
     <PackageVersion Include="Minio" Version="6.0.5" />
-    <PackageVersion Include="MongoDB.Driver" Version="3.8.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.8.1" />
     <PackageVersion Include="NEST" Version="7.17.5" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="Nito.AsyncEx.Context" Version="5.1.2" />

--- a/docs/en/package-version-changes.md
+++ b/docs/en/package-version-changes.md
@@ -7,6 +7,12 @@
 
 # Package Version Changes
 
+## 10.4.0-rc.2
+
+| Package | Old Version | New Version | PR |
+|---------|-------------|-------------|-----|
+| MongoDB.Driver | 3.8.0 | 3.8.1 | #25404 |
+
 ## 10.4.0-rc.1
 
 | Package | Old Version | New Version | PR |


### PR DESCRIPTION
Upgrade `MongoDB.Driver` from `3.8.0` to `3.8.1`.

https://github.com/mongodb/mongo-csharp-driver/releases/tag/v3.8.1

Patch release that updates `Snappier` to fix a security issue ([GHSA-pggp-6c3x-2xmx](https://github.com/advisories/GHSA-pggp-6c3x-2xmx)).