### PR TITLE
Upgrade jQuery to 4.0.0 and add jQuery Migrate

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Packages/Volo/Abp/AspNetCore/Mvc/UI/Packages/JQuery/JQueryScriptContributor.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Packages/Volo/Abp/AspNetCore/Mvc/UI/Packages/JQuery/JQueryScriptContributor.cs
@@ -11,6 +11,7 @@ public class JQueryScriptContributor : BundleContributor
     public override void ConfigureBundle(BundleConfigurationContext context)
     {
         context.Files.AddIfNotContains("/libs/jquery/jquery.js");
+        context.Files.AddIfNotContains("/libs/jquery-migrate/jquery-migrate.js");
         context.Files.AddIfNotContains("/libs/abp/jquery/abp.jquery.js");
     }
 }

--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/wwwroot/libs/abp/aspnetcore-mvc-ui-theme-shared/sweetalert2/abp-sweetalert2.js
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared/wwwroot/libs/abp/aspnetcore-mvc-ui-theme-shared/sweetalert2/abp-sweetalert2.js
@@ -83,7 +83,7 @@ var abp = abp || {};
             text: message
         };
 
-        if ($.isFunction(titleOrCallback)) {
+        if (typeof titleOrCallback === 'function') {
             closeOnEsc = callback;
             callback = titleOrCallback;
         } else if (titleOrCallback) {
@@ -111,7 +111,7 @@ var abp = abp || {};
             html: abp.utils.htmlEscape(message).replace(/\n/g, '<br>')
         };
 
-        if ($.isFunction(titleOrOptionsOrCallback)) {
+        if (typeof titleOrOptionsOrCallback === 'function') {
             callback = titleOrOptionsOrCallback;
         } else if (typeof titleOrOptionsOrCallback === 'string') {
             userOpts.title = titleOrOptionsOrCallback;

--- a/npm/packs/bootstrap-daterangepicker/src/daterangepicker.js
+++ b/npm/packs/bootstrap-daterangepicker/src/daterangepicker.js
@@ -405,31 +405,31 @@
         //
 
         this.container.find('.drp-calendar')
-            .on('click.daterangepicker', '.prev', $.proxy(this.clickPrev, this))
-            .on('click.daterangepicker', '.next', $.proxy(this.clickNext, this))
-            .on('mousedown.daterangepicker', 'td.available', $.proxy(this.clickDate, this))
-            .on('mouseenter.daterangepicker', 'td.available', $.proxy(this.hoverDate, this))
-            .on('change.daterangepicker', 'select.yearselect', $.proxy(this.monthOrYearChanged, this))
-            .on('change.daterangepicker', 'select.monthselect', $.proxy(this.monthOrYearChanged, this))
-            .on('change.daterangepicker', 'select.hourselect,select.minuteselect,select.secondselect,select.ampmselect', $.proxy(this.timeChanged, this));
+            .on('click.daterangepicker', '.prev', this.clickPrev.bind(this))
+            .on('click.daterangepicker', '.next', this.clickNext.bind(this))
+            .on('mousedown.daterangepicker', 'td.available', this.clickDate.bind(this))
+            .on('mouseenter.daterangepicker', 'td.available', this.hoverDate.bind(this))
+            .on('change.daterangepicker', 'select.yearselect', this.monthOrYearChanged.bind(this))
+            .on('change.daterangepicker', 'select.monthselect', this.monthOrYearChanged.bind(this))
+            .on('change.daterangepicker', 'select.hourselect,select.minuteselect,select.secondselect,select.ampmselect', this.timeChanged.bind(this));
 
         this.container.find('.ranges')
-            .on('click.daterangepicker', 'li', $.proxy(this.clickRange, this));
+            .on('click.daterangepicker', 'li', this.clickRange.bind(this));
 
         this.container.find('.drp-buttons')
-            .on('click.daterangepicker', 'button.applyBtn', $.proxy(this.clickApply, this))
-            .on('click.daterangepicker', 'button.cancelBtn', $.proxy(this.clickCancel, this));
+            .on('click.daterangepicker', 'button.applyBtn', this.clickApply.bind(this))
+            .on('click.daterangepicker', 'button.cancelBtn', this.clickCancel.bind(this));
 
         if (this.element.is('input') || this.element.is('button')) {
             this.element.on({
-                'click.daterangepicker': $.proxy(this.show, this),
-                'focus.daterangepicker': $.proxy(this.show, this),
-                'keyup.daterangepicker': $.proxy(this.elementChanged, this),
-                'keydown.daterangepicker': $.proxy(this.keydown, this) //IE 11 compatibility
+                'click.daterangepicker': this.show.bind(this),
+                'focus.daterangepicker': this.show.bind(this),
+                'keyup.daterangepicker': this.elementChanged.bind(this),
+                'keydown.daterangepicker': this.keydown.bind(this) //IE 11 compatibility
             });
         } else {
-            this.element.on('click.daterangepicker', $.proxy(this.toggle, this));
-            this.element.on('keydown.daterangepicker', $.proxy(this.toggle, this));
+            this.element.on('click.daterangepicker', this.toggle.bind(this));
+            this.element.on('keydown.daterangepicker', this.toggle.bind(this));
         }
 
         //
@@ -1115,7 +1115,7 @@
             if (this.isShowing) return;
 
             // Create a click proxy that is private to this instance of datepicker, for unbinding
-            this._outsideClickProxy = $.proxy(function(e) { this.outsideClick(e); }, this);
+            this._outsideClickProxy = (function(e) { this.outsideClick(e); }).bind(this);
 
             // Bind global datepicker mousedown for hiding and
             $(document)
@@ -1128,7 +1128,7 @@
               .on('focusin.daterangepicker', this._outsideClickProxy);
 
             // Reposition the picker if the window is resized while it's open
-            $(window).on('resize.daterangepicker', $.proxy(function(e) { this.move(e); }, this));
+            $(window).on('resize.daterangepicker', (function(e) { this.move(e); }).bind(this));
 
             this.oldStartDate = this.startDate.clone();
             this.oldEndDate = this.endDate.clone();

--- a/npm/packs/jquery-validation/package.json
+++ b/npm/packs/jquery-validation/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@abp/jquery": "~10.7.0-rc.1",
-    "jquery-validation": "^1.21.0"
+    "jquery-validation": "^1.22.1"
   },
   "gitHead": "bb4ea17d5996f01889134c138d00b6c8f858a431",
   "homepage": "https://abp.io",

--- a/npm/packs/jquery/abp.resourcemapping.js
+++ b/npm/packs/jquery/abp.resourcemapping.js
@@ -1,6 +1,9 @@
 module.exports = {
     mappings: {
         "@node_modules/jquery/dist/jquery.js": "@libs/jquery/",
+        "@node_modules/jquery-migrate/dist/jquery-migrate.js": "@libs/jquery-migrate/",
+        "@node_modules/jquery-migrate/dist/jquery-migrate.min.js": "@libs/jquery-migrate/",
+        "@node_modules/jquery-migrate/dist/jquery-migrate.min.map": "@libs/jquery-migrate/",
         "@node_modules/@abp/jquery/src/*.*": "@libs/abp/jquery/"
     }
 }

--- a/npm/packs/jquery/package.json
+++ b/npm/packs/jquery/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "@abp/core": "~10.7.0-rc.1",
-    "jquery": "~3.7.1"
+    "jquery": "~4.0.0",
+    "jquery-migrate": "~4.0.2"
   },
   "gitHead": "bb4ea17d5996f01889134c138d00b6c8f858a431",
   "homepage": "https://abp.io",

--- a/npm/packs/jquery/src/abp.jquery.js
+++ b/npm/packs/jquery/src/abp.jquery.js
@@ -29,7 +29,7 @@ var abp = abp || {};
     };
 
     abp.utils.isFunction = function (obj) {
-        return $.isFunction(obj);
+        return typeof obj === 'function';
     };
 
     // JQUERY EXTENSIONS //////////////////////////////////////////////////////

