### PR TITLE
Serialize batch state checkers per permission in dynamic distribution

### DIFF
--- a/framework/src/Volo.Abp.Authorization/Volo/Abp/Authorization/Permissions/AuthenticatedSimpleStateCheckerSerializerContributor.cs
+++ b/framework/src/Volo.Abp.Authorization/Volo/Abp/Authorization/Permissions/AuthenticatedSimpleStateCheckerSerializerContributor.cs
@@ -10,7 +10,7 @@ public class AuthenticatedSimpleStateCheckerSerializerContributor :
 {
     public const string CheckerShortName = "A";
     
-    public string? SerializeToJson<TState>(ISimpleStateChecker<TState> checker) 
+    public string? SerializeToJson<TState>(ISimpleStateChecker<TState> checker)
         where TState : IHasSimpleStateCheckers<TState>
     {
         if (checker is not RequireAuthenticatedSimpleStateChecker<TState>)
@@ -24,6 +24,10 @@ public class AuthenticatedSimpleStateCheckerSerializerContributor :
 
         return jsonObject.ToJsonString();
     }
+
+    public string? SerializeToJson<TState>(ISimpleStateChecker<TState> checker, TState state)
+        where TState : IHasSimpleStateCheckers<TState>
+        => SerializeToJson(checker);
 
     public ISimpleStateChecker<TState>? Deserialize<TState>(JsonObject jsonObject, TState state)
         where TState : IHasSimpleStateCheckers<TState>

--- a/framework/src/Volo.Abp.Authorization/Volo/Abp/Authorization/Permissions/PermissionsSimpleStateCheckerSerializerContributor.cs
+++ b/framework/src/Volo.Abp.Authorization/Volo/Abp/Authorization/Permissions/PermissionsSimpleStateCheckerSerializerContributor.cs
@@ -20,13 +20,31 @@ public class PermissionsSimpleStateCheckerSerializerContributor :
             return null;
         }
 
-        var jsonObject = new JsonObject {
+        return BuildJson(permissionsSimpleStateChecker.RequiresAll, permissionsSimpleStateChecker.PermissionNames);
+    }
+
+    public string? SerializeToJson<TState>(ISimpleStateChecker<TState> checker, TState state)
+        where TState : IHasSimpleStateCheckers<TState>
+    {
+        if (checker is RequirePermissionsSimpleBatchStateChecker<TState> batch)
+        {
+            var model = batch.GetModelOrNull(state);
+            return model == null ? null : BuildJson(model.RequiresAll, model.Permissions);
+        }
+
+        return SerializeToJson(checker);
+    }
+
+    private static string BuildJson(bool requiresAll, string[] permissionNames)
+    {
+        var jsonObject = new JsonObject
+        {
             ["T"] = CheckerShortName,
-            ["A"] = permissionsSimpleStateChecker.RequiresAll
+            ["A"] = requiresAll
         };
 
         var nameArray = new JsonArray();
-        foreach (var permissionName in permissionsSimpleStateChecker.PermissionNames)
+        foreach (var permissionName in permissionNames)
         {
             nameArray.Add(permissionName);
         }

--- a/framework/src/Volo.Abp.Authorization/Volo/Abp/Authorization/Permissions/RequirePermissionsSimpleBatchStateChecker.cs
+++ b/framework/src/Volo.Abp.Authorization/Volo/Abp/Authorization/Permissions/RequirePermissionsSimpleBatchStateChecker.cs
@@ -27,9 +27,12 @@ public class RequirePermissionsSimpleBatchStateChecker<TState> : SimpleBatchStat
 
     private readonly List<RequirePermissionsSimpleBatchStateCheckerModel<TState>> _models;
 
+    private readonly Dictionary<TState, RequirePermissionsSimpleBatchStateCheckerModel<TState>> _modelsByState;
+
     public RequirePermissionsSimpleBatchStateChecker()
     {
         _models = new List<RequirePermissionsSimpleBatchStateCheckerModel<TState>>();
+        _modelsByState = new Dictionary<TState, RequirePermissionsSimpleBatchStateCheckerModel<TState>>();
     }
 
     public RequirePermissionsSimpleBatchStateChecker<TState> AddCheckModels(params RequirePermissionsSimpleBatchStateCheckerModel<TState>[] models)
@@ -37,6 +40,13 @@ public class RequirePermissionsSimpleBatchStateChecker<TState> : SimpleBatchStat
         Check.NotNullOrEmpty(models, nameof(models));
 
         _models.AddRange(models);
+        foreach (var model in models)
+        {
+            if (!_modelsByState.ContainsKey(model.State))
+            {
+                _modelsByState[model.State] = model;
+            }
+        }
         return this;
     }
 
