### PR TITLE
Skip dynamic permission initialization during migrations

### DIFF
--- a/modules/permission-management/src/Volo.Abp.PermissionManagement.Domain/Volo/Abp/PermissionManagement/AbpPermissionManagementDomainModule.cs
+++ b/modules/permission-management/src/Volo.Abp.PermissionManagement.Domain/Volo/Abp/PermissionManagement/AbpPermissionManagementDomainModule.cs
@@ -48,9 +48,12 @@ public class AbpPermissionManagementDomainModule : AbpModule
 
     public override async Task OnApplicationInitializationAsync(ApplicationInitializationContext context)
     {
-        var rootServiceProvider = context.ServiceProvider.GetRequiredService<IRootServiceProvider>();
-        var initializer = rootServiceProvider.GetRequiredService<PermissionDynamicInitializer>();
-        await initializer.InitializeAsync(true, _cancellationTokenSource.Token);
+        if (!context.ServiceProvider.IsDataMigrationEnvironment())
+        {
+            var rootServiceProvider = context.ServiceProvider.GetRequiredService<IRootServiceProvider>();
+            var initializer = rootServiceProvider.GetRequiredService<PermissionDynamicInitializer>();
+            await initializer.InitializeAsync(true, _cancellationTokenSource.Token);
+        }
     }
 
     public override Task OnApplicationShutdownAsync(ApplicationShutdownContext context)


### PR DESCRIPTION
## What changed

- Skips `PermissionDynamicInitializer` during the data migration environment.
- Keeps normal application initialization behavior unchanged outside migration runs.

## Why

When `PermissionManagementOptions.IsDynamicPermissionStoreEnabled` is enabled, the dynamic permission initializer can pre-cache permissions during application initialization. In migration runs without an available database, that path can produce unnecessary error logs.

## Impact

Migration execution no longer attempts dynamic permission initialization, avoiding noisy logs when the database is not available. Runtime behavior outside the migration environment is unchanged.

## Validation

- `dotnet build modules/permission-management/src/Volo.Abp.PermissionManagement.Domain/Volo.Abp.PermissionManagement.Domain.csproj --no-restore` completed with `0 Error(s)` and existing warnings.