### PR TITLE
Use a per-connection in-memory SQLite database in unit tests

### DIFF
--- a/framework/src/Volo.Abp.EntityFrameworkCore.Sqlite/Volo/Abp/EntityFrameworkCore/Sqlite/AbpUnitTestSqliteDatabase.cs
+++ b/framework/src/Volo.Abp.EntityFrameworkCore.Sqlite/Volo/Abp/EntityFrameworkCore/Sqlite/AbpUnitTestSqliteDatabase.cs
@@ -1,0 +1,50 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Volo.Abp.EntityFrameworkCore.Sqlite;
+
+/// <summary>
+/// A named shared-cache in-memory SQLite database for unit tests. Each <see cref="DbContext"/> opens its
+/// own connection via <see cref="ConnectionString"/> rather than sharing one connection object, so they
+/// don't race registering EF's SQLite functions on the same handle. Dispose in OnApplicationShutdown.
+/// </summary>
+/// <remarks>
+/// Shared-cache SQLite has a single writer, so an independent write unit of work (<c>requiresNew</c>)
+/// nested inside an open transactional one deadlocks on the second connection. Disable such a side write
+/// in the test, or run it against SQL Server.
+/// </remarks>
+public sealed class AbpUnitTestSqliteDatabase : IDisposable
+{
+    public string ConnectionString { get; }
+
+    private readonly AbpUnitTestSqliteConnection _keepAliveConnection;
+
+    public AbpUnitTestSqliteDatabase()
+    {
+        ConnectionString = $"Data Source=AbpUnitTest_{Guid.NewGuid():N};Mode=Memory;Cache=Shared;Pooling=False";
+        _keepAliveConnection = new AbpUnitTestSqliteConnection(ConnectionString);
+        _keepAliveConnection.Open();
+    }
+
+    /// <summary>
+    /// Creates the schema for the given contexts (pass contexts built with <see cref="ConnectionString"/>).
+    /// The passed contexts are disposed after their tables are created.
+    /// </summary>
+    public void CreateTables(params DbContext[] dbContexts)
+    {
+        foreach (var dbContext in dbContexts)
+        {
+            using (dbContext)
+            {
+                dbContext.GetService<IRelationalDatabaseCreator>().CreateTables();
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        _keepAliveConnection.Dispose();
+    }
+}

--- a/framework/test/Volo.Abp.Auditing.Tests/Volo/Abp/Auditing/AbpAuditingTestModule.cs
+++ b/framework/test/Volo.Abp.Auditing.Tests/Volo/Abp/Auditing/AbpAuditingTestModule.cs
@@ -1,8 +1,7 @@
-﻿using Microsoft.Data.Sqlite;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Storage;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Volo.Abp;
+using Volo.Abp.Data;
 using Volo.Abp.Auditing.App.Entities;
 using Volo.Abp.Auditing.App.EntityFrameworkCore;
 using Volo.Abp.Autofac;
@@ -19,6 +18,8 @@ namespace Volo.Abp.Auditing;
 )]
 public class AbpAuditingTestModule : AbpModule
 {
+    private AbpUnitTestSqliteDatabase _database;
+
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
         context.Services.AddAbpDbContext<AbpAuditingTestDbContext>(options =>
@@ -30,13 +31,20 @@ public class AbpAuditingTestModule : AbpModule
             });
         });
 
-        var sqliteConnection = CreateDatabaseAndGetConnection();
+        _database = new AbpUnitTestSqliteDatabase();
+        _database.CreateTables(
+            new AbpAuditingTestDbContext(new DbContextOptionsBuilder<AbpAuditingTestDbContext>().UseSqlite(_database.ConnectionString).AddAbpDbContextOptionsExtension().Options));
+
+        Configure<AbpDbConnectionOptions>(options =>
+        {
+            options.ConnectionStrings.Default = _database.ConnectionString;
+        });
 
         Configure<AbpDbContextOptions>(options =>
         {
             options.Configure(abpDbContextConfigurationContext =>
             {
-                abpDbContextConfigurationContext.DbContextOptions.UseSqlite(sqliteConnection);
+                abpDbContextConfigurationContext.UseSqlite();
             });
         });
 
@@ -67,17 +75,9 @@ public class AbpAuditingTestModule : AbpModule
         context.Services.AddType<Auditing_Tests.MyAuditedObject1>();
     }
 
-    private static SqliteConnection CreateDatabaseAndGetConnection()
+    public override void OnApplicationShutdown(ApplicationShutdownContext context)
     {
-        var connection = new AbpUnitTestSqliteConnection("Data Source=:memory:");
-        connection.Open();
-
-        using (var context = new AbpAuditingTestDbContext(new DbContextOptionsBuilder<AbpAuditingTestDbContext>()
-            .UseSqlite(connection).AddAbpDbContextOptionsExtension().Options))
-        {
-            context.GetService<IRelationalDatabaseCreator>().CreateTables();
-        }
-
-        return connection;
+        _database?.Dispose();
     }
+
 }

--- a/framework/test/Volo.Abp.EntityFrameworkCore.Tests/Volo/Abp/EntityFrameworkCore/AbpEntityFrameworkCoreTestModule.cs
+++ b/framework/test/Volo.Abp.EntityFrameworkCore.Tests/Volo/Abp/EntityFrameworkCore/AbpEntityFrameworkCoreTestModule.cs
@@ -1,11 +1,11 @@
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using Volo.Abp.Autofac;
+using Volo.Abp.Data;
 using Volo.Abp.Domain.Repositories;
 using Volo.Abp.EntityFrameworkCore.Domain;
 using Volo.Abp.EntityFrameworkCore.Sqlite;
@@ -27,6 +27,8 @@ namespace Volo.Abp.EntityFrameworkCore;
 [DependsOn(typeof(AbpEfCoreTestSecondContextModule))]
 public class AbpEntityFrameworkCoreTestModule : AbpModule
 {
+    private AbpUnitTestSqliteDatabase _database;
+
     public override void PreConfigureServices(ServiceConfigurationContext context)
     {
         TestEntityExtensionConfigurator.Configure();
@@ -77,15 +79,26 @@ public class AbpEntityFrameworkCoreTestModule : AbpModule
             options.AddDefaultRepositories(true);
         });
 
-        var sqliteConnection = CreateDatabaseAndGetConnection();
+        _database = new AbpUnitTestSqliteDatabase();
+        CreateTables();
+
+        Configure<AbpDbConnectionOptions>(options =>
+        {
+            options.ConnectionStrings.Default = _database.ConnectionString;
+        });
 
         Configure<AbpDbContextOptions>(options =>
         {
             options.Configure(abpDbContextConfigurationContext =>
             {
-                abpDbContextConfigurationContext.DbContextOptions.UseSqlite(sqliteConnection).AddAbpDbContextOptionsExtension();
+                abpDbContextConfigurationContext.UseSqlite().AddAbpDbContextOptionsExtension();
             });
         });
+    }
+
+    public override void OnApplicationShutdown(ApplicationShutdownContext context)
+    {
+        _database?.Dispose();
     }
 
     public override void OnPreApplicationInitialization(ApplicationInitializationContext context)
@@ -106,19 +119,14 @@ public class AbpEntityFrameworkCoreTestModule : AbpModule
         }
     }
 
