### PR TITLE
Upgrade `MongoDB.Driver` to 3.11.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -123,7 +123,7 @@
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.19.1" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.19.1" />
     <PackageVersion Include="Minio" Version="6.0.5" />
-    <PackageVersion Include="MongoDB.Driver" Version="3.10.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.11.0" />
     <PackageVersion Include="NEST" Version="7.17.5" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="Nito.AsyncEx.Context" Version="5.1.2" />

--- a/docs/en/package-version-changes.md
+++ b/docs/en/package-version-changes.md
@@ -7,6 +7,12 @@
 
 # Package Version Changes
 
+## 10.8.0-rc.1
+
+| Package | Old Version | New Version | PR |
+|---------|-------------|-------------|-----|
+| MongoDB.Driver | 3.10.0 | 3.11.0 | #25979 |
+
 ## 10.7.0-rc.1
 
 | Package | Old Version | New Version | PR |


### PR DESCRIPTION
Bump `MongoDB.Driver` from 3.10.0 to 3.11.0 in `Directory.Packages.props`.