### PR TITLE
Add modern vs classic template docs

### DIFF
--- a/docs/en/docs-nav.json
+++ b/docs/en/docs-nav.json
@@ -2094,6 +2094,10 @@
           "path": "solution-templates/guide.md"
         },
         {
+          "text": "Modern vs Classic Templates",
+          "path": "solution-templates/modern-vs-classic.md"
+        },
+        {
           "text": "Single-Layer Solution",
           "isLazyExpandable": true,
           "path": "solution-templates/single-layer-web-application",

--- a/docs/en/get-started/index.md
+++ b/docs/en/get-started/index.md
@@ -20,7 +20,7 @@ Please select one of the following documents best fits for your application:
   - [WPF Application](wpf.md)
   - [Console Application](console.md)
 
-If you seek a React-based web UI, use the **modern template system** with ABP Studio or `abp new --modern`. See [UI options](../framework/ui/index.md) for the full list of officially supported UI frameworks.
+If you are choosing between the **Modern** and **Classic** ABP Studio template families, see [Modern vs Classic Templates](../solution-templates/modern-vs-classic.md). If you seek a React-based web UI, use the **modern template system** with ABP Studio or `abp new --modern`. See [UI options](../framework/ui/index.md) for the full list of officially supported UI frameworks.
 
 ## Which Startup Template is Suitable for Me?
 

--- a/docs/en/solution-templates/index.md
+++ b/docs/en/solution-templates/index.md
@@ -9,7 +9,7 @@
 
 ABP provides pre-architected and production-ready templates to jump start a new solution.
 
-> **You can see the [Solution Template Selection Guide](guide.md) if you are not sure which solution template is suitable for you.**
+> **You can see the [Solution Template Selection Guide](guide.md) if you are not sure which solution template is suitable for you. See [Modern vs Classic Templates](modern-vs-classic.md) if you are choosing between ABP Studio's Modern and Classic template families.**
 
 The reference pages below cover both classic and modern ABP Studio template families. The Single-Layer and Layered pages document the classic templates. The Modular Monolith and Microservice pages call out the current modern structure where it differs.
 

--- a/docs/en/solution-templates/modern-vs-classic.md
+++ b/docs/en/solution-templates/modern-vs-classic.md
@@ -1,0 +1,55 @@
+```json
+//[doc-seo]
+{
+    "Description": "Compare Modern and Classic ABP Studio templates, including architecture mapping, UI choices, mobile options, and when to choose each template family."
+}
+```
+
+# Modern vs Classic Templates
+
+ABP Studio provides two solution template families: **Modern** and **Classic**. Both families create production-ready ABP solutions and share the same ABP backend concepts, such as Entity Framework Core and MongoDB database options, OpenIddict authentication, multi-tenancy, optional modules, test projects, language selection and deployment-related configuration where they are supported.
+
+The main difference is how you choose and shape the solution. **Classic templates** are the traditional template-first flow. You first choose a concrete template, such as Single-Layer, Layered or Microservice, and then select UI, database, mobile and module options. **Modern templates** are the newer architecture-first flow. You first choose the backend architecture, then ABP Studio maps your selection to the proper modern template.
+
+## Template Families
+
+| Template family | Template names | Main idea |
+| --- | --- | --- |
+| Classic | `app-nolayers`, `app`, `microservice` | The traditional ABP Studio solution templates with the broadest UI framework choices. |
+| Modern | `app-nolayers-modern`, `app-modern`, `microservice-modern` | The newer ABP Studio templates focused on React-based web applications and an architecture-first creation flow. |
+
+## Modern Architecture Mapping
+
+When you use the Modern solution creation flow in ABP Studio, your selected architecture maps to a modern template:
+
+| Modern architecture | Generated template | Notes |
+| --- | --- | --- |
+| Simple Monolith | `app-nolayers-modern` | A simpler application structure with the main backend code in one host project. |
+| Layered Monolith | `app-modern` | A layered solution based on Domain Driven Design practices. |
+| Modular Monolith | `app-nolayers-modern` | Uses the modern single-layer template with modular solution options enabled. |
+| Microservice | `microservice-modern` | A distributed solution with dedicated services, gateways and applications. |
+
+## Practical Differences
+
+| Area | Classic templates | Modern templates |
+| --- | --- | --- |
+| Creation flow | Template-first: select Single-Layer, Layered or Microservice first. | Architecture-first: select Simple Monolith, Layered Monolith, Modular Monolith or Microservice first. |
+| Web UI choices | Supports MVC / Razor Pages, Angular, Blazor WebAssembly, Blazor Server, Blazor Web App, MAUI Blazor and No UI depending on the selected template. | Supports React or No UI. |
+| Mobile choices | Keeps broader mobile choices, including MAUI and React Native in templates that support mobile applications. | Supports React Native or no mobile application. |
+| Public website | Uses the classic public website structure where the selected template supports it. | Uses React-based public web assets where the selected modern template supports a public website. |
+| Frontend assets | Uses the established ABP UI framework integrations and theme options for MVC, Angular and Blazor applications. | Uses newer React and `shadcn`-oriented frontend assets. |
+| Best fit | Existing projects, teams using MVC / Angular / Blazor / MAUI, and scenarios that need the broadest UI framework choices. | New React-focused solutions and teams that prefer the newer Studio creation experience. |
+
+## Which One Should I Choose?
+
+Choose **Modern** if you are starting a new solution with React UI, want a React Native mobile application, prefer the newer architecture-first ABP Studio flow, or plan to use AI-assisted programming for an AI-driven project.
+
+Choose **Classic** if you want MVC / Razor Pages, Angular, Blazor, MAUI Blazor or MAUI mobile options, or if your team is following existing Classic-template tutorials, conventions or project structure.
+
+ABP Studio may show or hide some templates and options based on your license. For example, Microservice templates require a higher license level than regular application templates, and Modern application templates are not shown in the Community Edition.
+
+## See Also
+
+* [Solution Template Selection Guide](guide.md)
+* [Startup Solution Templates](index.md)
+* [Get Started](../get-started/index.md)


### PR DESCRIPTION
## Summary
- Add a Modern vs Classic Templates comparison page under Solution Templates.
- Link the page from Get Started and Solution Templates for discoverability.
- Add the page to the docs navigation.

Closes [abp #1244](https://workspace.volosoft.com/projects/abp/tasks/1244)

## Validation
- `Get-Content C:\P\abp\docs\en\docs-nav.json | ConvertFrom-Json`
- `rg -n "modern-vs-classic|Modern vs Classic|AI-assisted" docs\en\docs-nav.json docs\en\get-started\index.md docs\en\solution-templates\index.md docs\en\solution-templates\modern-vs-classic.md`
- `git diff --check --cached`