### PR TITLE
Add new version 10.5.0 to latest-versions.json

### DIFF
--- a/latest-versions.json
+++ b/latest-versions.json
@@ -1,5 +1,14 @@
 [
   {
+    "version": "10.5.0",
+    "releaseDate": "",
+    "type": "stable",
+    "message": "",
+    "leptonx": {
+      "version": "5.5.0"
+    }
+  },
+  {
     "version": "10.4.1",
     "releaseDate": "",
     "type": "stable",


### PR DESCRIPTION
`abp update` resolves the latest stable version from this file, so it needs a 10.5.0 entry for the CLI to update projects to 10.5.