### PR TITLE
Add an attribute adapter for EnumDataTypeAttribute

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/DataAnnotations/AbpValidationAttributeAdapterProvider.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/DataAnnotations/AbpValidationAttributeAdapterProvider.cs
@@ -33,6 +33,11 @@ public class AbpValidationAttributeAdapterProvider : IValidationAttributeAdapter
             return new DynamicRangeAttributeAdapter((DynamicRangeAttribute)attribute, stringLocalizer);
         }
 
+        if (type == typeof(EnumDataTypeAttribute))
+        {
+            return new EnumDataTypeAttributeAdapter((EnumDataTypeAttribute)attribute, stringLocalizer);
+        }
+
         return _defaultAdapter.GetAttributeAdapter(attribute, stringLocalizer);
     }
 }

--- a/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/DataAnnotations/EnumDataTypeAttributeAdapter.cs
+++ b/framework/src/Volo.Abp.AspNetCore.Mvc/Volo/Abp/AspNetCore/Mvc/DataAnnotations/EnumDataTypeAttributeAdapter.cs
@@ -1,0 +1,34 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc.DataAnnotations;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+using Microsoft.Extensions.Localization;
+
+namespace Volo.Abp.AspNetCore.Mvc.DataAnnotations;
+
+public class EnumDataTypeAttributeAdapter : AttributeAdapterBase<EnumDataTypeAttribute>
+{
+    public EnumDataTypeAttributeAdapter(
+        EnumDataTypeAttribute attribute,
+        IStringLocalizer? stringLocalizer)
+        : base(attribute, stringLocalizer)
+    {
+    }
+
+    public override void AddValidation(ClientModelValidationContext context)
+    {
+        Check.NotNull(context, nameof(context));
+
+        //There is no built-in client side validation rule for enum values.
+        //This adapter is used to localize the error message on the server side.
+    }
+
+    public override string GetErrorMessage(ModelValidationContextBase validationContext)
+    {
+        Check.NotNull(validationContext, nameof(validationContext));
+
+        return GetErrorMessage(
+            validationContext.ModelMetadata,
+            validationContext.ModelMetadata.GetDisplayName()
+        );
+    }
+}

--- a/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/DataAnnotations/AbpValidationAttributeAdapterProvider_Tests.cs
+++ b/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/DataAnnotations/AbpValidationAttributeAdapterProvider_Tests.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.DataAnnotations;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+using Microsoft.Extensions.Localization;
+using Shouldly;
+using Xunit;
+
+namespace Volo.Abp.AspNetCore.Mvc.DataAnnotations;
+
+public class AbpValidationAttributeAdapterProvider_Tests
+{
+    private readonly AbpValidationAttributeAdapterProvider _provider = new(new ValidationAttributeAdapterProvider());
+
+    [Fact]
+    public void Should_Return_An_Adapter_For_The_EnumDataTypeAttribute()
+    {
+        //ASP.NET Core does not provide an adapter for the EnumDataTypeAttribute.
+        new ValidationAttributeAdapterProvider()
+            .GetAttributeAdapter(new EnumDataTypeAttribute(typeof(MyEnum)), null)
+            .ShouldBeNull();
+
+        _provider.GetAttributeAdapter(new EnumDataTypeAttribute(typeof(MyEnum)), null)
+            .ShouldBeOfType<EnumDataTypeAttributeAdapter>();
+    }
+
+    [Fact]
+    public void Should_Localize_The_Error_Message_Of_The_EnumDataTypeAttribute()
+    {
+        var attribute = new EnumDataTypeAttribute(typeof(MyEnum)) { ErrorMessage = "MyEnumIsInvalid" };
+
+        var adapter = _provider.GetAttributeAdapter(attribute, new TestStringLocalizer())!;
+
+        adapter.GetErrorMessage(CreateValidationContext()).ShouldBe("Localized:MyEnumIsInvalid");
+    }
+
+    private static ModelValidationContextBase CreateValidationContext()
+    {
+        var metadataProvider = new EmptyModelMetadataProvider();
+
+        return new ClientModelValidationContext(
+            new ActionContext(),
+            metadataProvider.GetMetadataForProperty(typeof(MyModel), nameof(MyModel.Value)),
+            metadataProvider,
+            new Dictionary<string, string>()
+        );
+    }
+
+    public enum MyEnum
+    {
+        Value1 = 1
+    }
+
+    public class MyModel
+    {
+        public MyEnum Value { get; set; }
+    }
+
+    private class TestStringLocalizer : IStringLocalizer
+    {
+        public LocalizedString this[string name] => new(name, "Localized:" + name);
+
+        public LocalizedString this[string name, params object[] arguments] => new(name, "Localized:" + name);
+
+        public IEnumerable<LocalizedString> GetAllStrings(bool includeParentCultures)
+        {
+            return new List<LocalizedString>();
+        }
+    }
+}


### PR DESCRIPTION
### Description

Resolves #26121

ASP.NET Core's `ValidationAttributeAdapterProvider` returns `null` for
`EnumDataTypeAttribute`. Without an adapter, MVC never passes the attribute's
`ErrorMessage` through `IStringLocalizer`, so the raw localization key is returned
to the client - unlike every other common validation attribute (`Required`,
`StringLength`, `Range`, `EmailAddress`, `Phone`, `Url`, `CreditCard`,
`FileExtensions`), which all have adapters.

This PR adds `EnumDataTypeAttributeAdapter` and returns it from
`AbpValidationAttributeAdapterProvider`, alongside the existing dynamic attribute
adapters.

`AddValidation` is intentionally empty: there is no built-in client-side validation
rule for enum values, so there is nothing meaningful to emit. (Mapping it onto
`data-val-required` would be wrong - `EnumDataTypeAttribute` treats `null` as
valid.) The adapter exists to localize the message on the server side.

Not a breaking change: when `ErrorMessage` is not set, `AttributeAdapterBase` falls
back to `Attribute.FormatErrorMessage(...)`, which is exactly what happened before.

**Correction:** an earlier version of the commit message said this also affected
enum extension properties via `ObjectExtensionManager`. That was wrong, and
@maliming is right - `ExtensibleObjectValidator` calls `attribute.GetValidationResult(...)`
directly, with no localizer in that path, so extension properties never reach the
MVC adapter pipeline. I have dropped that sentence. This PR only covers normal
model properties.

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] I documented it (or no need to document or I will create a separate documentation issue)

### How to test it?

`AbpValidationAttributeAdapterProvider_Tests` is added with two tests:

- `Should_Return_An_Adapter_For_The_EnumDataTypeAttribute` asserts the default
  ASP.NET Core provider returns `null` and that ABP's provider returns the new
  adapter.
- `Should_Localize_The_Error_Message_Of_The_EnumDataTypeAttribute` asserts the
  `ErrorMessage` is resolved through the `IStringLocalizer`.

Both pass on `rel-10.7`.