### PR TITLE
Fix MySQL index key too long for ResourcePermissionGrant

### DIFF
--- a/modules/permission-management/src/Volo.Abp.PermissionManagement.EntityFrameworkCore/Volo/Abp/PermissionManagement/EntityFrameworkCore/AbpPermissionManagementDbContextModelBuilderExtensions.cs
+++ b/modules/permission-management/src/Volo.Abp.PermissionManagement.EntityFrameworkCore/Volo/Abp/PermissionManagement/EntityFrameworkCore/AbpPermissionManagementDbContextModelBuilderExtensions.cs
@@ -33,9 +33,14 @@ public static class AbpPermissionManagementDbContextModelBuilderExtensions
 
             b.ConfigureByConvention();
 
+            // MySQL has a 3072 bytes index key length limit (utf8mb4), the composite
+            // unique index below exceeds it, so shorten these columns for MySQL only.
+            var maxResourceNameLength = builder.IsUsingMySQL() ? 128 : PermissionGrantConsts.MaxResourceNameLength;
+            var maxResourceKeyLength = builder.IsUsingMySQL() ? 128 : PermissionGrantConsts.MaxResourceKeyLength;
+
             b.Property(x => x.Name).HasMaxLength(PermissionDefinitionRecordConsts.MaxNameLength).IsRequired();
-            b.Property(x => x.ResourceName).HasMaxLength(PermissionGrantConsts.MaxResourceNameLength).IsRequired();
-            b.Property(x => x.ResourceKey).HasMaxLength(PermissionGrantConsts.MaxResourceKeyLength).IsRequired();
+            b.Property(x => x.ResourceName).HasMaxLength(maxResourceNameLength).IsRequired();
+            b.Property(x => x.ResourceKey).HasMaxLength(maxResourceKeyLength).IsRequired();
             b.Property(x => x.ProviderName).HasMaxLength(PermissionGrantConsts.MaxProviderNameLength).IsRequired();
             b.Property(x => x.ProviderKey).HasMaxLength(PermissionGrantConsts.MaxProviderKeyLength).IsRequired();
 


### PR DESCRIPTION
Creating a new MySQL app fails on the initial EF Core migration with "Specified key was too long; max key length is 3072 bytes". The `ResourcePermissionGrant` 6-column unique index reaches 3108 bytes under utf8mb4. Shorten `ResourceName`/`ResourceKey` to 128 on MySQL only so the index fits the 3072 limit; other databases keep 256.

Resolves #25492