### PR TITLE
Show invalid password error on login when user should change password

### DIFF
--- a/modules/account/src/Volo.Abp.Account.Web.IdentityServer/Pages/Account/IdentityServerSupportedLoginModel.cs
+++ b/modules/account/src/Volo.Abp.Account.Web.IdentityServer/Pages/Account/IdentityServerSupportedLoginModel.cs
@@ -159,6 +159,23 @@ public class IdentityServerSupportedLoginModel : LoginModel
 
         if (result.IsNotAllowed)
         {
+            var notAllowedUser = await UserManager.FindByNameAsync(LoginInput.UserNameOrEmailAddress) ??
+                                 await UserManager.FindByEmailAsync(LoginInput.UserNameOrEmailAddress);
+            if (notAllowedUser != null)
+            {
+                using (CurrentTenant.Change(notAllowedUser.TenantId))
+                {
+                    await IdentityOptions.SetAsync();
+                    if ((notAllowedUser.ShouldChangePasswordOnNextLogin ||
+                            await UserManager.ShouldPeriodicallyChangePasswordAsync(notAllowedUser)) &&
+                        !await UserManager.CheckPasswordAsync(notAllowedUser, LoginInput.Password))
+                    {
+                        Alerts.Danger(L["InvalidUserNameOrPassword"]);
+                        return Page();
+                    }
+                }
+            }
+
             Alerts.Warning(L["LoginIsNotAllowed"]);
             return Page();
         }

--- a/modules/account/src/Volo.Abp.Account.Web/Pages/Account/Login.cshtml.cs
+++ b/modules/account/src/Volo.Abp.Account.Web/Pages/Account/Login.cshtml.cs
@@ -130,6 +130,21 @@ public class LoginModel : AccountPageModel
 
         if (result.IsNotAllowed)
         {
+            var notAllowedUser = await UserManager.FindByNameAsync(LoginInput.UserNameOrEmailAddress) ??
+                                 await UserManager.FindByEmailAsync(LoginInput.UserNameOrEmailAddress);
+            if (notAllowedUser != null)
+            {
+                using (CurrentTenant.Change(notAllowedUser.TenantId))
+                {
+                    await IdentityOptions.SetAsync();
+                    if (!await UserManager.CheckPasswordAsync(notAllowedUser, LoginInput.Password))
+                    {
+                        Alerts.Danger(L["InvalidUserNameOrPassword"]);
+                        return Page();
+                    }
+                }
+            }
+
             Alerts.Warning(L["LoginIsNotAllowed"]);
             return Page();
         }

--- a/modules/account/src/Volo.Abp.Account.Web/Pages/Account/Login.cshtml.cs
+++ b/modules/account/src/Volo.Abp.Account.Web/Pages/Account/Login.cshtml.cs
@@ -137,7 +137,9 @@ public class LoginModel : AccountPageModel
                 using (CurrentTenant.Change(notAllowedUser.TenantId))
                 {
                     await IdentityOptions.SetAsync();
-                    if (!await UserManager.CheckPasswordAsync(notAllowedUser, LoginInput.Password))
+                    if ((notAllowedUser.ShouldChangePasswordOnNextLogin ||
+                            await UserManager.ShouldPeriodicallyChangePasswordAsync(notAllowedUser)) &&
+                        !await UserManager.CheckPasswordAsync(notAllowedUser, LoginInput.Password))
                     {
                         Alerts.Danger(L["InvalidUserNameOrPassword"]);
                         return Page();

--- a/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/AbpSignInManager_Tests.cs
+++ b/modules/identity/test/Volo.Abp.Identity.AspNetCore.Tests/Volo/Abp/Identity/AspNetCore/AbpSignInManager_Tests.cs
@@ -1,8 +1,10 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
 using Shouldly;
+using Volo.Abp.Uow;
 using Xunit;
 
 namespace Volo.Abp.Identity.AspNetCore;
@@ -44,5 +46,37 @@ public class AbpSignInManager_Tests : AbpIdentityAspNetCoreTestBase
         );
 
         result.ShouldBe("NotAllowed");
+    }
+
+    [Fact]
+    public async Task Should_Return_NotAllowed_For_User_That_Should_Change_Password_Regardless_Of_Password()
+    {
+        // PreSignInCheck rejects users with ShouldChangePasswordOnNextLogin=true before the
+        // password is verified, so PasswordSignInAsync returns NotAllowed for both right and
+        // wrong passwords. Callers that surface a login error to the user (Login page) need
+        // to recheck the password themselves to distinguish the two cases.
+        var userManager = GetRequiredService<IdentityUserManager>();
+        var unitOfWorkManager = GetRequiredService<IUnitOfWorkManager>();
+
+        const string userName = "must-change-password";
+        const string password = "1q2w3E*";
+
+        using (var uow = unitOfWorkManager.Begin())
+        {
+            var user = new IdentityUser(Guid.NewGuid(), userName, userName + "@abp.io");
+            user.SetShouldChangePasswordOnNextLogin(true);
+            (await userManager.CreateAsync(user, password)).Succeeded.ShouldBeTrue();
+            await uow.CompleteAsync();
+        }
+
+        var withWrongPassword = await GetResponseAsStringAsync(
+            $"api/signin-test/password?userName={userName}&password=WRONG_PASSWORD"
+        );
+        withWrongPassword.ShouldBe("NotAllowed");
+
+        var withCorrectPassword = await GetResponseAsStringAsync(
+            $"api/signin-test/password?userName={userName}&password={password}"
+        );
+        withCorrectPassword.ShouldBe("NotAllowed");
     }
 }


### PR DESCRIPTION
Fix #25481.

When `ShouldChangePasswordOnNextLogin` is `true`, `AbpSignInManager.PreSignInCheck` rejects the sign-in before the password is verified, so `PasswordSignInAsync` returns `NotAllowed` for both right and wrong passwords. The Login page used to show `LoginIsNotAllowed` for both cases, leaving users with a wrong password unable to tell their credentials were invalid.

The Login page now re-checks the password under the user's tenant only when the user has `ShouldChangePasswordOnNextLogin` or `ShouldPeriodicallyChangePasswordAsync` set, and surfaces `InvalidUserNameOrPassword` if the password is wrong. Other `NotAllowed` reasons (inactive, unconfirmed, etc.) keep the existing generic `LoginIsNotAllowed` warning to avoid turning them into a password oracle.