### PR TITLE
Refresh ABP vs ASP.NET Zero docs

### DIFF
--- a/docs/en/others/aspnet-zero-vs-abp.md
+++ b/docs/en/others/aspnet-zero-vs-abp.md
@@ -9,13 +9,7 @@
 
 [ASP.NET Zero](https://aspnetzero.com/) is a startup project template which is also developed by [Volosoft](https://volosoft.com/). Here you can see the feature differences between ASP.NET Zero and ABP Platform (with commercial licenses).
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-
-<head>
-<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
-</head>
-<body>
+ABP is generally better suited to modular monolith and microservice architectures. ASP.NET Zero is a more opinionated, ready-made application foundation.
 
 <table id="TemplateComparisonTable" class="table">
         <thead>
@@ -508,7 +502,36 @@
         </tbody>
     </table>
 
+## Licensing, delivery, and AI
 
-</body>
-
-</html>
+<table class="table" style="table-layout: fixed; width: 100%;">
+    <colgroup>
+        <col style="width: 22%;" />
+        <col style="width: 39%;" />
+        <col style="width: 39%;" />
+    </colgroup>
+    <thead>
+        <tr>
+            <th>Topic</th>
+            <th>ABP</th>
+            <th>ASP.NET Zero</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>License model</td>
+            <td>Developer seats + feature tier. After the license period, you can keep developing and deploying existing projects; renewal mainly covers updates, support, Suite/Studio, and creating new projects.</td>
+            <td>Per product/project capacity (a defined number of products and developers). The app can be used indefinitely; renewal mainly covers updates, support, repository access, and tools.</td>
+        </tr>
+        <tr>
+            <td>Source code</td>
+            <td>Open-source framework; commercial modules/tooling as private NuGet/NPM packages. Module source download depends on the plan. Self-hosted—no Volosoft runtime dependency; ABP.io does not host your application source.</td>
+            <td>Full application source. Self-hosted—no Volosoft runtime dependency.</td>
+        </tr>
+        <tr>
+            <td>AI-assisted development</td>
+            <td>Works with Copilot and similar tools on normal source repositories. Also ABP Studio AI Agent, ABP-oriented workflows, and MCP via compatible clients/IDEs.</td>
+            <td>Works with Copilot and similar tools on normal source repositories. Primarily IDE-based AI, with product rules, skills, and workflow instructions from the license.</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/en/others/aspnet-zero-vs-abp.md
+++ b/docs/en/others/aspnet-zero-vs-abp.md
@@ -520,17 +520,17 @@ ABP is generally better suited to modular monolith and microservice architecture
     <tbody>
         <tr>
             <td>License model</td>
-            <td>Developer seats + feature tier. After the license period, you can keep developing and deploying existing projects; renewal mainly covers updates, support, Suite/Studio, and creating new projects.</td>
+            <td>Developer seats + feature tier. After the license period, you can keep developing and deploying existing projects; renewal mainly covers updates, support, ABP Suite and ABP Studio, and creating new projects.</td>
             <td>Per product/project capacity (a defined number of products and developers). The app can be used indefinitely; renewal mainly covers updates, support, repository access, and tools.</td>
         </tr>
         <tr>
             <td>Source code</td>
-            <td>Open-source framework; commercial modules/tooling as private NuGet/NPM packages. Module source download depends on the plan. Self-hosted—no Volosoft runtime dependency; ABP.io does not host your application source.</td>
-            <td>Full application source. Self-hosted—no Volosoft runtime dependency.</td>
+            <td>Open-source framework; commercial modules/tooling as private NuGet/NPM packages. Module source download depends on the plan. Self-hosted with no Volosoft runtime dependency; ABP.io does not host your application source.</td>
+            <td>Full application source. Self-hosted with no Volosoft runtime dependency.</td>
         </tr>
         <tr>
             <td>AI-assisted development</td>
-            <td>Works with Copilot and similar tools on normal source repositories. Also ABP Studio AI Agent, ABP-oriented workflows, and MCP via compatible clients/IDEs.</td>
+            <td>Works with Copilot and similar tools on normal source repositories. Also ABP Studio AI Agent, ABP-oriented workflows, and MCP tool connections (ABP Studio AI Agent can connect to MCP servers).</td>
             <td>Works with Copilot and similar tools on normal source repositories. Primarily IDE-based AI, with product rules, skills, and workflow instructions from the license.</td>
         </tr>
     </tbody>


### PR DESCRIPTION
Remove the leftover HTML wrapper from the comparison page, add a short positioning summary for ABP and ASP.NET Zero, and extend the document with a new section covering licensing, source delivery, and AI-assisted development differences.

/docs/latest/others/aspnet-zero-vs-abp

<img width="1321" height="993" alt="image" src="https://github.com/user-attachments/assets/74eac401-74b3-4199-81da-7c8f2198e78c" />
