### PR TITLE
Stop warning for plain strings without the localization separator

### DIFF
--- a/npm/ng-packs/packages/core/src/lib/services/localization.service.ts
+++ b/npm/ng-packs/packages/core/src/lib/services/localization.service.ts
@@ -230,7 +230,8 @@ export class LocalizationService {
     };
 
     if (keys.length < 2) {
-      warn('The localization source separator (::) not found.');
+      // A plain string without the `::` separator is a valid passthrough value
+      // (e.g. text piped through `abpLocalization`), so it must not warn here.
       return defaultValue || (key as string);
     }
     if (!state.localization) return defaultValue || keys[1];

--- a/npm/ng-packs/packages/core/src/lib/tests/localization.service.spec.ts
+++ b/npm/ng-packs/packages/core/src/lib/tests/localization.service.spec.ts
@@ -28,6 +28,7 @@ describe('LocalizationService', () => {
         provide: ConfigStateService,
         useValue: {
           getOne: vi.fn(),
+          getAll: vi.fn(() => ({})),
           refreshAppState: vi.fn(),
           getDeep: vi.fn(),
           getDeep$: vi.fn(() => new Subject()),
@@ -68,6 +69,30 @@ describe('LocalizationService', () => {
     it('should return sync localization', () => {
       const result = service.localizeSync('test', 'key', 'default');
       expect(result).toBeDefined();
+    });
+  });
+
+  describe('#instant (missing :: separator)', () => {
+    const separatorWarning = 'The localization source separator (::) not found.';
+
+    it('should not warn for a plain string used as a passthrough value', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      const result = service.instant('Plain text');
+
+      expect(result).toBe('Plain text');
+      expect(warnSpy).not.toHaveBeenCalledWith(separatorWarning);
+      warnSpy.mockRestore();
+    });
+
+    it('should return the default value without warning', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      const result = service.instant({ key: 'Plain text', defaultValue: 'Fallback' });
+
+      expect(result).toBe('Fallback');
+      expect(warnSpy).not.toHaveBeenCalledWith(separatorWarning);
+      warnSpy.mockRestore();
     });
   });
 });


### PR DESCRIPTION
`getLocalization` logged `The localization source separator (::) not found.` for every plain string passed through `abpLocalization`, spamming the dev console even though a plain string is a valid passthrough value. Dropped that dev warning. Closes #23287