### PR TITLE
Upgrade vulnerable NuGet packages to patched versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -48,15 +48,15 @@
     <PackageVersion Include="Google.Cloud.Storage.V1" Version="4.13.0" />
     <PackageVersion Include="Hangfire.AspNetCore" Version="1.8.21" />
     <PackageVersion Include="Hangfire.SqlServer" Version="1.8.21" />
-    <PackageVersion Include="HtmlSanitizer" Version="9.0.886" />
+    <PackageVersion Include="HtmlSanitizer" Version="9.0.892" />
     <PackageVersion Include="Duende.IdentityModel" Version="7.1.0" />
     <PackageVersion Include="IdentityServer4" Version="4.1.2" />
     <PackageVersion Include="IdentityServer4.AspNetIdentity" Version="4.1.2" />
     <PackageVersion Include="JetBrains.Annotations" Version="2025.2.2" />
     <PackageVersion Include="LdapForNet" Version="2.7.15" />
     <PackageVersion Include="LibGit2Sharp" Version="0.31.0" />
-    <PackageVersion Include="Magick.NET-Q16-AnyCPU" Version="14.13.0" />
-    <PackageVersion Include="MailKit" Version="4.13.0" />
+    <PackageVersion Include="Magick.NET-Q16-AnyCPU" Version="14.15.0" />
+    <PackageVersion Include="MailKit" Version="4.17.0" />
     <PackageVersion Include="Markdig.Signed" Version="0.42.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.9" />
@@ -151,7 +151,7 @@
     <PackageVersion Include="Rebus" Version="8.8.0" />
     <PackageVersion Include="Rebus.ServiceProvider" Version="10.5.0" />
     <PackageVersion Include="Riok.Mapperly" Version="4.3.1" />
-    <PackageVersion Include="Scriban" Version="7.2.1" />
+    <PackageVersion Include="Scriban" Version="7.2.5" />
     <PackageVersion Include="Serilog" Version="4.3.0" />
     <PackageVersion Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageVersion Include="Serilog.Extensions.Hosting" Version="9.0.0" />

--- a/docs/en/package-version-changes.md
+++ b/docs/en/package-version-changes.md
@@ -11,6 +11,9 @@
 
 | Package | Old Version | New Version | PR |
 |---------|-------------|-------------|-----|
+| HtmlSanitizer | 9.0.886 | 9.0.892 | #25811 |
+| Magick.NET-Q16-AnyCPU | 14.13.0 | 14.15.0 | #25811 |
+| MailKit | 4.13.0 | 4.17.0 | #25811 |
 | Microsoft.AspNetCore.Authentication.JwtBearer | 10.0.7 | 10.0.9 | #25706 |
 | Microsoft.AspNetCore.Authentication.OpenIdConnect | 10.0.7 | 10.0.9 | #25706 |
 | Microsoft.AspNetCore.Authorization | 10.0.7 | 10.0.9 | #25706 |
@@ -65,6 +68,7 @@
 | Microsoft.IdentityModel.Protocols.OpenIdConnect | 8.16.0 | 8.19.1 | #25706 |
 | Microsoft.IdentityModel.Tokens | 8.16.0 | 8.19.1 | #25706 |
 | MongoDB.Driver | 3.9.0 | 3.10.0 | #25773 |
+| Scriban | 7.2.1 | 7.2.5 | #25811 |
 | System.Collections.Immutable | 10.0.7 | 10.0.9 | #25706 |
 | System.IdentityModel.Tokens.Jwt | 8.16.0 | 8.19.1 | #25706 |
 | System.Management | 10.0.7 | 10.0.9 | #25706 |


### PR DESCRIPTION
Resolve #25810

Bump `Magick.NET-Q16-AnyCPU`, `MailKit`, `Scriban` and `HtmlSanitizer` to versions that patch known vulnerabilities.