### PR TITLE
Move the 10.7 dependency changes to the 10.7 section

### DIFF
--- a/docs/en/package-version-changes.md
+++ b/docs/en/package-version-changes.md
@@ -7,15 +7,15 @@
 
 # Package Version Changes
 
-## 10.8.0-rc.1
+## 10.7.0-rc.3
 
 | Package | Old Version | New Version | PR |
 |---------|-------------|-------------|-----|
 | AWSSDK.S3 | 4.0.7.2 | 4.0.102.3 | #26040 |
 | AWSSDK.SecurityToken | 4.0.2.2 | 4.0.100.10 | #26040 |
-| MongoDB.Driver | 3.10.0 | 3.11.1 | #25979, #26103 |
+| MongoDB.Driver | 3.10.0 | 3.11.1 | #26103 |
 
-# 10.7.0-rc.3
+**Added:**
 
 | Package | Version | PR |
 |---------|---------|-----|


### PR DESCRIPTION
#26040, #26103 and #26113 all target `rel-10.7`, but they were recorded under `10.8.0-rc.1` because `common.props` on `rel-10.7` was wrong at the time. `dev` and `rel-10.7` now ship the same versions for all of them, so nothing is left for the 10.8 section.

The `10.7.0-rc.3` heading also used a single `#`, which `update_dependency_changes.py` does not match and keeps overwriting.