-    private static SqliteConnection CreateDatabaseAndGetConnection()
+    private void CreateTables()
     {
-        var connection = new AbpUnitTestSqliteConnection("Data Source=:memory:");
-        connection.Open();
-
-        using (var context = new TestMigrationsDbContext(new DbContextOptionsBuilder<TestMigrationsDbContext>().UseSqlite(connection).AddAbpDbContextOptionsExtension().Options))
+        using (var context = new TestMigrationsDbContext(new DbContextOptionsBuilder<TestMigrationsDbContext>().UseSqlite(_database.ConnectionString).AddAbpDbContextOptionsExtension().Options))
         {
             context.GetService<IRelationalDatabaseCreator>().CreateTables();
             context.Database.ExecuteSqlRaw(
-                @"CREATE VIEW View_PersonView AS 
+                @"CREATE VIEW View_PersonView AS
                       SELECT Name, CreationTime, Birthday, LastActive FROM People");
         }
-
-        return connection;
     }
 }

--- a/framework/test/Volo.Abp.EntityFrameworkCore.Tests/Volo/Abp/EntityFrameworkCore/Sqlite/AbpUnitTestSqliteDatabase_Tests.cs
+++ b/framework/test/Volo.Abp.EntityFrameworkCore.Tests/Volo/Abp/EntityFrameworkCore/Sqlite/AbpUnitTestSqliteDatabase_Tests.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Volo.Abp.Domain.Repositories;
+using Volo.Abp.EntityFrameworkCore.Sqlite;
+using Volo.Abp.EntityFrameworkCore.TestApp.SecondContext;
+using Volo.Abp.TestApp.Domain;
+using Volo.Abp.TestApp.EntityFrameworkCore;
+using Volo.Abp.TestApp.Testing;
+using Volo.Abp.Uow;
+using Xunit;
+
+namespace Volo.Abp.EntityFrameworkCore.Sqlite;
+
+public class AbpUnitTestSqliteDatabase_Tests : TestAppTestBase<AbpEntityFrameworkCoreTestModule>
+{
+    [Fact]
+    public async Task Non_Transactional_DbContexts_Should_Use_Separate_Connections_To_The_Same_Database()
+    {
+        DbConnection firstConnection = null;
+        DbConnection secondConnection = null;
+
+        await WithUnitOfWorkAsync(new AbpUnitOfWorkOptions { IsTransactional = false }, async () =>
+        {
+            firstConnection = (await GetTestAppDbContextAsync()).Database.GetDbConnection();
+        });
+
+        await WithUnitOfWorkAsync(new AbpUnitOfWorkOptions { IsTransactional = false }, async () =>
+        {
+            secondConnection = (await GetTestAppDbContextAsync()).Database.GetDbConnection();
+        });
+
+        firstConnection.ShouldNotBeSameAs(secondConnection);
+        firstConnection.ConnectionString.ShouldBe(secondConnection.ConnectionString);
+    }
+
+    [Fact]
+    public async Task Transactional_Uow_Should_Share_One_Connection_And_Transaction_Across_DbContexts()
+    {
+        await WithUnitOfWorkAsync(new AbpUnitOfWorkOptions { IsTransactional = true }, async () =>
+        {
+            var firstDbContext = await GetTestAppDbContextAsync();
+            var secondDbContext = await ServiceProvider
+                .GetRequiredService<IDbContextProvider<SecondDbContext>>()
+                .GetDbContextAsync();
+
+            firstDbContext.Database.GetDbConnection().ShouldBeSameAs(secondDbContext.Database.GetDbConnection());
+
+            firstDbContext.Database.CurrentTransaction.ShouldNotBeNull();
+            secondDbContext.Database.CurrentTransaction.ShouldNotBeNull();
+            firstDbContext.Database.CurrentTransaction.GetDbTransaction()
+                .ShouldBeSameAs(secondDbContext.Database.CurrentTransaction.GetDbTransaction());
+        });
+    }
+
+    [Fact]
+    public async Task Concurrent_DbContext_Initialization_Should_Not_Race_On_Sqlite_Function_Registration()
+    {
+        var tasks = new List<Task>();
+
+        for (var i = 0; i < 12; i++)
+        {
+            tasks.Add(Task.Run(async () =>
+            {
+                for (var round = 0; round < 20; round++)
+                {
+                    await WithUnitOfWorkAsync(new AbpUnitOfWorkOptions { IsTransactional = false }, async () =>
+                    {
+                        var repository = ServiceProvider.GetRequiredService<IReadOnlyRepository<Person, Guid>>();
+                        await repository.GetListAsync();
+                    });
+                }
+            }));
+        }
+
+        // A shared connection object would throw "unable to delete/modify user-function due to active statements".
+        await Task.WhenAll(tasks);
+    }
+
+    [Fact]
+    public void Named_Database_Should_Live_And_Die_With_The_Keeper_Connection()
+    {
+        var database = new AbpUnitTestSqliteDatabase();
+        var connectionString = database.ConnectionString;
+
+        connectionString.ShouldContain("Mode=Memory");
+        connectionString.ShouldContain("Cache=Shared");
+
+        using (var writer = new AbpUnitTestSqliteConnection(connectionString))
+        {
+            writer.Open();
+            using var command = writer.CreateCommand();
+            command.CommandText = "CREATE TABLE KeeperProbe (Id INTEGER PRIMARY KEY);";
+            command.ExecuteNonQuery();
+        }
+
+        using (var reader = new AbpUnitTestSqliteConnection(connectionString))
+        {
+            reader.Open();
+            using var command = reader.CreateCommand();
+            command.CommandText = "SELECT COUNT(*) FROM KeeperProbe;";
+            Convert.ToInt64(command.ExecuteScalar()).ShouldBe(0L);
+        }
+
+        database.Dispose();
+
+        using (var afterDispose = new AbpUnitTestSqliteConnection(connectionString))
+        {
+            afterDispose.Open();
+            using var command = afterDispose.CreateCommand();
+            command.CommandText = "SELECT COUNT(*) FROM KeeperProbe;";
+            Should.Throw<SqliteException>(() => command.ExecuteScalar());
+        }
+    }
+
+    private async Task<TestAppDbContext> GetTestAppDbContextAsync()
+    {
+        return await ServiceProvider
+            .GetRequiredService<IDbContextProvider<TestAppDbContext>>()
+            .GetDbContextAsync();
+    }
+}

--- a/modules/account/test/Volo.Abp.Account.Application.Tests/Volo/Abp/Account/AbpAccountApplicationTestModule.cs
+++ b/modules/account/test/Volo.Abp.Account.Application.Tests/Volo/Abp/Account/AbpAccountApplicationTestModule.cs
@@ -1,8 +1,6 @@
-﻿using Microsoft.Data.Sqlite;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Storage;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Volo.Abp;
 using Volo.Abp.Authorization;
 using Volo.Abp.Autofac;
 using Volo.Abp.Data;
@@ -28,35 +26,34 @@ namespace Volo.Abp.Account;
 )]
 public class AbpAccountApplicationTestModule : AbpModule
 {
+    private AbpUnitTestSqliteDatabase _database;
+
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
         context.Services.AddAlwaysAllowAuthorization();
 
-        var sqliteConnection = CreateDatabaseAndGetConnection();
+        _database = new AbpUnitTestSqliteDatabase();
+        _database.CreateTables(
+            new IdentityDbContext(new DbContextOptionsBuilder<IdentityDbContext>().UseSqlite(_database.ConnectionString).Options),
+            new PermissionManagementDbContext(new DbContextOptionsBuilder<PermissionManagementDbContext>().UseSqlite(_database.ConnectionString).Options));
+
+        Configure<AbpDbConnectionOptions>(options =>
+        {
+            options.ConnectionStrings.Default = _database.ConnectionString;
+        });
 
         Configure<AbpDbContextOptions>(options =>
         {
             options.Configure(abpDbContextConfigurationContext =>
             {
-                abpDbContextConfigurationContext.DbContextOptions.UseSqlite(sqliteConnection);
+                abpDbContextConfigurationContext.UseSqlite();
             });
         });
     }
