### PR TITLE
Upgrade Blazorise packages to version 2.2.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,10 +19,10 @@
     <PackageVersion Include="Azure.Identity" Version="1.14.2" />
     <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.25.0" />
-    <PackageVersion Include="Blazorise" Version="2.1.3" />
-    <PackageVersion Include="Blazorise.Components" Version="2.1.3" />
-    <PackageVersion Include="Blazorise.DataGrid" Version="2.1.3" />
-    <PackageVersion Include="Blazorise.Snackbar" Version="2.1.3" />
+    <PackageVersion Include="Blazorise" Version="2.2.1" />
+    <PackageVersion Include="Blazorise.Components" Version="2.2.1" />
+    <PackageVersion Include="Blazorise.DataGrid" Version="2.2.1" />
+    <PackageVersion Include="Blazorise.Snackbar" Version="2.2.1" />
     <PackageVersion Include="MudBlazor" Version="9.4.0" />
     <PackageVersion Include="Castle.Core" Version="5.2.1" />
     <PackageVersion Include="Castle.Core.AsyncInterceptor" Version="2.1.0" />

--- a/docs/en/package-version-changes.md
+++ b/docs/en/package-version-changes.md
@@ -16,6 +16,10 @@
 | Blazorise.Components | 2.0.4 | 2.1.3 | #25494 |
 | Blazorise.DataGrid | 2.0.4 | 2.1.3 | #25494 |
 | Blazorise.Snackbar | 2.0.4 | 2.1.3 | #25494 |
+| Blazorise | 2.1.3 | 2.2.1 | #25680 |
+| Blazorise.Components | 2.1.3 | 2.2.1 | #25680 |
+| Blazorise.DataGrid | 2.1.3 | 2.2.1 | #25680 |
+| Blazorise.Snackbar | 2.1.3 | 2.2.1 | #25680 |
 
 ## 10.4.1
 


### PR DESCRIPTION
Follow-up to #25494 (which upgraded the Blazorise packages to 2.1.3). This bumps them to the latest stable **2.2.1**.

| Package | Old Version | New Version |
| --- | --- | --- |
| Blazorise | 2.1.3 | 2.2.1 |
| Blazorise.Components | 2.1.3 | 2.2.1 |
| Blazorise.DataGrid | 2.1.3 | 2.2.1 |
| Blazorise.Snackbar | 2.1.3 | 2.2.1 |

Keeps the Blazorise dependency current and picks up the DataGrid and other fixes released in Blazorise 2.2.0 / 2.2.1.
