### PR TITLE
Copy the global feature policy to the extension property DTO

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,11 +1,5 @@
 {
   "permissions": {
-    "allow": [
-      "Bash(yarn nx g:*)",
-      "Bash(npx vitest:*)",
-      "Bash(xargs:*)",
-      "Bash(dotnet build:*)",
-      "Bash(git show:*)"
-    ]
+    "allow": []
   }
 }

--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/ApplicationConfigurations/ObjectExtending/CachedObjectExtensionsDtoService.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/ApplicationConfigurations/ObjectExtending/CachedObjectExtensionsDtoService.cs
@@ -147,8 +147,8 @@ public class CachedObjectExtensionsDtoService : ICachedObjectExtensionsDtoServic
             {
                 GlobalFeatures = new ExtensionPropertyGlobalFeaturePolicyDto
                 {
-                    Features = propertyConfig.Policy.Features.Features,
-                    RequiresAll = propertyConfig.Policy.Features.RequiresAll
+                    Features = propertyConfig.Policy.GlobalFeatures.Features,
+                    RequiresAll = propertyConfig.Policy.GlobalFeatures.RequiresAll
                 },
                 Features = new ExtensionPropertyFeaturePolicyDto
                 {

--- a/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/ApplicationConfigurations/ObjectExtending/CachedObjectExtensionsDtoService_Tests.cs
+++ b/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/ApplicationConfigurations/ObjectExtending/CachedObjectExtensionsDtoService_Tests.cs
@@ -1,0 +1,44 @@
+using Shouldly;
+using Volo.Abp.ObjectExtending;
+using Volo.Abp.ObjectExtending.Modularity;
+using Xunit;
+
+namespace Volo.Abp.AspNetCore.Mvc.ApplicationConfigurations.ObjectExtending;
+
+public class CachedObjectExtensionsDtoService_Tests
+{
+    private const string ModuleName = "CachedObjectExtensionsDtoServiceTestModule";
+    private const string EntityName = "TestEntity";
+
+    [Fact]
+    public void Should_Keep_The_Feature_And_Global_Feature_Policies_Apart()
+    {
+        ObjectExtensionManager.Instance.Modules()
+            .ConfigureModule<ModuleExtensionConfiguration>(ModuleName, module =>
+            {
+                module.ConfigureEntity(EntityName, entity =>
+                {
+                    entity.AddOrUpdateProperty<string>("TestProperty", property =>
+                    {
+                        property.Policy.Features.Features = ["TestFeature"];
+                        property.Policy.Features.RequiresAll = true;
+                        property.Policy.GlobalFeatures.Features = ["TestGlobalFeature"];
+                        property.Policy.GlobalFeatures.RequiresAll = false;
+                    });
+                });
+            });
+
+        var service = new CachedObjectExtensionsDtoService(new ExtensionPropertyAttributeDtoFactory());
+
+        var policy = service.Get()
+            .Modules[ModuleName]
+            .Entities[EntityName]
+            .Properties["TestProperty"]
+            .Policy;
+
+        policy.Features.Features.ShouldBe(["TestFeature"]);
+        policy.Features.RequiresAll.ShouldBeTrue();
+        policy.GlobalFeatures.Features.ShouldBe(["TestGlobalFeature"]);
+        policy.GlobalFeatures.RequiresAll.ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
`CachedObjectExtensionsDtoService` filled the `GlobalFeatures` DTO from the feature policy, so the global feature policy never reached the clients.