--- a/npm/packs/jquery/yarn.lock
+++ b/npm/packs/jquery/yarn.lock
@@ -2,6 +2,31 @@
 # yarn lockfile v1
 
 
-jquery@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
+"@abp/core@~10.7.0-rc.1":
+  version "10.7.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@abp/core/-/core-10.7.0-rc.1.tgz#40017b504c37e9b4b8e5e85823ed59768e49d93c"
+  integrity sha512-aoAIRmrkHXdw06ZTxC2rF7Bj6zNSw+WHG39dC2vYQXc70MAZ78v2J4xEY/hk8+12UNdjKIVmwvqhMi2DJwSQjg==
+  dependencies:
+    "@abp/utils" "~10.7.0-rc.1"
+
+"@abp/utils@~10.7.0-rc.1":
+  version "10.7.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@abp/utils/-/utils-10.7.0-rc.1.tgz#e727045304bec1cdb65132e0c0fcfe18337fa767"
+  integrity sha512-kkqzS2Pd/+CKkxVEpYwyRs4yHye0xi4kc3Ip4TIEZXCJ+whjB9b4qKh+AuglKGwz3RvnFvB+QxQhluUHu0oyaA==
+  dependencies:
+    just-compare "^2.3.0"
+
+jquery-migrate@~4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/jquery-migrate/-/jquery-migrate-4.0.2.tgz#d296a64e05073017c54877462ac563f1927ee21f"
+  integrity sha512-J15ilpECoAsObLv2robklj0qf1qt9QCnZwwNcJAXkM7dIiOgcac2dqC3HgDtUF0fmRwKZa/ggTkxTj9S4Vk+HQ==
+
+jquery@~4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-4.0.0.tgz#95c33ac29005ff72ec444c5ba1cf457e61404fbb"
+  integrity sha512-TXCHVR3Lb6TZdtw1l3RTLf8RBWVGexdxL6AC8/e0xZKEpBflBsjh9/8LXw+dkNFuOyW9B7iB3O1sP7hS0Kiacg==
+
+just-compare@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/just-compare/-/just-compare-2.3.0.tgz#a2adcc1d1940536263275f5a1ef1298bcacfeda7"
+  integrity sha512-6shoR7HDT+fzfL3gBahx1jZG3hWLrhPAf+l7nCwahDdT9XDtosB9kIF0ZrzUp5QY8dJWfQVr5rnsPqsbvflDzg==


### PR DESCRIPTION
Resolve #25123

Upgrades `@abp/jquery` to jQuery 4.0.0 and adds jQuery Migrate 4.0.2 right after jQuery in the default bundle, so the plugins we ship and existing application code keep working. Removed APIs are cleaned up in our own scripts and `jquery-validation` moves to 1.22.1.

Migrate does not cover the behavioral changes in jQuery 4, so watch the `JQMIGRATE` messages in development.
