### PR TITLE
docs: fix angular README to reference Vitest instead of Karma

### DIFF
--- a/templates/app/angular/README.md
+++ b/templates/app/angular/README.md
@@ -16,7 +16,7 @@ Run `ng build` to build the project. The build artifacts will be stored in the `
 
 ## Running unit tests
 
-Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.io).
+Run `ng test` to execute the unit tests via [Vitest](https://vitest.dev).
 
 ## Running end-to-end tests
 


### PR DESCRIPTION
The Angular starter template README still references Karma as the unit test runner. Since #24725, ABP Angular templates use Vitest by default. This updates the README to reflect the correct testing framework.
