### PR TITLE
Wrap IdentityServer test seed in single UoW to fix flaky SQLite lock

### DIFF
--- a/modules/identityserver/test/Volo.Abp.IdentityServer.TestBase/Volo/Abp/IdentityServer/AbpIdentityServerTestBaseModule.cs
+++ b/modules/identityserver/test/Volo.Abp.IdentityServer.TestBase/Volo/Abp/IdentityServer/AbpIdentityServerTestBaseModule.cs
@@ -2,6 +2,7 @@
 using Volo.Abp.Autofac;
 using Volo.Abp.Modularity;
 using Volo.Abp.Threading;
+using Volo.Abp.Uow;
 
 namespace Volo.Abp.IdentityServer;
 
@@ -38,9 +39,17 @@ public class AbpIdentityServerTestBaseModule : AbpModule
     {
         using (var scope = context.ServiceProvider.CreateScope())
         {
-            AsyncHelper.RunSync(() => scope.ServiceProvider
-                .GetRequiredService<AbpIdentityServerTestDataBuilder>()
-                .BuildAsync());
+            AsyncHelper.RunSync(async () =>
+            {
+                var unitOfWorkManager = scope.ServiceProvider.GetRequiredService<IUnitOfWorkManager>();
+                using (var uow = unitOfWorkManager.Begin(requiresNew: true))
+                {
+                    await scope.ServiceProvider
+                        .GetRequiredService<AbpIdentityServerTestDataBuilder>()
+                        .BuildAsync();
+                    await uow.CompleteAsync();
+                }
+            });
         }
     }
 }


### PR DESCRIPTION
Wrap the seed loop in `AbpIdentityServerTestBaseModule.SeedTestData` with a single outer UoW so all `InsertAsync` calls share one `DbContext`. Previously each call resolved a new `SqliteRelationalConnection` and re-ran `InitializeDbConnection` against the shared in-memory `SqliteConnection`, occasionally racing into `SQLITE_BUSY` (`SQLite Error 5: 'database is locked'`) on CI.