-    private static SqliteConnection CreateDatabaseAndGetConnection()
+
+    public override void OnApplicationShutdown(ApplicationShutdownContext context)
     {
-        var connection = new AbpUnitTestSqliteConnection("Data Source=:memory:");
-        connection.Open();
-
-        new IdentityDbContext(
-            new DbContextOptionsBuilder<IdentityDbContext>().UseSqlite(connection).Options
-        ).GetService<IRelationalDatabaseCreator>().CreateTables();
-
-        new PermissionManagementDbContext(
-            new DbContextOptionsBuilder<PermissionManagementDbContext>().UseSqlite(connection).Options
-        ).GetService<IRelationalDatabaseCreator>().CreateTables();
-
-
-        return connection;
+        _database?.Dispose();
     }
 
     public override void OnApplicationInitialization(ApplicationInitializationContext context)

--- a/modules/audit-logging/test/Volo.Abp.AuditLogging.EntityFrameworkCore.Tests/Volo/Abp/AuditLogging/EntityFrameworkCore/AbpAuditLoggingEntityFrameworkCoreTestModule.cs
+++ b/modules/audit-logging/test/Volo.Abp.AuditLogging.EntityFrameworkCore.Tests/Volo/Abp/AuditLogging/EntityFrameworkCore/AbpAuditLoggingEntityFrameworkCoreTestModule.cs
@@ -1,8 +1,6 @@
-﻿using Microsoft.Data.Sqlite;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Storage;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Volo.Abp.Data;
 using Volo.Abp.EntityFrameworkCore;
 using Volo.Abp.EntityFrameworkCore.Sqlite;
 using Volo.Abp.Modularity;
@@ -16,6 +14,8 @@ namespace Volo.Abp.AuditLogging.EntityFrameworkCore;
 )]
 public class AbpAuditLoggingEntityFrameworkCoreTestModule : AbpModule
 {
+    private AbpUnitTestSqliteDatabase _database;
+
     public override void PreConfigureServices(ServiceConfigurationContext context)
     {
         PreConfigure<AbpSqliteOptions>(x => x.BusyTimeout = null);
@@ -23,26 +23,27 @@ public class AbpAuditLoggingEntityFrameworkCoreTestModule : AbpModule
 
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        var sqliteConnection = CreateDatabaseAndGetConnection();
+        _database = new AbpUnitTestSqliteDatabase();
+        _database.CreateTables(
+            new AbpAuditLoggingDbContext(new DbContextOptionsBuilder<AbpAuditLoggingDbContext>().UseSqlite(_database.ConnectionString).Options));
+
+        Configure<AbpDbConnectionOptions>(options =>
+        {
+            options.ConnectionStrings.Default = _database.ConnectionString;
+        });
 
         Configure<AbpDbContextOptions>(options =>
         {
             options.Configure(ctx =>
             {
-                ctx.DbContextOptions.UseSqlite(sqliteConnection);
+                ctx.UseSqlite();
             });
         });
     }
 
-    private static SqliteConnection CreateDatabaseAndGetConnection()
+    public override void OnApplicationShutdown(ApplicationShutdownContext context)
     {
-        var connection = new AbpUnitTestSqliteConnection("Data Source=:memory:");
-        connection.Open();
-
-        new AbpAuditLoggingDbContext(
-            new DbContextOptionsBuilder<AbpAuditLoggingDbContext>().UseSqlite(connection).Options
-        ).GetService<IRelationalDatabaseCreator>().CreateTables();
-
-        return connection;
+        _database?.Dispose();
     }
+
 }

--- a/modules/background-jobs/test/Volo.Abp.BackgroundJobs.EntityFrameworkCore.Tests/Volo/Abp/BackgroundJobs/EntityFrameworkCore/AbpBackgroundJobsEntityFrameworkCoreTestModule.cs
+++ b/modules/background-jobs/test/Volo.Abp.BackgroundJobs.EntityFrameworkCore.Tests/Volo/Abp/BackgroundJobs/EntityFrameworkCore/AbpBackgroundJobsEntityFrameworkCoreTestModule.cs
@@ -1,8 +1,6 @@
-﻿using Microsoft.Data.Sqlite;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Storage;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Volo.Abp.Data;
 using Volo.Abp.EntityFrameworkCore;
 using Volo.Abp.EntityFrameworkCore.Sqlite;
 using Volo.Abp.Modularity;
@@ -16,6 +14,8 @@ namespace Volo.Abp.BackgroundJobs.EntityFrameworkCore;
     )]
 public class AbpBackgroundJobsEntityFrameworkCoreTestModule : AbpModule
 {
+    private AbpUnitTestSqliteDatabase _database;
+
     public override void PreConfigureServices(ServiceConfigurationContext context)
     {
         PreConfigure<AbpSqliteOptions>(x => x.BusyTimeout = null);
@@ -23,26 +23,27 @@ public class AbpBackgroundJobsEntityFrameworkCoreTestModule : AbpModule
 
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        var sqliteConnection = CreateDatabaseAndGetConnection();
+        _database = new AbpUnitTestSqliteDatabase();
+        _database.CreateTables(
+            new BackgroundJobsDbContext(new DbContextOptionsBuilder<BackgroundJobsDbContext>().UseSqlite(_database.ConnectionString).Options));
+
+        Configure<AbpDbConnectionOptions>(options =>
+        {
+            options.ConnectionStrings.Default = _database.ConnectionString;
+        });
 
         Configure<AbpDbContextOptions>(options =>
         {
             options.Configure(abpDbContextConfigurationContext =>
             {
-                abpDbContextConfigurationContext.DbContextOptions.UseSqlite(sqliteConnection);
+                abpDbContextConfigurationContext.UseSqlite();
             });
         });
     }
 
-    private static SqliteConnection CreateDatabaseAndGetConnection()
+    public override void OnApplicationShutdown(ApplicationShutdownContext context)
     {
-        var connection = new AbpUnitTestSqliteConnection("Data Source=:memory:");
-        connection.Open();
-
-        new BackgroundJobsDbContext(
-            new DbContextOptionsBuilder<BackgroundJobsDbContext>().UseSqlite(connection).Options
-        ).GetService<IRelationalDatabaseCreator>().CreateTables();
-
-        return connection;
+        _database?.Dispose();
     }
+
 }

--- a/modules/blob-storing-database/test/Volo.Abp.BlobStoring.Database.EntityFrameworkCore.Tests/EntityFrameworkCore/BlobStoringDatabaseEntityFrameworkCoreTestModule.cs
+++ b/modules/blob-storing-database/test/Volo.Abp.BlobStoring.Database.EntityFrameworkCore.Tests/EntityFrameworkCore/BlobStoringDatabaseEntityFrameworkCoreTestModule.cs
@@ -1,7 +1,5 @@
-﻿using Microsoft.Data.Sqlite;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Storage;
+﻿using Microsoft.EntityFrameworkCore;
+using Volo.Abp.Data;
 using Volo.Abp.EntityFrameworkCore.Sqlite;
 using Volo.Abp.EntityFrameworkCore;
 using Volo.Abp.Modularity;
