### PR TITLE
Blob container ProviderType does not fall back to default container configuration

### DIFF
--- a/framework/src/Volo.Abp.BlobStoring/Volo/Abp/BlobStoring/BlobContainerConfiguration.cs
+++ b/framework/src/Volo.Abp.BlobStoring/Volo/Abp/BlobStoring/BlobContainerConfiguration.cs
@@ -43,6 +43,20 @@ public class BlobContainerConfiguration
         _properties = new Dictionary<string, object?>();
     }
 
+    /// <summary>
+    /// Returns the naming normalizers in effect for this container, inheriting from the fallback
+    /// configuration only when this container has none and does not override <see cref="ProviderType"/>.
+    /// </summary>
+    public IEnumerable<Type> GetEffectiveNamingNormalizers()
+    {
+        if (NamingNormalizers.Count == 0 && _providerType == null && _fallbackConfiguration != null)
+        {
+            return _fallbackConfiguration.GetEffectiveNamingNormalizers();
+        }
+
+        return NamingNormalizers;
+    }
+
     public T? GetConfigurationOrDefault<T>(string name, T? defaultValue = default)
     {
         return (T?)GetConfigurationOrNull(name, defaultValue);

--- a/framework/src/Volo.Abp.BlobStoring/Volo/Abp/BlobStoring/BlobContainerConfiguration.cs
+++ b/framework/src/Volo.Abp.BlobStoring/Volo/Abp/BlobStoring/BlobContainerConfiguration.cs
@@ -7,10 +7,16 @@ namespace Volo.Abp.BlobStoring;
 
 public class BlobContainerConfiguration
 {
+    private Type? _providerType;
+
     /// <summary>
     /// The provider to be used to store BLOBs of this container.
     /// </summary>
-    public Type? ProviderType { get; set; }
+    public Type? ProviderType
+    {
+        get => _providerType ?? _fallbackConfiguration?.ProviderType;
+        set => _providerType = value;
+    }
 
     /// <summary>
     /// Indicates whether this container is multi-tenant or not.

--- a/framework/src/Volo.Abp.BlobStoring/Volo/Abp/BlobStoring/BlobNormalizeNamingService.cs
+++ b/framework/src/Volo.Abp.BlobStoring/Volo/Abp/BlobStoring/BlobNormalizeNamingService.cs
@@ -19,15 +19,15 @@ public class BlobNormalizeNamingService : IBlobNormalizeNamingService, ITransien
         string? containerName,
         string? blobName)
     {
-
-        if (!configuration.NamingNormalizers.Any())
+        var normalizerTypes = configuration.GetEffectiveNamingNormalizers();
+        if (!normalizerTypes.Any())
         {
             return new BlobNormalizeNaming(containerName, blobName);
         }
 
         using (var scope = ServiceProvider.CreateScope())
         {
-            foreach (var normalizerType in configuration.NamingNormalizers)
+            foreach (var normalizerType in normalizerTypes)
             {
                 var normalizer = scope.ServiceProvider
                     .GetRequiredService(normalizerType)
@@ -43,21 +43,11 @@ public class BlobNormalizeNamingService : IBlobNormalizeNamingService, ITransien
 
     public string NormalizeContainerName(BlobContainerConfiguration configuration, string containerName)
     {
-        if (!configuration.NamingNormalizers.Any())
-        {
-            return containerName;
-        }
-
         return NormalizeNaming(configuration, containerName, null).ContainerName!;
     }
 
     public string NormalizeBlobName(BlobContainerConfiguration configuration, string blobName)
     {
-        if (!configuration.NamingNormalizers.Any())
-        {
-            return blobName;
-        }
-
         return NormalizeNaming(configuration, null, blobName).BlobName!;
     }
 }

--- a/framework/test/Volo.Abp.BlobStoring.Tests/Volo/Abp/BlobStoring/AbpBlobStoringOptions_Tests.cs
+++ b/framework/test/Volo.Abp.BlobStoring.Tests/Volo/Abp/BlobStoring/AbpBlobStoringOptions_Tests.cs
@@ -36,4 +36,15 @@ public class AbpBlobStoringOptions_Tests : AbpBlobStoringTestBase
         config.IsMultiTenant.ShouldBeFalse();
         config.GetConfigurationOrNull("TestConfigDefault").ShouldBe("TestValueDefault");
     }
+
+    [Fact]
+    public void Should_Resolve_Fallback_Chain_Through_Configuration_Provider()
+    {
+        var testContainer1Config = _configurationProvider.Get<TestContainer1>();
+        testContainer1Config.IsMultiTenant.ShouldBeTrue();
+
+        var testContainer3Config = _configurationProvider.Get<TestContainer3>();
+        testContainer3Config.IsMultiTenant.ShouldBeFalse();
+        testContainer3Config.ProviderType.ShouldBe(typeof(FakeBlobProvider1));
+    }
 }

--- a/framework/test/Volo.Abp.BlobStoring.Tests/Volo/Abp/BlobStoring/AbpBlobStoringOptions_Tests.cs
+++ b/framework/test/Volo.Abp.BlobStoring.Tests/Volo/Abp/BlobStoring/AbpBlobStoringOptions_Tests.cs
@@ -33,6 +33,7 @@ public class AbpBlobStoringOptions_Tests : AbpBlobStoringTestBase
     {
         var config = _configurationProvider.Get<TestContainer3>();
         config.ProviderType.ShouldBe(typeof(FakeBlobProvider1));
+        config.IsMultiTenant.ShouldBeFalse();
         config.GetConfigurationOrNull("TestConfigDefault").ShouldBe("TestValueDefault");
     }
 }

