### PR TITLE
Upgrade MudBlazor to 9.7.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,7 +23,7 @@
     <PackageVersion Include="Blazorise.Components" Version="2.2.1" />
     <PackageVersion Include="Blazorise.DataGrid" Version="2.2.1" />
     <PackageVersion Include="Blazorise.Snackbar" Version="2.2.1" />
-    <PackageVersion Include="MudBlazor" Version="9.4.0" />
+    <PackageVersion Include="MudBlazor" Version="9.7.0" />
     <PackageVersion Include="Castle.Core" Version="5.2.1" />
     <PackageVersion Include="Castle.Core.AsyncInterceptor" Version="2.1.0" />
     <PackageVersion Include="CommonMark.NET" Version="0.15.1" />

--- a/docs/en/package-version-changes.md
+++ b/docs/en/package-version-changes.md
@@ -7,6 +7,12 @@
 
 # Package Version Changes
 
+## 10.7.0-rc.1
+
+| Package | Old Version | New Version | PR |
+|---------|-------------|-------------|-----|
+| MudBlazor | 9.4.0 | 9.7.0 | #25902 |
+
 ## 10.6.0-rc.1
 
 | Package | Old Version | New Version | PR |

--- a/modules/permission-management/src/Volo.Abp.PermissionManagement.Blazor.MudBlazor/Components/ResourcePermissionManagementModal.razor.cs
+++ b/modules/permission-management/src/Volo.Abp.PermissionManagement.Blazor.MudBlazor/Components/ResourcePermissionManagementModal.razor.cs
@@ -109,7 +109,9 @@ public partial class ResourcePermissionManagementModal
         ProviderKeys = new List<SearchProviderKeyInfo>();
         if (_createFormRef != null)
         {
-            await _createFormRef.ResetAsync();
+            // ResetAsync would clear the radio group too, which feeds back into
+            // OnLookupServiceCheckedValueChanged and wipes CurrentLookupService.
+            await _createFormRef.ResetValidationAsync();
         }
 
         CreateEntity = new CreateModel
@@ -211,7 +213,7 @@ public partial class ResourcePermissionManagementModal
         ProviderKeys = new List<SearchProviderKeyInfo>();
         if (_createFormRef != null)
         {
-            await _createFormRef.ResetAsync();
+            await _createFormRef.ResetValidationAsync();
         }
         await InvokeAsync(StateHasChanged);
     }


### PR DESCRIPTION
9.7.0 makes `MudRadioGroup` reset go through the standard path, so a form reset now fires `ValueChanged`. In `ResourcePermissionManagementModal` that fed back into `OnLookupServiceCheckedValueChanged` and cleared `CurrentLookupService`, leaving the provider key search with no results. Both call sites now use `ResetValidationAsync`.