### PR TITLE
Handle mud message alert and menu updates on the dispatcher

### DIFF
--- a/framework/src/Volo.Abp.MudBlazorUI/Components/UiMessageAlert.razor.cs
+++ b/framework/src/Volo.Abp.MudBlazorUI/Components/UiMessageAlert.razor.cs
@@ -88,13 +88,16 @@ public partial class UiMessageAlert : ComponentBase, IDisposable
 
     private async void OnMessageReceived(object? sender, UiMessageEventArgs e)
     {
-        MessageType = e.MessageType;
-        Message = e.Message;
-        Title = e.Title;
-        Options = e.Options;
-        Callback = e.Callback;
+        await InvokeAsync(async () =>
+        {
+            MessageType = e.MessageType;
+            Message = e.Message;
+            Title = e.Title;
+            Options = e.Options;
+            Callback = e.Callback;
 
-        await ShowMessageAlert();
+            await ShowMessageAlert();
+        });
     }
 
     protected virtual async Task ShowMessageAlert()

--- a/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.Web.MudBlazorBasicTheme/Themes/Basic/NavMenu.razor.cs
+++ b/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.Web.MudBlazorBasicTheme/Themes/Basic/NavMenu.razor.cs
@@ -27,7 +27,7 @@ public partial class NavMenu : IDisposable
         _ = InvokeAsync(async () =>
         {
             Menu = await MenuManager.GetMainMenuAsync();
-            StateHasChanged();
+            await InvokeAsync(StateHasChanged);
         });
     }
 

--- a/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.Web.MudBlazorBasicTheme/Themes/Basic/NavToolbar.razor
+++ b/modules/basic-theme/src/Volo.Abp.AspNetCore.Components.Web.MudBlazorBasicTheme/Themes/Basic/NavToolbar.razor
@@ -49,7 +49,7 @@
         _ = InvokeAsync(async () =>
         {
             await GetToolbarItemRendersAsync();
-            StateHasChanged();
+            await InvokeAsync(StateHasChanged);
         });
     }
 


### PR DESCRIPTION
`UiMessageAlert` now applies the received message and shows the dialog inside `InvokeAsync`, and the MudBlazor basic theme menu handlers no longer call `StateHasChanged` after an await has left the dispatcher.