### PR TITLE
Document minimal Low-Code formula definitions

### DIFF
--- a/docs/en/low-code/formula-properties.md
+++ b/docs/en/low-code/formula-properties.md
@@ -22,6 +22,36 @@ Both kinds can participate in filtering, sorting, paging, count, projection, gro
 
 Calculated and rollup properties can be authored in a writable Runtime JSON-backed layer that supports direct model changes. The corresponding commands are disabled when the selected Designer layer does not support them.
 
+## Model definition
+
+A formula definition stores only the expression and its result type. Dev JSON does not require generated identifiers, definition hashes, or a dependency list:
+
+```json
+{
+  "name": "LineTotal",
+  "type": "decimal",
+  "isMappedToDbField": false,
+  "formula": {
+    "expression": "UnitPrice * Quantity",
+    "resultType": "decimal"
+  }
+}
+```
+
+The equivalent code-layer definition is also minimal:
+
+```csharp
+property.Formula = new EntityFormulaDescriptor
+{
+    Expression = "UnitPrice * Quantity",
+    ResultType = EntityPropertyType.Decimal
+};
+```
+
+The model loader parses the expression and derives its dependencies whenever the layer is loaded or refreshed. Do not persist `formulaId`, `definitionVersion`, or `dependencies`; they are not authored model fields.
+
+Rollups likewise store only their source entity, foreign key, optional value property, and operation. They do not use generated identifiers, definition versions, or authored dependency lists.
+
 ## Create a calculated property
 
 In the Low-Code Designer:

--- a/docs/en/low-code/model-json.md
+++ b/docs/en/low-code/model-json.md
@@ -240,7 +240,7 @@ Entities describe the persisted data model. UI is not configured with legacy pro
 | `isMappedToDbField` | Whether a dynamic scalar property uses a dedicated physical column instead of dynamic data storage |
 | `decimalPlaces` | Decimal scale for `decimal` and `money` properties |
 | `currencySymbol` | Optional UI currency symbol for `money` properties |
-| `collection` | Primitive collection settings: `maxCount`, required `uniqueItems`, and stable `storageKey` |
+| `collection` | Primitive collection settings: optional `maxCount` and `uniqueItems` |
 | `foreignKey` | Lookup relation metadata |
 | `validators` | Backend/UI validation rules |
 
@@ -261,7 +261,7 @@ For virtual calculated fields and related-record aggregates, see [Calculated and
 | `enum` | Integer-backed enum; requires `enumType` |
 | `file`, `image` | Upload metadata handled by the low-code file pipeline |
 
-Add `collection` to any supported primitive type to store an ordered value list. Do not hand-edit a generated `storageKey` after data exists.
+Add `collection` to any supported primitive type to store an ordered value list.
 
 ### File, Image, and Attachments
 


### PR DESCRIPTION
## Summary
- document formula definitions with only an expression and result type
- explain that formula dependencies are derived when model layers load or refresh
- clarify that rollups do not require generated identifiers, versions, or authored dependencies
- align primitive collection documentation with the current minimal model contract