### PR TITLE
Render empty state on Settings page when no group is available

### DIFF
--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Blazor/Pages/SettingManagement/SettingManagement.razor
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Blazor/Pages/SettingManagement/SettingManagement.razor
@@ -47,7 +47,7 @@
         else
         {
             <div class="text-center text-muted py-5">
-                <i class="bi bi-gear-fill" style="font-size: 3rem; opacity: 0.4;"></i>
+                <i class="bi bi-gear-fill" style="font-size: 3rem; opacity: 0.4;" aria-hidden="true"></i>
                 <p class="mt-3 mb-0">@L["NoSettingsAvailable"]</p>
             </div>
         }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Blazor/Pages/SettingManagement/SettingManagement.razor
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Blazor/Pages/SettingManagement/SettingManagement.razor
@@ -44,5 +44,12 @@
                 </Content>
             </Tabs>
         }
+        else
+        {
+            <div class="text-center text-muted py-5">
+                <i class="bi bi-gear-fill" style="font-size: 3rem; opacity: 0.4;"></i>
+                <p class="mt-3 mb-0">@L["NoSettingsAvailable"]</p>
+            </div>
+        }
     </CardBody>
 </Card>

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/ar.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/ar.json
@@ -37,6 +37,7 @@
     "Feature:SettingManagementEnableDescription": "تفعيل إعداد نظام الإدارة في التطبيق.",
     "Feature:AllowChangingEmailSettings": "السماح لتغيير إعدادات البريد الإلكتروني",
     "Feature:AllowChangingEmailSettingsDescription": "السماح لتغيير إعدادات البريد الإلكتروني.",
-    "SmtpPasswordPlaceholder": "أدخل قيمة لتحديث كلمة المرور"
+    "SmtpPasswordPlaceholder": "أدخل قيمة لتحديث كلمة المرور",
+    "NoSettingsAvailable": "لا توجد إعدادات لعرضها."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/cs.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/cs.json
@@ -37,6 +37,7 @@
     "Feature:SettingManagementEnableDescription": "Povolit systém správy nastavení v aplikaci.",
     "Feature:AllowChangingEmailSettings": "Povolit změnu nastavení e-mailu",
     "Feature:AllowChangingEmailSettingsDescription": "Povolit změnu nastavení e-mailu.",
-    "SmtpPasswordPlaceholder": "Zadejte hodnotu pro aktualizaci hesla"
+    "SmtpPasswordPlaceholder": "Zadejte hodnotu pro aktualizaci hesla",
+    "NoSettingsAvailable": "Nejsou k dispozici žádná nastavení."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/de-DE.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/de-DE.json
@@ -37,6 +37,7 @@
     "Feature:SettingManagementEnableDescription": "Aktivieren Sie das Einstellungsverwaltungssystem in der Anwendung.",
     "Feature:AllowChangingEmailSettings": "Änderung der E-Mail-Einstellungen zulassen",
     "Feature:AllowChangingEmailSettingsDescription": "Änderung der E-Mail-Einstellungen zulassen.",
-    "SmtpPasswordPlaceholder": "Geben Sie einen Wert ein, um das Passwort zu aktualisieren"
+    "SmtpPasswordPlaceholder": "Geben Sie einen Wert ein, um das Passwort zu aktualisieren",
+    "NoSettingsAvailable": "Es sind keine Einstellungen anzuzeigen."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/de.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/de.json
@@ -38,6 +38,7 @@
     "Feature:SettingManagementEnableDescription": "Aktivieren Sie das Einstellungsverwaltungssystem in der Anwendung.",
     "Feature:AllowChangingEmailSettings": "Erlauben Sie das Ändern der E-Mail-Einstellungen",
     "Feature:AllowChangingEmailSettingsDescription": "Erlauben Sie das Ändern der E-Mail-Einstellungen.",
-    "SmtpPasswordPlaceholder": "Geben Sie einen Wert ein, um das Passwort zu aktualisieren"
+    "SmtpPasswordPlaceholder": "Geben Sie einen Wert ein, um das Passwort zu aktualisieren",
+    "NoSettingsAvailable": "Es sind keine Einstellungen anzuzeigen."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/el.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/el.json
@@ -33,6 +33,7 @@
     "Feature:SettingManagementEnableDescription": "Ενεργοποίηση συστήματος διαχείρισης ρυθμίσεων στην εφαρμογή.",
     "Feature:AllowChangingEmailSettings": "Επιτρέψτε την αλλαγή των ρυθμίσεων email",
     "Feature:AllowChangingEmailSettingsDescription": "Επιτρέψτε την αλλαγή των ρυθμίσεων email.",
