### PR TITLE
Fix MudBlazor resource permission management modal

### DIFF
--- a/modules/permission-management/src/Volo.Abp.PermissionManagement.Blazor.MudBlazor/Components/ResourcePermissionManagementModal.razor
+++ b/modules/permission-management/src/Volo.Abp.PermissionManagement.Blazor.MudBlazor/Components/ResourcePermissionManagementModal.razor
@@ -1,7 +1,7 @@
 @using global::MudBlazor
 @inherits Volo.Abp.AspNetCore.Components.AbpComponentBase
 
-<MudDialog DefaultFocus="DefaultFocus.FirstChild" @bind-Visible="@_isVisible" Options="@(new DialogOptions { MaxWidth = MaxWidth.ExtraLarge, FullWidth = true, CloseOnEscapeKey = true, BackdropClick = false })">
+<MudDialog DefaultFocus="DefaultFocus.FirstChild" @bind-Visible="@_isVisible" Options="@(new DialogOptions { MaxWidth = MaxWidth.Large, FullWidth = true, CloseOnEscapeKey = true, BackdropClick = false })">
     <TitleContent>
         <MudText Typo="Typo.h6">@L["ResourcePermissions"] - @ResourceDisplayName</MudText>
     </TitleContent>
@@ -80,75 +80,69 @@
 </MudDialog>
 
 @* Create Resource Permission Dialog *@
-@if (_createDialogVisible)
-{
-    <MudDialog DefaultFocus="DefaultFocus.FirstChild" @bind-Visible="@_createDialogVisible" Options="@(new DialogOptions { MaxWidth = MaxWidth.Medium, FullWidth = true, CloseOnEscapeKey = true, BackdropClick = false })">
-        <TitleContent>
-            <MudText Typo="Typo.h6">@L["AddResourcePermission"]</MudText>
-        </TitleContent>
-        <DialogContent>
-            <MudForm @ref="@_createFormRef" Model="@CreateEntity">
-                <MudText Typo="Typo.subtitle1" Class="mb-2">@L["ResourcePermissionTarget"]</MudText>
-                <MudRadioGroup T="string" SelectedOption="@CurrentLookupService" SelectedOptionChanged="@OnLookupServiceCheckedValueChanged">
-                    @foreach (var keyLookupService in ResourceProviderKeyLookupServices)
-                    {
-                        <MudRadio Color="Color.Primary" T="string" Option="@keyLookupService.Name">@keyLookupService.DisplayName</MudRadio>
-                    }
-                </MudRadioGroup>
-                <MudAutocomplete Margin="Margin.Dense" T="SearchProviderKeyInfo"
-                               Value="@_selectedProviderKey"
-                               ValueChanged="@SelectedProviderKeyChanged"
-                               SearchFunc="@SearchProviderKeyAsync"
-                               ToStringFunc="@(item => item?.ProviderDisplayName ?? string.Empty)"
-                               Label="@L["ProviderKey"]"
-                               Required="true"
-                               RequiredError="@L["ThisFieldIsRequired."]"
-                               Class="mt-2" />
-                <MudText Typo="Typo.subtitle1" Class="mb-2 mt-4">@L["ResourcePermissionPermissions"]</MudText>
-                <MudSwitch Color="Color.Primary" T="bool" Value="@_grantAllCreate" 
-                          ValueChanged="@(async (bool b) => await GrantAllCreateAsync(b))"
-                          Label="@L["GrantAllResourcePermissions"]" />
-                <div class="mt-2">
-                    @foreach (var permission in CreateEntity.Permissions)
-                    {
-                        <MudCheckBox Color="Color.Primary" UncheckedColor="Color.Default" T="bool" @bind-Value="@permission.IsGranted" 
-                                    Label="@permission.DisplayName" />
-                    }
-                </div>
-            </MudForm>
-        </DialogContent>
-        <DialogActions>
-            <MudButton OnClick="@CloseCreateDialogAsync">@L["Cancel"]</MudButton>
-            <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="@CreateResourcePermissionAsync">@L["Save"]</MudButton>
-        </DialogActions>
-    </MudDialog>
-}
+<MudDialog DefaultFocus="DefaultFocus.FirstChild" @bind-Visible="@_createDialogVisible" Options="@(new DialogOptions { MaxWidth = MaxWidth.Medium, FullWidth = true, CloseOnEscapeKey = true, BackdropClick = false })">
+    <TitleContent>
+        <MudText Typo="Typo.h6">@L["AddResourcePermission"]</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudForm @ref="@_createFormRef" Model="@CreateEntity">
+            <MudText Typo="Typo.subtitle1" Class="mb-2">@L["ResourcePermissionTarget"]</MudText>
+            <MudRadioGroup T="string" Value="@CurrentLookupService" ValueChanged="@OnLookupServiceCheckedValueChanged">
+                @foreach (var keyLookupService in ResourceProviderKeyLookupServices)
+                {
+                    <MudRadio Color="Color.Primary" T="string" Value="@keyLookupService.Name">@keyLookupService.DisplayName</MudRadio>
+                }
+            </MudRadioGroup>
+            <MudAutocomplete Margin="Margin.Dense" T="SearchProviderKeyInfo"
+                           Value="@_selectedProviderKey"
+                           ValueChanged="@SelectedProviderKeyChanged"
+                           SearchFunc="@SearchProviderKeyAsync"
+                           ToStringFunc="@(item => item?.ProviderDisplayName ?? string.Empty)"
+                           Label="@L["SearchProviderKey"]"
+                           Required="true"
+                           RequiredError="@L["ThisFieldIsRequired."]"
+                           Class="mt-2" />
+            <MudText Typo="Typo.subtitle1" Class="mb-2 mt-4">@L["ResourcePermissionPermissions"]</MudText>
+            <MudSwitch Color="Color.Primary" T="bool" Value="@CreateEntity.Permissions.All(x => x.IsGranted)"
+                      ValueChanged="@(async (bool b) => await GrantAllCreateAsync(b))"
+                      Label="@L["GrantAllResourcePermissions"]" />
+            <div class="mt-2">
+                @foreach (var permission in CreateEntity.Permissions)
+                {
+                    <MudCheckBox Color="Color.Primary" UncheckedColor="Color.Default" T="bool" @bind-Value="@permission.IsGranted"
+                                Label="@permission.DisplayName" />
+                }
+            </div>
+        </MudForm>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@CloseCreateDialogAsync">@L["Cancel"]</MudButton>
+        <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="@CreateResourcePermissionAsync">@L["Save"]</MudButton>
+    </DialogActions>
+</MudDialog>
 
 @* Edit Resource Permission Dialog *@