--- a/framework/test/Volo.Abp.BlobStoring.Tests/Volo/Abp/BlobStoring/AbpBlobStoringOptions_Tests.cs
+++ b/framework/test/Volo.Abp.BlobStoring.Tests/Volo/Abp/BlobStoring/AbpBlobStoringOptions_Tests.cs
@@ -29,7 +29,7 @@ public class AbpBlobStoringOptions_Tests : AbpBlobStoringTestBase
     }
 
     [Fact]
-    public void Should_Fallback_To_Default_Configuration_If_Not_Specialized()
+    public void Should_Fallback_To_Default_ProviderType_When_Not_Explicitly_Configured()
     {
         var config = _configurationProvider.Get<TestContainer3>();
         config.ProviderType.ShouldBe(typeof(FakeBlobProvider1));

--- a/framework/test/Volo.Abp.BlobStoring.Tests/Volo/Abp/BlobStoring/AbpBlobStoringTestModule.cs
+++ b/framework/test/Volo.Abp.BlobStoring.Tests/Volo/Abp/BlobStoring/AbpBlobStoringTestModule.cs
@@ -36,6 +36,10 @@ public class AbpBlobStoringTestModule : AbpModule
                 {
                     container.SetConfiguration("TestConfig2", "TestValue2");
                     container.ProviderType = typeof(FakeBlobProvider2);
+                })
+                .Configure<TestContainer3>(container =>
+                {
+                    container.IsMultiTenant = false;
                 });
         });
     }