-    "SmtpPasswordPlaceholder": "Εισαγάγετε μια τιμή για ενημέρωση κωδικού πρόσβασης"
+    "SmtpPasswordPlaceholder": "Εισαγάγετε μια τιμή για ενημέρωση κωδικού πρόσβασης",
+    "NoSettingsAvailable": "Δεν υπάρχουν ρυθμίσεις για εμφάνιση."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/en-GB.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/en-GB.json
@@ -2,6 +2,7 @@
   "culture": "en-GB",
   "texts": {
     "Settings": "Settings",
-    "SavedSuccessfully": "Saved successfully"
+    "SavedSuccessfully": "Saved successfully",
+    "NoSettingsAvailable": "There are no settings to display."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/en.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/en.json
@@ -37,6 +37,7 @@
     "Feature:SettingManagementEnableDescription": "Enable setting management system in the application.",
     "Feature:AllowChangingEmailSettings": "Allow changing email settings",
     "Feature:AllowChangingEmailSettingsDescription": "Allow changing email settings.",
-    "SmtpPasswordPlaceholder": "Enter a value to update password"
+    "SmtpPasswordPlaceholder": "Enter a value to update password",
+    "NoSettingsAvailable": "There are no settings to display."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/es.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/es.json
@@ -37,6 +37,7 @@
     "Feature:SettingManagementEnableDescription": "Habilite el sistema de gestión de la configuración en la aplicación.",
     "Feature:AllowChangingEmailSettings": "Permitir cambiar la configuración de correo electrónico",
     "Feature:AllowChangingEmailSettingsDescription": "Permitir cambiar la configuración de correo electrónico.",
-    "SmtpPasswordPlaceholder": "Ingrese un valor para actualizar la contraseña"
+    "SmtpPasswordPlaceholder": "Ingrese un valor para actualizar la contraseña",
+    "NoSettingsAvailable": "No hay ajustes para mostrar."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/fa.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/fa.json
@@ -18,6 +18,7 @@
     "DefaultFromDisplayName": "نام نمایشی ارسال کننده پیش فرض",
     "Feature:SettingManagementGroup": "تنظیمات مدیریت",
     "Feature:SettingManagementEnable": "فعال کردن مدیریت تنظیمات",
-    "Feature:SettingManagementEnableDescription": "سیستم مدیریت تنظیمات را در برنامه فعال کنید."
+    "Feature:SettingManagementEnableDescription": "سیستم مدیریت تنظیمات را در برنامه فعال کنید.",
+    "NoSettingsAvailable": "تنظیماتی برای نمایش وجود ندارد."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/fi.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/fi.json
@@ -37,6 +37,7 @@
     "Feature:SettingManagementEnableDescription": "Ota asetustenhallintajärjestelmä käyttöön sovelluksessa.",
     "Feature:AllowChangingEmailSettings": "Salli sähköpostiasetusten muuttaminen",
     "Feature:AllowChangingEmailSettingsDescription": "Salli sähköpostiasetusten muuttaminen.",
-    "SmtpPasswordPlaceholder": "Syötä arvo päivittääksesi salasana"
+    "SmtpPasswordPlaceholder": "Syötä arvo päivittääksesi salasana",
+    "NoSettingsAvailable": "Näytettäviä asetuksia ei ole."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/fr.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/fr.json
@@ -37,6 +37,7 @@
     "Feature:SettingManagementEnableDescription": "Activer le système de gestion des paramètres dans l'application.",
     "Feature:AllowChangingEmailSettings": "Autoriser la modification des paramètres de messagerie",
     "Feature:AllowChangingEmailSettingsDescription": "Autoriser la modification des paramètres de messagerie.",
-    "SmtpPasswordPlaceholder": "Entrez une valeur pour mettre à jour le mot de passe"
+    "SmtpPasswordPlaceholder": "Entrez une valeur pour mettre à jour le mot de passe",
+    "NoSettingsAvailable": "Aucun paramètre à afficher."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/hi.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/hi.json
@@ -37,6 +37,7 @@
     "Feature:SettingManagementEnableDescription": "एप्लिकेशन में सेटिंग प्रबंधन प्रणाली सक्षम करें।",
     "Feature:AllowChangingEmailSettings": "ईमेल सेटिंग्स बदलने की अनुमति दें।",
     "Feature:AllowChangingEmailSettingsDescription": "ईमेल सेटिंग्स बदलने की अनुमति दें।",
-    "SmtpPasswordPlaceholder": "पासवर्ड अपडेट करने के लिए एक मान दर्ज करें"
+    "SmtpPasswordPlaceholder": "पासवर्ड अपडेट करने के लिए एक मान दर्ज करें",
+    "NoSettingsAvailable": "दिखाने के लिए कोई सेटिंग नहीं है।"
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/hr.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/hr.json
@@ -38,6 +38,7 @@
     "Feature:SettingManagementEnableDescription": "Omogućite sustav upravljanja postavkama u aplikaciji.",
     "Feature:AllowChangingEmailSettings": "Dopusti promjenu postavki e-pošte",
     "Feature:AllowChangingEmailSettingsDescription": "Dopusti promjenu postavki e-pošte.",
-    "SmtpPasswordPlaceholder": "Unesite vrijednost za ažuriranje lozinke"
+    "SmtpPasswordPlaceholder": "Unesite vrijednost za ažuriranje lozinke",
+    "NoSettingsAvailable": "Nema postavki za prikaz."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/hu.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/hu.json
@@ -37,6 +37,7 @@
     "Feature:SettingManagementEnableDescription": "A beállításkezelő rendszer engedélyezése az alkalmazásban.",
     "Feature:AllowChangingEmailSettings": "Az e-mail beállítások módosításának engedélyezése",
     "Feature:AllowChangingEmailSettingsDescription": "Az e-mail beállítások módosításának engedélyezése.",
-    "SmtpPasswordPlaceholder": "Adjon meg egy értéket a jelszó frissítéséhez"
+    "SmtpPasswordPlaceholder": "Adjon meg egy értéket a jelszó frissítéséhez",
+    "NoSettingsAvailable": "Nincs megjeleníthető beállítás."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/is.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/is.json
@@ -37,6 +37,7 @@
     "Feature:SettingManagementEnableDescription": "Virkja stillingar í forritinu.",
     "Feature:AllowChangingEmailSettings": "Leyfa að breyta stillingum tölvupósts",
     "Feature:AllowChangingEmailSettingsDescription": "Leyfa að breyta stillingum tölvupósts.",
-    "SmtpPasswordPlaceholder": "Sláðu inn gildi til að uppfæra lykilorð"
+    "SmtpPasswordPlaceholder": "Sláðu inn gildi til að uppfæra lykilorð",
+    "NoSettingsAvailable": "Engar stillingar til að sýna."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/it.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/it.json
@@ -37,6 +37,7 @@
     "Feature:SettingManagementEnableDescription": "Abilita sistema gestione impostazioni nell'applicazione",
     "Feature:AllowChangingEmailSettings": "Consenti di modificare le loro impostazioni e-mail",
     "Feature:AllowChangingEmailSettingsDescription": "Consenti di modificare le loro impostazioni e-mail.",
-    "SmtpPasswordPlaceholder": "Inserisci un valore per aggiornare la password"
+    "SmtpPasswordPlaceholder": "Inserisci un valore per aggiornare la password",
+    "NoSettingsAvailable": "Non ci sono impostazioni da visualizzare."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/nl.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/nl.json
@@ -37,6 +37,7 @@
     "Feature:SettingManagementEnableDescription": "Schakel het instellingsbeheersysteem in de toepassing in.",
     "Feature:AllowChangingEmailSettings": "Toestaan om e-mailinstellingen te wijzigen",
     "Feature:AllowChangingEmailSettingsDescription": "Toestaan om e-mailinstellingen te wijzigen.",
-    "SmtpPasswordPlaceholder": "Voer een waarde in om het wachtwoord bij te werken"
+    "SmtpPasswordPlaceholder": "Voer een waarde in om het wachtwoord bij te werken",
+    "NoSettingsAvailable": "Er zijn geen instellingen om weer te geven."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/pl-PL.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/pl-PL.json
@@ -37,6 +37,7 @@
     "Feature:SettingManagementEnableDescription": "Włącz system zarządzania ustawieniami w aplikacji.",
     "Feature:AllowChangingEmailSettings": "Zezwól na zmianę ustawień poczty e-mail",
     "Feature:AllowChangingEmailSettingsDescription": "Zezwól na zmianę ustawień poczty e-mail.",
-    "SmtpPasswordPlaceholder": "Wprowadź wartość, aby zaktualizować hasło"
+    "SmtpPasswordPlaceholder": "Wprowadź wartość, aby zaktualizować hasło",
+    "NoSettingsAvailable": "Brak ustawień do wyświetlenia."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/pt-BR.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/pt-BR.json
@@ -37,6 +37,7 @@
     "Feature:SettingManagementEnableDescription": "Habilite o sistema de gerenciamento de configuração no aplicativo.",
     "Feature:AllowChangingEmailSettings": "Permitir alterar as configurações de e-mail",
     "Feature:AllowChangingEmailSettingsDescription": "Permitir alterar as configurações de e-mail.",
-    "SmtpPasswordPlaceholder": "Digite um valor para atualizar a senha"
+    "SmtpPasswordPlaceholder": "Digite um valor para atualizar a senha",
+    "NoSettingsAvailable": "Não há configurações para exibir."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/ro-RO.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/ro-RO.json
@@ -37,6 +37,7 @@
     "Feature:SettingManagementEnableDescription": "Activează sistemul de administrare a setărilor în aplicaţie.",
     "Feature:AllowChangingEmailSettings": "Permiteți modificarea setărilor de e-mail",
     "Feature:AllowChangingEmailSettingsDescription": "Permiteți modificarea setărilor de e-mail.",
-    "SmtpPasswordPlaceholder": "Introduceți o valoare pentru a actualiza parola"
+    "SmtpPasswordPlaceholder": "Introduceți o valoare pentru a actualiza parola",
+    "NoSettingsAvailable": "Nu există setări de afișat."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/ru.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/ru.json
@@ -37,6 +37,7 @@
     "Feature:SettingManagementEnableDescription": "Включите систему управления настройками в приложении.",
     "Feature:AllowChangingEmailSettings": "Разрешить изменение настроек электронной почты",
     "Feature:AllowChangingEmailSettingsDescription": "Разрешить изменение настроек электронной почты.",
-    "SmtpPasswordPlaceholder": "Введите значение для обновления пароля"
+    "SmtpPasswordPlaceholder": "Введите значение для обновления пароля",
+    "NoSettingsAvailable": "Нет настроек для отображения."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/sk.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/sk.json
@@ -37,6 +37,7 @@
     "Feature:SettingManagementEnableDescription": "Povoliť systém správy nastavení v aplikácii.",
     "Feature:AllowChangingEmailSettings": "Povoliť zmenu nastavení e-mailu",
     "Feature:AllowChangingEmailSettingsDescription": "Povoliť zmenu nastavení e-mailu.",
-    "SmtpPasswordPlaceholder": "Zadajte hodnotu pre aktualizáciu hesla"
+    "SmtpPasswordPlaceholder": "Zadajte hodnotu pre aktualizáciu hesla",
+    "NoSettingsAvailable": "Nie sú k dispozícii žiadne nastavenia."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/sl.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/sl.json
@@ -37,6 +37,7 @@
     "Feature:SettingManagementEnableDescription": "Omogočite nastavitev sistema upravljanja v aplikaciji.",
     "Feature:AllowChangingEmailSettings": "Dovoli spreminjanje e-poštnih nastavitev",
     "Feature:AllowChangingEmailSettingsDescription": "Dovoli spreminjanje e-poštnih nastavitev.",
-    "SmtpPasswordPlaceholder": "Vnesite vrednost za posodobitev gesla"
+    "SmtpPasswordPlaceholder": "Vnesite vrednost za posodobitev gesla",
+    "NoSettingsAvailable": "Ni nastavitev za prikaz."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/sv.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/sv.json
@@ -36,6 +36,7 @@
     "Feature:SettingManagementEnableDescription": "Aktivera inställningshanteringssystem i applikationen.",
     "Feature:AllowChangingEmailSettings": "Tillåt ändring av e-postinställningar",
     "Feature:AllowChangingEmailSettingsDescription": "Tillåt ändring av e-postinställningar.",
-    "SmtpPasswordPlaceholder": "Ange ett värde för att uppdatera lösenordet"
+    "SmtpPasswordPlaceholder": "Ange ett värde för att uppdatera lösenordet",
+    "NoSettingsAvailable": "Det finns inga inställningar att visa."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/tr.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/tr.json
@@ -37,6 +37,7 @@
     "Feature:SettingManagementEnableDescription": "Uygulamada ayar yönetim sistemini etkinleştirin.",
     "Feature:AllowChangingEmailSettings": "E-posta ayarlarını değiştirmeye izin verin",
     "Feature:AllowChangingEmailSettingsDescription": "E-posta ayarlarını değiştirmeye izin verin.",
-    "SmtpPasswordPlaceholder": "Şifreyi güncellemek için bir değer girin"
+    "SmtpPasswordPlaceholder": "Şifreyi güncellemek için bir değer girin",
+    "NoSettingsAvailable": "Görüntülenecek ayar yok."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/vi.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/vi.json
@@ -37,6 +37,7 @@
     "Feature:SettingManagementEnableDescription": "Bật cài đặt hệ thống quản lý trong ứng dụng.",
     "Feature:AllowChangingEmailSettings": "Cho phép thay đổi cài đặt email",
     "Feature:AllowChangingEmailSettingsDescription": "Cho phép thay đổi cài đặt email.",
-    "SmtpPasswordPlaceholder": "Nhập một giá trị để cập nhật mật khẩu"
+    "SmtpPasswordPlaceholder": "Nhập một giá trị để cập nhật mật khẩu",
+    "NoSettingsAvailable": "Không có cài đặt nào để hiển thị."
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/zh-Hans.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/zh-Hans.json
@@ -37,6 +37,7 @@
     "Feature:SettingManagementEnableDescription": "在应用程序中启用设置管理系统。",
     "Feature:AllowChangingEmailSettings": "允许更改邮件设置",
     "Feature:AllowChangingEmailSettingsDescription": "允许更改邮件设置。",
-    "SmtpPasswordPlaceholder": "输入一个值以更新密码"
+    "SmtpPasswordPlaceholder": "输入一个值以更新密码",
+    "NoSettingsAvailable": "没有可显示的设置。"
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/zh-Hant.json
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Domain.Shared/Volo/Abp/SettingManagement/Localization/Resources/AbpSettingManagement/zh-Hant.json
@@ -37,6 +37,7 @@
     "Feature:SettingManagementEnableDescription": "在應用程序中啟用設定管理系統.",
     "Feature:AllowChangingEmailSettings": "允許更改電子郵件設置",
     "Feature:AllowChangingEmailSettingsDescription": "允許更改電子郵件設置。",
-    "SmtpPasswordPlaceholder": "輸入一個值以更新密碼"
+    "SmtpPasswordPlaceholder": "輸入一個值以更新密碼",
+    "NoSettingsAvailable": "沒有可顯示的設定。"
   }
 }

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Web/Pages/SettingManagement/Index.cshtml
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Web/Pages/SettingManagement/Index.cshtml
@@ -25,24 +25,34 @@
 <div id="SettingManagementWrapper">
     <abp-card>
         <abp-card-body>
