### PR TITLE
Create AbpText and AbpDynamicText

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpDynamicTextTagHelper.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpDynamicTextTagHelper.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Grid;
+
+namespace Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Form;
+
+[HtmlTargetElement("abp-dynamic-text", TagStructure = TagStructure.NormalOrSelfClosing)]
+public class AbpDynamicTextTagHelper : AbpTagHelper<AbpDynamicTextTagHelper, AbpDynamicTextTagHelperService>
+{
+    [HtmlAttributeName("abp-model")]
+    public ModelExpression Model { get; set; } = default!;
+
+    [HtmlAttributeName("column-size")]
+    public ColumnSize ColumnSize { get; set; }
+
+    [HtmlAttributeName("label-width")]
+    public ColumnSize LabelWidth { get; set; } = ColumnSize._4;
+
+    public AbpDynamicTextTagHelper(AbpDynamicTextTagHelperService tagHelperService)
+        : base(tagHelperService)
+    {
+
+    }
+}

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpDynamicTextTagHelperService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpDynamicTextTagHelperService.cs
@@ -1,0 +1,214 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.Microsoft.AspNetCore.Razor.TagHelpers;
+using Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Extensions;
+using Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Grid;
+using Volo.Abp.Localization;
+
+namespace Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Form;
+
+public class AbpDynamicTextTagHelperService : AbpTagHelperService<AbpDynamicTextTagHelper>
+{
+    protected HtmlEncoder HtmlEncoder { get; }
+    protected IServiceProvider ServiceProvider { get; }
+    protected List<ModelExpression> Models = new();
+    protected readonly IAbpEnumLocalizer AbpEnumLocalizer;
+    protected readonly IStringLocalizerFactory StringLocalizerFactory;
+
+    public AbpDynamicTextTagHelperService(
+        HtmlEncoder htmlEncoder,
+        IServiceProvider serviceProvider,
+        IAbpEnumLocalizer abpEnumLocalizer,
+        IStringLocalizerFactory stringLocalizerFactory
+        )
+    {
+        HtmlEncoder = htmlEncoder;
+        ServiceProvider = serviceProvider;
+        AbpEnumLocalizer = abpEnumLocalizer;
+        StringLocalizerFactory = stringLocalizerFactory;
+    }
+
+    public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+    {
+        Models = GetModels(context, output);
+        NormalizeTagMode(context, output);
+        var childContent = await output.GetChildContentAsync();
+        var html = await GetHtmlAsync(context, output);
+        SetContent(context, output, html, childContent);
+        SetAttributes(context, output);
+    }
+
+    protected virtual void NormalizeTagMode(TagHelperContext context, TagHelperOutput output)
+    {
+        output.TagMode = TagMode.StartTagAndEndTag;
+        output.TagName = "div";
+    }
+
+    protected virtual void SetAttributes(TagHelperContext context, TagHelperOutput output)
+    {
+        output.Attributes.AddIfNotContains("class", "abp-dynamic-text");
+    }
+
+    protected virtual void SetContent(TagHelperContext context, TagHelperOutput output, string html, TagHelperContent childContent)
+    {
+        var content = childContent.GetContent();
+
+        if (content.Contains(AbpFormContentPlaceHolder))
+        {
+            content = content.Replace(AbpFormContentPlaceHolder, html);
+        }
+        else
+        {
+            content = html + content;
+        }
+
+        output.Content.SetHtmlContent(content);
+    }
+
+    protected virtual async Task<string> GetHtmlAsync(TagHelperContext context, TagHelperOutput output)
+    {
+        var contentBuilder = new StringBuilder();
+
+        foreach (var model in Models)
+        {
+            var textTagHelper = GetTextTagHelper(model);
+            var textHtml = await textTagHelper.RenderAsync(new TagHelperAttributeList(), context, HtmlEncoder, "div", TagMode.StartTagAndEndTag);
+
+            if (TagHelper.ColumnSize > ColumnSize.Undefined)
+            {
+                var columnSize = $"col-12 col-sm-{(int)TagHelper.ColumnSize}";
+                var hidden = IsHidden(model.ModelExplorer) ? " d-none" : "";
+                contentBuilder.AppendLine($"<div class=\"{columnSize}{hidden}\">{textHtml}</div>");
+            }
+            else
+            {
+                contentBuilder.AppendLine(textHtml);
+            }
+        }
+
+        if (TagHelper.ColumnSize > ColumnSize.Undefined)
+        {
+            contentBuilder.Insert(0, "<div class=\"row\">");
+            contentBuilder.AppendLine("</div>");
+        }
+
+        return contentBuilder.ToString();
+    }
+
+    protected virtual AbpTextTagHelper GetTextTagHelper(ModelExpression model)
+    {
+        var textTagHelper = ServiceProvider.GetRequiredService<AbpTextTagHelper>();
+        textTagHelper.AspFor = model;
+        textTagHelper.ViewContext = TagHelper.ViewContext;
+
+        var textAttribute = model.ModelExplorer.GetAttribute<AbpText>();
+        if (textAttribute != null)
+        {
+            textTagHelper.Format = textAttribute.Format;
+            textTagHelper.LabelWidth = textAttribute.LabelWidth;
+            textTagHelper.SuppressLabel = textAttribute.SuppressLabel;
+            return textTagHelper;
+        }
+
+        textTagHelper.LabelWidth = TagHelper.LabelWidth;
+
+        return textTagHelper;
+    }
+
+    protected bool IsHidden(ModelExplorer model)
+    {
+        return model.GetAttribute<HiddenInputAttribute>() != null;
+    }
+
+    protected virtual List<ModelExpression> GetModels(TagHelperContext context, TagHelperOutput output)
+    {
+        return TagHelper.Model.ModelExplorer.Properties.Aggregate(new List<ModelExpression>(), ExploreModelsRecursively);
+    }
+
+    protected virtual List<ModelExpression> ExploreModelsRecursively(List<ModelExpression> list, ModelExplorer model)
+    {
+        if (model.GetAttribute<DynamicFormIgnore>() != null)
+        {
+            return list;
+        }
+
+        if (IsCsharpClassOrPrimitive(model.ModelType) || IsListOfCsharpClassOrPrimitive(model.ModelType))
+        {
+            list.Add(ModelExplorerToModelExpressionConverter(model));
+            return list;
+        }
+
+        if (IsListOfSelectItem(model.ModelType) || IsFile(model.ModelType))
+        {
+            list.Add(ModelExplorerToModelExpressionConverter(model));
+            return list;
+        }
+
+        return model.Properties.Aggregate(list, ExploreModelsRecursively);
+    }
+
+    protected virtual ModelExpression ModelExplorerToModelExpressionConverter(ModelExplorer explorer)
+    {
+        var temp = explorer;
+        var propertyName = explorer.Metadata.PropertyName;
+
+        while (temp?.Container?.Metadata?.PropertyName != null)
+        {
+            temp = temp.Container;
+            propertyName = temp.Metadata.PropertyName + "." + propertyName;
+        }
+
+        return new ModelExpression(propertyName ?? string.Empty, explorer);
+    }
+
+    protected virtual bool IsListOfCsharpClassOrPrimitive(Type type)
+    {
+        var genericType = type.GenericTypeArguments.FirstOrDefault();
+
+        if (genericType == null || !IsCsharpClassOrPrimitive(genericType))
+        {
+            return false;
+        }
+
+        return type.ToString().StartsWith("System.Collections.Generic.IEnumerable`") ||
+               type.ToString().StartsWith("System.Collections.Generic.List`");
+    }
+
+    protected virtual bool IsCsharpClassOrPrimitive(Type? type)
+    {
+        if (type == null) return false;
+
+        return type.IsPrimitive ||
+               type.IsValueType ||
+               type == typeof(string) ||
+               type == typeof(Guid) ||
+               type == typeof(DateTime) ||
+               type == typeof(ValueType) ||
+               type == typeof(TimeSpan) ||
+               type == typeof(DateTimeOffset) ||
+               type.IsEnum;
+    }
+
+    protected virtual bool IsListOfSelectItem(Type type)
+    {
+        return type == typeof(List<SelectListItem>) ||
+               type == typeof(IEnumerable<SelectListItem>);
+    }
+
+    protected virtual bool IsFile(Type type)
+    {
+        return typeof(IFormFile).IsAssignableFrom(type) ||
+               typeof(IEnumerable<IFormFile>).IsAssignableFrom(type);
+    }
+}

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpDynamicTextTagHelperService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpDynamicTextTagHelperService.cs
@@ -1,20 +1,18 @@
-﻿using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Rendering;
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
-using Microsoft.AspNetCore.Razor.TagHelpers;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Localization;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.Extensions.DependencyInjection;
 using Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.Microsoft.AspNetCore.Razor.TagHelpers;
 using Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Extensions;
 using Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Grid;
