### PR TITLE
Update release-notes and roadmap after v10.4 stable

### DIFF
--- a/docs/en/release-info/release-notes.md
+++ b/docs/en/release-info/release-notes.md
@@ -14,9 +14,9 @@ Also see the following notes about ABP releases:
 - [ABP Studio release notes](../studio/release-notes.md)
 - [Change logs for ABP pro packages](https://abp.io/pro-releases)
 
-## 10.4 (2026-04-29)
+## 10.4 (2026-05-14)
 
-ABP v10.4 is currently in the release candidate stage; the stable version has not been released yet. See the detailed **[blog post / announcement](https://abp.io/community/announcements/announcing-abp-10-4-release-candidate-7ukyudm0)** for the v10.4 RC release.
+See the detailed **[blog post / announcement](https://abp.io/community/announcements/announcing-abp-10-4-stable-release-e0u81o2z)** for the v10.4 release.
 
 - URL-Based Localization
 - Localization File Splitting
@@ -29,7 +29,7 @@ ABP v10.4 is currently in the release candidate stage; the stable version has no
 
 ## 10.3 (2026-04-15)
 
-See the detailed **[blog post / announcement](https://abp.io/community/announcements/announcing-abp-10-3-release-candidate-hgnpr9jq)** for the v10.3 release.
+See the detailed **[blog post / announcement](https://abp.io/community/announcements/announcing-abp-10-3-stable-release-aryi10am)** for the v10.3 release.
 
 - OpenIddict: `private_key_jwt` Client Authentication + `abp generate-jwks`
 - Event Bus: String-Based Event Publishing with Dynamic Payload

--- a/docs/en/release-info/road-map.md
+++ b/docs/en/release-info/road-map.md
@@ -17,12 +17,15 @@ The next planned version will be 10.5, which is scheduled to be released as a st
 
 * Framework
   * Token Verification Improvements (Refresh Token Support)
+  * Dynamic Background Worker Scheduler Capabilities
+  * Default Scopes Fallback for OpenIddict Grants
   * Upgrading 3rd-party Dependencies
   * Enhancements in the Core Points
 
 * ABP Suite
   * Improvements on the generated codes for nullability
   * Improvements on Master-Detail Page Design (making it more compact)
+  * LowCode System Integration
 
 * ABP Studio
   * Allow to Directly Create New Solutions with ABP's RC (Release Candidate) Versions
@@ -30,10 +33,15 @@ The next planned version will be 10.5, which is scheduled to be released as a st
   * Allow to Download ABP Samples from ABP Studio
   * Support Multiple Concurrent Kubernetes Deployment/Integration Scenarios
   * Improve the Module Installation Experience / Installation Guides
+  * AI Coding Agent and MCP Integration
+  * Modern Solution Wizard with Low-Code Support
+  * ABP Thin UI: React Templates
+  * Theme Builder: Live Preview, Project Integration and Import/Export
 
 * Application Modules
   * AI Management: Chat History & Multi-Tenancy Features
   * New Module: Chat with your data
+  * Admin Console: LowCode Designer
   * CMS Kit: CodeMirror v6 Compatibility Update
   * Payment Module: Email Notification Improvements
   * UI/UX Improvements on Existing Application Modules

--- a/docs/en/release-info/road-map.md
+++ b/docs/en/release-info/road-map.md
@@ -34,7 +34,7 @@ The next planned version will be 10.5, which is scheduled to be released as a st
   * Support Multiple Concurrent Kubernetes Deployment/Integration Scenarios
   * Improve the Module Installation Experience / Installation Guides
   * AI Coding Agent and MCP Integration
-  * Modern Solution Wizard with Low-Code Support
+  * Modern Solution Wizard with LowCode Support
   * ABP Thin UI: React Templates
   * Theme Builder: Live Preview, Project Integration and Import/Export
 

--- a/docs/en/release-info/road-map.md
+++ b/docs/en/release-info/road-map.md
@@ -25,7 +25,7 @@ The next planned version will be 10.5, which is scheduled to be released as a st
 * ABP Suite
   * Improvements on the generated codes for nullability
   * Improvements on Master-Detail Page Design (making it more compact)
-  * LowCode System Integration
+  * Low-Code System Integration
 
 * ABP Studio
   * Allow to Directly Create New Solutions with ABP's RC (Release Candidate) Versions
@@ -34,14 +34,14 @@ The next planned version will be 10.5, which is scheduled to be released as a st
   * Support Multiple Concurrent Kubernetes Deployment/Integration Scenarios
   * Improve the Module Installation Experience / Installation Guides
   * AI Coding Agent and MCP Integration
-  * Modern Solution Wizard with LowCode Support
+  * Modern Solution Wizard with Low-Code Support
   * ABP Thin UI: React Templates
   * Theme Builder: Live Preview, Project Integration and Import/Export
 
 * Application Modules
   * AI Management: Chat History & Multi-Tenancy Features
   * New Module: Chat with your data
-  * Admin Console: LowCode Designer
+  * Admin Console: Low-Code Designer
   * CMS Kit: CodeMirror v6 Compatibility Update
   * Payment Module: Email Notification Improvements
   * UI/UX Improvements on Existing Application Modules


### PR DESCRIPTION
Closes #25441.

- release-notes.md: v10.4 RC -> stable wording, date and blog URL; also fix v10.3 blog URL that was still pointing at the RC slug.
- road-map.md: refresh v10.5 plan based on current 10.5-preview milestone work across abp / volo / abp-studio.