### PR TITLE
Update React dependencies with abp update

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/PackageJsonFileFinder.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/PackageJsonFileFinder.cs
@@ -33,6 +33,8 @@ public class PackageJsonFileFinder : ITransientDependency
 
         return
             Directory.GetFiles(directory, "*.csproj", searchOption: SearchOption.TopDirectoryOnly).Any() ||
-            File.Exists(Path.Combine(directory, "angular.json"));
+            File.Exists(Path.Combine(directory, "angular.json")) ||
+            File.Exists(Path.Combine(directory, "vite.config.ts")) ||
+            File.Exists(Path.Combine(directory, "next.config.ts"));
     }
 }

--- a/framework/test/Volo.Abp.Cli.Core.Tests/Volo/Abp/Cli/ProjectModification/PackageJsonFileFinder_Tests.cs
+++ b/framework/test/Volo.Abp.Cli.Core.Tests/Volo/Abp/Cli/ProjectModification/PackageJsonFileFinder_Tests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.IO;
+using Shouldly;
+using Volo.Abp.Cli.ProjectModification;
+using Xunit;
+
+namespace Volo.Abp.Cli;
+
+public class PackageJsonFileFinder_Tests
+{
+    [Theory]
+    [InlineData("Test.csproj", true)]
+    [InlineData("angular.json", true)]
+    [InlineData("vite.config.ts", true)]
+    [InlineData("next.config.ts", true)]
+    [InlineData("", false)]
+    public void Should_Find_Package_Json_For_Supported_Project_Types(string projectFileName, bool expected)
+    {
+        var testDirectory = Path.Combine(Path.GetTempPath(), "abp-cli-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(testDirectory);
+
+        try
+        {
+            var packageJsonPath = Path.Combine(testDirectory, "package.json");
+            File.WriteAllText(packageJsonPath, "{}");
+
+            if (!projectFileName.IsNullOrEmpty())
+            {
+                File.WriteAllText(Path.Combine(testDirectory, projectFileName), string.Empty);
+            }
+
+            var result = new PackageJsonFileFinder().Find(testDirectory);
+
+            result.Contains(packageJsonPath).ShouldBe(expected);
+        }
+        finally
+        {
+            Directory.Delete(testDirectory, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
### Description

Implements [Volobox task 1566](https://workspace.volosoft.com/projects/abp/tasks/1566).

`abp update` already updates ABP-scoped dependencies in discovered `package.json` files, but standalone React projects were excluded because package discovery only recognized .NET and Angular project markers.

This change:

- recognizes the `vite.config.ts` marker used by the ABP Studio React and React Admin Console templates
- recognizes the `next.config.ts` marker used by the React Public Web templates
- adds regression coverage for .NET, Angular, Vite, Next.js, and unmarked package manifests

No ABP Studio template change is required. The current ModernTemplates already contain these markers and use supported `@volo/*` dependencies.

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (no documentation change is needed)

### How to test it?

1. Create an ABP solution with a React UI from ABP Studio.
2. Set one of the generated `@volo/*` dependencies to an older version.
3. Run `abp update --npm` from the solution directory.
4. Verify that the React `package.json` dependency is updated.

Automated validation:

- focused `PackageJsonFileFinder_Tests`: 5 passed
- complete `Volo.Abp.Cli.Core.Tests`: 95 passed