-using Volo.Abp.Localization;
 
 namespace Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Form;
 
@@ -23,20 +21,14 @@ public class AbpDynamicTextTagHelperService : AbpTagHelperService<AbpDynamicText
     protected HtmlEncoder HtmlEncoder { get; }
     protected IServiceProvider ServiceProvider { get; }
     protected List<ModelExpression> Models = new();
-    protected readonly IAbpEnumLocalizer AbpEnumLocalizer;
-    protected readonly IStringLocalizerFactory StringLocalizerFactory;
 
     public AbpDynamicTextTagHelperService(
         HtmlEncoder htmlEncoder,
-        IServiceProvider serviceProvider,
-        IAbpEnumLocalizer abpEnumLocalizer,
-        IStringLocalizerFactory stringLocalizerFactory
+        IServiceProvider serviceProvider
         )
     {
         HtmlEncoder = htmlEncoder;
         ServiceProvider = serviceProvider;
-        AbpEnumLocalizer = abpEnumLocalizer;
-        StringLocalizerFactory = stringLocalizerFactory;
     }
 
     public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
@@ -113,15 +105,15 @@ public class AbpDynamicTextTagHelperService : AbpTagHelperService<AbpDynamicText
         textTagHelper.ViewContext = TagHelper.ViewContext;
 
         var textAttribute = model.ModelExplorer.GetAttribute<AbpText>();
