### PR TITLE
Upgrade `Swashbuckle.AspNetCore` to 10.2.3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -169,7 +169,7 @@
     <PackageVersion Include="Slugify.Core" Version="5.1.1" />
     <PackageVersion Include="Spectre.Console" Version="0.51.1" />
     <PackageVersion Include="StackExchange.Redis" Version="2.9.17" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.0.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     <PackageVersion Include="System.Collections.Immutable" Version="10.0.7" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.6.7" />

--- a/docs/en/package-version-changes.md
+++ b/docs/en/package-version-changes.md
@@ -7,6 +7,12 @@
 
 # Package Version Changes
 
+## 10.5.1
+
+| Package | Old Version | New Version | PR |
+|---------|-------------|-------------|-----|
+| Swashbuckle.AspNetCore | 10.0.1 | 10.2.3 | #25759 |
+
 ## 10.5.0-rc.4
 
 | Package | Old Version | New Version | PR |


### PR DESCRIPTION
Resolve abpframework/abp#25758

Bump `Swashbuckle.AspNetCore` from 10.0.1 to 10.2.3 so the transitive `Microsoft.OpenApi` moves from 2.3.0 to 2.7.5, clearing the GHSA-v5pm-xwqc-g5wc security warning. `dotnet list package --vulnerable --include-transitive` now reports no vulnerable packages.
