### PR TITLE
Keep `path` on breadcrumb segments so they render as links

### DIFF
--- a/npm/ng-packs/packages/theme-shared/src/lib/components/breadcrumb/breadcrumb.component.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/components/breadcrumb/breadcrumb.component.ts
@@ -44,7 +44,7 @@ export class BreadcrumbComponent implements OnInit {
 
           while (node.parent) {
             node = node.parent;
-            const { parent, children, isLeaf, path, ...segment } = node;
+            const { parent, children, isLeaf, ...segment } = node;
             if (!isAdministration(segment)) this.segments.unshift(segment);
           }
 

--- a/npm/ng-packs/packages/theme-shared/src/lib/tests/breadcrumb.component.spec.ts
+++ b/npm/ng-packs/packages/theme-shared/src/lib/tests/breadcrumb.component.spec.ts
@@ -10,6 +10,7 @@ import {
   ConfigStateService,
 } from '@abp/ng.core';
 import { RouterModule } from '@angular/router';
+import { By } from '@angular/platform-browser';
 import { createRoutingFactory, SpectatorRouting } from '@ngneat/spectator/vitest';
 import { of } from 'rxjs';
 import { BreadcrumbComponent, BreadcrumbItemsComponent } from '../components';
@@ -117,5 +118,19 @@ describe('BreadcrumbComponent', () => {
     await spectator.router.navigateByUrl('/identity/users');
     spectator.detectChanges();
     expect(spectator.component).toBeTruthy();
+  });
+
+  it('should keep the path on segments so breadcrumbs render as links', async () => {
+    routes.add(mockRoutes);
+    await spectator.router.navigateByUrl('/identity/users');
+    spectator.detectChanges();
+
+    const breadcrumb = spectator.fixture.debugElement.query(By.directive(BreadcrumbComponent))
+      .componentInstance as BreadcrumbComponent;
+
+    expect(breadcrumb.segments.map(segment => segment.path)).toEqual([
+      '/identity',
+      '/identity/users',
+    ]);
   });
 });


### PR DESCRIPTION
The breadcrumb built each segment with `const { parent, children, isLeaf, path, ...segment } = node`, dropping `path` from the rest, so `breadcrumb-items` always fell back to the non-link template. Kept `path` on the segment. Closes #22930