### PR TITLE
Document MCP integration configuration in ABP Studio

### DIFF
--- a/docs/en/Community-Articles/2026-06-18-deep-dive-5-mcp/post.md
+++ b/docs/en/Community-Articles/2026-06-18-deep-dive-5-mcp/post.md
@@ -100,26 +100,18 @@ MCP servers are configured under **Settings > MCP Servers**.
 
 When no server is connected, the page is intentionally simple. It is an empty list waiting for the first server. That is important because MCP should be explicit. If I have not connected a server, the agent should not behave as if it has access to that external system.
 
-![The MCP Servers page in ABP Studio, before any server is added](mcp-servers-empty.png)
-
-When I add a server, ABP Studio asks how it should connect.
+**Add integration** opens a curated gallery of common MCP servers. Each entry shows information such as whether it is official, read-only, authenticated by the provider, or runs a local command. If the integration has configurable values, ABP Studio opens a focused setup form and lets me update those values later. New integrations are disabled until I review and enable them.
 
 There are two main connection types:
 
 - **Stdio:** ABP Studio runs the MCP server as a local process. I provide the command, arguments, and environment variables the server needs.
 - **HTTP:** ABP Studio connects to an MCP server over the network. I provide the URL and any required headers.
 
-![Adding an MCP server: pick stdio or HTTP, then provide the command, arguments, and environment variables](add-mcp-server.png)
-
 This is useful because different MCP servers are packaged in different ways. Some are local command-line programs. Some are hosted services. Some need environment variables for tokens or configuration.
 
-In the example below, I am adding an HTTP MCP server named **SEO Analyzer**. It exposes a small set of SEO-related tools through a remote MCP endpoint.
+For integrations outside the gallery, **Edit JSON** opens the complete server collection as one `mcpServers` document. ABP Studio validates and applies the entire document together, so a server omitted from the document is removed. Environment-variable and HTTP-header secrets are stored separately and appear in the editor as `${secret:NAME}` placeholders.
 
-![Adding the SEO Analyzer MCP server over HTTP](add-seo-analyzer-mcp-server.png)
-
-ABP Studio does not require every server to be created manually from scratch. If I already use MCP elsewhere, I can import existing configuration from tools like Cursor, Claude, VS Code, Windsurf, or a plain MCP server JSON file. It can also export configuration in the standard `mcpServers` JSON shape.
-
-That matters because MCP is an open ecosystem. The same server definition can often move between tools. ABP Studio becomes another place where I can use that server, but now in the context of an ABP-aware agent.
+See [ABP Studio: AI Agent Configuration](../../studio/ai-agent-configuration.md#mcp-tool-connections) for the supported JSON fields and secret-storage behavior.
 
 ## What A Connected Server Shows
 

--- a/docs/en/studio/ai-agent-configuration.md
+++ b/docs/en/studio/ai-agent-configuration.md
@@ -104,20 +104,71 @@ Permission choices include allow once, allow always, and skip. "Allow always" pe
 
 ABP Studio can connect to user-configured Model Context Protocol (MCP) servers and expose their tools to Agent mode. This is an MCP client integration for the AI Agent. ABP Studio AI Agent does not expose itself as an MCP server for external AI clients.
 
-MCP server connections can be configured with:
+### Adding an Integration
+
+Open **Settings > MCP Servers** and select **Add integration** to browse the curated integration gallery. Integrations that require settings open a configuration form for values such as an optional Context7 API key, a Microsoft Learn response limit, or a local timezone. You can open the same form later to change or remove those values.
+
+New integrations are added disabled. Review the server and its tools before enabling it.
+
+MCP server connections use one of these transports:
 
 | Transport | Configuration |
 | --- | --- |
 | Stdio | Command, arguments, and environment variables. |
 | HTTP | URL and headers. |
 
-Studio imports MCP server configuration from Cursor, Claude, VS Code, Windsurf, and bare MCP server JSON formats. Studio exports MCP server configuration in the standard `mcpServers` JSON shape.
+### Editing the Complete JSON Configuration
+
+Select **Edit JSON** to edit the complete MCP server collection as one document. Studio validates and saves the collection together. Servers omitted from the document are removed, and an empty `mcpServers` object removes all servers.
+
+Studio writes the conventional `mcpServers` document shape:
+
+```json
+{
+  "mcpServers": {
+    "Context7": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@upstash/context7-mcp"
+      ]
+    },
+    "Microsoft Learn": {
+      "url": "https://learn.microsoft.com/api/mcp"
+    }
+  }
+}
+```
+
+The server name is the key under `mcpServers`. A stdio server requires `command` and can include `args` and `env`. An HTTP server requires `url` and can include `headers`. The JSON document does not contain server IDs or enabled state; enable or disable each server from the MCP Servers page.
+
+The editor accepts strict JSON and rejects unknown server properties or root metadata that Studio cannot preserve. New servers and servers whose command, arguments, or URL changed are saved disabled.
+
+### MCP Secrets
+
+Values entered under `env` or `headers` are stored separately from the AI Agent settings. When you reopen **Edit JSON**, an existing secret is represented by a placeholder such as:
+
+```json
+"CONTEXT7_API_KEY": "${secret:CONTEXT7_API_KEY}"
+```
+
+- Keep the placeholder unchanged to retain the stored value.
+- Replace it with a literal value to update the stored secret.
+- Remove the property to delete the stored secret.
+
+Do not create placeholders manually. A placeholder is valid only when it refers to an existing stored value for the same property. Command arguments and URLs are not secret fields and are saved as plain text; use stdio environment variables or HTTP headers for credentials.
+
+MCP secrets use the platform credential storage available to ABP Studio:
+
+| Platform | Storage |
+| --- | --- |
+| Windows | Windows Data Protection API (DPAPI), scoped to the current user. |
+| macOS | A generic password in Keychain under the `AbpStudio` service. |
+| Linux and secure-storage fallback | An encrypted file in the user's `.abp/studio` directory with owner-only read/write permissions. |
 
 Connected MCP servers show their connection status, tool count, tools, and resources. Individual MCP tools can be disabled. Disabled MCP tools are omitted from Agent mode. MCP resources can be opened from settings for inspection.
 
 MCP tools are added only for connected and enabled servers. Plan and Ask modes do not receive MCP tools.
-
-![mcp-servers-settings](./images/ai-agent/mcp-servers-settings.png)
 
 ## `.abpignore`
 


### PR DESCRIPTION
## What changed

- document the ABP Studio MCP integration gallery and focused configuration forms
- document editing the complete MCP server list as one JSON configuration
- describe the supported stdio and HTTP fields and replacement behavior
- explain secret placeholders and platform-specific secure storage
- update the MCP deep-dive community article to remove the old import/export workflow

## Why

ABP Studio now provides a simpler MCP configuration experience in which users can add common integrations through forms or edit the complete server list as JSON. The documentation needs to describe Studio-specific behavior, validation, and secret handling without teaching generic JSON syntax.

This is the documentation companion for [volosoft/abp-studio#5200](https://github.com/volosoft/abp-studio/pull/5200).

## Validation

- `git diff --check`
- parsed the documented JSON example with PowerShell `ConvertFrom-Json`
- verified the relative documentation link resolves
- verified stale import/export instructions and obsolete screenshot references were removed