@@ -49,7 +59,7 @@ public class RequirePermissionsSimpleBatchStateChecker<TState> : SimpleBatchStat
 
     public virtual RequirePermissionsSimpleBatchStateCheckerModel<TState>? GetModelOrNull(TState state)
     {
-        return _models.FirstOrDefault(m => EqualityComparer<TState>.Default.Equals(m.State, state));
+        return _modelsByState.TryGetValue(state, out var model) ? model : null;
     }
 
     public override async Task<SimpleStateCheckerResult<TState>> IsEnabledAsync(SimpleBatchStateCheckerContext<TState> context)

--- a/framework/src/Volo.Abp.Authorization/Volo/Abp/Authorization/Permissions/RequirePermissionsSimpleBatchStateChecker.cs
+++ b/framework/src/Volo.Abp.Authorization/Volo/Abp/Authorization/Permissions/RequirePermissionsSimpleBatchStateChecker.cs
@@ -47,6 +47,11 @@ public class RequirePermissionsSimpleBatchStateChecker<TState> : SimpleBatchStat
         return new DisposeAction(() => _current.Value = previousValue);
     }
 
+    public virtual RequirePermissionsSimpleBatchStateCheckerModel<TState>? GetModelOrNull(TState state)
+    {
+        return _models.FirstOrDefault(m => EqualityComparer<TState>.Default.Equals(m.State, state));
+    }
+
     public override async Task<SimpleStateCheckerResult<TState>> IsEnabledAsync(SimpleBatchStateCheckerContext<TState> context)
     {
         var permissionChecker = context.ServiceProvider.GetRequiredService<IPermissionChecker>();

--- a/framework/src/Volo.Abp.Core/Volo/Abp/SimpleStateChecking/ISimpleStateCheckerSerializer.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/SimpleStateChecking/ISimpleStateCheckerSerializer.cs
@@ -7,6 +7,10 @@ public interface ISimpleStateCheckerSerializer
     public string? Serialize<TState>(ISimpleStateChecker<TState> checker)
         where TState : IHasSimpleStateCheckers<TState>;
 
+
+    public string? Serialize<TState>(ISimpleStateChecker<TState> checker, TState state)
+        where TState : IHasSimpleStateCheckers<TState>;
+
     public ISimpleStateChecker<TState>? Deserialize<TState>(JsonObject jsonObject, TState state)
         where TState : IHasSimpleStateCheckers<TState>;
 }

--- a/framework/src/Volo.Abp.Core/Volo/Abp/SimpleStateChecking/ISimpleStateCheckerSerializerContributor.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/SimpleStateChecking/ISimpleStateCheckerSerializerContributor.cs
@@ -7,6 +7,9 @@ public interface ISimpleStateCheckerSerializerContributor
     public string? SerializeToJson<TState>(ISimpleStateChecker<TState> checker)
         where TState : IHasSimpleStateCheckers<TState>;
 
+    public string? SerializeToJson<TState>(ISimpleStateChecker<TState> checker, TState state)
+        where TState : IHasSimpleStateCheckers<TState>;
+
     public ISimpleStateChecker<TState>? Deserialize<TState>(JsonObject jsonObject, TState state)
         where TState : IHasSimpleStateCheckers<TState>;
 }

