### PR TITLE
Upgrade MongoDB.Driver to 3.10.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -123,7 +123,7 @@
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.19.1" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.19.1" />
     <PackageVersion Include="Minio" Version="6.0.5" />
-    <PackageVersion Include="MongoDB.Driver" Version="3.9.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.10.0" />
     <PackageVersion Include="NEST" Version="7.17.5" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="Nito.AsyncEx.Context" Version="5.1.2" />

--- a/docs/en/package-version-changes.md
+++ b/docs/en/package-version-changes.md
@@ -64,6 +64,7 @@
 | Microsoft.IdentityModel.JsonWebTokens | 8.16.0 | 8.19.1 | #25706 |
 | Microsoft.IdentityModel.Protocols.OpenIdConnect | 8.16.0 | 8.19.1 | #25706 |
 | Microsoft.IdentityModel.Tokens | 8.16.0 | 8.19.1 | #25706 |
+| MongoDB.Driver | 3.9.0 | 3.10.0 | #25773 |
 | System.Collections.Immutable | 10.0.7 | 10.0.9 | #25706 |
 | System.IdentityModel.Tokens.Jwt | 8.16.0 | 8.19.1 | #25706 |
 | System.Management | 10.0.7 | 10.0.9 | #25706 |


### PR DESCRIPTION
Bumps MongoDB.Driver from 3.9.0 to 3.10.0.

Release notes: https://github.com/mongodb/mongo-csharp-driver/releases/tag/v3.10.0