### PR TITLE
Avoid stack overflow when logging exceptions in Blazor WebAssembly

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Components.WebAssembly/Volo/Abp/AspNetCore/Components/WebAssembly/AbpAspNetCoreComponentsWebAssemblyModule.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Components.WebAssembly/Volo/Abp/AspNetCore/Components/WebAssembly/AbpAspNetCoreComponentsWebAssemblyModule.cs
@@ -48,7 +48,8 @@ public class AbpAspNetCoreComponentsWebAssemblyModule : AbpModule
         context.Services.AddHttpClient();
         context.Services
             .GetHostBuilder().Logging
-            .AddProvider(new AbpExceptionHandlingLoggerProvider(context.Services));
+            .AddProvider(new AbpExceptionHandlingLoggerProvider(context.Services))
+            .AddFilter<AbpExceptionHandlingLoggerProvider>(typeof(UserExceptionInformer).FullName, LogLevel.None);
         
         if (!context.Services.ExecutePreConfiguredActions<AbpAspNetCoreComponentsWebOptions>().IsBlazorWebApp)
         {

--- a/framework/test/Volo.Abp.AspNetCore.Components.Web.Theming.Tests/Volo/Abp/AspNetCore/Components/Web/ExceptionHandling/AbpExceptionHandlingLogger_Tests.cs
+++ b/framework/test/Volo.Abp.AspNetCore.Components.Web.Theming.Tests/Volo/Abp/AspNetCore/Components/Web/ExceptionHandling/AbpExceptionHandlingLogger_Tests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+using Volo.Abp.AspNetCore.Components.ExceptionHandling;
+using Xunit;
+
+namespace Volo.Abp.AspNetCore.Components.Web.ExceptionHandling;
+
+public class AbpExceptionHandlingLogger_Tests
+{
+    [Fact]
+    public void Should_Not_Recurse_When_Informer_Writes_To_Same_Logger_Pipeline()
+    {
+        var services = new ServiceCollection();
+        var informer = new RecordingUserExceptionInformer();
+        services.AddSingleton<IUserExceptionInformer>(informer);
+
+        var provider = new AbpExceptionHandlingLoggerProvider(services);
+        services.AddLogging(builder => builder
+            .AddProvider(provider)
+            .AddFilter<AbpExceptionHandlingLoggerProvider>(typeof(UserExceptionInformer).FullName, LogLevel.None));
+
+        var accessor = services.AddObjectAccessor<IServiceProvider>();
+        var sp = services.BuildServiceProvider();
+        accessor.Value = sp;
+
+        informer.Logger = sp.GetRequiredService<ILoggerFactory>()
+            .CreateLogger(typeof(UserExceptionInformer).FullName!);
+
+        var entryLogger = sp.GetRequiredService<ILogger<AbpExceptionHandlingLogger_Tests>>();
+        entryLogger.LogError(new InvalidOperationException("boom"), "entry");
+
+        informer.InformCalls.ShouldBe(1);
+    }
+
+    private sealed class RecordingUserExceptionInformer : IUserExceptionInformer
+    {
+        private const int RecursionCircuitBreaker = 50;
+
+        public int InformCalls;
+        public ILogger? Logger;
+
+        public void Inform(UserExceptionInformerContext context)
+        {
+            InformCalls++;
+            if (InformCalls > RecursionCircuitBreaker)
+            {
+                return;
+            }
+
+            Logger?.LogError(context.Exception, context.Exception.Message);
+        }
+
+        public Task InformAsync(UserExceptionInformerContext context)
+        {
+            Inform(context);
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #25463

`AbpExceptionHandlingLoggerProvider` is registered in the MEL pipeline by the WebAssembly module so that any `Error`/`Critical` log with an exception is forwarded to `IUserExceptionInformer.Inform` for UI display. The default `UserExceptionInformer.LogException` then writes the same exception back through `ILogger<UserExceptionInformer>`, which re-enters the same provider and recurses until the browser stack overflows.

Filter out the `UserExceptionInformer` category from `AbpExceptionHandlingLoggerProvider` at registration time so the informer's own log writes do not loop back into the provider. Other logger providers (console, Serilog, etc.) still receive these log records.