### PR TITLE
docs: move AI Agent nav under ABP Studio

### DIFF
--- a/docs/en/docs-nav.json
+++ b/docs/en/docs-nav.json
@@ -341,36 +341,6 @@
                   "path": "studio/monitoring-applications.md"
                 },
                 {
-                  "text": "AI Agent",
-                  "items": [
-                    {
-                      "text": "Overview",
-                      "path": "studio/ai-agent.md",
-                      "isIndex": true
-                    },
-                    {
-                      "text": "Configuration",
-                      "path": "studio/ai-agent-configuration.md"
-                    },
-                    {
-                      "text": "Workflows",
-                      "path": "studio/ai-agent-workflows.md"
-                    },
-                    {
-                      "text": "Built-in Capabilities",
-                      "path": "studio/ai-agent-built-in-capabilities.md"
-                    },
-                    {
-                      "text": "Git Integration",
-                      "path": "studio/ai-agent-git-integration.md"
-                    },
-                    {
-                      "text": "Coding with AI Agent",
-                      "path": "studio/coding-with-ai-agent.md"
-                    }
-                  ]
-                },
-                {
                   "text": "Working with Kubernetes",
                   "path": "studio/kubernetes.md"
                 },
@@ -381,6 +351,36 @@
                 {
                   "text": "Custom Commands",
                   "path": "studio/custom-commands.md"
+                }
+              ]
+            },
+            {
+              "text": "AI Agent",
+              "items": [
+                {
+                  "text": "Overview",
+                  "path": "studio/ai-agent.md",
+                  "isIndex": true
+                },
+                {
+                  "text": "Configuration",
+                  "path": "studio/ai-agent-configuration.md"
+                },
+                {
+                  "text": "Workflows",
+                  "path": "studio/ai-agent-workflows.md"
+                },
+                {
+                  "text": "Built-in Capabilities",
+                  "path": "studio/ai-agent-built-in-capabilities.md"
+                },
+                {
+                  "text": "Git Integration",
+                  "path": "studio/ai-agent-git-integration.md"
+                },
+                {
+                  "text": "Coding with AI Agent",
+                  "path": "studio/coding-with-ai-agent.md"
                 }
               ]
             },
@@ -1070,7 +1070,7 @@
                   ]
                 }
               ]
-            },
+            }
           ]
         },
         {


### PR DESCRIPTION
## Summary
- Move the ABP Studio AI Agent navigation group out of Fundamentals and directly under ABP Studio.
- Keep the existing AI Agent child pages unchanged.
- Remove an existing trailing comma in docs-nav.json so the file parses as strict JSON.

## Validation
- python -m json.tool docs/en/docs-nav.json
- node JSON.parse structural check: AI Agent direct under ABP Studio = 1, under Fundamentals = 0
- git diff --check