-@if (_editDialogVisible)
-{
-    <MudDialog DefaultFocus="DefaultFocus.FirstChild" @bind-Visible="@_editDialogVisible" Options="@(new DialogOptions { MaxWidth = MaxWidth.Medium, FullWidth = true, CloseOnEscapeKey = true, BackdropClick = false })">
-        <TitleContent>
-            <MudText Typo="Typo.h6">@L["UpdateResourcePermission"]</MudText>
-        </TitleContent>
-        <DialogContent>
-            <MudForm @ref="@_editFormRef" Model="@EditEntity">
-                <MudText Typo="Typo.subtitle1" Class="mb-2">@L["ResourcePermissionPermissions"]</MudText>
-                <MudSwitch Color="Color.Primary" T="bool" Value="@_grantAllEdit" 
-                          ValueChanged="@(async (bool b) => await GrantAllEditAsync(b))"
-                          Label="@L["GrantAllResourcePermissions"]" />
-                <div class="mt-2">
-                    @foreach (var permission in EditEntity.Permissions)
-                    {
-                        <MudCheckBox Color="Color.Primary" UncheckedColor="Color.Default" T="bool" @bind-Value="@permission.IsGranted" 
-                                    Label="@permission.DisplayName" />
-                    }
-                </div>
-            </MudForm>
-        </DialogContent>
-        <DialogActions>
-            <MudButton OnClick="@CloseEditDialogAsync">@L["Cancel"]</MudButton>
-            <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="@UpdateResourcePermissionAsync">@L["Save"]</MudButton>
-        </DialogActions>
-    </MudDialog>
-}
+<MudDialog DefaultFocus="DefaultFocus.FirstChild" @bind-Visible="@_editDialogVisible" Options="@(new DialogOptions { MaxWidth = MaxWidth.Medium, FullWidth = true, CloseOnEscapeKey = true, BackdropClick = false })">
+    <TitleContent>
+        <MudText Typo="Typo.h6">@L["UpdateResourcePermission"]</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudForm @ref="@_editFormRef" Model="@EditEntity">
+            <MudText Typo="Typo.subtitle1" Class="mb-2">@L["ResourcePermissionPermissions"]</MudText>
+            <MudSwitch Color="Color.Primary" T="bool" Value="@EditEntity.Permissions.All(x => x.IsGranted)"
+                      ValueChanged="@(async (bool b) => await GrantAllEditAsync(b))"
+                      Label="@L["GrantAllResourcePermissions"]" />
+            <div class="mt-2">
+                @foreach (var permission in EditEntity.Permissions)
+                {
+                    <MudCheckBox Color="Color.Primary" UncheckedColor="Color.Default" T="bool" @bind-Value="@permission.IsGranted"
+                                Label="@permission.DisplayName" />
+                }
+            </div>
+        </MudForm>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@CloseEditDialogAsync">@L["Cancel"]</MudButton>
+        <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="@UpdateResourcePermissionAsync">@L["Save"]</MudButton>
+    </DialogActions>
+</MudDialog>

