### PR TITLE
Render only the active tab in MudBlazor permission and feature modals

### DIFF
--- a/modules/feature-management/src/Volo.Abp.FeatureManagement.Blazor.MudBlazor/Components/FeatureManagementModal.razor
+++ b/modules/feature-management/src/Volo.Abp.FeatureManagement.Blazor.MudBlazor/Components/FeatureManagementModal.razor
@@ -16,7 +16,7 @@
         }
         else
         {
-            <MudTabs KeepPanelsAlive="true" @bind-ActivePanelIndex="@_activeTabIndex" Variant="Variant.Pills" Position="Position.Left"
+            <MudTabs @bind-ActivePanelIndex="@_activeTabIndex" Variant="Variant.Pills" Position="Position.Left"
                 PanelClass="pa-4">
                 @foreach (var group in Groups)
                 {

--- a/modules/permission-management/src/Volo.Abp.PermissionManagement.Blazor.MudBlazor/Components/PermissionManagementModal.razor
+++ b/modules/permission-management/src/Volo.Abp.PermissionManagement.Blazor.MudBlazor/Components/PermissionManagementModal.razor
@@ -33,7 +33,7 @@
 
             @if (_groups != null && _groups.Any())
             {
-                <MudTabs KeepPanelsAlive="true" @bind-ActivePanelIndex="@_activeTabIndex"
+                <MudTabs @bind-ActivePanelIndex="@_activeTabIndex"
                         Variant="Variant.Pills"
                         Position="Position.Left"
                         PanelClass="pa-4">


### PR DESCRIPTION
`KeepPanelsAlive="true"` mounted every group up front, so both dialogs rendered all tabs instead of only the active one. Neither modal has an `AutoFocus` input, which is the only thing that flag exists for (see the modal focus setup in `forms-validation.md`).