-            <div class="row">
-                <div class="col-md-3">
-                    <ul class="nav flex-column nav-pills" id="tabs-nav" role="tablist">
-                        @for (var i = 0; i < Model.SettingPageCreationContext.Groups.Count; i++)
-                        {
-                            var group = Model.SettingPageCreationContext.Groups[i];
-                            var active = i == 0 ? "active" : string.Empty;
-                            <li class="nav-item">
-                                <a href="javascript:;" class="nav-link @active" data-id="@group.Id" data-bs-toggle="pill" role="tab">@group.DisplayName</a>
-                            </li>
-                        }
-                    </ul>
-                </div>
-                <div class="col-md-9">
-                    <div class="tab-content pt-0" id="tab-content">
+            @if (Model.SettingPageCreationContext.Groups.Count > 0)
+            {
+                <div class="row">
+                    <div class="col-md-3">
+                        <ul class="nav flex-column nav-pills" id="tabs-nav" role="tablist">
+                            @for (var i = 0; i < Model.SettingPageCreationContext.Groups.Count; i++)
+                            {
+                                var group = Model.SettingPageCreationContext.Groups[i];
+                                var active = i == 0 ? "active" : string.Empty;
+                                <li class="nav-item">
+                                    <a href="javascript:;" class="nav-link @active" data-id="@group.Id" data-bs-toggle="pill" role="tab">@group.DisplayName</a>
+                                </li>
+                            }
+                        </ul>
+                    </div>
+                    <div class="col-md-9">
+                        <div class="tab-content pt-0" id="tab-content">
+                        </div>
                     </div>
                 </div>
-            </div>
+            }
+            else
+            {
+                <div class="text-center text-muted py-5">
+                    <i class="bi bi-gear-fill" style="font-size: 3rem; opacity: 0.4;"></i>
+                    <p class="mt-3 mb-0">@L["NoSettingsAvailable"]</p>
+                </div>
+            }
         </abp-card-body>
     </abp-card>
 </div>