-        if (textAttribute != null)
+        if (textAttribute == null)
         {
-            textTagHelper.Format = textAttribute.Format;
-            textTagHelper.LabelWidth = textAttribute.LabelWidth;
-            textTagHelper.SuppressLabel = textAttribute.SuppressLabel;
+            textTagHelper.LabelWidth = TagHelper.LabelWidth;
             return textTagHelper;
         }
 
-        textTagHelper.LabelWidth = TagHelper.LabelWidth;
+        textTagHelper.Format = textAttribute.Format;
+        textTagHelper.LabelWidth = textAttribute.LabelWidth ?? TagHelper.LabelWidth;
+        textTagHelper.SuppressLabel = textAttribute.SuppressLabel;
 
         return textTagHelper;
     }

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpText.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpText.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Grid;
+
+namespace Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Form;
+
+[AttributeUsage(AttributeTargets.Property)]
+public class AbpText : Attribute
+{
+    public ColumnSize LabelWidth { get; set; }
+
+    public bool SuppressLabel { get; set; } = false;
+
+    public string? Format { get; set; }
+
+    public AbpText(ColumnSize labelWidth = ColumnSize._4, string? format = null)
+    {
+        LabelWidth = labelWidth;
+        Format = format;
+    }
+}

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpText.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpText.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Microsoft.AspNetCore.Razor.TagHelpers;
 using Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Grid;
 
 namespace Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Form;
@@ -7,15 +6,13 @@ namespace Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Form;
 [AttributeUsage(AttributeTargets.Property)]
 public class AbpText : Attribute
 {
-    public ColumnSize LabelWidth { get; set; }
+    public ColumnSize? LabelWidth { get; set; }
 
     public bool SuppressLabel { get; set; } = false;
 
     public string? Format { get; set; }
 
-    public AbpText(ColumnSize labelWidth = ColumnSize._4, string? format = null)
+    public AbpText()
     {
-        LabelWidth = labelWidth;
-        Format = format;
     }
 }

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpTextTagHelper.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpTextTagHelper.cs
@@ -14,7 +14,7 @@ public class AbpTextTagHelper : AbpTagHelper<AbpTextTagHelper, AbpTextTagHelperS
     public string? Label { get; set; }
 
     [HtmlAttributeName("label-width")]
