### PR TITLE
Fix: Add dependency on DocsCommonHttpApiClientModule in DocsAdmin and Docs ClientModule

### DIFF
--- a/modules/docs/src/Volo.Docs.Admin.HttpApi.Client/Volo.Docs.Admin.HttpApi.Client.csproj
+++ b/modules/docs/src/Volo.Docs.Admin.HttpApi.Client/Volo.Docs.Admin.HttpApi.Client.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Volo.Docs.Admin.Application.Contracts\Volo.Docs.Admin.Application.Contracts.csproj" />
     <ProjectReference Include="..\..\..\..\framework\src\Volo.Abp.Http.Client\Volo.Abp.Http.Client.csproj" />
+    <ProjectReference Include="..\Volo.Docs.Common.HttpApi.Client\Volo.Docs.Common.HttpApi.Client.csproj" />
 
   </ItemGroup>
 

--- a/modules/docs/src/Volo.Docs.Admin.HttpApi.Client/Volo/Docs/Admin/DocsAdminHttpApiClientModule.cs
+++ b/modules/docs/src/Volo.Docs.Admin.HttpApi.Client/Volo/Docs/Admin/DocsAdminHttpApiClientModule.cs
@@ -6,6 +6,7 @@ using Volo.Abp.VirtualFileSystem;
 namespace Volo.Docs.Admin
 {
     [DependsOn(
+        typeof(DocsCommonHttpApiClientModule),
         typeof(DocsAdminApplicationContractsModule),
         typeof(AbpHttpClientModule))]
     public class DocsAdminHttpApiClientModule : AbpModule

--- a/modules/docs/src/Volo.Docs.HttpApi.Client/Volo.Docs.HttpApi.Client.csproj
+++ b/modules/docs/src/Volo.Docs.HttpApi.Client/Volo.Docs.HttpApi.Client.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Volo.Docs.Application.Contracts\Volo.Docs.Application.Contracts.csproj" />
     <ProjectReference Include="..\..\..\..\framework\src\Volo.Abp.Http.Client\Volo.Abp.Http.Client.csproj" />
+    <ProjectReference Include="..\Volo.Docs.Common.HttpApi.Client\Volo.Docs.Common.HttpApi.Client.csproj" />
   </ItemGroup>
 
 </Project>

--- a/modules/docs/src/Volo.Docs.HttpApi.Client/Volo/Docs/DocsHttpApiClientModule.cs
+++ b/modules/docs/src/Volo.Docs.HttpApi.Client/Volo/Docs/DocsHttpApiClientModule.cs
@@ -5,7 +5,7 @@ using Volo.Abp.VirtualFileSystem;
 
 namespace Volo.Docs
 {
-    [DependsOn( 
+    [DependsOn(
         typeof(DocsCommonHttpApiClientModule),
         typeof(DocsApplicationContractsModule),
         typeof(AbpHttpClientModule)

--- a/modules/docs/src/Volo.Docs.HttpApi.Client/Volo/Docs/DocsHttpApiClientModule.cs
+++ b/modules/docs/src/Volo.Docs.HttpApi.Client/Volo/Docs/DocsHttpApiClientModule.cs
@@ -5,7 +5,8 @@ using Volo.Abp.VirtualFileSystem;
 
 namespace Volo.Docs
 {
-    [DependsOn(
+    [DependsOn( 
+        typeof(DocsCommonHttpApiClientModule),
         typeof(DocsApplicationContractsModule),
         typeof(AbpHttpClientModule)
     )]


### PR DESCRIPTION
Fix DependencyResolutionException for IProjectAppService in layered projects

## Problem

Using `abp install-module Volo.Docs` When installing the Volo.Docs module in a layered/split project and navigating to the `/Documents` URL, the following error occurs:

```
An exception was thrown while activating Volo.Docs.Pages.Documents.IndexModel.
System.InvalidOperationException: An exception was thrown while activating Volo.Docs.Pages.Documents.IndexModel.
 ---> Autofac.Core.DependencyResolutionException: An exception was thrown while activating Volo.Docs.Pages.Documents.IndexModel.
 ---> Autofac.Core.DependencyResolutionException: None of the constructors found on type 'Volo.Docs.Pages.Documents.IndexModel' can be invoked with the available services and parameters:
Cannot resolve parameter 'Volo.Docs.Common.Projects.IProjectAppService projectAppService' of constructor 'Void .ctor(Volo.Docs.Common.Projects.IProjectAppService, Microsoft.Extensions.Options.IOptions`1[Volo.Docs.DocsUiOptions])'.
```

## Temporary workaround

Modified the `xxxHttpApiClientModule.cs` file in the `You.Project.HttpApi.Client` project, and manually added `typeof(DocsCommonHttpApiClientModule)` inside the `DependsOn` method.

## Root Cause

`DocsHttpApiClientModule` and `DocsAdminHttpApiClientModule` were missing the dependency on `DocsCommonHttpApiClientModule`, which registers `IProjectAppService` (and related services) in the DI container. As a result, when `IndexModel` attempted to resolve `IProjectAppService` via constructor injection, Autofac could not find a registered implementation.

## Changes

- Added `Volo.Docs.Common.HttpApi.Client` project reference to `Volo.Docs.HttpApi.Client.csproj`
- Added `Volo.Docs.Common.HttpApi.Client` project reference to `Volo.Docs.Admin.HttpApi.Client.csproj`
- Added `DependsOn(typeof(DocsCommonHttpApiClientModule))` to `DocsHttpApiClientModule`
- Added `DependsOn(typeof(DocsCommonHttpApiClientModule))` to `DocsAdminHttpApiClientModule`
