### PR TITLE
Bump `@abp/ng.account` to rc.2 in cms-kit Angular demo

### DIFF
--- a/modules/cms-kit/angular/package.json
+++ b/modules/cms-kit/angular/package.json
@@ -15,7 +15,7 @@
     },
     "private": true,
     "dependencies": {
-        "@abp/ng.account": "~10.7.0-rc.1",
+        "@abp/ng.account": "~10.7.0-rc.2",
         "@abp/ng.identity": "~10.7.0-rc.2",
         "@abp/ng.setting-management": "~10.7.0-rc.2",
         "@abp/ng.tenant-management": "~10.7.0-rc.2",


### PR DESCRIPTION
The npm version automation left this single dependency at `10.7.0-rc.1` while every other `@abp/*` package in the same file moved to `rc.2`.