### PR TITLE
Fixes the use of DataGrid Template Contexts for ExtraProperties

### DIFF
--- a/framework/src/Volo.Abp.BlazoriseUI/Components/AbpExtensibleDataGrid.razor
+++ b/framework/src/Volo.Abp.BlazoriseUI/Components/AbpExtensibleDataGrid.razor
@@ -122,7 +122,7 @@
                             <DataGridColumn TItem="TItem" Field="@nameof(IHasExtraProperties.ExtraProperties)" SortField="@column.PropertyName" Width="@BlazoriseFluentSizingParse.Parse(column.Width, SizingType.Width)" Caption="@column.Title" Displayable="column.Visible" Sortable="@column.Sortable">
                                 <DisplayTemplate>
                                     @{
-                                        var entity = context as IHasExtraProperties;
+                                        var entity = context.Item as IHasExtraProperties;
                                         var propertyName = ExtensionPropertiesRegex.Match(column.Data).Groups[1].Value;
                                         var propertyValue = entity?.GetProperty(propertyName);
                                         if (propertyValue != null && propertyValue.GetType() == typeof(bool))


### PR DESCRIPTION
### Description

Resolves #25465

TODO: As per [Blazorise migration docs](https://blazorise.com/news/migration/200) DataGrid Template Contexts now receive context objects instead of the raw row item and any code that assumes context is TItem should be updated. So the line `var entity = context as IHasExtraProperties;` should be `var entity = context.Item as IHasExtraProperties;` otherwise entity is null and propertyValue is also null.
 

### Checklist

- [x] I fully tested it as developer
- [x] I documented it (or no need to document or I will create a separate documentation issue)