### PR TITLE
docs: restore ABP Studio MCP server docs

### DIFF
--- a/docs/en/cli/index.md
+++ b/docs/en/cli/index.md
@@ -1107,7 +1107,7 @@ abp install-old-cli [options]
 
 Starts an MCP stdio bridge for AI tools (Cursor, Claude Desktop, VS Code, etc.) that connects to the local ABP Studio instance. ABP Studio must be running for this command to work.
 
-> You do not need to run this command manually. It is invoked automatically by your AI tool once you add the MCP configuration to your IDE. See the [Configuration](#configuration) examples below.
+> You do not need to run this command manually. It is invoked automatically by your AI tool once you add the MCP configuration to your IDE. See the [Configuration](../studio/model-context-protocol.md#configuration) examples.
 
 > This command connects to the **local ABP Studio** instance. It is separate from the `abp mcp` command, which connects to the ABP.IO cloud MCP service and requires an active license.
 

--- a/docs/en/cli/index.md
+++ b/docs/en/cli/index.md
@@ -76,6 +76,7 @@ Here is the list of all available commands before explaining their details:
 - [clear-download-cache](../cli#clear-download-cache): Clears the templates download cache.
 - [check-extensions](../cli#check-extensions): Checks the latest version of the ABP CLI extensions.
 - [install-old-cli](../cli#install-old-cli): Installs old ABP CLI.
+- [mcp-studio](../cli#mcp-studio): Starts ABP Studio MCP bridge for AI tools (requires ABP Studio running).
 - [generate-razor-page](../cli#generate-razor-page): Generates a page class that you can use it in the ASP NET Core pipeline to return an HTML page.
 - [generate-jwks](../cli#generate-jwks): Generates an RSA key pair (JWKS public key + PEM private key) for OpenIddict `private_key_jwt` client authentication.
 
@@ -1101,6 +1102,35 @@ Usage:
 ```bash
 abp install-old-cli [options]
 ```
+
+### mcp-studio
+
+Starts an MCP stdio bridge for AI tools (Cursor, Claude Desktop, VS Code, etc.) that connects to the local ABP Studio instance. ABP Studio must be running for this command to work.
+
+> You do not need to run this command manually. It is invoked automatically by your AI tool once you add the MCP configuration to your IDE. See the [Configuration](#configuration) examples below.
+
+> This command connects to the **local ABP Studio** instance. It is separate from the `abp mcp` command, which connects to the ABP.IO cloud MCP service and requires an active license.
+
+Usage:
+
+```bash
+abp mcp-studio [options]
+```
+
+Options:
+
+- `--endpoint` or `-e`: Overrides ABP Studio MCP endpoint. Default value is `http://localhost:38280/mcp/`.
+
+Example:
+
+```bash
+abp mcp-studio
+abp mcp-studio --endpoint http://localhost:38280/mcp/
+```
+
+For detailed configuration examples (Cursor, Claude Desktop, VS Code) and the full list of available MCP tools, see the [Model Context Protocol (MCP)](../studio/model-context-protocol.md) documentation.
+
+> You can also run `abp help mcp-studio` to see available options and example IDE configuration snippets directly in your terminal.
 
 ### generate-razor-page
 

--- a/docs/en/docs-nav.json
+++ b/docs/en/docs-nav.json
@@ -341,6 +341,10 @@
                   "path": "studio/monitoring-applications.md"
                 },
                 {
+                  "text": "Model Context Protocol (MCP)",
+                  "path": "studio/model-context-protocol.md"
+                },
+                {
                   "text": "Working with Kubernetes",
                   "path": "studio/kubernetes.md"
                 },

--- a/docs/en/studio/ai-agent-configuration.md
+++ b/docs/en/studio/ai-agent-configuration.md
@@ -102,7 +102,7 @@ Permission choices include allow once, allow always, and skip. "Allow always" pe
 
 ## MCP Tool Connections
 
-ABP Studio can connect to user-configured Model Context Protocol (MCP) servers and expose their tools to Agent mode. This is an MCP client integration for the AI Agent. ABP Studio AI Agent does not expose itself as an MCP server for external AI clients.
+ABP Studio can connect to user-configured Model Context Protocol (MCP) servers and expose their tools to Agent mode. This section is about that MCP client integration. For the other direction, where external AI clients connect to ABP Studio and use its own tools, see the [Model Context Protocol (MCP)](model-context-protocol.md) documentation.
 
 ### Adding an Integration
 

--- a/docs/en/studio/model-context-protocol.md
+++ b/docs/en/studio/model-context-protocol.md
@@ -1,0 +1,133 @@
+```json
+//[doc-seo]
+{
+    "Description": "Learn how to connect AI tools like Cursor, Claude Desktop, and VS Code to ABP Studio using the Model Context Protocol (MCP)."
+}
+```
+
+# ABP Studio: Model Context Protocol (MCP)
+
+````json
+//[doc-nav]
+{
+  "Next": {
+    "Name": "Working with Kubernetes",
+    "Path": "studio/kubernetes"
+  }
+}
+````
+
+ABP Studio includes built-in [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) support so AI tools can query runtime telemetry and control solution runner operations.
+
+## How It Works
+
+ABP Studio runs a local MCP server in the background. The `abp mcp-studio` CLI command acts as a stdio bridge that AI clients connect to. The bridge forwards requests to ABP Studio and returns responses.
+
+```text
+MCP Client (Cursor / Claude Desktop / VS Code)
+  ──stdio──▶  abp mcp-studio  ──HTTP──▶  ABP Studio
+```
+
+> ABP Studio must be running while MCP is used. If ABP Studio is not running (or its MCP endpoint is unavailable), `abp mcp-studio` returns an error to the AI client.
+
+## Configuration
+
+### Cursor (`.cursor/mcp.json`)
+
+```json
+{
+  "mcpServers": {
+    "abp-studio": {
+      "command": "abp",
+      "args": ["mcp-studio"]
+    }
+  }
+}
+```
+
+### Claude Desktop (`claude_desktop_config.json`)
+
+```json
+{
+  "mcpServers": {
+    "abp-studio": {
+      "command": "abp",
+      "args": ["mcp-studio"]
+    }
+  }
+}
+```
+
+Claude Desktop config file locations:
+
+- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+- Linux: `~/.config/Claude/claude_desktop_config.json`
+
+### VS Code (`.vscode/mcp.json`)
+
+```json
+{
+  "servers": {
+    "abp-studio": {
+      "command": "abp",
+      "args": ["mcp-studio"]
+    }
+  }
+}
+```
+
+### Quick Reference
+
+You can run `abp help mcp-studio` at any time to see the available options and example configuration snippets for each supported IDE directly in your terminal.
+
+### Generating Config Files from ABP Studio
+
+When creating a new solution, ABP Studio can generate MCP configuration files for Cursor and VS Code automatically.
+
+## Available Tools
+
+ABP Studio exposes the following tools to MCP clients. All tools operate on the currently open solution and selected run profile in ABP Studio.
+
+### Monitoring
+
+| Tool | Description |
+|------|-------------|
+| `list_applications` | Lists all running ABP applications connected to ABP Studio. |
+| `get_exceptions` | Gets recent exceptions including stack traces and error messages. |
+| `get_logs` | Gets log entries. Can be filtered by log level. |
+| `get_requests` | Gets HTTP request information. Can be filtered by status code. |
+| `get_events` | Gets distributed events for debugging inter-service communication. |
+| `clear_monitor` | Clears collected monitor data. |
+
+### Application Control
+
+| Tool | Description |
+|------|-------------|
+| `list_runnable_applications` | Lists all applications in the current run profile with their state. |
+| `start_application` | Starts a stopped application. |
+| `stop_application` | Stops a running application. |
+| `restart_application` | Restarts a running application. |
+| `build_application` | Builds a .NET application using `dotnet build`. |
+
+### Container Control
+
+| Tool | Description |
+|------|-------------|
+| `list_containers` | Lists Docker containers in the current run profile with their state. |
+| `start_containers` | Starts Docker containers (docker-compose up). |
+| `stop_containers` | Stops Docker containers (docker-compose down). |
+
+### Solution Structure
+
+| Tool | Description |
+|------|-------------|
+| `get_solution_info` | Gets solution name, path, template, and run profile information. |
+| `list_modules` | Lists all modules in the solution. |
+| `list_packages` | Lists packages (projects) in the solution. Can be filtered by module. |
+| `get_module_dependencies` | Gets module dependency/import information. |
+
+## Notes
+
+- Monitor data (exceptions, logs, requests, events) is kept in memory and is cleared when the solution is closed.
+- The `abp mcp-studio` command connects to the local ABP Studio instance. This is separate from the `abp mcp` command, which connects to the ABP.IO cloud MCP service and requires an active license.

--- a/docs/en/studio/model-context-protocol.md
+++ b/docs/en/studio/model-context-protocol.md
@@ -79,44 +79,53 @@ Claude Desktop config file locations:
 
 ### Quick Reference
 
-You can run `abp help mcp-studio` at any time to see the available options and example configuration snippets for each supported IDE directly in your terminal.
+You can run `abp help mcp-studio` at any time to see the available options and the Cursor and Claude Desktop configuration snippets directly in your terminal.
 
 ### Generating Config Files from ABP Studio
 
-When creating a new solution, ABP Studio can generate MCP configuration files for Cursor and VS Code automatically.
+The `app`, `app-nolayers` and `microservice` templates already contain a `.vscode/mcp.json` file, so a solution created from one of them works with VS Code without any extra configuration.
+
+> The endpoint is not authenticated. It only listens on `localhost`, but any local process can call it, and a connected client can read the monitoring data, build the solution, run the configured tasks and start or stop applications and containers. Only configure MCP clients you trust, and do not forward or expose the endpoint.
 
 ## Available Tools
 
-ABP Studio exposes the following tools to MCP clients. All tools operate on the currently open solution and selected run profile in ABP Studio.
+ABP Studio exposes the following tools to MCP clients. The monitoring tools work on their own. The build and solution tools need a solution to be open. The application, container and task tools also need a run profile to be selected.
 
 ### Monitoring
 
 | Tool | Description |
 |------|-------------|
-| `list_applications` | Lists all running ABP applications connected to ABP Studio. |
 | `get_exceptions` | Gets recent exceptions including stack traces and error messages. |
 | `get_logs` | Gets log entries. Can be filtered by log level. |
 | `get_requests` | Gets HTTP request information. Can be filtered by status code. |
 | `get_events` | Gets distributed events for debugging inter-service communication. |
-| `clear_monitor` | Clears collected monitor data. |
 
 ### Application Control
 
 | Tool | Description |
 |------|-------------|
-| `list_runnable_applications` | Lists all applications in the current run profile with their state. |
-| `start_application` | Starts a stopped application. |
-| `stop_application` | Stops a running application. |
-| `restart_application` | Restarts a running application. |
-| `build_application` | Builds a .NET application using `dotnet build`. |
+| `start_applications` | Starts applications of the selected run profile. A running application is stopped and started again. |
+| `stop_applications` | Stops running applications. |
 
 ### Container Control
 
 | Tool | Description |
 |------|-------------|
-| `list_containers` | Lists Docker containers in the current run profile with their state. |
-| `start_containers` | Starts Docker containers (docker-compose up). |
-| `stop_containers` | Stops Docker containers (docker-compose down). |
+| `start_containers` | Starts Docker containers of the selected run profile. |
+| `stop_containers` | Stops Docker containers of the selected run profile. |
+
+### Tasks
+
+| Tool | Description |
+|------|-------------|
+| `run_task` | Runs a task of the selected run profile. It waits for the task, and on timeout it returns while the task keeps running in the background. |
+
+### Build
+
+| Tool | Description |
+|------|-------------|
+| `dotnet_build` | Builds the solution, a module or a package using `dotnet build`. |
+| `install_libs` | Runs `abp install-libs` at the solution root. |
 
 ### Solution Structure
 
@@ -125,7 +134,6 @@ ABP Studio exposes the following tools to MCP clients. All tools operate on the 
 | `get_solution_info` | Gets solution name, path, template, and run profile information. |
 | `list_modules` | Lists all modules in the solution. |
 | `list_packages` | Lists packages (projects) in the solution. Can be filtered by module. |
-| `get_module_dependencies` | Gets module dependency/import information. |
 
 ## Notes
 

--- a/docs/en/studio/model-context-protocol.md
+++ b/docs/en/studio/model-context-protocol.md
@@ -83,7 +83,7 @@ You can run `abp help mcp-studio` at any time to see the available options and t
 
 ### Generating Config Files from ABP Studio
 
-The `app`, `app-nolayers` and `microservice` templates already contain a `.vscode/mcp.json` file, so a solution created from one of them works with VS Code without any extra configuration.
+By default, the `app`, `app-nolayers` and `microservice` templates create a `.vscode/mcp.json` file, so a solution created from one of them works with VS Code without any extra configuration.
 
 > The endpoint is not authenticated. It only listens on `localhost`, but any local process can call it, and a connected client can read the monitoring data, build the solution, run the configured tasks and start or stop applications and containers. Only configure MCP clients you trust, and do not forward or expose the endpoint.
 

--- a/docs/en/studio/monitoring-applications.md
+++ b/docs/en/studio/monitoring-applications.md
@@ -11,8 +11,8 @@
 //[doc-nav]
 {
   "Next": {
-    "Name": "AI Agent",
-    "Path": "studio/ai-agent"
+    "Name": "Model Context Protocol (MCP)",
+    "Path": "studio/model-context-protocol"
   }
 }
 ````

--- a/docs/en/studio/overview.md
+++ b/docs/en/studio/overview.md
@@ -103,6 +103,8 @@ This pane is dedicated to managing Kubernetes services. It simplifies the proces
 
 The AI Agent is an integrated coding agent in ABP Studio. It can answer ABP-related questions, create implementation plans, and work on the current solution with controlled access to files, Studio tools, workflows, Git context, and configured MCP tools.
 
+For external AI tool integrations through MCP, see the [Model Context Protocol (MCP)](./model-context-protocol.md) documentation.
+
 ![ai-agent](./images/ai-agent/ai-agent-panel.png)
 
 Key features of the AI Agent include:


### PR DESCRIPTION
## Summary

- revert #25518 and restore the ABP Studio external MCP documentation
- restore the `abp mcp-studio` CLI reference, Studio navigation entry, and overview link
- preserve the current ABP Studio AI Agent content while reconnecting the restored MCP page

## Verification

- parsed `docs/en/docs-nav.json` successfully
- verified all restored local documentation targets exist
- ran `git diff --check`
- verified against ABP Studio `rel-3.0` at `f2eda9c65a0567c79937a2d7d3dca6c44e607053` that Studio starts/stops `IMcpServer` and `abp mcp-studio` uses the documented `http://localhost:38280/mcp/` endpoint