--- a/modules/setting-management/src/Volo.Abp.SettingManagement.Web/Pages/SettingManagement/Index.cshtml
+++ b/modules/setting-management/src/Volo.Abp.SettingManagement.Web/Pages/SettingManagement/Index.cshtml
@@ -49,7 +49,7 @@
             else
             {
                 <div class="text-center text-muted py-5">
-                    <i class="bi bi-gear-fill" style="font-size: 3rem; opacity: 0.4;"></i>
+                    <i class="bi bi-gear-fill" style="font-size: 3rem; opacity: 0.4;" aria-hidden="true"></i>
                     <p class="mt-3 mb-0">@L["NoSettingsAvailable"]</p>
                 </div>
             }

--- a/npm/ng-packs/packages/setting-management/src/lib/components/setting-management.component.html
+++ b/npm/ng-packs/packages/setting-management/src/lib/components/setting-management.component.html
@@ -25,7 +25,7 @@
           </div>
         } @else {
           <div class="text-center text-muted py-5">
-            <i class="bi bi-gear-fill" style="font-size: 3rem; opacity: 0.4;"></i>
+            <i class="bi bi-gear-fill" style="font-size: 3rem; opacity: 0.4;" aria-hidden="true"></i>
             <p class="mt-3 mb-0">{{ 'AbpSettingManagement::NoSettingsAvailable' | abpLocalization }}</p>
           </div>
         }

