### PR TITLE
Angular - Fixing the cookie language provider to set proper cookie path

### DIFF
--- a/npm/ng-packs/packages/core/src/lib/providers/cookie-language.provider.ts
+++ b/npm/ng-packs/packages/core/src/lib/providers/cookie-language.provider.ts
@@ -14,7 +14,7 @@ export function setLanguageToCookie() {
   const cookieLanguageKey = injector.get(COOKIE_LANGUAGE_KEY);
   sessionState.getLanguage$().subscribe(language => {
     const cookieValue = encodeURIComponent(`c=${language}|uic=${language}`);
-    document.cookie = `${cookieLanguageKey}=${cookieValue}`;
+    document.cookie = `${cookieLanguageKey}=${cookieValue}; path=/`;
   });
 }
 


### PR DESCRIPTION
### Description

Resolves #25858

<img width="1470" height="821" alt="Screenshot 2026-07-23 at 10 51 24" src="https://github.com/user-attachments/assets/4f1c64cb-b6fb-4d60-8543-945a917eb88c" />
<img width="1470" height="821" alt="Screenshot 2026-07-23 at 10 53 37" src="https://github.com/user-attachments/assets/43f3d91b-b78a-47eb-adf7-090f4d681a05" />


### Checklist

- [X] I fully tested it as developer / designer and created unit / integration tests
- [X] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

- You can switch to this branch for testing `test/issue-25858`
- Run this command `yarn copy-to:app` under `npm > ng-packs`
- Use this application for tests `templates > app`

### Verify the bug is fixed

1. Open DevTools → **Application** → **Cookies** → `http://localhost:4200`
2. Delete `.AspNetCore.Culture` if it exists
3. Change the UI language
4. Check `.AspNetCore.Culture`:
    - **Expected:** `Path=/`
    - **Wrong (old behavior):** `Path=/web`
5. Open DevTools → **Network**
6. Trigger an API call (refresh or open a page that loads data)
7. Select a request to `http://localhost:4200/api/...`
8. Inspect **Request Headers** → `Cookie`
    - **Expected:** includes `.AspNetCore.Culture=...`
    - **Wrong (old behavior):** `.AspNetCore.Culture` missing