@@ -15,6 +13,8 @@ namespace Volo.Abp.BlobStoring.Database.EntityFrameworkCore;
     )]
 public class BlobStoringDatabaseEntityFrameworkCoreTestModule : AbpModule
 {
+    private AbpUnitTestSqliteDatabase _database;
+
     public override void PreConfigureServices(ServiceConfigurationContext context)
     {
         PreConfigure<AbpSqliteOptions>(x => x.BusyTimeout = null);
@@ -22,26 +22,27 @@ public class BlobStoringDatabaseEntityFrameworkCoreTestModule : AbpModule
 
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        var sqliteConnection = CreateDatabaseAndGetConnection();
+        _database = new AbpUnitTestSqliteDatabase();
+        _database.CreateTables(
+            new BlobStoringDbContext(new DbContextOptionsBuilder<BlobStoringDbContext>().UseSqlite(_database.ConnectionString).Options));
+
+        Configure<AbpDbConnectionOptions>(options =>
+        {
+            options.ConnectionStrings.Default = _database.ConnectionString;
+        });
 
         Configure<AbpDbContextOptions>(options =>
         {
             options.Configure(abpDbContextConfigurationContext =>
             {
-                abpDbContextConfigurationContext.DbContextOptions.UseSqlite(sqliteConnection);
+                abpDbContextConfigurationContext.UseSqlite();
             });
         });
     }
 
-    private static SqliteConnection CreateDatabaseAndGetConnection()
+    public override void OnApplicationShutdown(ApplicationShutdownContext context)
     {
-        var connection = new AbpUnitTestSqliteConnection("Data Source=:memory:");
-        connection.Open();
-
-        new BlobStoringDbContext(
-            new DbContextOptionsBuilder<BlobStoringDbContext>().UseSqlite(connection).Options
-        ).GetService<IRelationalDatabaseCreator>().CreateTables();
-
-        return connection;
+        _database?.Dispose();
     }
+
 }

--- a/modules/blogging/test/Volo.Blogging.EntityFrameworkCore.Tests/Volo/Blogging/EntityFrameworkCore/BloggingEntityFrameworkCoreTestModule.cs
+++ b/modules/blogging/test/Volo.Blogging.EntityFrameworkCore.Tests/Volo/Blogging/EntityFrameworkCore/BloggingEntityFrameworkCoreTestModule.cs
@@ -1,8 +1,6 @@
-﻿using Microsoft.Data.Sqlite;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Storage;
+﻿using Microsoft.EntityFrameworkCore;
 using Volo.Abp;
+using Volo.Abp.Data;
 using Volo.Abp.EntityFrameworkCore;
 using Volo.Abp.EntityFrameworkCore.Sqlite;
 using Volo.Abp.Modularity;
@@ -16,7 +14,7 @@ namespace Volo.Blogging.EntityFrameworkCore
     )]
     public class BloggingEntityFrameworkCoreTestModule : AbpModule
     {
-        private SqliteConnection _sqliteConnection;
+        private AbpUnitTestSqliteDatabase _database;
 
         public override void PreConfigureServices(ServiceConfigurationContext context)
         {
@@ -25,34 +23,27 @@ namespace Volo.Blogging.EntityFrameworkCore
 
         public override void ConfigureServices(ServiceConfigurationContext context)
         {
-            _sqliteConnection = CreateDatabaseAndGetConnection();
+            _database = new AbpUnitTestSqliteDatabase();
+            _database.CreateTables(
+                new BloggingDbContext(new DbContextOptionsBuilder<BloggingDbContext>().UseSqlite(_database.ConnectionString).Options));
+
+            Configure<AbpDbConnectionOptions>(options =>
+            {
+                options.ConnectionStrings.Default = _database.ConnectionString;
+            });
 
             Configure<AbpDbContextOptions>(options =>
             {
                 options.Configure(abpDbContextConfigurationContext =>
                 {
-                    abpDbContextConfigurationContext.DbContextOptions.UseSqlite(_sqliteConnection);
+                    abpDbContextConfigurationContext.UseSqlite();
                 });
             });
         }
 
-        private static SqliteConnection CreateDatabaseAndGetConnection()
-        {
-            var connection = new AbpUnitTestSqliteConnection("Data Source=:memory:");
-            connection.Open();
-
-            var options = new DbContextOptionsBuilder<BloggingDbContext>().UseSqlite(connection).Options;
-            using (var context = new BloggingDbContext(options))
-            {
-                context.GetService<IRelationalDatabaseCreator>().CreateTables();
-            }
-
-            return connection;
-        }
-
         public override void OnApplicationShutdown(ApplicationShutdownContext context)
         {
-            _sqliteConnection.Dispose();
+            _database?.Dispose();
         }
     }
 }

--- a/modules/cms-kit/test/Volo.CmsKit.EntityFrameworkCore.Tests/EntityFrameworkCore/CmsKitEntityFrameworkCoreTestModule.cs
+++ b/modules/cms-kit/test/Volo.CmsKit.EntityFrameworkCore.Tests/EntityFrameworkCore/CmsKitEntityFrameworkCoreTestModule.cs
@@ -1,8 +1,6 @@
-﻿using Microsoft.Data.Sqlite;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Storage;
+﻿using Microsoft.EntityFrameworkCore;
 using Volo.Abp.Data;
+using Volo.Abp;
 using Volo.Abp.EntityFrameworkCore;
 using Volo.Abp.EntityFrameworkCore.Sqlite;
 using Volo.Abp.Modularity;
@@ -18,6 +16,8 @@ namespace Volo.CmsKit.EntityFrameworkCore;
     )]
 public class CmsKitEntityFrameworkCoreTestModule : AbpModule
 {
+    private AbpUnitTestSqliteDatabase _database;
+
     public override void PreConfigureServices(ServiceConfigurationContext context)
     {
         PreConfigure<AbpSqliteOptions>(x => x.BusyTimeout = null);
@@ -26,30 +26,28 @@ public class CmsKitEntityFrameworkCoreTestModule : AbpModule
 
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        var sqliteConnection = CreateDatabaseAndGetConnection();
+        _database = new AbpUnitTestSqliteDatabase();
+        _database.CreateTables(
+            new CmsKitDbContext(new DbContextOptionsBuilder<CmsKitDbContext>().UseSqlite(_database.ConnectionString).Options),
+            new SettingManagementDbContext(new DbContextOptionsBuilder<SettingManagementDbContext>().UseSqlite(_database.ConnectionString).Options));
+
+        Configure<AbpDbConnectionOptions>(options =>
+        {
+            options.ConnectionStrings.Default = _database.ConnectionString;
+        });
 
         Configure<AbpDbContextOptions>(options =>
         {
             options.Configure(abpDbContextConfigurationContext =>
             {
-                abpDbContextConfigurationContext.DbContextOptions.UseSqlite(sqliteConnection);
+                abpDbContextConfigurationContext.UseSqlite();
             });
         });
     }
 
-    private static SqliteConnection CreateDatabaseAndGetConnection()
+    public override void OnApplicationShutdown(ApplicationShutdownContext context)
     {
-        var connection = new AbpUnitTestSqliteConnection("Data Source=:memory:");
-        connection.Open();
-
-        new CmsKitDbContext(
-            new DbContextOptionsBuilder<CmsKitDbContext>().UseSqlite(connection).Options
-        ).GetService<IRelationalDatabaseCreator>().CreateTables();
-
-        new SettingManagementDbContext(
-            new DbContextOptionsBuilder<SettingManagementDbContext>().UseSqlite(connection).Options
-        ).GetService<IRelationalDatabaseCreator>().CreateTables();
-
-        return connection;
+        _database?.Dispose();
     }
+
 }