-    public ColumnSize LabelWidth { get; set; } = ColumnSize._4;
+    public ColumnSize? LabelWidth { get; set; }
 
     [HtmlAttributeName("suppress-label")]
     public bool SuppressLabel { get; set; } = false;

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpTextTagHelper.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpTextTagHelper.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Grid;
+
+namespace Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Form;
+
+[HtmlTargetElement("abp-text", TagStructure = TagStructure.NormalOrSelfClosing)]
+public class AbpTextTagHelper : AbpTagHelper<AbpTextTagHelper, AbpTextTagHelperService>
+{
+    [HtmlAttributeName("asp-for")]
+    public ModelExpression AspFor { get; set; } = default!;
+
+    [HtmlAttributeName("label")]
+    public string? Label { get; set; }
+
+    [HtmlAttributeName("label-width")]
+    public ColumnSize LabelWidth { get; set; } = ColumnSize._4;
+
+    [HtmlAttributeName("suppress-label")]
+    public bool SuppressLabel { get; set; } = false;
+
+    [HtmlAttributeName("format")]
+    public string? Format { get; set; }
+
+    public AbpTextTagHelper(AbpTextTagHelperService tagHelperService)
+        : base(tagHelperService)
+    {
+
+    }
+}

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpTextTagHelperService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpTextTagHelperService.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Reflection.Emit;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
@@ -10,6 +9,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.Extensions.Localization;
 using Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.Microsoft.AspNetCore.Razor.TagHelpers;
 using Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Extensions;
+using Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Grid;
 using Volo.Abp.Localization;
 
 namespace Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Form;
@@ -20,6 +20,7 @@ public class AbpTextTagHelperService : AbpTagHelperService<AbpTextTagHelper>
     private readonly IAbpTagHelperLocalizer _tagHelperLocalizer;
     protected readonly IAbpEnumLocalizer _abpEnumLocalizer;
     protected readonly IStringLocalizerFactory _stringLocalizerFactory;
