### PR TITLE
Restore `Data` binding on tenant management data grid

### DIFF
--- a/modules/tenant-management/src/Volo.Abp.TenantManagement.Blazor/Pages/TenantManagement/TenantManagement.razor
+++ b/modules/tenant-management/src/Volo.Abp.TenantManagement.Blazor/Pages/TenantManagement/TenantManagement.razor
@@ -25,6 +25,7 @@
     <CardBody>
         @* ************************* DATA GRID ************************* *@
         <AbpExtensibleDataGrid TItem="TenantDto"
+                               Data="@Entities"
                                ReadData="@OnDataGridReadAsync"
                                TotalItems="@TotalCount"
                                ShowPager="true"


### PR DESCRIPTION
The `<AbpExtensibleDataGrid>` on the Blazorise tenant management page lost its `Data="@Entities"` binding in #25235, so the grid never re-renders with the refreshed `Entities` collection after create/update/delete and the page only shows the new row after a manual refresh.

Identity `RoleManagement.razor` / `UserManagement.razor` keep the binding and work as expected; this restores the same binding on `TenantManagement.razor`.

Fixes volosoft/volo#22330