### PR TITLE
Pass `configAction` in generic `HubConfigList.AddOrUpdate` overload

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.SignalR/Volo/Abp/AspNetCore/SignalR/HubConfigList.cs
+++ b/framework/src/Volo.Abp.AspNetCore.SignalR/Volo/Abp/AspNetCore/SignalR/HubConfigList.cs
@@ -7,7 +7,7 @@ public class HubConfigList : List<HubConfig>
 {
     public void AddOrUpdate<THub>(Action<HubConfig>? configAction = null)
     {
-        AddOrUpdate(typeof(THub));
+        AddOrUpdate(typeof(THub), configAction);
     }
 
     public void AddOrUpdate(Type hubType, Action<HubConfig>? configAction = null)

--- a/framework/test/Volo.Abp.AspNetCore.SignalR.Tests/Volo/Abp/AspNetCore/SignalR/HubConfigList_Tests.cs
+++ b/framework/test/Volo.Abp.AspNetCore.SignalR.Tests/Volo/Abp/AspNetCore/SignalR/HubConfigList_Tests.cs
@@ -1,0 +1,32 @@
+using System.Linq;
+using Shouldly;
+using Volo.Abp.AspNetCore.SignalR.SampleHubs;
+using Xunit;
+
+namespace Volo.Abp.AspNetCore.SignalR;
+
+public class HubConfigList_Tests
+{
+    [Fact]
+    public void Should_Apply_ConfigAction_For_Generic_Overload()
+    {
+        var list = new HubConfigList();
+
+        list.AddOrUpdate<RegularHub>(config => config.RoutePattern = "/custom-route");
+
+        var hubConfig = list.Single(c => c.HubType == typeof(RegularHub));
+        hubConfig.RoutePattern.ShouldBe("/custom-route");
+    }
+
+    [Fact]
+    public void Should_Update_Existing_Hub_For_Generic_Overload()
+    {
+        var list = new HubConfigList();
+
+        list.AddOrUpdate<RegularHub>();
+        list.AddOrUpdate<RegularHub>(config => config.RoutePattern = "/custom-route");
+
+        list.Count.ShouldBe(1);
+        list.Single(c => c.HubType == typeof(RegularHub)).RoutePattern.ShouldBe("/custom-route");
+    }
+}


### PR DESCRIPTION
The generic `AddOrUpdate<THub>(configAction)` did not forward `configAction` to the non-generic overload, so the config was silently dropped. Closes #22896