### PR TITLE
Wrap MudBlazor action menu callbacks with `InvokeAsync`

### DIFF
--- a/framework/src/Volo.Abp.MudBlazorUI/Components/AbpMudActionMenu.razor.cs
+++ b/framework/src/Volo.Abp.MudBlazorUI/Components/AbpMudActionMenu.razor.cs
@@ -130,7 +130,7 @@ public partial class AbpMudActionMenu : ComponentBase
     {
         if (_menu != null)
         {
-            await _menu.CloseAllMenusAsync();
+            await InvokeAsync(() => _menu.CloseAllMenusAsync());
         }
     }
 }

--- a/framework/src/Volo.Abp.MudBlazorUI/Components/AbpMudActionMenuItem.razor.cs
+++ b/framework/src/Volo.Abp.MudBlazorUI/Components/AbpMudActionMenuItem.razor.cs
@@ -67,9 +67,9 @@ public partial class AbpMudActionMenuItem : ComponentBase
         }
         else if (ParentMudMenu != null)
         {
-            await ParentMudMenu.CloseAllMenusAsync();
+            await InvokeAsync(() => ParentMudMenu.CloseAllMenusAsync());
         }
 
-        await OnClick.InvokeAsync(args);
+        await InvokeAsync(() => OnClick.InvokeAsync(args));
     }
 }


### PR DESCRIPTION
Clicking an action menu item threw `The current thread is not associated with the Dispatcher` in `InteractiveServer` mode: `AbpMudActionMenuItem` resumed off the dispatcher after awaiting the menu close, because release builds weave `ConfigureAwait(false)` into the components. Same fix as #25349.