### PR TITLE
Upgrade Blazorise packages to version 2.3.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,10 +19,10 @@
     <PackageVersion Include="Azure.Identity" Version="1.14.2" />
     <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.25.0" />
-    <PackageVersion Include="Blazorise" Version="2.2.1" />
-    <PackageVersion Include="Blazorise.Components" Version="2.2.1" />
-    <PackageVersion Include="Blazorise.DataGrid" Version="2.2.1" />
-    <PackageVersion Include="Blazorise.Snackbar" Version="2.2.1" />
+    <PackageVersion Include="Blazorise" Version="2.3.0" />
+    <PackageVersion Include="Blazorise.Components" Version="2.3.0" />
+    <PackageVersion Include="Blazorise.DataGrid" Version="2.3.0" />
+    <PackageVersion Include="Blazorise.Snackbar" Version="2.3.0" />
     <PackageVersion Include="MudBlazor" Version="9.7.0" />
     <PackageVersion Include="Castle.Core" Version="5.2.1" />
     <PackageVersion Include="Castle.Core.AsyncInterceptor" Version="2.1.0" />

--- a/docs/en/package-version-changes.md
+++ b/docs/en/package-version-changes.md
@@ -7,6 +7,15 @@
 
 # Package Version Changes
 
+## 10.7.0-rc.2
+
+| Package | Old Version | New Version | PR |
+|---------|-------------|-------------|-----|
+| Blazorise | 2.2.1 | 2.3.0 | #25992 |
+| Blazorise.Components | 2.2.1 | 2.3.0 | #25992 |
+| Blazorise.DataGrid | 2.2.1 | 2.3.0 | #25992 |
+| Blazorise.Snackbar | 2.2.1 | 2.3.0 | #25992 |
+
 ## 10.7.0-rc.1
 
 | Package | Old Version | New Version | PR |

--- a/framework/src/Volo.Abp.BlazoriseUI/wwwroot/volo.abp.blazoriseui.css
+++ b/framework/src/Volo.Abp.BlazoriseUI/wwwroot/volo.abp.blazoriseui.css
@@ -62,10 +62,3 @@
 .table-responsive .dropdown-menu-position-strategy-fixed {
     position: fixed !important;
 }
-
-/* 
-    blazorise picker workaround for https://github.com/Megabit/Blazorise/issues/4917
-*/
-.card .flatpickr-calendar.static {
-    top: unset !important;
-}


### PR DESCRIPTION
Resolve #25985

Upgrade Blazorise to 2.3.0 and remove the Flatpickr positioning workaround, since Blazorise 2.3.0 replaced Flatpickr with a native picker implementation.