+    private readonly ColumnSize DefaultLabelWidth = ColumnSize._4;
 
     public AbpTextTagHelperService(
         HtmlEncoder htmlEncoder,
@@ -74,8 +75,8 @@ public class AbpTextTagHelperService : AbpTagHelperService<AbpTextTagHelper>
 
     protected virtual string GetHtml(TagHelperContext context, TagHelperOutput output)
     {
-        var labelHtml = GetLabelHtml();
-        var textHtml = GetTextHtml();
+        var label = GetLabel();
+        var text = GetText();
         var fieldId = GetFieldId();
         var value = TagHelper.AspFor.Model;
 
@@ -85,14 +86,17 @@ public class AbpTextTagHelperService : AbpTagHelperService<AbpTextTagHelper>
 
         if (!TagHelper.SuppressLabel)
         {
-            var labelWidth = $"col-{(int)TagHelper.LabelWidth}";
+            var width = TagHelper.LabelWidth ??
+                TagHelper.AspFor.ModelExplorer.GetAttribute<AbpText>()?.LabelWidth ??
+                DefaultLabelWidth;
+            var labelWidth = $"col-{(int)width}";
             contentBuilder.AppendLine($"<div class=\"{labelWidth}\">");
-            contentBuilder.AppendLine(labelHtml);
+            contentBuilder.AppendLine(label);
             contentBuilder.AppendLine("</div>");
         }
 
         contentBuilder.AppendLine($"<div class=\"col\" id=\"{fieldId}\" data-value=\"{HtmlEncoder.Encode(value?.ToString() ?? string.Empty)}\">");
-        contentBuilder.AppendLine(textHtml);
+        contentBuilder.AppendLine(text);
         contentBuilder.AppendLine("</div>");
 
         contentBuilder.AppendLine("</div>");
@@ -108,7 +112,7 @@ public class AbpTextTagHelperService : AbpTagHelperService<AbpTextTagHelper>
             .Replace("]", "_");
     }
 
-    protected virtual string GetLabelHtml()
+    protected virtual string GetLabel()
     {
         var label = TagHelper.Label ??
                TagHelper.AspFor.Metadata.DisplayName ??
@@ -118,46 +122,45 @@ public class AbpTextTagHelperService : AbpTagHelperService<AbpTextTagHelper>
         return $"<strong>{HtmlEncoder.Encode(label)}</strong>";
     }
 
-    protected virtual string GetTextHtml()
+    protected virtual string GetText()
+    {
+        if (IsEnum())
+        {
+            return EnumText();
+        }
+        if (IsDate())
+        {
+            return DateText();
+        }
+        if (IsBoolean())
+        {
+            return BooleanText();
+        }
+        if (IsFile())
+        {
+            return FileText();
+        }
+        if (IsCollection())
+        {
+            return CollectionText();
+        }
+
+        return DefaultText();
+    }
+
+    protected virtual string DefaultText()
     {
         var value = TagHelper.AspFor.Model;
-
-        if (value == null)
+        if (value == null || string.IsNullOrWhiteSpace(value.ToString()))
         {
             return "<span class=\"text-muted\">-</span>";
         }
-
-        if (IsEnum())
-        {
-            return ToFormat(GetEnumValue());
-        }
-
-        if (IsDate())
-        {
-            return GetDateValue();
-        }
-
-        if (IsBoolean())
-        {
-            return GetBooleanValue();
-        }
-
-        if (IsFile())
-        {
-            return GetFileValue();
-        }
-
-        if (IsCollection())
-        {
-            return ToFormat(GetCollectionValue());
-        }
-
-        return ToFormat(HtmlEncoder.Encode(value.ToString()!));
+        return StringFormat(HtmlEncoder.Encode(value.ToString()!));
     }
 
-    protected string ToFormat(string? value)
+    protected virtual string StringFormat(string? value)
     {
-        var format = TagHelper.Format ?? TagHelper.AspFor.ModelExplorer.GetAttribute<AbpText>()?.Format ?? string.Empty;
+        var format = GetFormatString();
         if (format.IsNullOrEmpty() || value.IsNullOrWhiteSpace())
         {
             return value ?? string.Empty;
@@ -165,9 +168,19 @@ public class AbpTextTagHelperService : AbpTagHelperService<AbpTextTagHelper>
         return string.Format(format, value);
     }
 
-    protected virtual string GetEnumValue()
+    private string GetFormatString()
+    {
+        return TagHelper.Format ?? TagHelper.AspFor.ModelExplorer.GetAttribute<AbpText>()?.Format ?? string.Empty;
+    }
+
+    protected virtual string EnumText()
     {
         var value = TagHelper.AspFor.Model;
+        if (value == null)
+        {
+            return DefaultText();
+        }
+
         var modelType = value.GetType();
         var enumType = modelType.IsEnum ? modelType : Nullable.GetUnderlyingType(modelType);
         var containerLocalizer = _tagHelperLocalizer.GetLocalizerOrNull(TagHelper.AspFor.ModelExplorer.Container.ModelType.Assembly);
@@ -177,15 +190,18 @@ public class AbpTextTagHelperService : AbpTagHelperService<AbpTextTagHelper>
                 containerLocalizer,
                 _stringLocalizerFactory.CreateDefaultOrNull()
                }!);
-        return HtmlEncoder.Encode(localizedMemberName ?? string.Empty);
+        return StringFormat(HtmlEncoder.Encode(localizedMemberName ?? string.Empty));
     }
 
-    protected virtual string GetDateValue()
+    protected virtual string DateText()
     {
         var value = TagHelper.AspFor.Model;
+        if (value == null)
+        {
+            return DefaultText();
+        }
 
-        var format = TagHelper.Format ?? TagHelper.AspFor.ModelExplorer.GetAttribute<AbpText>()?.Format;
-
+        var format = GetFormatString();
         if (value is DateTime dateTime)
         {
             return dateTime.ToString(format);
@@ -196,12 +212,16 @@ public class AbpTextTagHelperService : AbpTagHelperService<AbpTextTagHelper>
             return dateTimeOffset.ToString(format);
         }
 
-        return value.ToString() ?? string.Empty;
+        return StringFormat(value.ToString());
     }
 
