### PR TITLE
Drop jQuery Migrate from the default bundle

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Packages/Volo/Abp/AspNetCore/Mvc/UI/Packages/JQuery/JQueryScriptContributor.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc.UI.Packages/Volo/Abp/AspNetCore/Mvc/UI/Packages/JQuery/JQueryScriptContributor.cs
@@ -11,7 +11,6 @@ public class JQueryScriptContributor : BundleContributor
     public override void ConfigureBundle(BundleConfigurationContext context)
     {
         context.Files.AddIfNotContains("/libs/jquery/jquery.js");
-        context.Files.AddIfNotContains("/libs/jquery-migrate/jquery-migrate.js");
         context.Files.AddIfNotContains("/libs/abp/jquery/abp.jquery.js");
     }
 }

--- a/npm/packs/jquery/abp.resourcemapping.js
+++ b/npm/packs/jquery/abp.resourcemapping.js
@@ -1,9 +1,6 @@
 module.exports = {
     mappings: {
         "@node_modules/jquery/dist/jquery.js": "@libs/jquery/",
-        "@node_modules/jquery-migrate/dist/jquery-migrate.js": "@libs/jquery-migrate/",
-        "@node_modules/jquery-migrate/dist/jquery-migrate.min.js": "@libs/jquery-migrate/",
-        "@node_modules/jquery-migrate/dist/jquery-migrate.min.map": "@libs/jquery-migrate/",
         "@node_modules/@abp/jquery/src/*.*": "@libs/abp/jquery/"
     }
 }

--- a/npm/packs/jquery/package.json
+++ b/npm/packs/jquery/package.json
@@ -11,8 +11,7 @@
   },
   "dependencies": {
     "@abp/core": "~10.7.0-rc.3",
-    "jquery": "~4.0.0",
-    "jquery-migrate": "~4.0.2"
+    "jquery": "~4.0.0"
   },
   "gitHead": "bb4ea17d5996f01889134c138d00b6c8f858a431",
   "homepage": "https://abp.io",

--- a/npm/packs/select2/package.json
+++ b/npm/packs/select2/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@abp/core": "~10.7.0-rc.3",
-    "select2": "^4.0.13"
+    "select2": "^4.1.0"
   },
   "gitHead": "bb4ea17d5996f01889134c138d00b6c8f858a431",
   "homepage": "https://abp.io",


### PR DESCRIPTION
Resolve #25973

Remove `jquery-migrate` from `JQueryScriptContributor` and the `@abp/jquery` package. select2 is bumped to `^4.1.0` because 4.0.13 calls the removed `jQuery.isArray` on every initialization; it will be pinned to the first upstream release that drops the wrong `engines` field (select2/select2#6446).