### PR TITLE
Fix `SimpleStateCheckerManager` overwriting result between batch checkers

### DIFF
--- a/framework/src/Volo.Abp.Core/Volo/Abp/SimpleStateChecking/SimpleStateCheckerManager.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/SimpleStateChecking/SimpleStateCheckerManager.cs
@@ -46,7 +46,7 @@ public class SimpleStateCheckerManager<TState> : ISimpleStateCheckerManager<TSta
 
                 foreach (var x in await stateChecker.IsEnabledAsync(context))
                 {
-                    result[x.Key] = x.Value;
+                    result[x.Key] = result[x.Key] && x.Value;
                 }
 
                 if (result.Values.All(x => !x))

--- a/framework/test/Volo.Abp.Core.Tests/Volo/Abp/SimpleStateChecking/SimpleStateChecker_AndCombineResults_Tests.cs
+++ b/framework/test/Volo.Abp.Core.Tests/Volo/Abp/SimpleStateChecking/SimpleStateChecker_AndCombineResults_Tests.cs
@@ -1,0 +1,101 @@
+using System.Threading.Tasks;
+using Shouldly;
+using Volo.Abp.DependencyInjection;
+using Xunit;
+
+namespace Volo.Abp.SimpleStateChecking;
+
+public class SimpleStateChecker_AndCombineResults_Tests : SimpleStateCheckerTestBase
+{
+    [Fact]
+    public async Task False_Result_From_One_Batch_Checker_Should_Not_Be_Overwritten_By_Later_True_Checker()
+    {
+        // Regression test for the bug fixed in SimpleStateCheckerManager.IsEnabledAsync:
+        // when a state had multiple batch checkers the manager used to OVERWRITE
+        // result[x.Key] on each checker, so a later "true" silently masked an earlier "false".
+        // The fix AND-combines results.
+        //
+        // To make sure we actually hit the second batch checker (and not the early-return
+        // `result.Values.All(x => !x)` short-circuit), we use two states:
+        //   - state1: [falseChecker, trueChecker]  - the target case
+        //   - state2: [trueChecker]                - keeps result.Values not all-false
+        //                                             so the loop continues to the next checker
+
+        var falseChecker = new AlwaysFalseBatchStateChecker();
+        var trueChecker = new AlwaysTrueBatchStateChecker();
+
+        var state1 = new MyStateEntity();
+        state1.AddSimpleStateChecker(falseChecker);
+        state1.AddSimpleStateChecker(trueChecker);
+
+        var state2 = new MyStateEntity();
+        state2.AddSimpleStateChecker(trueChecker);
+
+        var result = await SimpleStateCheckerManager.IsEnabledAsync(new[] { state1, state2 });
+
+        result[state1].ShouldBeFalse();   // before the fix this was True (bug)
+        result[state2].ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task True_Result_From_One_Batch_Checker_Should_Be_AND_Combined_With_Later_False_Checker()
+    {
+        // Reverse order: true first then false. Add a second always-true state to keep
+        // result.Values not all-false after both checkers ran.
+        var trueChecker = new AlwaysTrueBatchStateChecker();
+        var falseChecker = new AlwaysFalseBatchStateChecker();
+
+        var state1 = new MyStateEntity();
+        state1.AddSimpleStateChecker(trueChecker);
+        state1.AddSimpleStateChecker(falseChecker);
+
+        var state2 = new MyStateEntity();
+        state2.AddSimpleStateChecker(trueChecker);
+
+        var result = await SimpleStateCheckerManager.IsEnabledAsync(new[] { state1, state2 });
+
+        result[state1].ShouldBeFalse();
+        result[state2].ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task All_True_Batch_Checkers_Should_Produce_True()
+    {
+        var trueChecker1 = new AlwaysTrueBatchStateChecker();
+        var trueChecker2 = new AlwaysTrueBatchStateChecker();
+
+        var state = new MyStateEntity();
+        state.AddSimpleStateChecker(trueChecker1);
+        state.AddSimpleStateChecker(trueChecker2);
+
+        var result = await SimpleStateCheckerManager.IsEnabledAsync(new[] { state });
+
+        result[state].ShouldBeTrue();
+    }
+
+    public class AlwaysFalseBatchStateChecker : SimpleBatchStateCheckerBase<MyStateEntity>, ITransientDependency
+    {
+        public override Task<SimpleStateCheckerResult<MyStateEntity>> IsEnabledAsync(SimpleBatchStateCheckerContext<MyStateEntity> context)
+        {
+            var result = new SimpleStateCheckerResult<MyStateEntity>(context.States);
+            foreach (var x in result)
+            {
+                result[x.Key] = false;
+            }
+            return Task.FromResult(result);
+        }
+    }
+
+    public class AlwaysTrueBatchStateChecker : SimpleBatchStateCheckerBase<MyStateEntity>, ITransientDependency
+    {
+        public override Task<SimpleStateCheckerResult<MyStateEntity>> IsEnabledAsync(SimpleBatchStateCheckerContext<MyStateEntity> context)
+        {
+            var result = new SimpleStateCheckerResult<MyStateEntity>(context.States);
+            foreach (var x in result)
+            {
+                result[x.Key] = true;
+            }
+            return Task.FromResult(result);
+        }
+    }
+}


### PR DESCRIPTION
When a state has multiple batch checkers (e.g. `RequirePermissions` plus `RequireFeatures`), `SimpleStateCheckerManager.IsEnabledAsync(TState[])` overwrites the per-state result on every checker pass, so a later `true` silently masks an earlier `false`. AND-combine the results so all checkers must pass.

This shows up in practice on menu items that chain `.RequireFeatures(...).RequirePermissions(...)` (e.g. `Language management`, `Text templates`, `Audit logs`): when a role grants the feature but not the permission, the menu item still becomes visible because the feature checker's `true` overwrites the permission checker's `false`.

Added regression tests under `framework/test/Volo.Abp.Core.Tests/Volo/Abp/SimpleStateChecking/SimpleStateChecker_AndCombineResults_Tests.cs` covering false-then-true, true-then-false and all-true orderings. Reverse-verified: with the fix removed, the false-then-true test fails.