### PR TITLE
Fix user edit modal failing when creator or modifier is soft-deleted

### DIFF
--- a/modules/identity/src/Volo.Abp.Identity.Application.Contracts/Volo/Abp/Identity/IIdentityUserAppService.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Application.Contracts/Volo/Abp/Identity/IIdentityUserAppService.cs
@@ -22,4 +22,6 @@ public interface IIdentityUserAppService
     Task<IdentityUserDto> FindByUsernameAsync(string userName);
 
     Task<IdentityUserDto> FindByEmailAsync(string email);
+
+    Task<IdentityUserDto> FindByIdAsync(Guid id);
 }

--- a/modules/identity/src/Volo.Abp.Identity.Application/Volo/Abp/Identity/IdentityUserAppService.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Application/Volo/Abp/Identity/IdentityUserAppService.cs
@@ -180,6 +180,14 @@ public class IdentityUserAppService : IdentityAppServiceBase, IIdentityUserAppSe
         );
     }
 
+    [Authorize(IdentityPermissions.Users.Default)]
+    public virtual async Task<IdentityUserDto> FindByIdAsync(Guid id)
+    {
+        return ObjectMapper.Map<IdentityUser, IdentityUserDto>(
+            await UserManager.FindByIdAsync(id.ToString())
+        );
+    }
+
     protected virtual async Task UpdateUserByInput(IdentityUser user, IdentityUserCreateOrUpdateDtoBase input)
     {
         if (!string.Equals(user.Email, input.Email, StringComparison.InvariantCultureIgnoreCase))

--- a/modules/identity/src/Volo.Abp.Identity.HttpApi.Client/ClientProxies/Volo/Abp/Identity/IdentityUserClientProxy.Generated.cs
+++ b/modules/identity/src/Volo.Abp.Identity.HttpApi.Client/ClientProxies/Volo/Abp/Identity/IdentityUserClientProxy.Generated.cs
@@ -58,6 +58,14 @@ public partial class IdentityUserClientProxy : ClientProxyBase<IIdentityUserAppS
         });
     }
 
+    public virtual async Task<IdentityUserDto> FindByIdAsync(Guid id)
+    {
+        return await RequestAsync<IdentityUserDto>(nameof(FindByIdAsync), new ClientProxyRequestTypeValue
+        {
+            { typeof(Guid), id }
+        });
+    }
+
     public virtual async Task<ListResultDto<IdentityRoleDto>> GetRolesAsync(Guid id)
     {
         return await RequestAsync<ListResultDto<IdentityRoleDto>>(nameof(GetRolesAsync), new ClientProxyRequestTypeValue

--- a/modules/identity/src/Volo.Abp.Identity.HttpApi.Client/ClientProxies/identity-generate-proxy.json
+++ b/modules/identity/src/Volo.Abp.Identity.HttpApi.Client/ClientProxies/identity-generate-proxy.json
@@ -488,6 +488,23 @@
                   }
                 },
                 {
+                  "name": "FindByIdAsync",
+                  "parametersOnMethod": [
+                    {
+                      "name": "id",
+                      "typeAsString": "System.Guid, System.Private.CoreLib",
+                      "type": "System.Guid",
+                      "typeSimple": "string",
+                      "isOptional": false,
+                      "defaultValue": null
+                    }
+                  ],
+                  "returnValue": {
+                    "type": "Volo.Abp.Identity.IdentityUserDto",
+                    "typeSimple": "Volo.Abp.Identity.IdentityUserDto"
+                  }
+                },
+                {
                   "name": "GetAsync",
                   "parametersOnMethod": [
                     {
@@ -1005,6 +1022,43 @@
                   "name": "email",
                   "jsonName": null,
                   "type": "System.String",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null,
+                  "constraintTypes": [],
+                  "bindingSourceId": "Path",
+                  "descriptorName": ""
+                }
+              ],
+              "returnValue": {
+                "type": "Volo.Abp.Identity.IdentityUserDto",
+                "typeSimple": "Volo.Abp.Identity.IdentityUserDto"
+              },
+              "allowAnonymous": null,
+              "implementFrom": "Volo.Abp.Identity.IIdentityUserAppService"
+            },
+            "FindByIdAsyncById": {
+              "uniqueName": "FindByIdAsyncById",
+              "name": "FindByIdAsync",
+              "httpMethod": "GET",
+              "url": "api/identity/users/by-id/{id}",
+              "supportedVersions": [],
+              "parametersOnMethod": [
+                {
+                  "name": "id",
+                  "typeAsString": "System.Guid, System.Private.CoreLib",
+                  "type": "System.Guid",
+                  "typeSimple": "string",
+                  "isOptional": false,
+                  "defaultValue": null
+                }
+              ],
+              "parameters": [
+                {
+                  "nameOnMethod": "id",
+                  "name": "id",
+                  "jsonName": null,
+                  "type": "System.Guid",
                   "typeSimple": "string",
                   "isOptional": false,
                   "defaultValue": null,

--- a/modules/identity/src/Volo.Abp.Identity.HttpApi/Volo/Abp/Identity/IdentityUserController.cs
+++ b/modules/identity/src/Volo.Abp.Identity.HttpApi/Volo/Abp/Identity/IdentityUserController.cs
@@ -54,6 +54,13 @@ public class IdentityUserController : AbpControllerBase, IIdentityUserAppService
     }
 
     [HttpGet]
+    [Route("by-id/{id}")]
+    public virtual Task<IdentityUserDto> FindByIdAsync(Guid id)
+    {
+        return UserAppService.FindByIdAsync(id);
+    }
+
+    [HttpGet]
     [Route("{id}/roles")]
     public virtual Task<ListResultDto<IdentityRoleDto>> GetRolesAsync(Guid id)
     {

--- a/modules/identity/src/Volo.Abp.Identity.Web/Pages/Identity/Users/EditModal.cshtml.cs
+++ b/modules/identity/src/Volo.Abp.Identity.Web/Pages/Identity/Users/EditModal.cshtml.cs
@@ -83,8 +83,8 @@ public class EditModalModel : IdentityPageModel
             return null;
         }
 
-        var user = await IdentityUserAppService.GetAsync(userId.Value);
-        return user.UserName;
+        var user = await IdentityUserAppService.FindByIdAsync(userId.Value);
+        return user?.UserName;
     }
 
     public virtual async Task<IActionResult> OnPostAsync()

--- a/modules/identity/src/Volo.Abp.Identity.Web/wwwroot/client-proxies/identity-proxy.js
+++ b/modules/identity/src/Volo.Abp.Identity.Web/wwwroot/client-proxies/identity-proxy.js
@@ -102,6 +102,13 @@
       }, ajaxParams));
     };
 
