### PR TITLE
Remove redundant `FallbackToProvider` call in `MedallionAbpDistributedLock`

### DIFF
--- a/framework/src/Volo.Abp.DistributedLocking/Volo/Abp/DistributedLocking/MedallionAbpDistributedLock.cs
+++ b/framework/src/Volo.Abp.DistributedLocking/Volo/Abp/DistributedLocking/MedallionAbpDistributedLock.cs
@@ -32,8 +32,6 @@ public class MedallionAbpDistributedLock : IAbpDistributedLock, ITransientDepend
     {
         Check.NotNullOrWhiteSpace(name, nameof(name));
         var key = DistributedLockKeyNormalizer.NormalizeKey(name);
-        
-        CancellationTokenProvider.FallbackToProvider(cancellationToken);
 
         var handle = await DistributedLockProvider.TryAcquireLockAsync(
             key,


### PR DESCRIPTION
Removes the standalone `CancellationTokenProvider.FallbackToProvider(cancellationToken)` call in `MedallionAbpDistributedLock.TryAcquireAsync` whose return value was discarded. The same call is made again on the next line as the argument to `TryAcquireLockAsync`, and `FallbackToProvider` is a pure extension method with no side effects.

Resolves #25496