### PR TITLE
Document ABP Studio shell environment overrides

### DIFF
--- a/docs/en/studio/installation.md
+++ b/docs/en/studio/installation.md
@@ -41,24 +41,6 @@ Follow these steps to install ABP Studio:
 
 3. **First Launch:** When you first launch ABP Studio, it will automatically check for and install required dependencies. This process may take several minutes, and you'll see progress indicators for each component being installed.
 
-## Shell Environment Detection (macOS and Linux)
-
-On macOS and Linux, ABP Studio starts a shell during application startup and imports the environment variables printed by it. This allows Studio to discover tools configured by shell startup files, such as user-managed .NET or Node.js installations. By default, Studio starts the shell as an interactive login shell and runs `env`.
-
-| Variable | Description | Fallback |
-|---|---|---|
-| `ABP_STUDIO_SHELL` | Overrides the shell executable used to load the environment. Set it to a valid, non-empty executable path. | When unset, `SHELL`, then `/bin/zsh` on macOS or `/bin/bash` on Linux |
-| `ABP_STUDIO_SHELL_ARGS` | Replaces the complete argument string passed to the selected shell. | When unset or empty, `-i -l -c 'env'` |
-
-Set these variables in the environment that launches ABP Studio, then restart the application. Usually, you only need to override the shell executable. For example:
-
-```bash
-export ABP_STUDIO_SHELL=/bin/bash
-export ABP_STUDIO_SHELL_ARGS="-i -l -c 'env'"
-```
-
-> **Note:** Custom `ABP_STUDIO_SHELL_ARGS` must make the shell exit successfully and print the environment to standard output as newline-separated `NAME=value` entries. These settings have no effect on Windows.
-
 ## Login
 After installation is complete, you can log in to access all features:
 
@@ -87,3 +69,25 @@ When you see the "New Version Available" window, follow these steps to upgrade A
 ## Installing a Specific Version
 
 There is no official support for installing an older version of ABP Studio yet. But, if you want to install an older version of ABP Studio, you can use approach explanined here [https://github.com/enisn/AbpDevTools?tab=readme-ov-file#switch-abp-studio-version](https://github.com/enisn/AbpDevTools?tab=readme-ov-file#switch-abp-studio-version)
+
+## Troubleshooting
+
+### Shell Environment Detection (macOS and Linux)
+
+ABP Studio normally detects the shell environment automatically, so you do not need to configure the following variables. Use them only if Studio cannot find a tool that is available in your terminal, such as a user-managed .NET or Node.js installation.
+
+On macOS and Linux, ABP Studio starts a shell during application startup and imports the environment variables printed by it. By default, Studio starts the shell as an interactive login shell and runs `env`.
+
+| Variable | Description | Fallback |
+|---|---|---|
+| `ABP_STUDIO_SHELL` | Overrides the shell executable used to load the environment. Set it to a valid, non-empty executable path. | When unset, `SHELL`, then `/bin/zsh` on macOS or `/bin/bash` on Linux |
+| `ABP_STUDIO_SHELL_ARGS` | Replaces the complete argument string passed to the selected shell. | When unset or empty, `-i -l -c 'env'` |
+
+Set these variables in the environment that launches ABP Studio, then restart the application. Usually, you only need to override the shell executable. For example:
+
+```bash
+export ABP_STUDIO_SHELL=/bin/bash
+export ABP_STUDIO_SHELL_ARGS="-i -l -c 'env'"
+```
+
+> **Note:** Custom `ABP_STUDIO_SHELL_ARGS` must make the shell exit successfully and print the environment to standard output as newline-separated `NAME=value` entries. These settings have no effect on Windows.

--- a/docs/en/studio/installation.md
+++ b/docs/en/studio/installation.md
@@ -41,6 +41,24 @@ Follow these steps to install ABP Studio:
 
 3. **First Launch:** When you first launch ABP Studio, it will automatically check for and install required dependencies. This process may take several minutes, and you'll see progress indicators for each component being installed.
 
+## Shell Environment Detection (macOS and Linux)
+
+On macOS and Linux, ABP Studio starts a shell during application startup and imports the environment variables printed by it. This allows Studio to discover tools configured by shell startup files, such as user-managed .NET or Node.js installations. By default, Studio starts the shell as an interactive login shell and runs `env`.
+
+| Variable | Description | Fallback |
+|---|---|---|
+| `ABP_STUDIO_SHELL` | Overrides the shell executable used to load the environment. Set it to a valid, non-empty executable path. | When unset, `SHELL`, then `/bin/zsh` on macOS or `/bin/bash` on Linux |
+| `ABP_STUDIO_SHELL_ARGS` | Replaces the complete argument string passed to the selected shell. | When unset or empty, `-i -l -c 'env'` |
+
+Set these variables in the environment that launches ABP Studio, then restart the application. Usually, you only need to override the shell executable. For example:
+
+```bash
+export ABP_STUDIO_SHELL=/bin/bash
+export ABP_STUDIO_SHELL_ARGS="-i -l -c 'env'"
+```
+
+> **Note:** Custom `ABP_STUDIO_SHELL_ARGS` must make the shell exit successfully and print the environment to standard output as newline-separated `NAME=value` entries. These settings have no effect on Windows.
+
 ## Login
 After installation is complete, you can log in to access all features:
 

--- a/docs/en/studio/installation.md
+++ b/docs/en/studio/installation.md
@@ -68,7 +68,7 @@ When you see the "New Version Available" window, follow these steps to upgrade A
 
 ## Installing a Specific Version
 
-There is no official support for installing an older version of ABP Studio yet. But, if you want to install an older version of ABP Studio, you can use approach explanined here [https://github.com/enisn/AbpDevTools?tab=readme-ov-file#switch-abp-studio-version](https://github.com/enisn/AbpDevTools?tab=readme-ov-file#switch-abp-studio-version)
+There is no official support for installing an older version of ABP Studio yet. But, if you want to install an older version of ABP Studio, you can use approach explained here [https://github.com/enisn/AbpDevTools?tab=readme-ov-file#switch-abp-studio-version](https://github.com/enisn/AbpDevTools?tab=readme-ov-file#switch-abp-studio-version)
 
 ## Troubleshooting
 


### PR DESCRIPTION
### Description

Documents the ABP Studio startup environment overrides for macOS and Linux:

- `ABP_STUDIO_SHELL` selection and fallback behavior
- `ABP_STUDIO_SHELL_ARGS` default and full-replacement behavior
- the required `NAME=value` standard-output format and Windows scope

This is a documentation-only change.

### Checklist

- [x] I fully tested it as a developer by running the documentation syntax checker
- [x] I documented it

### How to test it?

Run the documentation syntax checker against `docs/en/studio/installation.md`:

```bash
dotnet run --project .github/scripts/CheckDocsSyntax/CheckDocsSyntax.csproj -c Release --no-restore -- docs/en/studio/installation.md
```

The checker should report zero errors and warnings.
