### PR TITLE
Update multi-lingual objects document

### DIFF
--- a/docs/en/docs-nav.json
+++ b/docs/en/docs-nav.json
@@ -551,10 +551,6 @@
               "path": "framework/fundamentals/localization.md"
             },
             {
-              "text": "Multi-Lingual Objects",
-              "path": "multi-lingual-entities.md"
-            },
-            {
               "text": "Logging",
               "path": "framework/fundamentals/logging.md"
             },

--- a/docs/en/framework/ui/angular/modifying-the-menu.md
+++ b/docs/en/framework/ui/angular/modifying-the-menu.md
@@ -16,7 +16,7 @@ The `logoUrl` property in the environment variables is the url of the logo.
 
 You can add your logo to `src/assets` folder and set the `logoUrl` as shown below:
 
-```js
+```ts
 export const environment = {
   // other configurations
   application: {
@@ -74,7 +74,7 @@ Add the following to your `src/styles.scss`:
 
 You can add routes to the menu by calling the `add` method of `RoutesService`. It is a singleton service, i.e. provided in root, so you can inject and use it immediately.
 
-```js
+```ts
 import { RoutesService, eLayoutType } from '@abp/ng.core';
 import { Component, inject } from '@angular/core';
 
@@ -106,7 +106,7 @@ export class AppComponent {
 
 An alternative and probably cleaner way is to use a route provider. First create a provider:
 
-```js
+```ts
 // route.provider.ts
 import { RoutesService, eLayoutType } from '@abp/ng.core';
 import { inject, provideAppInitializer } from '@angular/core';
@@ -142,7 +142,7 @@ function configureRoutes() {
 We can also define a group for navigation elements. It's an optional property
  - **Note:** It'll also include groups that were defined at the modules
 
-```js
+```ts
 // route.provider.ts
 import { RoutesService } from '@abp/ng.core';
 import { inject } from '@angular/core';
@@ -168,7 +168,7 @@ function configureRoutes() {
 To get the route items as grouped we can use the `groupedVisible` (or Observable one `groupedVisible$`)  getter methods
  - It returns `RouteGroup<T>[]` if there is any group in the route tree, otherwise it returns `undefined`
 
-```js
+```ts
 import { ABP, RoutesService, RouteGroup } from "@abp/ng.core";
 import { Component, inject } from "@angular/core";
 import { Observable } from "rxjs";
@@ -186,7 +186,7 @@ export class AppComponent {
 ...and then in app.config.ts...
  - The `groupedVisible` method will return the `Others` group for ungrouped items, the default key is `AbpUi::OthersGroup`, we can change this `key` via the `OTHERS_GROUP` injection token
 
-```js
+```ts
 import { OTHERS_GROUP } from '@abp/ng.core';
 import { APP_ROUTE_PROVIDER } from './route.provider';
 
@@ -240,7 +240,7 @@ You can define your routes by adding `routes` as a child property to `data` prop
 
 You can add the `routes` property like below:
 
-```js
+```ts
 {
   path: 'your-path',
   data: {
@@ -264,7 +264,7 @@ You can add the `routes` property like below:
 
 Alternatively, you can do this:
 
-```js
+```ts
 {
   path: 'your-path',
   data: {
@@ -298,7 +298,7 @@ After adding the `routes` property as described above, the navigation menu looks
 
 The `patch` method of `RoutesService` finds a route by its name and replaces its configuration with the new configuration passed as the second parameter. Similarly, `remove` method finds a route and removes it along with its children. Also you can use `removeByParam` method to delete the routes with given properties.
 
-```js
+```ts
 // this.routes is instance of RoutesService
 // eThemeSharedRouteNames enum can be imported from @abp/ng.theme.shared
 
@@ -344,7 +344,7 @@ After the operations above, the new menu looks like below:
 
 You can add elements to the right part of the menu by calling the `addItems` method of `NavItemsService`. It is a singleton service, i.e. provided in root, so you can inject and use it immediately.
 
-```js
+```ts
 import { NavItemsService } from '@abp/ng.theme.shared';
 import { Component, inject } from '@angular/core';
 
@@ -388,7 +388,7 @@ This inserts a search input and a sign out icon to the menu. The final UI looks 
 
 The `patchItem` method of `NavItemsService` finds an element by its `id` property and replaces its configuration with the new configuration passed as the second parameter. Similarly, `removeItem` method finds an element and removes it.
 
-```js
+```ts
 export class AppComponent {
   private navItems = inject(NavItemsService);
 

--- a/docs/en/multi-lingual-entities.md
+++ b/docs/en/multi-lingual-entities.md
@@ -7,17 +7,15 @@
 
 # Multi-Lingual Objects
 
-The `Volo.Abp.MultiLingualObject` package provides a contract and a selection service for objects that store one translation per language. Persistence mapping is application-specific; the package does not create a database relationship for the translations.
+> The `Volo.Abp.MultiLingualObject` package is **not published on NuGet**. It was removed from the release pipeline in [#8271](https://github.com/abpframework/abp/pull/8271) and re-designing this feature is tracked in [#11698](https://github.com/abpframework/abp/issues/11698). The source code is still maintained in the framework repository, so you can copy the [Volo.Abp.MultiLingualObjects](https://github.com/abpframework/abp/tree/dev/framework/src/Volo.Abp.MultiLingualObjects) project into your solution if you want to use the pattern described below.
 
-## Installation
+The `Volo.Abp.MultiLingualObjects` project provides a contract and a selection service for objects that store one translation per language. Persistence mapping is application-specific; it does not create a database relationship for the translations.
 
-Install the package in the project that defines the consuming module:
+## Getting the Code
 
-```bash
-abp add-package Volo.Abp.MultiLingualObject
-```
+Copy the [Volo.Abp.MultiLingualObjects](https://github.com/abpframework/abp/tree/dev/framework/src/Volo.Abp.MultiLingualObjects) project into your solution and reference it from the project that defines the consuming module.
 
-Add `AbpMultiLingualObjectsModule` as a dependency of that module when the package is installed manually:
+Add `AbpMultiLingualObjectsModule` as a dependency of that module:
 
 ````csharp
 using Volo.Abp.Modularity;


### PR DESCRIPTION
Explain that `Volo.Abp.MultiLingualObject` is not published on NuGet ([#8271](https://github.com/abpframework/abp/pull/8271), tracked in #11698), remove it from the docs navigation and replace the install step with copying the source project. Also mark TypeScript code blocks with `ts` in the Angular menu document.