-    protected virtual string GetBooleanValue()
+    protected virtual string BooleanText()
     {
         var value = TagHelper.AspFor.Model;
+        if (value == null)
+        {
+            return DefaultText();
+        }
 
         if (value is bool boolValue)
         {
@@ -210,17 +230,21 @@ public class AbpTextTagHelperService : AbpTagHelperService<AbpTextTagHelper>
                 : "<span class=\"fa fa-times\"></span>";
         }
 
-        return HtmlEncoder.Encode(value.ToString() ?? string.Empty);
+        return StringFormat(value.ToString());
     }
 
-    protected virtual string GetFileValue()
+    protected virtual string FileText()
     {
-        return "<span class=\"text-info\"><i class=\"bi bi-file\"></i> File</span>";
+        return "<span class=\"text-info\"><i class=\"bi bi-file\"></i></span>";
     }
 
-    protected virtual string GetCollectionValue()
+    protected virtual string CollectionText()
     {
         var value = TagHelper.AspFor.Model;
+        if (value == null)
+        {
+            return DefaultText();
+        }
 
         //todo Consider supporting collection render.
         if (value is System.Collections.IEnumerable enumerable)
@@ -234,7 +258,7 @@ public class AbpTextTagHelperService : AbpTagHelperService<AbpTextTagHelper>
             return count.ToString();
         }
 
