### PR TITLE
Upgrade Blazorise packages to version 2.1.3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,10 +19,10 @@
     <PackageVersion Include="Azure.Identity" Version="1.14.2" />
     <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.25.0" />
-    <PackageVersion Include="Blazorise" Version="2.0.4" />
-    <PackageVersion Include="Blazorise.Components" Version="2.0.4" />
-    <PackageVersion Include="Blazorise.DataGrid" Version="2.0.4" />
-    <PackageVersion Include="Blazorise.Snackbar" Version="2.0.4" />
+    <PackageVersion Include="Blazorise" Version="2.1.3" />
+    <PackageVersion Include="Blazorise.Components" Version="2.1.3" />
+    <PackageVersion Include="Blazorise.DataGrid" Version="2.1.3" />
+    <PackageVersion Include="Blazorise.Snackbar" Version="2.1.3" />
     <PackageVersion Include="MudBlazor" Version="9.4.0" />
     <PackageVersion Include="Castle.Core" Version="5.2.1" />
     <PackageVersion Include="Castle.Core.AsyncInterceptor" Version="2.1.0" />

--- a/docs/en/package-version-changes.md
+++ b/docs/en/package-version-changes.md
@@ -7,6 +7,15 @@
 
 # Package Version Changes
 
+## 10.5.0-rc.1
+
+| Package | Old Version | New Version | PR |
+|---------|-------------|-------------|-----|
+| Blazorise | 2.0.4 | 2.1.3 | #25494 |
+| Blazorise.Components | 2.0.4 | 2.1.3 | #25494 |
+| Blazorise.DataGrid | 2.0.4 | 2.1.3 | #25494 |
+| Blazorise.Snackbar | 2.0.4 | 2.1.3 | #25494 |
+
 ## 10.4.1
 
 | Package | Old Version | New Version | PR |


### PR DESCRIPTION
Upgrade all Blazorise packages from 2.0.4 to 2.1.3.

Requested in #25489.