### PR TITLE
Update AWSSDK.S3 and AWSSDK.SecurityToken versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,8 +13,8 @@
     <PackageVersion Include="AutoMapper" Version="14.0.0" />
     <PackageVersion Include="Asp.Versioning.Mvc" Version="8.1.0" />
     <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
-    <PackageVersion Include="AWSSDK.S3" Version="4.0.7.2" />
-    <PackageVersion Include="AWSSDK.SecurityToken" Version="4.0.2.2" />
+    <PackageVersion Include="AWSSDK.S3" Version="4.0.102.3" />
+    <PackageVersion Include="AWSSDK.SecurityToken" Version="4.0.100.10" />
     <PackageVersion Include="BunnyCDN.Net.Storage" Version="1.0.4" />
     <PackageVersion Include="Azure.Identity" Version="1.14.2" />
     <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.20.1" />

--- a/docs/en/package-version-changes.md
+++ b/docs/en/package-version-changes.md
@@ -11,6 +11,8 @@
 
 | Package | Old Version | New Version | PR |
 |---------|-------------|-------------|-----|
+| AWSSDK.S3 | 4.0.7.2 | 4.0.102.3 | #26040 |
+| AWSSDK.SecurityToken | 4.0.2.2 | 4.0.100.10 | #26040 |
 | MongoDB.Driver | 3.10.0 | 3.11.0 | #25979 |
 
 ## 10.7.0-rc.2


### PR DESCRIPTION
### Description

Resolves #26038 

Updated the AWSSDK.S3 dependency to 4.0.102.3.

I tested the change in two ways:

Tested it in my own existing ABP project by updating the package and running the application and EF Core migration workflow.
Downloaded the library source, applied the package version change, built it, and tested the updated package independently.
No breaking changes are expected.

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [ ] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

Update AWSSDK.S3 from 4.0.7.2 to 4.0.102.3.
Restore and build the project.
Run the application and verify that the AWS S3 integration continues to work.
Run an EF Core migration using the Visual Studio Package Manager Console, for example:
Add-Migration TestMigration
Verify that the migration is generated successfully without the AWSSDK.Core NU1901 warning causing the command to terminate.
Verify that existing S3 functionality continues to work as expected.