### PR TITLE
Add `override` to `AbpMauiClientModule.OnApplicationInitializationAsync`

### DIFF
--- a/framework/src/Volo.Abp.Maui.Client/Volo/Abp/Maui/Client/AbpMauiClientModule.cs
+++ b/framework/src/Volo.Abp.Maui.Client/Volo/Abp/Maui/Client/AbpMauiClientModule.cs
@@ -11,7 +11,7 @@ namespace Volo.Abp.Maui.Client;
 )]
 public class AbpMauiClientModule : AbpModule
 {
-    public async Task OnApplicationInitializationAsync(ApplicationInitializationContext context)
+    public override async Task OnApplicationInitializationAsync(ApplicationInitializationContext context)
     {
         await context.ServiceProvider.GetRequiredService<IClientScopeServiceProviderAccessor>().ServiceProvider.GetRequiredService<MauiCachedApplicationConfigurationClient>().InitializeAsync();
     }


### PR DESCRIPTION
Resolve abpframework/abp#25713

`OnApplicationInitializationAsync` was missing the `override` modifier, so it hid the base `AbpModule` method instead of overriding it and never ran during application initialization.