### PR TITLE
Angular - Fixing the permission modal visibility constraint

### DIFF
--- a/npm/ng-packs/packages/core/src/lib/directives/replaceable-template.directive.ts
+++ b/npm/ng-packs/packages/core/src/lib/directives/replaceable-template.directive.ts
@@ -9,7 +9,7 @@ import {
   Type,
   ViewContainerRef,
   inject,
-  input
+  input,
 } from '@angular/core';
 import compare from 'just-compare';
 import { Subscription } from 'rxjs';
@@ -30,7 +30,9 @@ export class ReplaceableTemplateDirective implements OnInit, OnChanges {
   private replaceableComponents = inject(ReplaceableComponentsService);
   private subscription = inject(SubscriptionService);
 
-  readonly data = input.required<ReplaceableComponents.ReplaceableTemplateDirectiveInput<any, any>>({ alias: "abpReplaceableTemplate" });
+  readonly data = input.required<ReplaceableComponents.ReplaceableTemplateDirectiveInput<any, any>>(
+    { alias: 'abpReplaceableTemplate' },
+  );
 
   providedData = {
     inputs: {},

--- a/npm/ng-packs/packages/permission-management/src/lib/components/permission-management.component.ts
+++ b/npm/ng-packs/packages/permission-management/src/lib/components/permission-management.component.ts
@@ -3,11 +3,13 @@ import {
   Component,
   computed,
   DOCUMENT,
+  effect,
   inject,
   input,
   output,
   signal,
   TrackByFunction,
+  untracked,
 } from '@angular/core';
 import { NgStyle } from '@angular/common';
 import { FormsModule } from '@angular/forms';
@@ -224,6 +226,10 @@ export class PermissionManagementComponent {
   }
 
   set visible(value: boolean) {
+    this.setVisible(value);
+  }
+
+  private setVisible(value: boolean) {
     if (value && this.isClosingModal) {
       return;
     }
@@ -301,6 +307,19 @@ export class PermissionManagementComponent {
     this.setSelectedGroup(null);
     this.filter.set('');
     this.disabledSelectAllInAllTabsState.set(false);
+  }
+
+  // constructor() {
+  //   effect(() => {
+  //     this.setVisible(this.visibleInput());
+  //   });
+  // }
+
+  constructor() {
+    effect(() => {
+      const visible = this.visibleInput();
+      untracked(() => this.setVisible(visible));
+    });
   }
 
   getChecked(name: string) {


### PR DESCRIPTION
### Description

Fixes the permission modal visibility problem that relats the backward compatibility for the new signal-based constraints.