### PR TITLE
Fix EntityId truncate length in EntityChange constructor

### DIFF
--- a/modules/audit-logging/src/Volo.Abp.AuditLogging.Domain/Volo/Abp/AuditLogging/EntityChange.cs
+++ b/modules/audit-logging/src/Volo.Abp.AuditLogging.Domain/Volo/Abp/AuditLogging/EntityChange.cs
@@ -47,7 +47,7 @@ public class EntityChange : Entity<Guid>, IMultiTenant, IHasExtraProperties
         ChangeTime = entityChangeInfo.ChangeTime;
         ChangeType = entityChangeInfo.ChangeType;
         EntityTenantId = entityChangeInfo.EntityTenantId;
-        EntityId = entityChangeInfo.EntityId.Truncate(EntityChangeConsts.MaxEntityTypeFullNameLength);
+        EntityId = entityChangeInfo.EntityId.Truncate(EntityChangeConsts.MaxEntityIdLength);
         EntityTypeFullName = entityChangeInfo.EntityTypeFullName.TruncateFromBeginning(EntityChangeConsts.MaxEntityTypeFullNameLength);
 
         PropertyChanges = entityChangeInfo


### PR DESCRIPTION
The `EntityChange` constructor truncated `EntityId` with `MaxEntityTypeFullNameLength` (512) instead of `MaxEntityIdLength` (128), which mismatches the EF Core column length and can throw on insert.

Resolves https://github.com/abpframework/abp/issues/25554