### PR TITLE
Fix empty ExtraProperties cells in `AbpExtensibleDataGrid`

### DIFF
--- a/framework/src/Volo.Abp.BlazoriseUI/Components/AbpExtensibleDataGrid.razor
+++ b/framework/src/Volo.Abp.BlazoriseUI/Components/AbpExtensibleDataGrid.razor
@@ -120,9 +120,9 @@
                         else
                         {
                             <DataGridColumn TItem="TItem" Field="@nameof(IHasExtraProperties.ExtraProperties)" SortField="@column.PropertyName" Width="@BlazoriseFluentSizingParse.Parse(column.Width, SizingType.Width)" Caption="@column.Title" Displayable="column.Visible" Sortable="@column.Sortable">
-                                <DisplayTemplate>
+                                <DisplayTemplate Context="rowContext">
                                     @{
-                                        var entity = context.Item as IHasExtraProperties;
+                                        var entity = rowContext.Item as IHasExtraProperties;
                                         var propertyName = ExtensionPropertiesRegex.Match(column.Data).Groups[1].Value;
                                         var propertyValue = entity?.GetProperty(propertyName);
                                         if (propertyValue != null && propertyValue.GetType() == typeof(bool))
@@ -140,7 +140,7 @@
                                         {
                                             if (column.ValueConverter != null)
                                             {
-                                                @((MarkupString)GetConvertedFieldValue(context.Item, column))
+                                                @((MarkupString)GetConvertedFieldValue(rowContext.Item, column))
                                             }
                                             else
                                             {


### PR DESCRIPTION
The implicit `<DisplayTemplate>` context caused the Razor source generator to compile `context.Item as IHasExtraProperties` into `context as IHasExtraProperties` (dropping `.Item`). Since `CellDisplayContext<TItem>` itself does not implement `IHasExtraProperties`, the cast was always null and the cell rendered as `<!--!--> `.

Renaming the context with `Context="rowContext"` produces the expected `rowContext.Item as IHasExtraProperties` codegen and the cell now displays the extension property value.

Affects every page using `AbpExtensibleDataGrid` with JSON-only `ExtraProperties[xxx]` columns (Saas Tenants, Identity Users, etc.).

Reported in https://abp.io/support/questions/10690.