--- a/modules/docs/test/Volo.Docs.EntityFrameworkCore.Tests/Volo/Docs/EntityFrameworkCore/DocsEntityFrameworkCoreTestModule.cs
+++ b/modules/docs/test/Volo.Docs.EntityFrameworkCore.Tests/Volo/Docs/EntityFrameworkCore/DocsEntityFrameworkCoreTestModule.cs
@@ -1,7 +1,6 @@
-﻿using Microsoft.Data.Sqlite;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Storage;
+﻿using Microsoft.EntityFrameworkCore;
+using Volo.Abp;
+using Volo.Abp.Data;
 using Volo.Abp.EntityFrameworkCore;
 using Volo.Abp.EntityFrameworkCore.Sqlite;
 using Volo.Abp.Modularity;
@@ -15,6 +14,8 @@ namespace Volo.Docs.EntityFrameworkCore
         )]
     public class DocsEntityFrameworkCoreTestModule : AbpModule
     {
+        private AbpUnitTestSqliteDatabase _database;
+
         public override void PreConfigureServices(ServiceConfigurationContext context)
         {
             PreConfigure<AbpSqliteOptions>(x => x.BusyTimeout = null);
@@ -22,27 +23,28 @@ namespace Volo.Docs.EntityFrameworkCore
 
         public override void ConfigureServices(ServiceConfigurationContext context)
         {
-            var sqliteConnection = CreateDatabaseAndGetConnection();
+            _database = new AbpUnitTestSqliteDatabase();
+            _database.CreateTables(
+                new DocsDbContext(new DbContextOptionsBuilder<DocsDbContext>().UseSqlite(_database.ConnectionString).Options));
+
+            Configure<AbpDbConnectionOptions>(options =>
+            {
+                options.ConnectionStrings.Default = _database.ConnectionString;
+            });
 
             Configure<AbpDbContextOptions>(options =>
             {
                 options.Configure(abpDbContextConfigurationContext =>
                 {
-                    abpDbContextConfigurationContext.DbContextOptions.UseSqlite(sqliteConnection);
+                    abpDbContextConfigurationContext.UseSqlite();
                 });
             });
         }
-        
-        private static SqliteConnection CreateDatabaseAndGetConnection()
-        {
-            var connection = new AbpUnitTestSqliteConnection("Data Source=:memory:");
-            connection.Open();
 
-            new DocsDbContext(
-                new DbContextOptionsBuilder<DocsDbContext>().UseSqlite(connection).Options
-            ).GetService<IRelationalDatabaseCreator>().CreateTables();
-            
-            return connection;
+        public override void OnApplicationShutdown(ApplicationShutdownContext context)
+        {
+            _database?.Dispose();
         }
+
     }
 }

--- a/modules/feature-management/test/Volo.Abp.FeatureManagement.EntityFrameworkCore.Tests/Volo/Abp/FeatureManagement/EntityFrameworkCore/AbpFeatureManagementEntityFrameworkCoreTestModule.cs
+++ b/modules/feature-management/test/Volo.Abp.FeatureManagement.EntityFrameworkCore.Tests/Volo/Abp/FeatureManagement/EntityFrameworkCore/AbpFeatureManagementEntityFrameworkCoreTestModule.cs
@@ -1,9 +1,7 @@
 ﻿using System.Threading.Tasks;
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.DependencyInjection;
+using Volo.Abp.Data;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.EntityFrameworkCore;
 using Volo.Abp.EntityFrameworkCore.Sqlite;
@@ -20,6 +18,8 @@ namespace Volo.Abp.FeatureManagement.EntityFrameworkCore;
     )]
 public class AbpFeatureManagementEntityFrameworkCoreTestModule : AbpModule
 {
+    private AbpUnitTestSqliteDatabase _database;
+
     public override void PreConfigureServices(ServiceConfigurationContext context)
     {
         PreConfigure<AbpSqliteOptions>(x => x.BusyTimeout = null);
@@ -27,30 +27,31 @@ public class AbpFeatureManagementEntityFrameworkCoreTestModule : AbpModule
 
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        var sqliteConnection = CreateDatabaseAndGetConnection();
+        _database = new AbpUnitTestSqliteDatabase();
+        _database.CreateTables(
+            new FeatureManagementDbContext(new DbContextOptionsBuilder<FeatureManagementDbContext>().UseSqlite(_database.ConnectionString).Options));
+
+        Configure<AbpDbConnectionOptions>(options =>
+        {
+            options.ConnectionStrings.Default = _database.ConnectionString;
+        });
 
         Configure<AbpDbContextOptions>(options =>
         {
             options.Configure(abpDbContextConfigurationContext =>
             {
-                abpDbContextConfigurationContext.DbContextOptions.UseSqlite(sqliteConnection);
+                abpDbContextConfigurationContext.UseSqlite();
             });
         });
 
         context.Services.AddAlwaysDisableUnitOfWorkTransaction();
     }
 
-    private static SqliteConnection CreateDatabaseAndGetConnection()
+    public override void OnApplicationShutdown(ApplicationShutdownContext context)
     {
-        var connection = new AbpUnitTestSqliteConnection("Data Source=:memory:");
-        connection.Open();
-
-        new FeatureManagementDbContext(
-            new DbContextOptionsBuilder<FeatureManagementDbContext>().UseSqlite(connection).Options
-        ).GetService<IRelationalDatabaseCreator>().CreateTables();
-
-        return connection;
+        _database?.Dispose();
     }
+
 
     public override void OnApplicationInitialization(ApplicationInitializationContext context)
     {

--- a/modules/identity/test/Volo.Abp.Identity.EntityFrameworkCore.Tests/Volo/Abp/Identity/EntityFrameworkCore/AbpIdentityEntityFrameworkCoreTestModule.cs
+++ b/modules/identity/test/Volo.Abp.Identity.EntityFrameworkCore.Tests/Volo/Abp/Identity/EntityFrameworkCore/AbpIdentityEntityFrameworkCoreTestModule.cs
@@ -1,7 +1,5 @@
-﻿using Microsoft.Data.Sqlite;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Storage;
+﻿using Microsoft.EntityFrameworkCore;
+using Volo.Abp.Data;
 using Volo.Abp.EntityFrameworkCore;
 using Volo.Abp.EntityFrameworkCore.Sqlite;
 using Volo.Abp.Modularity;
@@ -18,6 +16,8 @@ namespace Volo.Abp.Identity.EntityFrameworkCore;
     )]
 public class AbpIdentityEntityFrameworkCoreTestModule : AbpModule
 {
+    private AbpUnitTestSqliteDatabase _database;
+
     public override void PreConfigureServices(ServiceConfigurationContext context)
     {
         PreConfigure<AbpSqliteOptions>(x => x.BusyTimeout = null);
@@ -25,32 +25,30 @@ public class AbpIdentityEntityFrameworkCoreTestModule : AbpModule
 
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        var sqliteConnection = CreateDatabaseAndGetConnection();
+        _database = new AbpUnitTestSqliteDatabase();
+        _database.CreateTables(
+            new IdentityDbContext(new DbContextOptionsBuilder<IdentityDbContext>().UseSqlite(_database.ConnectionString).Options),
+            new PermissionManagementDbContext(new DbContextOptionsBuilder<PermissionManagementDbContext>().UseSqlite(_database.ConnectionString).Options));
+
+        Configure<AbpDbConnectionOptions>(options =>
+        {
+            options.ConnectionStrings.Default = _database.ConnectionString;
+        });
 
         Configure<AbpDbContextOptions>(options =>
         {
             options.Configure(abpDbContextConfigurationContext =>
             {
-                abpDbContextConfigurationContext.DbContextOptions.UseSqlite(sqliteConnection);
+                abpDbContextConfigurationContext.UseSqlite();
             });
         });
 
         context.Services.AddAlwaysDisableUnitOfWorkTransaction();
     }
 
-    private static SqliteConnection CreateDatabaseAndGetConnection()
+    public override void OnApplicationShutdown(ApplicationShutdownContext context)
     {
-        var connection = new AbpUnitTestSqliteConnection("Data Source=:memory:");
-        connection.Open();
-
-        new IdentityDbContext(
-            new DbContextOptionsBuilder<IdentityDbContext>().UseSqlite(connection).Options
-        ).GetService<IRelationalDatabaseCreator>().CreateTables();
-
-        new PermissionManagementDbContext(
-            new DbContextOptionsBuilder<PermissionManagementDbContext>().UseSqlite(connection).Options
-        ).GetService<IRelationalDatabaseCreator>().CreateTables();
-
-        return connection;
+        _database?.Dispose();
     }
+
 }

