### PR TITLE
Update AWSSDK.S3 package version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="AutoMapper" Version="14.0.0" />
     <PackageVersion Include="Asp.Versioning.Mvc" Version="8.1.0" />
     <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
-    <PackageVersion Include="AWSSDK.S3" Version="4.0.7.2" />
+    <PackageVersion Include="AWSSDK.S3" Version="4.0.102.3" />
     <PackageVersion Include="AWSSDK.SecurityToken" Version="4.0.2.2" />
     <PackageVersion Include="BunnyCDN.Net.Storage" Version="1.0.4" />
     <PackageVersion Include="Azure.Identity" Version="1.14.2" />


### PR DESCRIPTION
Updated AWSSDK.S3 package version from 4.0.7.2 to 4.0.102.3.

### Description

Resolves #26038 

Updated the AWSSDK.S3 dependency to 4.0.102.3.

I tested the change in two ways:

Tested it in my own existing ABP project by updating the package and running the application and EF Core migration workflow.
Downloaded the library source, applied the package version change, built it, and tested the updated package independently.
No breaking changes are expected.

### Checklist

- [ ✅] I fully tested it as developer / designer and created unit / integration tests
- [ ] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

Update AWSSDK.S3 from 4.0.7.2 to 4.0.102.3.
Restore and build the project.
Run the application and verify that the AWS S3 integration continues to work.
Run an EF Core migration using the Visual Studio Package Manager Console, for example:
Add-Migration TestMigration
Verify that the migration is generated successfully without the AWSSDK.Core NU1901 warning causing the command to terminate.
Verify that existing S3 functionality continues to work as expected.
