### PR TITLE
Pin `select2` to 4.0.13

### DIFF
--- a/npm/packs/select2/package.json
+++ b/npm/packs/select2/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@abp/core": "~10.7.0-rc.3",
-    "select2": "^4.0.13"
+    "select2": "4.0.13"
   },
   "gitHead": "bb4ea17d5996f01889134c138d00b6c8f858a431",
   "homepage": "https://abp.io",


### PR DESCRIPTION
select2 4.1.0 declares `engines.node >=24` by mistake, so fresh installs fail on Node 20/22 with yarn. Pin the exact version until the upstream fix (select2/select2#6446) is released.