--- a/npm/ng-packs/packages/setting-management/src/lib/components/setting-management.component.html
+++ b/npm/ng-packs/packages/setting-management/src/lib/components/setting-management.component.html
@@ -2,28 +2,33 @@
   <div id="SettingManagementWrapper">
     <div class="card">
       <div class="card-body">
-        <div class="row" ngTabs>
-          <div class="col-12 col-md-3 mb-2 mb-md-0">
-            <div class="nav flex-column nav-pills" id="nav-tab" ngTabList orientation="vertical"
-              [selectedTab]="selected?.name">
+        @if (settings.length) {
+          <div class="row" ngTabs>
+            <div class="col-12 col-md-3 mb-2 mb-md-0">
+              <div class="nav flex-column nav-pills" id="nav-tab" ngTabList orientation="vertical"
+                [selectedTab]="selected?.name">
+                <ng-container *abpFor="let setting of settings; trackBy: trackByFn">
+                  <button ngTab #tab="ngTab" [value]="setting.name" (click)="selected = setting"
+                    class="nav-link text-start" [class.active]="tab.selected()" *abpPermission="setting.requiredPolicy">
+                    {{ setting.name | abpLocalization }}
+                  </button>
+                </ng-container>
+              </div>
+            </div>
+            <div class="col-12 col-md-9">
               <ng-container *abpFor="let setting of settings; trackBy: trackByFn">
-                <button ngTab #tab="ngTab" [value]="setting.name" (click)="selected = setting"
-                  class="nav-link text-start" [class.active]="tab.selected()" *abpPermission="setting.requiredPolicy">
-                  {{ setting.name | abpLocalization }}
-                </button>
+                <div ngTabPanel [value]="setting.name" class="tab-pane" *abpPermission="setting.requiredPolicy">
+                  <ng-container *ngComponentOutlet="setting.component" />
+                </div>
               </ng-container>
             </div>
           </div>
-          <div class="col-12 col-md-9">
-            @if (settings.length) {
-            <ng-container *abpFor="let setting of settings; trackBy: trackByFn">
-              <div ngTabPanel [value]="setting.name" class="tab-pane" *abpPermission="setting.requiredPolicy">
-                <ng-container *ngComponentOutlet="setting.component" />
-              </div>
-            </ng-container>
-            }
+        } @else {
+          <div class="text-center text-muted py-5">
+            <i class="bi bi-gear-fill" style="font-size: 3rem; opacity: 0.4;"></i>
+            <p class="mt-3 mb-0">{{ 'AbpSettingManagement::NoSettingsAvailable' | abpLocalization }}</p>
           </div>
-        </div>
+        }
       </div>
     </div>
   </div>


### PR DESCRIPTION
When all setting groups are hidden by contributors or permissions (e.g. tenant users in Shared user accounts mode), the Settings page went completely blank. Show a small empty state across MVC, Blazor and Angular, plus a localizable string in all locales.

<img width="1732" height="876" alt="image" src="https://github.com/user-attachments/assets/5b2bae8a-c6f8-4046-8a5f-fc8eec0200dc" />