--- a/modules/identityserver/test/Volo.Abp.IdentityServer.EntityFrameworkCore.Tests/Volo/Abp/IdentityServer/AbpIdentityServerTestEntityFrameworkCoreModule.cs
+++ b/modules/identityserver/test/Volo.Abp.IdentityServer.EntityFrameworkCore.Tests/Volo/Abp/IdentityServer/AbpIdentityServerTestEntityFrameworkCoreModule.cs
@@ -1,8 +1,7 @@
-using Microsoft.Data.Sqlite;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Storage;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Volo.Abp;
+using Volo.Abp.Data;
 using Volo.Abp.EntityFrameworkCore;
 using Volo.Abp.EntityFrameworkCore.Sqlite;
 using Volo.Abp.Identity.EntityFrameworkCore;
@@ -23,38 +22,35 @@ namespace Volo.Abp.IdentityServer;
     )]
 public class AbpIdentityServerTestEntityFrameworkCoreModule : AbpModule
 {
+    private AbpUnitTestSqliteDatabase _database;
+
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        var sqliteConnection = CreateDatabaseAndGetConnection();
+        _database = new AbpUnitTestSqliteDatabase();
+        _database.CreateTables(
+            new IdentityDbContext(new DbContextOptionsBuilder<IdentityDbContext>().UseSqlite(_database.ConnectionString).Options),
+            new IdentityServerDbContext(new DbContextOptionsBuilder<IdentityServerDbContext>().UseSqlite(_database.ConnectionString).Options),
+            new PermissionManagementDbContext(new DbContextOptionsBuilder<PermissionManagementDbContext>().UseSqlite(_database.ConnectionString).Options));
+
+        Configure<AbpDbConnectionOptions>(options =>
+        {
+            options.ConnectionStrings.Default = _database.ConnectionString;
+        });
 
         Configure<AbpDbContextOptions>(options =>
         {
             options.Configure(abpDbContextConfigurationContext =>
             {
-                abpDbContextConfigurationContext.DbContextOptions.UseSqlite(sqliteConnection);
+                abpDbContextConfigurationContext.UseSqlite();
             });
         });
 
         context.Services.AddAlwaysDisableUnitOfWorkTransaction();
     }
 
-    private static SqliteConnection CreateDatabaseAndGetConnection()
+    public override void OnApplicationShutdown(ApplicationShutdownContext context)
     {
-        var connection = new AbpUnitTestSqliteConnection("Data Source=:memory:");
-        connection.Open();
-
-        new IdentityDbContext(
-            new DbContextOptionsBuilder<IdentityDbContext>().UseSqlite(connection).Options
-        ).GetService<IRelationalDatabaseCreator>().CreateTables();
-
-        new IdentityServerDbContext(
-            new DbContextOptionsBuilder<IdentityServerDbContext>().UseSqlite(connection).Options
-        ).GetService<IRelationalDatabaseCreator>().CreateTables();
-
-        new PermissionManagementDbContext(
-            new DbContextOptionsBuilder<PermissionManagementDbContext>().UseSqlite(connection).Options
-        ).GetService<IRelationalDatabaseCreator>().CreateTables();
-
-        return connection;
+        _database?.Dispose();
     }
+
 }

--- a/modules/openiddict/test/Volo.Abp.OpenIddict.EntityFrameworkCore.Tests/Volo/Abp/OpenIddict/EntityFrameworkCore/OpenIddictEntityFrameworkCoreTestModule.cs
+++ b/modules/openiddict/test/Volo.Abp.OpenIddict.EntityFrameworkCore.Tests/Volo/Abp/OpenIddict/EntityFrameworkCore/OpenIddictEntityFrameworkCoreTestModule.cs
@@ -1,7 +1,5 @@
-﻿using Microsoft.Data.Sqlite;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Storage;
+﻿using Microsoft.EntityFrameworkCore;
+using Volo.Abp.Data;
 using Volo.Abp.EntityFrameworkCore;
 using Volo.Abp.EntityFrameworkCore.Sqlite;
 using Volo.Abp.Identity.EntityFrameworkCore;
@@ -20,6 +18,8 @@ namespace Volo.Abp.OpenIddict.EntityFrameworkCore;
     )]
 public class OpenIddictEntityFrameworkCoreTestModule : AbpModule
 {
+    private AbpUnitTestSqliteDatabase _database;
+
     public override void PreConfigureServices(ServiceConfigurationContext context)
     {
         PreConfigure<AbpSqliteOptions>(x => x.BusyTimeout = null);
@@ -27,36 +27,31 @@ public class OpenIddictEntityFrameworkCoreTestModule : AbpModule
 
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        var sqliteConnection = CreateDatabaseAndGetConnection();
+        _database = new AbpUnitTestSqliteDatabase();
+        _database.CreateTables(
+            new IdentityDbContext(new DbContextOptionsBuilder<IdentityDbContext>().UseSqlite(_database.ConnectionString).Options),
+            new OpenIddictDbContext(new DbContextOptionsBuilder<OpenIddictDbContext>().UseSqlite(_database.ConnectionString).Options),
+            new PermissionManagementDbContext(new DbContextOptionsBuilder<PermissionManagementDbContext>().UseSqlite(_database.ConnectionString).Options));
+
+        Configure<AbpDbConnectionOptions>(options =>
+        {
+            options.ConnectionStrings.Default = _database.ConnectionString;
+        });
 
         Configure<AbpDbContextOptions>(options =>
         {
             options.Configure(abpDbContextConfigurationContext =>
             {
-                abpDbContextConfigurationContext.DbContextOptions.UseSqlite(sqliteConnection);
+                abpDbContextConfigurationContext.UseSqlite();
             });
         });
 
         context.Services.AddAlwaysDisableUnitOfWorkTransaction();
     }
 
-    private static SqliteConnection CreateDatabaseAndGetConnection()
+    public override void OnApplicationShutdown(ApplicationShutdownContext context)
     {
-        var connection = new AbpUnitTestSqliteConnection("Data Source=:memory:");
-        connection.Open();
-
-        new IdentityDbContext(
-            new DbContextOptionsBuilder<IdentityDbContext>().UseSqlite(connection).Options
-        ).GetService<IRelationalDatabaseCreator>().CreateTables();
-
-        new OpenIddictDbContext(
-            new DbContextOptionsBuilder<OpenIddictDbContext>().UseSqlite(connection).Options
-        ).GetService<IRelationalDatabaseCreator>().CreateTables();
-
-        new PermissionManagementDbContext(
-            new DbContextOptionsBuilder<PermissionManagementDbContext>().UseSqlite(connection).Options
-        ).GetService<IRelationalDatabaseCreator>().CreateTables();
-
-        return connection;
+        _database?.Dispose();
     }
+
 }