+    volo.abp.identity.identityUser.findById = function(id, ajaxParams) {
+      return abp.ajax($.extend(true, {
+        url: abp.appPath + 'api/identity/users/by-id/' + id + '',
+        type: 'GET'
+      }, ajaxParams));
+    };
+
     volo.abp.identity.identityUser.getRoles = function(id, ajaxParams) {
       return abp.ajax($.extend(true, {
         url: abp.appPath + 'api/identity/users/' + id + '/roles',

--- a/modules/identity/test/Volo.Abp.Identity.Application.Tests/Volo/Abp/Identity/IdentityUserAppService_Tests.cs
+++ b/modules/identity/test/Volo.Abp.Identity.Application.Tests/Volo/Abp/Identity/IdentityUserAppService_Tests.cs
@@ -52,6 +52,37 @@ public class IdentityUserAppService_Tests : AbpIdentityApplicationTestBase
     }
 
     [Fact]
+    public async Task FindByIdAsync_Should_Return_User_When_Exists()
+    {
+        var johnNash = GetUser("john.nash");
+
+        var result = await _userAppService.FindByIdAsync(johnNash.Id);
+
+        result.ShouldNotBeNull();
+        result.Id.ShouldBe(johnNash.Id);
+        result.UserName.ShouldBe(johnNash.UserName);
+    }
+
+    [Fact]
+    public async Task FindByIdAsync_Should_Return_Null_When_User_Does_Not_Exist()
+    {
+        var result = await _userAppService.FindByIdAsync(Guid.NewGuid());
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task FindByIdAsync_Should_Return_Null_When_User_Is_Soft_Deleted()
+    {
+        var johnNash = GetUser("john.nash");
+        await _userAppService.DeleteAsync(johnNash.Id);
+
+        var result = await _userAppService.FindByIdAsync(johnNash.Id);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
     public async Task GetListAsync()
     {
         //Act


### PR DESCRIPTION
The Identity Users edit modal returned 404 when the user's creator or last modifier had been soft-deleted: `GetUserNameOrNullAsync` calls `IIdentityUserAppService.GetAsync` which throws on a missing user, so opening the modal failed and the error referenced the deleted creator's id instead of the user being edited.

Adds `IIdentityUserAppService.FindByIdAsync` (null-safe lookup, same pattern as `FindByUsernameAsync` / `FindByEmailAsync`) and switches the edit modal to use it. Now a soft-deleted creator/modifier just shows as blank instead of breaking the page.

Fixes #25555