### PR TITLE
docs: remove provider-specific model wording

### DIFF
--- a/docs/en/studio/ai-agent-configuration.md
+++ b/docs/en/studio/ai-agent-configuration.md
@@ -21,7 +21,7 @@ AI Agent configuration controls model selection, execution limits, enabled tools
 
 ## Model Provider
 
-ABP Studio uses an OpenRouter-backed model configuration by default. Studio maintains a model list with metadata such as provider, context length, maximum completion tokens, image support, reasoning support, and tool support.
+ABP Studio maintains a model list with metadata such as provider, context length, maximum completion tokens, image support, reasoning support, and tool support.
 
 The built-in default model set includes:
 
@@ -33,7 +33,7 @@ The built-in default model set includes:
 | GPT-5.5 | Optional main/review model | 1,050,000 |
 | GLM-5.1 | Optional text/code model without image support | 200,000 |
 
-The available model catalog can be refreshed from OpenRouter and is cached locally for a limited period.
+The available model catalog can be refreshed and is cached locally for a limited period.
 
 ![model-selector-menu](./images/ai-agent/model-selector-menu.png)
 


### PR DESCRIPTION
## Summary
- Remove backend provider-specific wording from the ABP Studio AI Agent model configuration documentation.
- Keep the model catalog behavior documented without naming an implementation detail.

## Validation
- Scanned docs/en for the removed provider name; no references remain.
- git diff --check