-        return HtmlEncoder.Encode(value.ToString() ?? string.Empty);
+        return StringFormat(value.ToString());
     }
 
     protected virtual bool IsHidden()

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpTextTagHelperService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Bootstrap/TagHelpers/Form/AbpTextTagHelperService.cs
@@ -1,0 +1,278 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection.Emit;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.Extensions.Localization;
+using Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.Microsoft.AspNetCore.Razor.TagHelpers;
+using Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Extensions;
+using Volo.Abp.Localization;
+
+namespace Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Form;
+
+public class AbpTextTagHelperService : AbpTagHelperService<AbpTextTagHelper>
+{
+    protected HtmlEncoder HtmlEncoder { get; }
+    private readonly IAbpTagHelperLocalizer _tagHelperLocalizer;
+    protected readonly IAbpEnumLocalizer _abpEnumLocalizer;
+    protected readonly IStringLocalizerFactory _stringLocalizerFactory;
+
+    public AbpTextTagHelperService(
+        HtmlEncoder htmlEncoder,
+        IAbpTagHelperLocalizer tagHelperLocalizer,
+        IAbpEnumLocalizer abpEnumLocalizer,
+        IStringLocalizerFactory stringLocalizerFactory)
+    {
+        HtmlEncoder = htmlEncoder;
+        _tagHelperLocalizer = tagHelperLocalizer;
+        _abpEnumLocalizer = abpEnumLocalizer;
+        _stringLocalizerFactory = stringLocalizerFactory;
+    }
+
+    public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+    {
+        var childContent = await output.GetChildContentAsync();
+
+        NormalizeTagMode(context, output);
+        SetAttributes(context, output);
+
+        var html = GetHtml(context, output);
+        SetContent(context, output, html, childContent);
+    }
+
+    protected virtual void NormalizeTagMode(TagHelperContext context, TagHelperOutput output)
+    {
+        output.TagMode = TagMode.StartTagAndEndTag;
+        output.TagName = "div";
+    }
+
+    protected virtual void SetAttributes(TagHelperContext context, TagHelperOutput output)
+    {
+        var cssClass = "mb-3";
+        output.Attributes.AddIfNotContains("class", cssClass);
+    }
+
+    protected virtual void SetContent(TagHelperContext context, TagHelperOutput output, string html, TagHelperContent childContent)
+    {
+        var content = childContent.GetContent();
+
+        if (!string.IsNullOrEmpty(content))
+        {
+            content = html + content;
+        }
+        else
+        {
+            content = html;
+        }
+
+        output.Content.SetHtmlContent(content);
+    }
+
+    protected virtual string GetHtml(TagHelperContext context, TagHelperOutput output)
+    {
+        var labelHtml = GetLabelHtml();
+        var textHtml = GetTextHtml();
+        var fieldId = GetFieldId();
+        var value = TagHelper.AspFor.Model;
+
+        var contentBuilder = new StringBuilder();
+        var hidden = IsHidden() ? " d-none" : "";
+        contentBuilder.AppendLine($"<div class=\"row{hidden}\">");
+
+        if (!TagHelper.SuppressLabel)
+        {
+            var labelWidth = $"col-{(int)TagHelper.LabelWidth}";
+            contentBuilder.AppendLine($"<div class=\"{labelWidth}\">");
+            contentBuilder.AppendLine(labelHtml);
+            contentBuilder.AppendLine("</div>");
+        }
+
+        contentBuilder.AppendLine($"<div class=\"col\" id=\"{fieldId}\" data-value=\"{HtmlEncoder.Encode(value?.ToString() ?? string.Empty)}\">");
+        contentBuilder.AppendLine(textHtml);
+        contentBuilder.AppendLine("</div>");
+
+        contentBuilder.AppendLine("</div>");
+
+        return contentBuilder.ToString();
+    }
+
+    protected virtual string GetFieldId()
+    {
+        return TagHelper.AspFor.Name
+            .Replace(".", "_")
+            .Replace("[", "_")
+            .Replace("]", "_");
+    }
+
+    protected virtual string GetLabelHtml()
+    {
+        var label = TagHelper.Label ??
+               TagHelper.AspFor.Metadata.DisplayName ??
+               TagHelper.AspFor.Metadata.PropertyName ??
+               TagHelper.AspFor.Name;
+
+        return $"<strong>{HtmlEncoder.Encode(label)}</strong>";
+    }
+
+    protected virtual string GetTextHtml()
+    {
+        var value = TagHelper.AspFor.Model;
+
+        if (value == null)
+        {
+            return "<span class=\"text-muted\">-</span>";
+        }
+
+        if (IsEnum())
+        {
+            return ToFormat(GetEnumValue());
+        }
+
+        if (IsDate())
+        {
+            return GetDateValue();
+        }
+
+        if (IsBoolean())
+        {
+            return GetBooleanValue();
+        }
+
+        if (IsFile())
+        {
+            return GetFileValue();
+        }
+
+        if (IsCollection())
+        {
+            return ToFormat(GetCollectionValue());
+        }
+
+        return ToFormat(HtmlEncoder.Encode(value.ToString()!));
+    }
+
+    protected string ToFormat(string? value)
+    {
+        var format = TagHelper.Format ?? TagHelper.AspFor.ModelExplorer.GetAttribute<AbpText>()?.Format ?? string.Empty;
+        if (format.IsNullOrEmpty() || value.IsNullOrWhiteSpace())
+        {
+            return value ?? string.Empty;
+        }
+        return string.Format(format, value);
+    }
+
+    protected virtual string GetEnumValue()
+    {
+        var value = TagHelper.AspFor.Model;
+        var modelType = value.GetType();
+        var enumType = modelType.IsEnum ? modelType : Nullable.GetUnderlyingType(modelType);
+        var containerLocalizer = _tagHelperLocalizer.GetLocalizerOrNull(TagHelper.AspFor.ModelExplorer.Container.ModelType.Assembly);
+        var localizedMemberName = value == null ? "-" : _abpEnumLocalizer.GetString(enumType!, (int)value,
+               new[]
+               {
+                containerLocalizer,
+                _stringLocalizerFactory.CreateDefaultOrNull()
+               }!);
+        return HtmlEncoder.Encode(localizedMemberName ?? string.Empty);
+    }
+
+    protected virtual string GetDateValue()
+    {
+        var value = TagHelper.AspFor.Model;
+
+        var format = TagHelper.Format ?? TagHelper.AspFor.ModelExplorer.GetAttribute<AbpText>()?.Format;
+
+        if (value is DateTime dateTime)
+        {
+            return dateTime.ToString(format);
+        }
+
+        if (value is DateTimeOffset dateTimeOffset)
+        {
+            return dateTimeOffset.ToString(format);
+        }
+
+        return value.ToString() ?? string.Empty;
+    }
+
+    protected virtual string GetBooleanValue()
+    {
+        var value = TagHelper.AspFor.Model;
+
+        if (value is bool boolValue)
+        {
+            return boolValue
+                ? "<span class=\"fa fa-check\"></span>"
+                : "<span class=\"fa fa-times\"></span>";
+        }
+
+        return HtmlEncoder.Encode(value.ToString() ?? string.Empty);
+    }
+
+    protected virtual string GetFileValue()
+    {
+        return "<span class=\"text-info\"><i class=\"bi bi-file\"></i> File</span>";
+    }
+
+    protected virtual string GetCollectionValue()
+    {
+        var value = TagHelper.AspFor.Model;
+
+        //todo Consider supporting collection render.
+        if (value is System.Collections.IEnumerable enumerable)
+        {
+            var count = 0;
+            foreach (var item in enumerable)
+            {
+                count++;
+            }
+
+            return count.ToString();
+        }
+
+        return HtmlEncoder.Encode(value.ToString() ?? string.Empty);
+    }
+
+    protected virtual bool IsHidden()
+    {
+        return TagHelper.AspFor.ModelExplorer.GetAttribute<HiddenInputAttribute>() != null;
+    }
+
+    protected virtual bool IsEnum()
+    {
+        return TagHelper.AspFor.ModelExplorer.Metadata.IsEnum;
+    }
+
+    protected virtual bool IsDate()
+    {
+        var modelType = TagHelper.AspFor.Metadata.ModelType;
+        return modelType == typeof(DateTime) ||
+               modelType == typeof(DateTime?) ||
+               modelType == typeof(DateTimeOffset) ||
+               modelType == typeof(DateTimeOffset?);
+    }
+
+    protected virtual bool IsBoolean()
+    {
+        var modelType = TagHelper.AspFor.Metadata.ModelType;
+        return modelType == typeof(bool) || modelType == typeof(bool?);
+    }
+
+    protected virtual bool IsFile()
+    {
+        var modelType = TagHelper.AspFor.Metadata.ModelType;
+        return typeof(IFormFile).IsAssignableFrom(modelType) ||
+               typeof(IEnumerable<IFormFile>).IsAssignableFrom(modelType);
+    }
+
+    protected virtual bool IsCollection()
+    {
+        var modelType = TagHelper.AspFor.Metadata.ModelType;
+        return typeof(System.Collections.IEnumerable).IsAssignableFrom(modelType) &&
+               modelType != typeof(string);
+    }
+}