--- a/modules/permission-management/test/Volo.Abp.PermissionManagement.EntityFrameworkCore.Tests/Volo/Abp/PermissionManagement/EntityFrameworkCore/AbpPermissionManagementEntityFrameworkCoreTestModule.cs
+++ b/modules/permission-management/test/Volo.Abp.PermissionManagement.EntityFrameworkCore.Tests/Volo/Abp/PermissionManagement/EntityFrameworkCore/AbpPermissionManagementEntityFrameworkCoreTestModule.cs
@@ -1,14 +1,12 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.DependencyInjection;
+using Volo.Abp.Data;
 using Volo.Abp.EntityFrameworkCore;
 using Volo.Abp.EntityFrameworkCore.Sqlite;
 using Volo.Abp.Modularity;
 using Volo.Abp.Threading;
 using Volo.Abp.Uow;
-using Microsoft.Data.Sqlite;
 using Volo.Abp.DependencyInjection;
 
 namespace Volo.Abp.PermissionManagement.EntityFrameworkCore;
@@ -25,15 +23,25 @@ public class AbpPermissionManagementEntityFrameworkCoreTestModule : AbpModule
         PreConfigure<AbpSqliteOptions>(x => x.BusyTimeout = null);
     }
 
+    private AbpUnitTestSqliteDatabase _database;
+
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        var sqliteConnection = CreateDatabaseAndGetConnection();
+        _database = new AbpUnitTestSqliteDatabase();
+        _database.CreateTables(
+            new PermissionManagementDbContext(
+                new DbContextOptionsBuilder<PermissionManagementDbContext>().UseSqlite(_database.ConnectionString).Options));
+
+        Configure<AbpDbConnectionOptions>(options =>
+        {
+            options.ConnectionStrings.Default = _database.ConnectionString;
+        });
 
         Configure<AbpDbContextOptions>(options =>
         {
             options.Configure(abpDbContextConfigurationContext =>
             {
-                abpDbContextConfigurationContext.DbContextOptions.UseSqlite(sqliteConnection);
+                abpDbContextConfigurationContext.UseSqlite();
             });
         });
 
@@ -45,16 +53,9 @@ public class AbpPermissionManagementEntityFrameworkCoreTestModule : AbpModule
         context.Services.AddAlwaysDisableUnitOfWorkTransaction();
     }
 
-    private static SqliteConnection CreateDatabaseAndGetConnection()
+    public override void OnApplicationShutdown(ApplicationShutdownContext context)
     {
-        var connection = new AbpUnitTestSqliteConnection("Data Source=:memory:");
-        connection.Open();
-
-        new PermissionManagementDbContext(
-            new DbContextOptionsBuilder<PermissionManagementDbContext>().UseSqlite(connection).Options
-        ).GetService<IRelationalDatabaseCreator>().CreateTables();
-
-        return connection;
+        _database?.Dispose();
     }
 
     public override void OnApplicationInitialization(ApplicationInitializationContext context)

--- a/modules/setting-management/test/Volo.Abp.SettingManagement.EntityFrameworkCore.Tests/Volo/Abp/SettingManagement/EntityFrameworkCore/AbpSettingManagementEntityFrameworkCoreTestModule.cs
+++ b/modules/setting-management/test/Volo.Abp.SettingManagement.EntityFrameworkCore.Tests/Volo/Abp/SettingManagement/EntityFrameworkCore/AbpSettingManagementEntityFrameworkCoreTestModule.cs
@@ -1,8 +1,6 @@
-﻿using Microsoft.Data.Sqlite;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Storage;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Volo.Abp.Data;
 using Volo.Abp.EntityFrameworkCore;
 using Volo.Abp.EntityFrameworkCore.Sqlite;
 using Volo.Abp.Modularity;
@@ -17,6 +15,8 @@ namespace Volo.Abp.SettingManagement.EntityFrameworkCore;
     )]
 public class AbpSettingManagementEntityFrameworkCoreTestModule : AbpModule
 {
+    private AbpUnitTestSqliteDatabase _database;
+
     public override void PreConfigureServices(ServiceConfigurationContext context)
     {
         PreConfigure<AbpSqliteOptions>(x => x.BusyTimeout = null);
@@ -24,27 +24,28 @@ public class AbpSettingManagementEntityFrameworkCoreTestModule : AbpModule
 
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        var sqliteConnection = CreateDatabaseAndGetConnection();
+        _database = new AbpUnitTestSqliteDatabase();
+        _database.CreateTables(
+            new SettingManagementDbContext(new DbContextOptionsBuilder<SettingManagementDbContext>().UseSqlite(_database.ConnectionString).Options));
+
+        Configure<AbpDbConnectionOptions>(options =>
+        {
+            options.ConnectionStrings.Default = _database.ConnectionString;
+        });
 
         Configure<AbpDbContextOptions>(options =>
         {
             options.Configure(abpDbContextConfigurationContext =>
             {
-                abpDbContextConfigurationContext.DbContextOptions.UseSqlite(sqliteConnection);
+                abpDbContextConfigurationContext.UseSqlite();
             });
         });
         context.Services.AddAlwaysDisableUnitOfWorkTransaction();
     }
 
-    private static SqliteConnection CreateDatabaseAndGetConnection()
+    public override void OnApplicationShutdown(ApplicationShutdownContext context)
     {
-        var connection = new AbpUnitTestSqliteConnection("Data Source=:memory:");
-        connection.Open();
-
-        new SettingManagementDbContext(
-            new DbContextOptionsBuilder<SettingManagementDbContext>().UseSqlite(connection).Options
-        ).GetService<IRelationalDatabaseCreator>().CreateTables();
-
-        return connection;
+        _database?.Dispose();
     }
+
 }

--- a/modules/tenant-management/test/Volo.Abp.TenantManagement.EntityFrameworkCore.Tests/Volo/Abp/TenantManagement/EntityFrameworkCore/AbpTenantManagementEntityFrameworkCoreTestModule.cs
+++ b/modules/tenant-management/test/Volo.Abp.TenantManagement.EntityFrameworkCore.Tests/Volo/Abp/TenantManagement/EntityFrameworkCore/AbpTenantManagementEntityFrameworkCoreTestModule.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Storage;
+using Volo.Abp.Data;
 using Volo.Abp.EntityFrameworkCore;
 using Volo.Abp.EntityFrameworkCore.Sqlite;
 using Volo.Abp.Modularity;