--- a/framework/src/Volo.Abp.Core/Volo/Abp/SimpleStateChecking/SimpleStateCheckerSerializer.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/SimpleStateChecking/SimpleStateCheckerSerializer.cs
@@ -15,12 +15,27 @@ public class SimpleStateCheckerSerializer :
         _contributors = contributors;
     }
     
-    public string? Serialize<TState>(ISimpleStateChecker<TState> checker) 
+    public string? Serialize<TState>(ISimpleStateChecker<TState> checker)
         where TState : IHasSimpleStateCheckers<TState>
     {
         foreach (var contributor in _contributors)
         {
             var result = contributor.SerializeToJson(checker);
+            if (result != null)
+            {
+                return result;
+            }
+        }
+
+        return null;
+    }
+
+    public string? Serialize<TState>(ISimpleStateChecker<TState> checker, TState state)
+        where TState : IHasSimpleStateCheckers<TState>
+    {
+        foreach (var contributor in _contributors)
+        {
+            var result = contributor.SerializeToJson(checker, state);
             if (result != null)
             {
                 return result;

--- a/framework/src/Volo.Abp.Core/Volo/Abp/SimpleStateChecking/SimpleStateCheckerSerializerExtensions.cs
+++ b/framework/src/Volo.Abp.Core/Volo/Abp/SimpleStateChecking/SimpleStateCheckerSerializerExtensions.cs
@@ -8,8 +8,25 @@ namespace Volo.Abp.SimpleStateChecking;
 public static class SimpleStateCheckerSerializerExtensions
 {
     public static string? Serialize<TState>(
-        this ISimpleStateCheckerSerializer serializer, 
+        this ISimpleStateCheckerSerializer serializer,
         IList<ISimpleStateChecker<TState>> stateCheckers)
+        where TState : IHasSimpleStateCheckers<TState>
+    {
+        return SerializeCore(stateCheckers, serializer.Serialize);
+    }
+
+    public static string? Serialize<TState>(
+        this ISimpleStateCheckerSerializer serializer,
+        IList<ISimpleStateChecker<TState>> stateCheckers,
+        TState state)
+        where TState : IHasSimpleStateCheckers<TState>
+    {
+        return SerializeCore(stateCheckers, c => serializer.Serialize(c, state));
+    }
+
+    private static string? SerializeCore<TState>(
+        IList<ISimpleStateChecker<TState>> stateCheckers,
+        Func<ISimpleStateChecker<TState>, string?> serializeChecker)
         where TState : IHasSimpleStateCheckers<TState>
     {
         switch (stateCheckers.Count)
@@ -17,16 +34,16 @@ public static class SimpleStateCheckerSerializerExtensions
             case 0:
                 return null;
             case 1:
-                var serializedChecker = serializer.Serialize(stateCheckers.Single());
+                var serializedChecker = serializeChecker(stateCheckers.Single());
                 return serializedChecker != null
                     ? $"[{serializedChecker}]"
                     : null;
             default:
                 var serializedCheckers = new List<string>(stateCheckers.Count);
-                
+
                 foreach (var stateChecker in stateCheckers)
                 {
-                    var serialized = serializer.Serialize(stateChecker);
+                    var serialized = serializeChecker(stateChecker);
                     if (serialized != null)
                     {
                         serializedCheckers.Add(serialized);

--- a/framework/src/Volo.Abp.Features/Volo/Abp/Features/FeaturesSimpleStateCheckerSerializerContributor.cs
+++ b/framework/src/Volo.Abp.Features/Volo/Abp/Features/FeaturesSimpleStateCheckerSerializerContributor.cs
@@ -19,13 +19,31 @@ public class FeaturesSimpleStateCheckerSerializerContributor :
             return null;
         }
 
-        var jsonObject = new JsonObject {
+        return BuildJson(featuresSimpleStateChecker.RequiresAll, featuresSimpleStateChecker.FeatureNames);
+    }
+
+    public string? SerializeToJson<TState>(ISimpleStateChecker<TState> checker, TState state)
+        where TState : IHasSimpleStateCheckers<TState>
+    {
+        if (checker is RequireFeaturesSimpleBatchStateChecker<TState> batch)
+        {
+            var model = batch.GetModelOrNull(state);
+            return model == null ? null : BuildJson(model.RequiresAll, model.FeatureNames);
+        }
+
+        return SerializeToJson(checker);
+    }
+
+    private static string BuildJson(bool requiresAll, string[] featureNames)
+    {
+        var jsonObject = new JsonObject
+        {
             ["T"] = CheckerShortName,
-            ["A"] = featuresSimpleStateChecker.RequiresAll
+            ["A"] = requiresAll
         };
 
         var nameArray = new JsonArray();
-        foreach (var featureName in featuresSimpleStateChecker.FeatureNames)
+        foreach (var featureName in featureNames)
         {
             nameArray.Add(featureName);
         }

--- a/framework/src/Volo.Abp.Features/Volo/Abp/Features/RequireFeaturesSimpleBatchStateChecker.cs
+++ b/framework/src/Volo.Abp.Features/Volo/Abp/Features/RequireFeaturesSimpleBatchStateChecker.cs
@@ -48,6 +48,11 @@ public class RequireFeaturesSimpleBatchStateChecker<TState> : SimpleBatchStateCh
         return new DisposeAction(() => _current.Value = previousValue);
     }
 
+    public virtual RequireFeaturesSimpleBatchStateCheckerModel<TState>? GetModelOrNull(TState state)
+    {
+        return _models.FirstOrDefault(x => EqualityComparer<TState>.Default.Equals(x.State, state));
+    }
+
     public override async Task<SimpleStateCheckerResult<TState>> IsEnabledAsync(
         SimpleBatchStateCheckerContext<TState> context)
     {

--- a/framework/src/Volo.Abp.Features/Volo/Abp/Features/RequireFeaturesSimpleBatchStateChecker.cs
+++ b/framework/src/Volo.Abp.Features/Volo/Abp/Features/RequireFeaturesSimpleBatchStateChecker.cs
@@ -27,9 +27,12 @@ public class RequireFeaturesSimpleBatchStateChecker<TState> : SimpleBatchStateCh
 
     private readonly List<RequireFeaturesSimpleBatchStateCheckerModel<TState>> _models;
 
+    private readonly Dictionary<TState, RequireFeaturesSimpleBatchStateCheckerModel<TState>> _modelsByState;
+
     public RequireFeaturesSimpleBatchStateChecker()
     {
         _models = new List<RequireFeaturesSimpleBatchStateCheckerModel<TState>>();
+        _modelsByState = new Dictionary<TState, RequireFeaturesSimpleBatchStateCheckerModel<TState>>();
     }
 
     public RequireFeaturesSimpleBatchStateChecker<TState> AddCheckModels(
@@ -38,6 +41,13 @@ public class RequireFeaturesSimpleBatchStateChecker<TState> : SimpleBatchStateCh
         Check.NotNullOrEmpty(models, nameof(models));
 
         _models.AddRange(models);
+        foreach (var model in models)
+        {
+            if (!_modelsByState.ContainsKey(model.State))
+            {
+                _modelsByState[model.State] = model;
+            }
+        }
         return this;
     }
 
@@ -50,7 +60,7 @@ public class RequireFeaturesSimpleBatchStateChecker<TState> : SimpleBatchStateCh
 
     public virtual RequireFeaturesSimpleBatchStateCheckerModel<TState>? GetModelOrNull(TState state)
     {
-        return _models.FirstOrDefault(x => EqualityComparer<TState>.Default.Equals(x.State, state));
+        return _modelsByState.TryGetValue(state, out var model) ? model : null;
     }
 
     public override async Task<SimpleStateCheckerResult<TState>> IsEnabledAsync(

--- a/framework/src/Volo.Abp.GlobalFeatures/Volo/Abp/GlobalFeatures/GlobalFeaturesSimpleStateCheckerSerializerContributor.cs
+++ b/framework/src/Volo.Abp.GlobalFeatures/Volo/Abp/GlobalFeatures/GlobalFeaturesSimpleStateCheckerSerializerContributor.cs
@@ -34,6 +34,10 @@ public class GlobalFeaturesSimpleStateCheckerSerializerContributor :
         return jsonObject.ToJsonString();
     }
 
+    public string? SerializeToJson<TState>(ISimpleStateChecker<TState> checker, TState state)
+        where TState : IHasSimpleStateCheckers<TState>
+        => SerializeToJson(checker);
+
     public ISimpleStateChecker<TState>? Deserialize<TState>(JsonObject jsonObject, TState state)
         where TState : IHasSimpleStateCheckers<TState>
     {

--- a/framework/test/Volo.Abp.Features.Tests/Volo/Abp/Features/RequireFeaturesSimpleBatchStateChecker_Tests.cs
+++ b/framework/test/Volo.Abp.Features.Tests/Volo/Abp/Features/RequireFeaturesSimpleBatchStateChecker_Tests.cs
@@ -86,6 +86,23 @@ public class RequireFeaturesSimpleBatchStateChecker_Tests : FeatureTestBase
     }
 
     [Fact]
+    public void GetModelOrNull_Returns_First_Win_When_Same_State_Registered_Twice()
+    {
+        // Mirrors IsEnabledAsync's modelLookup behaviour: when the same state is registered
+        // multiple times, the first registration wins. Backed by the dictionary index.
+
+        var checker = new RequireFeaturesSimpleBatchStateChecker<NamedState>();
+        var state = new NamedState("A");
+
+        checker.AddCheckModels(
+            new RequireFeaturesSimpleBatchStateCheckerModel<NamedState>(state, new[] { "First" }, true));
+        checker.AddCheckModels(
+            new RequireFeaturesSimpleBatchStateCheckerModel<NamedState>(state, new[] { "Second" }, true));
+
+        checker.GetModelOrNull(state)!.FeatureNames.ShouldBe(new[] { "First" });
+    }
+
+    [Fact]
     public void GetModelOrNull_Uses_Same_Equality_As_Runtime()
     {
         // The runtime path (IsEnabledAsync) looks up models via HashSet<TState>(context.States),

--- a/framework/test/Volo.Abp.Features.Tests/Volo/Abp/Features/RequireFeaturesSimpleBatchStateChecker_Tests.cs
+++ b/framework/test/Volo.Abp.Features.Tests/Volo/Abp/Features/RequireFeaturesSimpleBatchStateChecker_Tests.cs
@@ -86,6 +86,41 @@ public class RequireFeaturesSimpleBatchStateChecker_Tests : FeatureTestBase
     }
 
     [Fact]
+    public void GetModelOrNull_Uses_Same_Equality_As_Runtime()
+    {
+        // The runtime path (IsEnabledAsync) looks up models via HashSet<TState>(context.States),
+        // i.e. EqualityComparer<TState>.Default. GetModelOrNull must use the same semantics or
+        // a custom TState.Equals would make the runtime gate and the serializer disagree.
+
+        var checker = new RequireFeaturesSimpleBatchStateChecker<NamedState>();
+        var stateA1 = new NamedState("A");
+        var stateA2 = new NamedState("A"); // distinct instance, equal by Name
+        var stateB = new NamedState("B");
+
+        checker.AddCheckModels(
+            new RequireFeaturesSimpleBatchStateCheckerModel<NamedState>(stateA1, new[] { "F1" }, true),
+            new RequireFeaturesSimpleBatchStateCheckerModel<NamedState>(stateB, new[] { "F2" }, true));
+
+        // Same equality semantics as the runtime: A2 hits A1's model.
+        checker.GetModelOrNull(stateA1).ShouldNotBeNull();
+        checker.GetModelOrNull(stateA2).ShouldNotBeNull();
+        checker.GetModelOrNull(stateA2)!.FeatureNames.ShouldBe(new[] { "F1" });
+        checker.GetModelOrNull(new NamedState("missing")).ShouldBeNull();
+    }
+
+    private sealed class NamedState : IHasSimpleStateCheckers<NamedState>, IEquatable<NamedState>
+    {
+        public string Name { get; }
+        public List<ISimpleStateChecker<NamedState>> StateCheckers { get; } = new();
+
+        public NamedState(string name) => Name = name;
+
+        public bool Equals(NamedState? other) => other is not null && other.Name == Name;
+        public override bool Equals(object? obj) => obj is NamedState other && Equals(other);
+        public override int GetHashCode() => Name.GetHashCode();
+    }
+
+    [Fact]
     public async Task Current_Should_Not_Be_Null_In_Fresh_ExecutionContext()
     {
         _ = RequireFeaturesSimpleBatchStateChecker<MyStateEntity3>.Current;

--- a/modules/permission-management/src/Volo.Abp.PermissionManagement.Domain/Volo/Abp/PermissionManagement/PermissionDefinitionSerializer.cs
+++ b/modules/permission-management/src/Volo.Abp.PermissionManagement.Domain/Volo/Abp/PermissionManagement/PermissionDefinitionSerializer.cs
@@ -93,7 +93,7 @@ public class PermissionDefinitionSerializer : IPermissionDefinitionSerializer, I
                 permission.IsEnabled,
                 permission.MultiTenancySide,
                 SerializeProviders(permission.Providers),
-                SerializeStateCheckers(permission.StateCheckers)
+                SerializeStateCheckers(permission, permission.StateCheckers)
             );
 
             foreach (var property in permission.Properties)
@@ -112,8 +112,10 @@ public class PermissionDefinitionSerializer : IPermissionDefinitionSerializer, I
             : null;
     }
 
-    protected virtual string SerializeStateCheckers(List<ISimpleStateChecker<PermissionDefinition>> stateCheckers)
+    protected virtual string SerializeStateCheckers(
+        PermissionDefinition permission,
+        List<ISimpleStateChecker<PermissionDefinition>> stateCheckers)
     {
-        return StateCheckerSerializer.Serialize(stateCheckers);
+        return StateCheckerSerializer.Serialize(stateCheckers, permission);
     }
 }

--- a/modules/permission-management/test/Volo.Abp.PermissionManagement.Domain.Tests/Volo/Abp/PermissionManagement/PermissionDefinitionSerializer_Tests.cs
+++ b/modules/permission-management/test/Volo.Abp.PermissionManagement.Domain.Tests/Volo/Abp/PermissionManagement/PermissionDefinitionSerializer_Tests.cs
@@ -80,6 +80,74 @@ public class PermissionDefinitionSerializer_Tests : PermissionTestBase
 
 
     [Fact]
+    public async Task Serialize_Permission_With_Default_Batch_RequireFeatures()
+    {
+        var context = new PermissionDefinitionContext(null);
+        var group = context.AddGroup("AbpAuditLogging");
+        var permission = group.AddPermission(
+                "AbpAuditLogging.Settings",
+                new LocalizableString(typeof(AbpPermissionManagementResource), "Permission1"))
+            .RequireFeatures("AbpAuditLogging.SettingManagement");
+
+        var record = await _serializer.SerializeAsync(permission, group);
+
+        record.StateCheckers.ShouldBe(
+            "[{\"T\":\"F\",\"A\":true,\"N\":[\"AbpAuditLogging.SettingManagement\"]}]");
+    }
+
+    [Fact]
+    public async Task Serialize_Permission_With_Default_Batch_RequireFeatures_Picks_Per_State_Model()
+    {
+        var context = new PermissionDefinitionContext(null);
+        var group = context.AddGroup("Group1");
+
+        var permA = group.AddPermission("PermA", new LocalizableString(typeof(AbpPermissionManagementResource), "Permission1"))
+            .RequireFeatures("FeatureForA");
+        var permB = group.AddPermission("PermB", new LocalizableString(typeof(AbpPermissionManagementResource), "Permission1"))
+            .RequireFeatures("FeatureForB1", "FeatureForB2");
+
+        var recordA = await _serializer.SerializeAsync(permA, group);
+        var recordB = await _serializer.SerializeAsync(permB, group);
+
+        recordA.StateCheckers.ShouldBe("[{\"T\":\"F\",\"A\":true,\"N\":[\"FeatureForA\"]}]");
+        recordB.StateCheckers.ShouldBe("[{\"T\":\"F\",\"A\":true,\"N\":[\"FeatureForB1\",\"FeatureForB2\"]}]");
+    }
+
+    [Fact]
+    public async Task Serialize_Permission_With_Default_Batch_RequirePermissions()
+    {
+        var context = new PermissionDefinitionContext(null);
+        var group = context.AddGroup("Group1");
+        var permission = group.AddPermission(
+                "Permission1",
+                new LocalizableString(typeof(AbpPermissionManagementResource), "Permission1"))
+            .RequirePermissions("OtherPermission1", "OtherPermission2");
+
+        var record = await _serializer.SerializeAsync(permission, group);
+
+        record.StateCheckers.ShouldBe(
+            "[{\"T\":\"P\",\"A\":true,\"N\":[\"OtherPermission1\",\"OtherPermission2\"]}]");
+    }
+
+    [Fact]
+    public async Task Serialize_Permission_With_Default_Batch_RequirePermissions_Picks_Per_State_Model()
+    {
+        var context = new PermissionDefinitionContext(null);
+        var group = context.AddGroup("Group1");
+
+        var permA = group.AddPermission("PermA", new LocalizableString(typeof(AbpPermissionManagementResource), "Permission1"))
+            .RequirePermissions("OtherForA");
+        var permB = group.AddPermission("PermB", new LocalizableString(typeof(AbpPermissionManagementResource), "Permission1"))
+            .RequirePermissions(requiresAll: false, "OtherForB1", "OtherForB2");
+
+        var recordA = await _serializer.SerializeAsync(permA, group);
+        var recordB = await _serializer.SerializeAsync(permB, group);
+
+        recordA.StateCheckers.ShouldBe("[{\"T\":\"P\",\"A\":true,\"N\":[\"OtherForA\"]}]");
+        recordB.StateCheckers.ShouldBe("[{\"T\":\"P\",\"A\":false,\"N\":[\"OtherForB1\",\"OtherForB2\"]}]");
+    }
+
+    [Fact]
     public async Task Serialize_Complex_Resource_Permission_Definition()
     {
         // Arrange


### PR DESCRIPTION
`RequireFeatures(...)` and `RequirePermissions(...)` default to a shared batch state checker (AsyncLocal singleton) that holds models for many permissions. The serializer contributor pipeline only recognised the non-batch types, so the batch instance was silently dropped from `PermissionDefinitionRecord` during dynamic permission distribution. Consumers ended up with empty `StateCheckers`, the feature / permission gate disappeared on that side, and they disagreed with the publisher's in-memory verdict (typical symptom: a UI tab whose backing API rejects with 403 because the publisher still enforces the gate).

`ISimpleStateCheckerSerializerContributor` and `ISimpleStateCheckerSerializer` now have a state-aware overload. The `Features` and `Permissions` contributors look up the per-state model on the batch checker (matched with the same `EqualityComparer<TState>.Default` semantics the runtime uses) and emit a non-batch record. `PermissionDefinitionSerializer` threads the owning permission through. Includes a regression test pinning the equality contract.

Regression introduced in https://github.com/abpframework/abp/pull/25276. Reported in https://github.com/volosoft/volo/issues/22319.