### PR TITLE
Declare array parameters as `readonly` in Angular proxy generation

### DIFF
--- a/npm/ng-packs/packages/schematics/src/tests/proxy-readonly-array-param.spec.ts
+++ b/npm/ng-packs/packages/schematics/src/tests/proxy-readonly-array-param.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { createActionToSignatureMapper } from '../utils/service';
+import { Action } from '../models/api-definition';
+
+// Real signature-generation pipeline for #25668: array parameters should be declared `readonly`.
+const buildSignature = (name: string, typeSimple: string, type: string) =>
+  createActionToSignatureMapper()({
+    uniqueName: 'GetAsync',
+    name: 'GetAsync',
+    httpMethod: 'GET',
+    url: 'api/app/my',
+    supportedVersions: [],
+    parametersOnMethod: [{ name, typeAsString: '', type, typeSimple, isOptional: false, defaultValue: null }],
+    parameters: [],
+    returnValue: { type: 'System.Void', typeSimple: 'void' },
+  } as unknown as Action);
+
+const paramType = (name: string, typeSimple: string, type: string) =>
+  (buildSignature(name, typeSimple, type).parameters.find(p => p.name === name) as { type: string })
+    .type;
+
+describe('proxy generation - readonly array params', () => {
+  it('declares a primitive array parameter as readonly', () => {
+    expect(paramType('ids', '[string]', 'System.String[]')).toBe('readonly string[]');
+  });
+
+  it('declares a complex array parameter as readonly', () => {
+    expect(paramType('items', '[Volo.Abp.Dto]', 'Volo.Abp.Dto[]')).toBe('readonly Dto[]');
+  });
+
+  it('leaves a non-array parameter unchanged', () => {
+    expect(paramType('name', 'string', 'System.String')).toBe('string');
+  });
+});

--- a/npm/ng-packs/packages/schematics/src/utils/service.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/service.ts
@@ -259,6 +259,12 @@ export function createActionToSignatureMapper() {
         type = adaptType(p.type);
       }
 
+      // Array params are only forwarded to the HTTP client and never mutated, so declare them
+      // `readonly` to also accept readonly arrays from callers without a type error.
+      if (type.endsWith('[]')) {
+        type = `readonly ${type}`;
+      }
+
       const parameter = new Property({ name: p.name, type });
       parameter.setDefault(p.defaultValue);
       parameter.setOptional(p.isOptional);


### PR DESCRIPTION
Generated Angular service proxies declared array parameters as mutable (`string[]`), so callers could not pass `readonly` arrays without a type error. Array params are only forwarded to the HTTP client and never mutated, so declare them `readonly`. Closes #25668