### PR TITLE
fix(schematics): avoid self-import for same-namespace generic base ty…

### DIFF
--- a/npm/ng-packs/packages/schematics/src/tests/proxy-self-import-generic-base.spec.ts
+++ b/npm/ng-packs/packages/schematics/src/tests/proxy-self-import-generic-base.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { createImportRefsToModelReducer } from '../utils/model';
+import { Type } from '../models/api-definition';
+import { ModelGeneratorParams } from '../utils/model';
+
+// Reproduces #25080: when a DTO inherits from a generic base type (e.g. PagedResultDto<T>)
+// whose type argument T lives in the SAME namespace, the proxy generator used to emit an
+// invalid self-import (`import type { TransactionDto } from './models'`) inside models.ts,
+// breaking the Angular/TypeScript build.
+describe('proxy generation - self-import for generic base type argument (#25080)', () => {
+  const solution = 'MyApp';
+
+  // TransactionPagedResultDto : PagedResultDto<TransactionDto>, both in MyApp.Transactions.
+  const types: Record<string, Type> = {
+    'MyApp.Transactions.TransactionDto': {
+      baseType: null,
+      isEnum: false,
+      enumNames: null,
+      enumValues: null,
+      genericArguments: null,
+      properties: [
+        {
+          name: 'Id',
+          jsonName: null,
+          type: 'System.Guid',
+          typeSimple: 'System.Guid',
+          isRequired: false,
+          isNullable: false,
+        },
+      ],
+    },
+    'MyApp.Transactions.TransactionPagedResultDto': {
+      baseType: 'Volo.Abp.Application.Dtos.PagedResultDto<MyApp.Transactions.TransactionDto>',
+      isEnum: false,
+      enumNames: null,
+      enumValues: null,
+      genericArguments: null,
+      properties: [
+        {
+          name: 'AmountSummary',
+          jsonName: null,
+          type: 'System.Int32',
+          typeSimple: 'number',
+          isRequired: false,
+          isNullable: false,
+        },
+      ],
+    },
+  };
+
+  const params: ModelGeneratorParams = {
+    targetPath: 'src/app/proxy',
+    solution,
+    types,
+    serviceImports: {},
+    modelImports: {},
+  };
+
+  it('does not emit a self-import for a same-namespace generic base argument', () => {
+    const reduce = createImportRefsToModelReducer(params);
+    const models = reduce([], ['MyApp.Transactions.TransactionPagedResultDto']);
+
+    const model = models.find(m => m.namespace === 'Transactions');
+    expect(model).toBeDefined();
+
+    // The buggy behavior produced an import with path './models' (a self-import).
+    const selfImports = model!.imports.filter(i => i.path === './models');
+    expect(selfImports).toEqual([]);
+
+    // Sanity: TransactionDto must NOT be imported at all, since it is declared in this same file.
+    const importsTransactionDto = model!.imports.some(i =>
+      i.specifiers.some(s => s === 'TransactionDto'),
+    );
+    expect(importsTransactionDto).toBe(false);
+
+    // The framework base type, however, should still be imported from @abp/ng.core.
+    const importsPagedResultDto = model!.imports.some(
+      i => i.path === '@abp/ng.core' && i.specifiers.includes('PagedResultDto'),
+    );
+    expect(importsPagedResultDto).toBe(true);
+  });
+});

--- a/npm/ng-packs/packages/schematics/src/utils/model.ts
+++ b/npm/ng-packs/packages/schematics/src/utils/model.ts
@@ -74,6 +74,14 @@ export function createImportRefsToModelReducer(params: ModelGeneratorParams) {
         if (baseType && parseNamespace(solution, baseType) !== model.namespace) {
           const baseTypeWithGenericParams = parseBaseTypeWithGenericTypes(baseType);
           baseTypeWithGenericParams.forEach(t => {
+            // A generic argument of the base type (e.g. T in PagedResultDto<T>) may live in the
+            // same namespace as this model, which means it is generated into the same models.ts
+            // file. Importing it would produce an invalid self-import (`from './models'`), so we
+            // skip same-namespace types here, mirroring the property handling below. See #25080.
+            if (parseNamespace(solution, t) === model.namespace) {
+              return;
+            }
+
             toBeImported.push({
               type: t,
               isEnum: false,


### PR DESCRIPTION
### Description

Resolves #25080

When generating Angular proxies, if a DTO inherits from a generic base type such as `PagedResultDto<TransactionDto>` and the generic argument (`TransactionDto`) lives in the **same C# namespace**, the model generator emitted an invalid **self-import** inside the generated `models.ts`:

```ts
// inside models.ts itself
import type { TransactionDto } from './models';
```

A module can't import from itself, so this breaks the Angular/TypeScript build.

**Cause:** In `npm/ng-packs/packages/schematics/src/utils/model.ts`, the base-type generic arguments were not filtered by namespace the way property refs already are. The outer guard only checked the base type's own namespace (`Volo.Abp.Application.Dtos.PagedResultDto`), which differs from the model, so the **entire** generic tree was imported — including same-namespace arguments.

**Fix:** Skip generic arguments whose namespace equals the model's, mirroring the existing property handling a few lines below. The framework base type (`PagedResultDto`) is still correctly imported from `@abp/ng.core`; only the bogus same-namespace self-import is dropped.

This is **not** a breaking change. No UI, so no screenshots.

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

**Automated (added in this PR):**

```bash
cd npm/ng-packs
vitest run --project schematics src/tests/proxy-self-import-generic-base.spec.ts
```

The new test reproduces the reported scenario. It fails on the previous code (asserting an `import ... from './models'` self-import is produced) and passes with this fix.

**Manual reproduction:**

1. In an ABP app, add two types in the **same namespace**:

```csharp
public class TransactionDto { }
public class TransactionPagedResultDto : PagedResultDto<TransactionDto> { }
```

2. Return `TransactionPagedResultDto` from a controller action.
3. Generate Angular proxies (`abp generate-proxy -t ng`).
4. **Before:** the generated `models.ts` contains `import type { TransactionDto } from './models';` and the build fails. **After:** no self-import is generated and the build succeeds.
