### PR TITLE
Remove indeterminate state from Grant All permissions

### DIFF
--- a/modules/permission-management/src/Volo.Abp.PermissionManagement.Blazor.MudBlazor/Components/PermissionManagementModal.razor
+++ b/modules/permission-management/src/Volo.Abp.PermissionManagement.Blazor.MudBlazor/Components/PermissionManagementModal.razor
@@ -43,7 +43,6 @@
                             <div>
                                 <MudCheckBox Color="Color.Primary" UncheckedColor="Color.Default"
                                             T="bool?"
-                                            TriState="true"
                                             Disabled="@(IsPermissionGroupDisabled(group))"
                                             Value="@(group.Permissions.Any(x => x.IsGranted) && !group.Permissions.All(x => x.IsGranted)
                                                 ? (bool?)null

--- a/modules/permission-management/src/Volo.Abp.PermissionManagement.Blazor.MudBlazor/Components/PermissionManagementModal.razor
+++ b/modules/permission-management/src/Volo.Abp.PermissionManagement.Blazor.MudBlazor/Components/PermissionManagementModal.razor
@@ -21,7 +21,6 @@
             </MudItem>
             <MudItem xs="12" sm="4" Class="d-flex align-items-center">
                 <MudCheckBox Color="Color.Primary" UncheckedColor="Color.Default" T="bool?"
-                            TriState="true"
                             Disabled="@_selectAllDisabled"
                             Value="@(GrantAny ? (bool?)null : (bool?)GrantAll)"
                             ValueChanged="@(async (bool? b) => await GrantAllAsync(b == true))"


### PR DESCRIPTION
Remove the ineffective interactive indeterminate state from the Grant All permissions checkbox.