### PR DESCRIPTION
### New AbpTextTagHelper
### New AbpDynamicTextTagHelper

### How to test it?
<img width="1001" height="975" alt="image" src="https://github.com/user-attachments/assets/84a74386-8cfe-41da-a5d9-a1f394176144" />

# abp-text
Usage:
``` html
<abp-text asp-for="@Model.Name"/>
<abp-text asp-for="@Model.Description "/>
``` 
``` c#
public class FormElementsModel : PageModel
{
        [Display(Name = "User Name")]
        public string Name { get; set; }

        [AbpText(LabelWidth = ColumnSize._3, Format = "<i class=\"fa-solid fa-book\"></i> <strong>{0}</strong>")]
        public string Description { get; set; }
}
```
### Tag Attributes

- **label-width** : Sets the width of the label column. Default is **ColumnSize._4** .
- **suppress-label** : When true , hides the label.
- **format** : Sets a format string for the value. 

# abp-dynamic-text
Usage:
``` xml
<abp-dynamic-text abp-model="@Model.MyModel" column-size="_6"/>
```

``` c#
public class FormElementsModel : PageModel
{
    public SampleModel MyModel { get; set; }

    public void OnGet()
    {
        MyModel = new SampleModel();
    }

    public class SampleModel
    {
        public string Name { get; set; }

        [AbpText(Format = "yyyy-MM-dd")]
        public DateTime BirthDate { get; set; }
        
        public StatusType Status { get; set; }
        
        public Address Address { get; set; }
    }
    
    public class Address
    {
        public string City { get; set; }
        
        public string Street { get; set; }
    }
    
    public enum StatusType
    {
        Active,
        Inactive
    }
}
```
### Tag Attributes
- **abp-model** : Sets the c# model for dynamic form. Properties of this modal are turned into inputs in the form.
- **column-size** : Use ColumnSize enum.
- **label-width** : Sets the width of the label column. Default is **ColumnSize._4** .