@@ -17,6 +15,8 @@ namespace Volo.Abp.TenantManagement.EntityFrameworkCore;
     )]
 public class AbpTenantManagementEntityFrameworkCoreTestModule : AbpModule
 {
+    private AbpUnitTestSqliteDatabase _database;
+
     public override void PreConfigureServices(ServiceConfigurationContext context)
     {
         PreConfigure<AbpSqliteOptions>(x => x.BusyTimeout = null);
@@ -24,13 +24,20 @@ public class AbpTenantManagementEntityFrameworkCoreTestModule : AbpModule
 
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        var sqliteConnection = CreateDatabaseAndGetConnection();
+        _database = new AbpUnitTestSqliteDatabase();
+        _database.CreateTables(
+            new TenantManagementDbContext(new DbContextOptionsBuilder<TenantManagementDbContext>().UseSqlite(_database.ConnectionString).Options));
+
+        Configure<AbpDbConnectionOptions>(options =>
+        {
+            options.ConnectionStrings.Default = _database.ConnectionString;
+        });
 
         Configure<AbpDbContextOptions>(options =>
         {
             options.Configure(abpDbContextConfigurationContext =>
             {
-                abpDbContextConfigurationContext.DbContextOptions.UseSqlite(sqliteConnection);
+                abpDbContextConfigurationContext.UseSqlite();
             });
         });
 
@@ -40,15 +47,9 @@ public class AbpTenantManagementEntityFrameworkCoreTestModule : AbpModule
             });
     }
 
-    private static SqliteConnection CreateDatabaseAndGetConnection()
+    public override void OnApplicationShutdown(ApplicationShutdownContext context)
     {
-        var connection = new AbpUnitTestSqliteConnection("Data Source=:memory:");
-        connection.Open();
-
-        new TenantManagementDbContext(
-            new DbContextOptionsBuilder<TenantManagementDbContext>().UseSqlite(connection).Options
-        ).GetService<IRelationalDatabaseCreator>().CreateTables();
-
-        return connection;
+        _database?.Dispose();
     }
+
 }

--- a/templates/app/aspnet-core/test/MyCompanyName.MyProjectName.EntityFrameworkCore.Tests/EntityFrameworkCore/MyProjectNameEntityFrameworkCoreTestModule.cs
+++ b/templates/app/aspnet-core/test/MyCompanyName.MyProjectName.EntityFrameworkCore.Tests/EntityFrameworkCore/MyProjectNameEntityFrameworkCoreTestModule.cs
@@ -1,9 +1,7 @@
-﻿using Microsoft.Data.Sqlite;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Storage;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Volo.Abp;
+using Volo.Abp.Data;
 using Volo.Abp.EntityFrameworkCore;
 using Volo.Abp.EntityFrameworkCore.Sqlite;
 using Volo.Abp.FeatureManagement;
@@ -21,7 +19,7 @@ namespace MyCompanyName.MyProjectName.EntityFrameworkCore;
     )]
 public class MyProjectNameEntityFrameworkCoreTestModule : AbpModule
 {
-    private SqliteConnection? _sqliteConnection;
+    private AbpUnitTestSqliteDatabase _database;
 
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
@@ -47,36 +45,27 @@ public class MyProjectNameEntityFrameworkCoreTestModule : AbpModule
 
     private void ConfigureInMemorySqlite(IServiceCollection services)
     {
-        _sqliteConnection = CreateDatabaseAndGetConnection();
+        _database = new AbpUnitTestSqliteDatabase();
+        _database.CreateTables(
+            new MyProjectNameDbContext(new DbContextOptionsBuilder<MyProjectNameDbContext>().UseSqlite(_database.ConnectionString).Options));
+
+        services.Configure<AbpDbConnectionOptions>(options =>
+        {
+            options.ConnectionStrings.Default = _database.ConnectionString;
+        });
 
         services.Configure<AbpDbContextOptions>(options =>
         {
             options.Configure(context =>
             {
-                context.DbContextOptions.UseSqlite(_sqliteConnection);
+                context.UseSqlite();
             });
         });
     }
 
     public override void OnApplicationShutdown(ApplicationShutdownContext context)
     {
-        _sqliteConnection?.Dispose();
+        _database?.Dispose();
     }
 
-    private static SqliteConnection CreateDatabaseAndGetConnection()
-    {
-        var connection = new AbpUnitTestSqliteConnection("Data Source=:memory:");
-        connection.Open();
-
-        var options = new DbContextOptionsBuilder<MyProjectNameDbContext>()
-            .UseSqlite(connection)
-            .Options;
-
-        using (var context = new MyProjectNameDbContext(options))
-        {
-            context.GetService<IRelationalDatabaseCreator>().CreateTables();
-        }
-
-        return connection;
-    }
 }

--- a/templates/module/aspnet-core/test/MyCompanyName.MyProjectName.EntityFrameworkCore.Tests/EntityFrameworkCore/MyProjectNameEntityFrameworkCoreTestModule.cs
+++ b/templates/module/aspnet-core/test/MyCompanyName.MyProjectName.EntityFrameworkCore.Tests/EntityFrameworkCore/MyProjectNameEntityFrameworkCoreTestModule.cs
@@ -1,7 +1,6 @@
-﻿using Microsoft.Data.Sqlite;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Storage;
+﻿using Microsoft.EntityFrameworkCore;
+using Volo.Abp;
+using Volo.Abp.Data;
 using Volo.Abp.EntityFrameworkCore;
 using Volo.Abp.EntityFrameworkCore.Sqlite;
 using Volo.Abp.Modularity;
@@ -16,30 +15,33 @@ namespace MyCompanyName.MyProjectName.EntityFrameworkCore;
 )]
 public class MyProjectNameEntityFrameworkCoreTestModule : AbpModule
 {
+    private AbpUnitTestSqliteDatabase _database;
+
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
         context.Services.AddAlwaysDisableUnitOfWorkTransaction();
 
-        var sqliteConnection = CreateDatabaseAndGetConnection();
+        _database = new AbpUnitTestSqliteDatabase();
+        _database.CreateTables(
+            new MyProjectNameDbContext(new DbContextOptionsBuilder<MyProjectNameDbContext>().UseSqlite(_database.ConnectionString).Options));
+
+        Configure<AbpDbConnectionOptions>(options =>
+        {
+            options.ConnectionStrings.Default = _database.ConnectionString;
+        });
 
         Configure<AbpDbContextOptions>(options =>
         {
             options.Configure(abpDbContextConfigurationContext =>
             {
-                abpDbContextConfigurationContext.DbContextOptions.UseSqlite(sqliteConnection);
+                abpDbContextConfigurationContext.UseSqlite();
             });
         });
     }
 
-    private static SqliteConnection CreateDatabaseAndGetConnection()
+    public override void OnApplicationShutdown(ApplicationShutdownContext context)
     {
-        var connection = new AbpUnitTestSqliteConnection("Data Source=:memory:");
-        connection.Open();
-
-        new MyProjectNameDbContext(
-            new DbContextOptionsBuilder<MyProjectNameDbContext>().UseSqlite(connection).Options
-        ).GetService<IRelationalDatabaseCreator>().CreateTables();
-
-        return connection;
+        _database?.Dispose();
     }
+
 }


### PR DESCRIPTION
In-memory SQLite tests shared one connection across `DbContext`s, which intermittently threw `unable to delete/modify user-function due to active statements` when EF registered its SQLite functions concurrently. The new `AbpUnitTestSqliteDatabase` gives each context its own connection to a named shared-cache database.