### PR TITLE
Fix `BlogAdminController` route token for `MoveAllBlogPostsAsync`

### DIFF
--- a/modules/cms-kit/src/Volo.CmsKit.Admin.HttpApi.Client/ClientProxies/cms-kit-admin-generate-proxy.json
+++ b/modules/cms-kit/src/Volo.CmsKit.Admin.HttpApi.Client/ClientProxies/cms-kit-admin-generate-proxy.json
@@ -406,7 +406,7 @@
               "uniqueName": "MoveAllBlogPostsAsyncByBlogIdAndAssignToBlogId",
               "name": "MoveAllBlogPostsAsync",
               "httpMethod": "PUT",
-              "url": "api/cms-kit-admin/blogs/{id}/move-all-blog-posts",
+              "url": "api/cms-kit-admin/blogs/{blogId}/move-all-blog-posts",
               "supportedVersions": [],
               "parametersOnMethod": [
                 {
@@ -436,7 +436,7 @@
                   "isOptional": false,
                   "defaultValue": null,
                   "constraintTypes": null,
-                  "bindingSourceId": "ModelBinding",
+                  "bindingSourceId": "Path",
                   "descriptorName": ""
                 },
                 {
@@ -449,18 +449,6 @@
                   "defaultValue": null,
                   "constraintTypes": null,
                   "bindingSourceId": "Query",
-                  "descriptorName": ""
-                },
-                {
-                  "nameOnMethod": "id",
-                  "name": "id",
-                  "jsonName": null,
-                  "type": null,
-                  "typeSimple": null,
-                  "isOptional": false,
-                  "defaultValue": null,
-                  "constraintTypes": [],
-                  "bindingSourceId": "Path",
                   "descriptorName": ""
                 }
               ],

--- a/modules/cms-kit/src/Volo.CmsKit.Admin.HttpApi/Volo/CmsKit/Admin/Blogs/BlogAdminController.cs
+++ b/modules/cms-kit/src/Volo.CmsKit.Admin.HttpApi/Volo/CmsKit/Admin/Blogs/BlogAdminController.cs
@@ -71,7 +71,7 @@ public class BlogAdminController : CmsKitAdminController, IBlogAdminAppService
     }
 
     [HttpPut]
-    [Route("{id}/move-all-blog-posts")]
+    [Route("{blogId}/move-all-blog-posts")]
     [Authorize(CmsKitAdminPermissions.Blogs.Delete)]
     public Task MoveAllBlogPostsAsync(Guid blogId, [FromQuery]Guid? assignToBlogId)
     {


### PR DESCRIPTION
Route template used `{id}` while the method parameter is named `blogId`, so ASP.NET Core ApiExplorer emitted an orphan path parameter `id`. `ClientProxyBase.BuildHttpProxyClientProxyContext` then threw `ArgumentOutOfRangeException` when deleting a blog from the MVC admin page (tiered).

Aligned the route token with the method parameter (`{blogId}`) and regenerated the affected entry in `cms-kit-admin-generate-proxy.json`. No application service contract changes.

Closes volosoft/volo#22300