--- a/framework/test/Volo.Abp.BlobStoring.Tests/Volo/Abp/BlobStoring/BlobContainerConfiguration_Tests.cs
+++ b/framework/test/Volo.Abp.BlobStoring.Tests/Volo/Abp/BlobStoring/BlobContainerConfiguration_Tests.cs
@@ -1,0 +1,62 @@
+using System.Linq;
+using Shouldly;
+using Volo.Abp.BlobStoring.Fakes;
+using Xunit;
+
+namespace Volo.Abp.BlobStoring;
+
+public class BlobContainerConfiguration_Tests
+{
+    [Fact]
+    public void Should_Override_Default_Container_ProviderType_When_Named_Container_Has_Its_Own()
+    {
+        var defaultConfig = new BlobContainerConfiguration();
+        defaultConfig.ProviderType = typeof(FakeBlobProvider1);
+
+        var namedConfig = new BlobContainerConfiguration(defaultConfig);
+        namedConfig.ProviderType = typeof(FakeBlobProvider2);
+
+        namedConfig.ProviderType.ShouldBe(typeof(FakeBlobProvider2));
+        defaultConfig.ProviderType.ShouldBe(typeof(FakeBlobProvider1));
+    }
+
+    [Fact]
+    public void Should_Inherit_Default_Container_NamingNormalizers_When_Provider_Also_Inherited()
+    {
+        var defaultConfig = new BlobContainerConfiguration();
+        defaultConfig.ProviderType = typeof(FakeBlobProvider1);
+        defaultConfig.NamingNormalizers.Add<FakeNamingNormalizer>();
+
+        var namedConfig = new BlobContainerConfiguration(defaultConfig);
+
+        namedConfig.GetEffectiveNamingNormalizers().ShouldContain(typeof(FakeNamingNormalizer));
+        namedConfig.NamingNormalizers.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Should_Not_Inherit_NamingNormalizers_When_Named_Container_Has_Its_Own_ProviderType()
+    {
+        var defaultConfig = new BlobContainerConfiguration();
+        defaultConfig.ProviderType = typeof(FakeBlobProvider1);
+        defaultConfig.NamingNormalizers.Add<FakeNamingNormalizer>();
+
+        var namedConfig = new BlobContainerConfiguration(defaultConfig);
+        namedConfig.ProviderType = typeof(FakeBlobProvider2);
+
+        namedConfig.GetEffectiveNamingNormalizers().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Should_Override_Default_Container_NamingNormalizers_When_Named_Container_Has_Its_Own()
+    {
+        var defaultConfig = new BlobContainerConfiguration();
+        defaultConfig.NamingNormalizers.Add<FakeNamingNormalizer>();
+
+        var namedConfig = new BlobContainerConfiguration(defaultConfig);
+        namedConfig.NamingNormalizers.Add<AnotherFakeNamingNormalizer>();
+
+        var effective = namedConfig.GetEffectiveNamingNormalizers().ToList();
+        effective.ShouldContain(typeof(AnotherFakeNamingNormalizer));
+        effective.ShouldNotContain(typeof(FakeNamingNormalizer));
+    }
+}

--- a/framework/test/Volo.Abp.BlobStoring.Tests/Volo/Abp/BlobStoring/Fakes/AnotherFakeNamingNormalizer.cs
+++ b/framework/test/Volo.Abp.BlobStoring.Tests/Volo/Abp/BlobStoring/Fakes/AnotherFakeNamingNormalizer.cs
@@ -1,0 +1,14 @@
+namespace Volo.Abp.BlobStoring.Fakes;
+
+public class AnotherFakeNamingNormalizer : IBlobNamingNormalizer
+{
+    public string NormalizeContainerName(string containerName)
+    {
+        return containerName;
+    }
+
+    public string NormalizeBlobName(string blobName)
+    {
+        return blobName;
+    }
+}

--- a/framework/test/Volo.Abp.BlobStoring.Tests/Volo/Abp/BlobStoring/Fakes/FakeNamingNormalizer.cs
+++ b/framework/test/Volo.Abp.BlobStoring.Tests/Volo/Abp/BlobStoring/Fakes/FakeNamingNormalizer.cs
@@ -1,0 +1,14 @@
+namespace Volo.Abp.BlobStoring.Fakes;
+
+public class FakeNamingNormalizer : IBlobNamingNormalizer
+{
+    public string NormalizeContainerName(string containerName)
+    {
+        return containerName;
+    }
+
+    public string NormalizeBlobName(string blobName)
+    {
+        return blobName;
+    }
+}


### PR DESCRIPTION
## Problem

When configuring a named blob container with only non-provider options, such as `IsMultiTenant`, the container loses access to the default provider configuration.

Example:

```csharp
Configure<AbpBlobStoringOptions>(options =>
{
    options.Containers.ConfigureDefault(container =>
    {
        container.UseDatabase();
    });

    options.Containers.Configure<WorkspaceDataSourceBlobContainer>(container =>
    {
        container.IsMultiTenant = false;
    });
});
```

In this case, `WorkspaceDataSourceBlobContainer` is created as a specialized named container with the default container as its fallback. However, `ProviderType` is a direct auto-property on `BlobContainerConfiguration`, so it does not use the fallback configuration.

As a result, provider resolution fails with:

```text
No BLOB Storage provider was used! At least one provider must be configured to be able to use the BLOB Storing System.
```

> See: https://github.com/volosoft/volo/issues/22446

## Expected Behavior

A named blob container should inherit `ProviderType` from the default container when it does not explicitly set its own provider type. (if it's null)

This should behave consistently with other configuration values that already fall back through `_fallbackConfiguration`.

## Actual Behavior

Custom configuration values use fallback resolution, but `ProviderType` does not.

This means a container configured only for options like `IsMultiTenant` must also repeat the provider configuration, even when a default provider is already configured.

## Suggested Fix

Update `BlobContainerConfiguration.ProviderType` to use the fallback configuration when the current container has no explicit provider type.

Suggested implementation:

```csharp
private Type? _providerType;

public Type? ProviderType
{
    get => _providerType ?? _fallbackConfiguration?.ProviderType;
    set => _providerType = value;
}
```