### PR TITLE
Render attached component in Basic theme user menu

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -86,7 +86,7 @@ jobs:
 
     - name: Codecov
       if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v7
       with:
         use_oidc: true
         fail_ci_if_error: true

--- a/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.Server.BasicTheme/Themes/Basic/LoginDisplay.razor
+++ b/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.Server.BasicTheme/Themes/Basic/LoginDisplay.razor
@@ -1,6 +1,7 @@
 ﻿@namespace Volo.Abp.AspNetCore.Components.Server.BasicTheme.Themes.Basic
 @using Volo.Abp.Users
 @using Volo.Abp.MultiTenancy
+@using Volo.Abp.UI.Navigation
 @using Microsoft.Extensions.Localization
 @using global::Localization.Resources.AbpUi
 @inject ICurrentUser CurrentUser
@@ -26,7 +27,15 @@
                 {
                     @foreach (var menuItem in Menu.Items)
                     {
-                        <a class="dropdown-item" href="@menuItem.Url?.TrimStart('/', '~')" target="@menuItem.Target">@menuItem.DisplayName</a>
+                        var componentType = menuItem.GetComponentTypeOrDefault();
+                        if (componentType != null)
+                        {
+                            <DynamicComponent Type="@componentType" />
+                        }
+                        else
+                        {
+                            <a class="dropdown-item" href="@menuItem.Url?.TrimStart('/', '~')" target="@menuItem.Target">@menuItem.DisplayName</a>
+                        }
                     }
                 }
             </DropdownMenu>

--- a/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.Server.MudBlazorBasicTheme/Themes/Basic/LoginDisplay.razor
+++ b/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.Server.MudBlazorBasicTheme/Themes/Basic/LoginDisplay.razor
@@ -32,7 +32,15 @@
             {
                 @foreach (var menuItem in Menu.Items)
                 {
-                    <MudMenuItem Href="@menuItem.Url?.TrimStart('/', '~')" Target="@menuItem.Target">@menuItem.DisplayName</MudMenuItem>
+                    var componentType = menuItem.GetComponentTypeOrDefault();
+                    if (componentType != null)
+                    {
+                        <DynamicComponent Type="@componentType" />
+                    }
+                    else
+                    {
+                        <MudMenuItem Href="@menuItem.Url?.TrimStart('/', '~')" Target="@menuItem.Target">@menuItem.DisplayName</MudMenuItem>
+                    }
                 }
             }
             </ChildContent>

--- a/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.WebAssembly.BasicTheme/Themes/Basic/LoginDisplay.razor
+++ b/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.WebAssembly.BasicTheme/Themes/Basic/LoginDisplay.razor
@@ -2,6 +2,7 @@
 @using global::Localization.Resources.AbpUi
 @using Microsoft.Extensions.Options
 @using Volo.Abp.AspNetCore.Components.Web
+@using Volo.Abp.UI.Navigation
 @inherits AbpComponentBase
 @inject IJSRuntime JsRuntime
 @inject NavigationManager Navigation
@@ -26,7 +27,15 @@
                 {
                     @foreach (var menuItem in Menu.Items)
                     {
-                        <DropdownItem Clicked="@(() => NavigateToAsync(menuItem.Url, menuItem.Target))">@menuItem.DisplayName</DropdownItem>
+                        var componentType = menuItem.GetComponentTypeOrDefault();
+                        if (componentType != null)
+                        {
+                            <DynamicComponent Type="@componentType" />
+                        }
+                        else
+                        {
+                            <DropdownItem Clicked="@(() => NavigateToAsync(menuItem.Url, menuItem.Target))">@menuItem.DisplayName</DropdownItem>
+                        }
                     }
                 }
                 <DropdownDivider />

--- a/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.WebAssembly.MudBlazorBasicTheme/Themes/Basic/LoginDisplay.razor
+++ b/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.WebAssembly.MudBlazorBasicTheme/Themes/Basic/LoginDisplay.razor
@@ -35,7 +35,15 @@
             {
                 @foreach (var menuItem in Menu.Items)
                 {
-                    <MudMenuItem OnClick="@(() => NavigateToAsync(menuItem.Url, menuItem.Target))">@menuItem.DisplayName</MudMenuItem>
+                    var componentType = menuItem.GetComponentTypeOrDefault();
+                    if (componentType != null)
+                    {
+                        <DynamicComponent Type="@componentType" />
+                    }
+                    else
+                    {
+                        <MudMenuItem OnClick="@(() => NavigateToAsync(menuItem.Url, menuItem.Target))">@menuItem.DisplayName</MudMenuItem>
+                    }
                 }
             }
             <MudDivider />


### PR DESCRIPTION
Mirror LeptonX Lite's `GetComponentTypeOrDefault()` check in Basic theme's `LoginDisplay.razor` (4 variants: Server/WebAssembly × Bootstrap/MudBlazor) so menu items attached via `UseComponent(...)` render correctly. Without this, `Account.BackToImpersonator` is rendered as a GET link and hits OpenIddict as an authorization request, failing with ID2029.