--- a/modules/permission-management/src/Volo.Abp.PermissionManagement.Blazor.MudBlazor/Components/ResourcePermissionManagementModal.razor.cs
+++ b/modules/permission-management/src/Volo.Abp.PermissionManagement.Blazor.MudBlazor/Components/ResourcePermissionManagementModal.razor.cs
@@ -59,8 +59,6 @@ public partial class ResourcePermissionManagementModal
         Permissions = new List<ResourcePermissionModel>()
     };
 
-    protected bool _grantAllCreate;
-    protected bool _grantAllEdit;
 
     public ResourcePermissionManagementModal()
     {
@@ -124,7 +122,6 @@ public partial class ResourcePermissionManagementModal
             }).ToList()
         };
 
-        _grantAllCreate = false;
         _createDialogVisible = true;
         await InvokeAsync(StateHasChanged);
     }
@@ -140,8 +137,6 @@ public partial class ResourcePermissionManagementModal
             {
                 permission.IsGranted = permissionGrants.Permissions.Any(p => p.Name == permission.Name && p.Providers.Contains(CurrentLookupService) && p.IsGranted);
             }
-
-            _grantAllCreate = CreateEntity.Permissions.All(x => x.IsGranted);
         }
 
         await InvokeAsync(StateHasChanged);
@@ -162,7 +157,6 @@ public partial class ResourcePermissionManagementModal
 
     protected virtual async Task GrantAllCreateAsync(bool value)
     {
-        _grantAllCreate = value;
         foreach (var permission in CreateEntity.Permissions)
         {
             permission.IsGranted = value;
@@ -172,7 +166,6 @@ public partial class ResourcePermissionManagementModal
 
     protected virtual async Task GrantAllEditAsync(bool value)
     {
-        _grantAllEdit = value;
         foreach (var permission in EditEntity.Permissions)
         {
             permission.IsGranted = value;
@@ -195,7 +188,6 @@ public partial class ResourcePermissionManagementModal
             }).ToList()
         };
 
-        _grantAllEdit = EditEntity.Permissions.All(x => x.IsGranted);
         _editDialogVisible = true;
         await InvokeAsync(StateHasChanged);
     }


### PR DESCRIPTION
Fix several issues in the MudBlazor `ResourcePermissionManagementModal`: the nested add/edit dialogs not closing, oversized dialog width, an unlocalized provider key label, the target radio group not switching the lookup service, and the grant-all switch not staying in sync with the permission checkboxes.