### PR TITLE
Set permissions in a single batch instead of one call per permission

### DIFF
--- a/docs/en/release-info/migration-guides/abp-10-8.md
+++ b/docs/en/release-info/migration-guides/abp-10-8.md
@@ -1,0 +1,50 @@
+```json
+//[doc-seo]
+{
+    "Description": "Upgrade your ABP solutions from v10.7 to v10.8 with this migration guide covering important behavior and integration changes."
+}
+```
+
+# ABP Version 10.8 Migration Guide
+
+This document is a guide for upgrading ABP v10.7 solutions to ABP v10.8. This version includes explicitly marked migration-impacting changes for specific customization scenarios, while most applications can upgrade with no additional action beyond the notes below.
+
+> **Package Version Changes:** Before upgrading, review the [Package Version Changes](../../package-version-changes.md) document to see version changes on dependent NuGet and NPM packages and align your project with ABP's internal package versions.
+
+## Open-Source (Framework)
+
+This version contains the following changes on the open-source side:
+
+### Batch Permission Update
+
+**Who is affected**
+
+- Applications that implement `IPermissionManager` themselves, instead of deriving from `PermissionManager`.
+- Applications that derive from `PermissionManager` and override `SetAsync(string, string, string, bool)`.
+
+**What changed**
+
+- `IPermissionManager` has a new `SetAsync(IEnumerable<KeyValuePair<string, bool>>, string, string)` member. It reads the current state of every requested permission once and writes only the permissions whose state changes, instead of querying the current state once per permission.
+- `PermissionAppService.UpdateAsync` calls the new overload once instead of calling the single-permission `SetAsync` in a loop. A derived `PermissionManager` that only overrides the single-permission overload still compiles, but the permission management UI no longer goes through it.
+
+**What to do**
+
+Implement the new member if you implement `IPermissionManager` yourself, and move the logic of an overridden single-permission `SetAsync` to the new overload.
+
+> See [#26126](https://github.com/abpframework/abp/pull/26126) for details.
+
+### Feature Value Update Skipped When Unchanged
+
+**Who is affected**
+
+- Applications that use MongoDB and handle `EntityUpdatedEventData<FeatureValue>`.
+
+**What changed**
+
+`FeatureManagementStore.SetAsync` does not update the feature value when the stored value already equals the requested one, so it no longer raises an entity updated event for it. The Entity Framework Core providers already behaved this way.
+
+**What to do**
+
+No action is required unless a handler of yours relies on receiving an event for a value that did not change.
+
+> See [#26126](https://github.com/abpframework/abp/pull/26126) for details.

--- a/docs/en/release-info/migration-guides/index.md
+++ b/docs/en/release-info/migration-guides/index.md
@@ -9,6 +9,7 @@
 
 The following documents explain how to migrate your existing ABP applications. We write migration documents only if you need to take an action while upgrading your solution. Otherwise, you can easily upgrade your solution using the [abp update command](../upgrading.md).
 
+- [10.7 to 10.8](abp-10-8.md)
 - [10.6 to 10.7](abp-10-7.md)
 - [10.5 to 10.6](abp-10-6.md)
 - [10.4 to 10.5](abp-10-5.md)

--- a/modules/feature-management/src/Volo.Abp.FeatureManagement.Domain/Volo/Abp/FeatureManagement/FeatureManagementStore.cs
+++ b/modules/feature-management/src/Volo.Abp.FeatureManagement.Domain/Volo/Abp/FeatureManagement/FeatureManagementStore.cs
@@ -44,7 +44,7 @@ public class FeatureManagementStore : IFeatureManagementStore, ITransientDepende
             featureValue = new FeatureValue(GuidGenerator.Create(), name, value, providerName, providerKey);
             await FeatureValueRepository.InsertAsync(featureValue, true);
         }
-        else
+        else if (featureValue.Value != value)
         {
             featureValue.Value = value;
             await FeatureValueRepository.UpdateAsync(featureValue, true);

--- a/modules/feature-management/test/Volo.Abp.FeatureManagement.TestBase/Volo/Abp/FeatureManagement/FeatureManagementStore_Tests.cs
+++ b/modules/feature-management/test/Volo.Abp.FeatureManagement.TestBase/Volo/Abp/FeatureManagement/FeatureManagementStore_Tests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Shouldly;
+using Volo.Abp.Domain.Entities.Events;
+using Volo.Abp.EventBus.Local;
 using Volo.Abp.Features;
 using Volo.Abp.Modularity;
 using Volo.Abp.Uow;
@@ -14,12 +16,14 @@ public abstract class FeatureManagementStore_Tests<TStartupModule> : FeatureMana
     private IFeatureManagementStore FeatureManagementStore { get; set; }
     private IFeatureValueRepository FeatureValueRepository { get; set; }
     private IUnitOfWorkManager UnitOfWorkManager { get; set; }
+    private ILocalEventBus LocalEventBus { get; set; }
 
     protected FeatureManagementStore_Tests()
     {
         FeatureManagementStore = GetRequiredService<IFeatureManagementStore>();
         FeatureValueRepository = GetRequiredService<IFeatureValueRepository>();
         UnitOfWorkManager = GetRequiredService<IUnitOfWorkManager>();
+        LocalEventBus = GetRequiredService<ILocalEventBus>();
     }
 
     [Fact]
@@ -72,6 +76,75 @@ public abstract class FeatureManagementStore_Tests<TStartupModule> : FeatureMana
         (await FeatureValueRepository.FindAsync(TestFeatureDefinitionProvider.SocialLogins,
             EditionFeatureValueProvider.ProviderName,
             TestEditionIds.Regular.ToString())).Value.ShouldBe(false.ToString().ToUpperInvariant());
+    }
+
+    [Fact]
+    public async Task Set_Should_Not_Update_The_Entity_When_The_Value_Is_Not_Changed()
+    {
+        // Arrange
+        var currentValue = (await FeatureValueRepository.FindAsync(TestFeatureDefinitionProvider.SocialLogins,
+            EditionFeatureValueProvider.ProviderName,
+            TestEditionIds.Regular.ToString())).Value;
+
+        var updatedEventCount = 0;
+        using (LocalEventBus.Subscribe<EntityUpdatedEventData<FeatureValue>>(_ =>
+               {
+                   updatedEventCount++;
+                   return Task.CompletedTask;
+               }))
+        {
+            // Act
+            await FeatureManagementStore.SetAsync(TestFeatureDefinitionProvider.SocialLogins,
+                currentValue,
+                EditionFeatureValueProvider.ProviderName,
+                TestEditionIds.Regular.ToString());
+        }
+
+        // Assert
+        updatedEventCount.ShouldBe(0);
+
+        (await FeatureValueRepository.FindAsync(TestFeatureDefinitionProvider.SocialLogins,
+            EditionFeatureValueProvider.ProviderName,
+            TestEditionIds.Regular.ToString())).Value.ShouldBe(currentValue);
+
+        (await FeatureManagementStore.GetOrNullAsync(TestFeatureDefinitionProvider.SocialLogins,
+            EditionFeatureValueProvider.ProviderName,
+            TestEditionIds.Regular.ToString())).ShouldBe(currentValue);
+    }
+
+    [Fact]
+    public async Task Set_Should_Update_The_Entity_When_The_Value_Is_Changed()
+    {
+        // Arrange
+        var newValue = false.ToString().ToUpperInvariant();
+        (await FeatureValueRepository.FindAsync(TestFeatureDefinitionProvider.SocialLogins,
+            EditionFeatureValueProvider.ProviderName,
+            TestEditionIds.Regular.ToString())).Value.ShouldNotBe(newValue);
+
+        var updatedEventCount = 0;
+        using (LocalEventBus.Subscribe<EntityUpdatedEventData<FeatureValue>>(_ =>
+               {
+                   updatedEventCount++;
+                   return Task.CompletedTask;
+               }))
+        {
+            // Act
+            await FeatureManagementStore.SetAsync(TestFeatureDefinitionProvider.SocialLogins,
+                newValue,
+                EditionFeatureValueProvider.ProviderName,
+                TestEditionIds.Regular.ToString());
+        }
+
+        // Assert
+        updatedEventCount.ShouldBe(1);
+
+        (await FeatureValueRepository.FindAsync(TestFeatureDefinitionProvider.SocialLogins,
+            EditionFeatureValueProvider.ProviderName,
+            TestEditionIds.Regular.ToString())).Value.ShouldBe(newValue);
+
+        (await FeatureManagementStore.GetOrNullAsync(TestFeatureDefinitionProvider.SocialLogins,
+            EditionFeatureValueProvider.ProviderName,
+            TestEditionIds.Regular.ToString())).ShouldBe(newValue);
     }
 
     [Fact]

--- a/modules/identity/src/Volo.Abp.Identity.EntityFrameworkCore/Volo/Abp/Identity/EntityFrameworkCore/EfCoreIdentityRoleRepository.cs
+++ b/modules/identity/src/Volo.Abp.Identity.EntityFrameworkCore/Volo/Abp/Identity/EntityFrameworkCore/EfCoreIdentityRoleRepository.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Dynamic.Core;
@@ -22,7 +22,7 @@ public class EfCoreIdentityRoleRepository : EfCoreRepository<IIdentityDbContext,
         bool includeDetails = true,
         CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .IncludeDetails(includeDetails)
             .OrderBy(x => x.Id)
             .FirstOrDefaultAsync(r => r.NormalizedName == normalizedRoleName, GetCancellationToken(cancellationToken));
@@ -67,14 +67,14 @@ public class EfCoreIdentityRoleRepository : EfCoreRepository<IIdentityDbContext,
         IEnumerable<Guid> ids,
         CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .Where(t => ids.Contains(t.Id))
             .ToListAsync(GetCancellationToken(cancellationToken));
     }
 
     public virtual async Task<List<IdentityRole>> GetListAsync(IEnumerable<string> names, CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .Where(t => names.Contains(t.Name))
             .ToListAsync(GetCancellationToken(cancellationToken));
     }
@@ -82,7 +82,7 @@ public class EfCoreIdentityRoleRepository : EfCoreRepository<IIdentityDbContext,
     public virtual async Task<List<IdentityRole>> GetDefaultOnesAsync(
         bool includeDetails = false, CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .IncludeDetails(includeDetails)
             .Where(r => r.IsDefault)
             .ToListAsync(GetCancellationToken(cancellationToken));
@@ -92,7 +92,7 @@ public class EfCoreIdentityRoleRepository : EfCoreRepository<IIdentityDbContext,
         string filter = null,
         CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .WhereIf(!filter.IsNullOrWhiteSpace(),
                 x => x.Name.Contains(filter) ||
                      x.NormalizedName.Contains(filter))
@@ -121,7 +121,7 @@ public class EfCoreIdentityRoleRepository : EfCoreRepository<IIdentityDbContext,
         bool includeDetails = false,
         CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .IncludeDetails(includeDetails)
             .WhereIf(!filter.IsNullOrWhiteSpace(),
                 x => x.Name.Contains(filter) ||

--- a/modules/identity/src/Volo.Abp.Identity.EntityFrameworkCore/Volo/Abp/Identity/EntityFrameworkCore/EfCoreIdentityUserRepository.cs
+++ b/modules/identity/src/Volo.Abp.Identity.EntityFrameworkCore/Volo/Abp/Identity/EntityFrameworkCore/EfCoreIdentityUserRepository.cs
@@ -25,7 +25,7 @@ public class EfCoreIdentityUserRepository : EfCoreRepository<IIdentityDbContext,
         bool includeDetails = true,
         CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .IncludeDetails(includeDetails)
             .OrderBy(x => x.Id)
             .FirstOrDefaultAsync(
@@ -96,7 +96,7 @@ public class EfCoreIdentityUserRepository : EfCoreRepository<IIdentityDbContext,
 
     public virtual async Task<IdentityUser> FindByPasskeyIdAsync(byte[] credentialId, bool includeDetails = true, CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .IncludeDetails(includeDetails)
             .Where(u => u.Passkeys.Any(x => x.CredentialId.SequenceEqual(credentialId)))
             .OrderBy(x => x.Id)
@@ -126,7 +126,7 @@ public class EfCoreIdentityUserRepository : EfCoreRepository<IIdentityDbContext,
         bool includeDetails = true,
         CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .IncludeDetails(includeDetails)
             .Where(u => u.Logins.Any(login => login.LoginProvider == loginProvider && login.ProviderKey == providerKey))
             .OrderBy(x => x.Id)
@@ -138,7 +138,7 @@ public class EfCoreIdentityUserRepository : EfCoreRepository<IIdentityDbContext,
         bool includeDetails = true,
         CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .IncludeDetails(includeDetails)
             .OrderBy(x => x.Id)
             .FirstOrDefaultAsync(u => u.NormalizedEmail == normalizedEmail, GetCancellationToken(cancellationToken));
@@ -149,7 +149,7 @@ public class EfCoreIdentityUserRepository : EfCoreRepository<IIdentityDbContext,
         bool includeDetails = false,
         CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .IncludeDetails(includeDetails)
             .Where(u => u.Claims.Any(c => c.ClaimType == claim.Type && c.ClaimValue == claim.Value))
             .ToListAsync(GetCancellationToken(cancellationToken));
@@ -400,7 +400,7 @@ public class EfCoreIdentityUserRepository : EfCoreRepository<IIdentityDbContext,
         bool includeDetails = true,
         CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .IncludeDetails(includeDetails)
             .FirstOrDefaultAsync(
                 u => u.TenantId == tenantId && u.UserName == userName,
@@ -410,7 +410,7 @@ public class EfCoreIdentityUserRepository : EfCoreRepository<IIdentityDbContext,
 
     public virtual async Task<List<IdentityUser>> GetListByIdsAsync(IEnumerable<Guid> ids, bool includeDetails = false, CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .IncludeDetails(includeDetails)
             .Where(x => ids.Contains(x.Id))
             .ToListAsync(GetCancellationToken(cancellationToken));
@@ -457,7 +457,7 @@ public class EfCoreIdentityUserRepository : EfCoreRepository<IIdentityDbContext,
 
     public virtual async Task<List<IdentityUser>> GetUsersByNormalizedUserNameAsync(string normalizedUserName, bool includeDetails = false, CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .IncludeDetails(includeDetails)
             .OrderBy(x => x.Id)
             .Where(u => u.NormalizedUserName == normalizedUserName)
@@ -466,7 +466,7 @@ public class EfCoreIdentityUserRepository : EfCoreRepository<IIdentityDbContext,
 
     public virtual async Task<List<IdentityUser>> GetUsersByNormalizedUserNamesAsync(string[] normalizedUserNames, bool includeDetails = false, CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .IncludeDetails(includeDetails)
             .OrderBy(x => x.Id)
             .Where(u => normalizedUserNames.Contains(u.NormalizedUserName))
@@ -476,7 +476,7 @@ public class EfCoreIdentityUserRepository : EfCoreRepository<IIdentityDbContext,
 
     public virtual async Task<List<IdentityUser>> GetUsersByNormalizedEmailAsync(string normalizedEmail, bool includeDetails = false, CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .IncludeDetails(includeDetails)
             .OrderBy(x => x.Id)
             .Where(u => u.NormalizedEmail == normalizedEmail)
@@ -485,7 +485,7 @@ public class EfCoreIdentityUserRepository : EfCoreRepository<IIdentityDbContext,
 
     public virtual async Task<List<IdentityUser>> GetUsersByNormalizedEmailsAsync(string[] normalizedEmails, bool includeDetails = false, CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .IncludeDetails(includeDetails)
             .OrderBy(x => x.Id)
             .Where(u => normalizedEmails.Contains(u.NormalizedEmail))
@@ -495,7 +495,7 @@ public class EfCoreIdentityUserRepository : EfCoreRepository<IIdentityDbContext,
 
     public virtual async Task<List<IdentityUser>> GetUsersByLoginAsync(string loginProvider, string providerKey, bool includeDetails = false, CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .IncludeDetails(includeDetails)
             .OrderBy(x => x.Id)
             .Where(u => u.Logins.Any(login => login.LoginProvider == loginProvider && login.ProviderKey == providerKey))
@@ -504,7 +504,7 @@ public class EfCoreIdentityUserRepository : EfCoreRepository<IIdentityDbContext,
 
     public virtual async Task<List<IdentityUser>> GetUsersByPasskeyIdAsync(byte[] credentialId, bool includeDetails = false, CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .IncludeDetails(includeDetails)
             .Where(u => u.Passkeys.Any(x => x.CredentialId.SequenceEqual(credentialId)))
             .OrderBy(x => x.Id)
@@ -513,7 +513,7 @@ public class EfCoreIdentityUserRepository : EfCoreRepository<IIdentityDbContext,
 
     public virtual async Task<IdentityUser> FindByNormalizedUserNameAsync(Guid? tenantId, string normalizedUserName, bool includeDetails = true, CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .IncludeDetails(includeDetails)
             .OrderBy(x => x.Id)
             .FirstOrDefaultAsync(
@@ -524,7 +524,7 @@ public class EfCoreIdentityUserRepository : EfCoreRepository<IIdentityDbContext,
 
     public virtual async Task<IdentityUser> FindByNormalizedEmailAsync(Guid? tenantId, string normalizedEmail, bool includeDetails = true, CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .IncludeDetails(includeDetails)
             .OrderBy(x => x.Id)
             .FirstOrDefaultAsync(

--- a/modules/identityserver/src/Volo.Abp.IdentityServer.EntityFrameworkCore/Volo/Abp/IdentityServer/Clients/ClientRepository.cs
+++ b/modules/identityserver/src/Volo.Abp.IdentityServer.EntityFrameworkCore/Volo/Abp/IdentityServer/Clients/ClientRepository.cs
@@ -23,7 +23,7 @@ public class ClientRepository : EfCoreRepository<IIdentityServerDbContext, Clien
         bool includeDetails = true,
         CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .IncludeDetails(includeDetails)
             .OrderBy(x => x.ClientId)
             .FirstOrDefaultAsync(x => x.ClientId == clientId, GetCancellationToken(cancellationToken));
@@ -33,7 +33,7 @@ public class ClientRepository : EfCoreRepository<IIdentityServerDbContext, Clien
         string sorting, int skipCount, int maxResultCount, string filter, bool includeDetails = false,
         CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .IncludeDetails(includeDetails)
             .WhereIf(!filter.IsNullOrWhiteSpace(), x => x.ClientId.Contains(filter))
             .OrderBy(sorting.IsNullOrWhiteSpace() ? nameof(Client.ClientName) : sorting)
@@ -43,7 +43,7 @@ public class ClientRepository : EfCoreRepository<IIdentityServerDbContext, Clien
 
     public virtual async Task<long> GetCountAsync(string filter = null, CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .WhereIf(!filter.IsNullOrWhiteSpace(), x => x.ClientId.Contains(filter))
             .LongCountAsync(GetCancellationToken(cancellationToken));
     }
@@ -58,7 +58,7 @@ public class ClientRepository : EfCoreRepository<IIdentityServerDbContext, Clien
 
     public virtual async Task<bool> CheckClientIdExistAsync(string clientId, Guid? expectedId = null, CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync()).AnyAsync(c => c.Id != expectedId && c.ClientId == clientId, GetCancellationToken(cancellationToken));
+        return await (await GetQueryableAsync()).AnyAsync(c => c.Id != expectedId && c.ClientId == clientId, GetCancellationToken(cancellationToken));
     }
 
     public async override Task DeleteAsync(Guid id, bool autoSave = false, CancellationToken cancellationToken = default)

--- a/modules/openiddict/src/Volo.Abp.OpenIddict.EntityFrameworkCore/Volo/Abp/OpenIddict/Applications/EfCoreOpenIddictApplicationRepository.cs
+++ b/modules/openiddict/src/Volo.Abp.OpenIddict.EntityFrameworkCore/Volo/Abp/OpenIddict/Applications/EfCoreOpenIddictApplicationRepository.cs
@@ -22,7 +22,7 @@ public class EfCoreOpenIddictApplicationRepository : EfCoreRepository<IOpenIddic
     public virtual async Task<List<OpenIddictApplication>> GetListAsync(string sorting, int skipCount, int maxResultCount, string filter = null,
         CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .WhereIf(!filter.IsNullOrWhiteSpace(), x => x.ClientId.Contains(filter))
             .OrderBy(sorting.IsNullOrWhiteSpace() ? nameof(OpenIddictApplication.CreationTime) + " desc" : sorting)
             .PageBy(skipCount, maxResultCount)
@@ -31,32 +31,32 @@ public class EfCoreOpenIddictApplicationRepository : EfCoreRepository<IOpenIddic
 
     public virtual async Task<long> GetCountAsync(string filter = null, CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .WhereIf(!filter.IsNullOrWhiteSpace(), x => x.ClientId.Contains(filter))
             .LongCountAsync(GetCancellationToken(cancellationToken));
     }
 
     public virtual async Task<OpenIddictApplication> FindByClientIdAsync(string clientId, CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .FirstOrDefaultAsync(x => x.ClientId == clientId, GetCancellationToken(cancellationToken));
     }
 
     public virtual async Task<List<OpenIddictApplication>> FindByPostLogoutRedirectUriAsync(string address, CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .Where(x => x.PostLogoutRedirectUris.Contains(address)).ToListAsync(GetCancellationToken(cancellationToken));
     }
 
     public virtual async Task<List<OpenIddictApplication>> FindByRedirectUriAsync(string address, CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .Where(x => x.RedirectUris.Contains(address)).ToListAsync(GetCancellationToken(cancellationToken));
     }
 
     public virtual async Task<List<OpenIddictApplication>> ListAsync(int? count, int? offset, CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .OrderBy(x => x.Id)
             .SkipIf<OpenIddictApplication, IQueryable<OpenIddictApplication>>(offset.HasValue, offset)
             .TakeIf<OpenIddictApplication, IQueryable<OpenIddictApplication>>(count.HasValue, count)

--- a/modules/permission-management/src/Volo.Abp.PermissionManagement.Application/Volo/Abp/PermissionManagement/PermissionAppService.cs
+++ b/modules/permission-management/src/Volo.Abp.PermissionManagement.Application/Volo/Abp/PermissionManagement/PermissionAppService.cs
@@ -205,10 +205,10 @@ public class PermissionAppService : ApplicationService, IPermissionAppService
         await CheckProviderPolicy(providerName);
         await FilterInputPermissionsByCurrentUserAsync(input);
 
-        foreach (var permissionDto in input.Permissions)
-        {
-            await PermissionManager.SetAsync(permissionDto.Name, providerName, providerKey, permissionDto.IsGranted);
-        }
+        await PermissionManager.SetAsync(
+            input.Permissions.Select(x => new KeyValuePair<string, bool>(x.Name, x.IsGranted)),
+            providerName,
+            providerKey);
     }
 
     public virtual async Task<GetResourceProviderListResultDto> GetResourceProviderKeyLookupServicesAsync(string resourceName)

--- a/modules/permission-management/src/Volo.Abp.PermissionManagement.Domain/Volo/Abp/PermissionManagement/IPermissionManager.cs
+++ b/modules/permission-management/src/Volo.Abp.PermissionManagement.Domain/Volo/Abp/PermissionManagement/IPermissionManager.cs
@@ -30,6 +30,12 @@ public interface IPermissionManager
         bool isGranted
     );
 
+    Task SetAsync(
+        [NotNull] IEnumerable<KeyValuePair<string, bool>> permissions,
+        string providerName,
+        string providerKey
+    );
+
     Task<PermissionGrant> UpdateProviderKeyAsync(
         PermissionGrant permissionGrant,
         string providerKey

--- a/modules/permission-management/src/Volo.Abp.PermissionManagement.Domain/Volo/Abp/PermissionManagement/PermissionManager.cs
+++ b/modules/permission-management/src/Volo.Abp.PermissionManagement.Domain/Volo/Abp/PermissionManagement/PermissionManager.cs
@@ -127,34 +127,93 @@ public class PermissionManager : IPermissionManager, ISingletonDependency
 
     public virtual async Task SetAsync(string permissionName, string providerName, string providerKey, bool isGranted)
     {
-        var permission = await PermissionDefinitionManager.GetOrNullAsync(permissionName);
-        if (permission == null)
+        await SetAsync(
+            new[] { new KeyValuePair<string, bool>(permissionName, isGranted) },
+            providerName,
+            providerKey
+        );
+    }
+
+    public virtual async Task SetAsync(
+        IEnumerable<KeyValuePair<string, bool>> permissions,
+        string providerName,
+        string providerKey)
+    {
+        Check.NotNull(permissions, nameof(permissions));
+
+        /* Each name is resolved only once, even if it is passed more than once. */
+        var permissionDefinitions = new Dictionary<string, PermissionDefinition>();
+        var permissionsToSet = new List<KeyValuePair<PermissionDefinition, bool>>();
+        foreach (var permission in permissions)
         {
-            /* Silently ignore undefined permissions,
-               maybe they were removed from dynamic permission definition store */
+            Check.NotNull(permission.Key, "permissionName");
+
+            if (!permissionDefinitions.TryGetValue(permission.Key, out var permissionDefinition))
+            {
+                permissionDefinition = await PermissionDefinitionManager.GetOrNullAsync(permission.Key);
+                permissionDefinitions[permission.Key] = permissionDefinition;
+            }
+
+            if (permissionDefinition == null)
+            {
+                /* Silently ignore undefined permissions,
+                   maybe they were removed from dynamic permission definition store */
+                continue;
+            }
+
+            permissionsToSet.Add(new KeyValuePair<PermissionDefinition, bool>(permissionDefinition, permission.Value));
+        }
+
+        if (!permissionsToSet.Any())
+        {
             return;
         }
 
-        if (!permission.IsEnabled || !await SimpleStateCheckerManager.IsEnabledAsync(permission))
+        var distinctPermissions = permissionsToSet.Select(x => x.Key).Distinct().ToArray();
+
+        var enabledPermissions = distinctPermissions.Where(x => x.IsEnabled).ToArray();
+        var stateCheckResult = enabledPermissions.Any()
+            ? await SimpleStateCheckerManager.IsEnabledAsync(enabledPermissions)
+            : new SimpleStateCheckerResult<PermissionDefinition>();
+
+        foreach (var permission in distinctPermissions)
         {
-            //TODO: BusinessException
-            throw new ApplicationException($"The permission named '{permission.Name}' is disabled!");
+            if (!permission.IsEnabled || !stateCheckResult[permission])
+            {
+                //TODO: BusinessException
+                throw new ApplicationException($"The permission named '{permission.Name}' is disabled!");
+            }
+
+            if (permission.Providers.Any() && !permission.Providers.Contains(providerName))
+            {
+                //TODO: BusinessException
+                throw new ApplicationException($"The permission named '{permission.Name}' is not compatible with the provider named '{providerName}'");
+            }
+
+            if (!permission.MultiTenancySide.HasFlag(CurrentTenant.GetMultiTenancySide()))
+            {
+                //TODO: BusinessException
+                throw new ApplicationException($"The permission named '{permission.Name}' has multitenancy side '{permission.MultiTenancySide}' which is not compatible with the current multitenancy side '{CurrentTenant.GetMultiTenancySide()}'");
+            }
         }
 
-        if (permission.Providers.Any() && !permission.Providers.Contains(providerName))
+        var currentGrantInfo = await GetInternalAsync(distinctPermissions, providerName, providerKey);
+        var currentGrants = currentGrantInfo.Result.ToDictionary(x => x.Name, x => x.IsGranted);
+
+        /* The last state wins when the same permission is passed more than once. */
+        var requestedGrants = new Dictionary<string, bool>();
+        foreach (var permission in permissionsToSet)
         {
-            //TODO: BusinessException
-            throw new ApplicationException($"The permission named '{permission.Name}' is not compatible with the provider named '{providerName}'");
+            requestedGrants[permission.Key.Name] = permission.Value;
         }
 
-        if (!permission.MultiTenancySide.HasFlag(CurrentTenant.GetMultiTenancySide()))
-        {
-            //TODO: BusinessException
-            throw new ApplicationException($"The permission named '{permission.Name}' has multitenancy side '{permission.MultiTenancySide}' which is not compatible with the current multitenancy side '{CurrentTenant.GetMultiTenancySide()}'");
-        }
+        var changedPermissions = distinctPermissions
+            .Select(x => x.Name)
+            .Where(x => currentGrants[x] != requestedGrants[x])
+            .Select(x => new KeyValuePair<string, bool>(x, requestedGrants[x]))
+            .ToList();
 
-        var currentGrantInfo = await GetInternalAsync(permission, providerName, providerKey);
-        if (currentGrantInfo.IsGranted == isGranted)
+        if (!changedPermissions.Any())
         {
             return;
         }
@@ -166,7 +225,10 @@ public class PermissionManager : IPermissionManager, ISingletonDependency
             throw new AbpException("Unknown permission management provider: " + providerName);
         }
 
-        await provider.SetAsync(permissionName, providerKey, isGranted);
+        foreach (var changedPermission in changedPermissions)
+        {
+            await provider.SetAsync(changedPermission.Key, providerKey, changedPermission.Value);
+        }
     }
 
     public virtual async Task<PermissionGrant> UpdateProviderKeyAsync(PermissionGrant permissionGrant, string providerKey)

--- a/modules/permission-management/src/Volo.Abp.PermissionManagement.EntityFrameworkCore/Volo/Abp/PermissionManagement/EntityFrameworkCore/EfCorePermissionGrantRepository.cs
+++ b/modules/permission-management/src/Volo.Abp.PermissionManagement.EntityFrameworkCore/Volo/Abp/PermissionManagement/EntityFrameworkCore/EfCorePermissionGrantRepository.cs
@@ -25,7 +25,7 @@ public class EfCorePermissionGrantRepository :
         string providerKey,
         CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .OrderBy(x => x.Id)
             .FirstOrDefaultAsync(s =>
                 s.Name == name &&
@@ -40,7 +40,7 @@ public class EfCorePermissionGrantRepository :
         string providerKey,
         CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .Where(s =>
                 s.ProviderName == providerName &&
                 s.ProviderKey == providerKey
@@ -50,7 +50,7 @@ public class EfCorePermissionGrantRepository :
     public virtual async Task<List<PermissionGrant>> GetListAsync(string[] names, string providerName, string providerKey,
         CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .Where(s =>
                 names.Contains(s.Name) &&
                 s.ProviderName == providerName &&

--- a/modules/permission-management/src/Volo.Abp.PermissionManagement.EntityFrameworkCore/Volo/Abp/PermissionManagement/EntityFrameworkCore/EfCoreResourcePermissionGrantRepository.cs
+++ b/modules/permission-management/src/Volo.Abp.PermissionManagement.EntityFrameworkCore/Volo/Abp/PermissionManagement/EntityFrameworkCore/EfCoreResourcePermissionGrantRepository.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -19,7 +19,7 @@ public class EfCoreResourcePermissionGrantRepository : EfCoreRepository<IPermiss
 
     public virtual async Task<ResourcePermissionGrant> FindAsync(string name, string resourceName, string resourceKey, string providerName, string providerKey, CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .OrderBy(x => x.Id)
             .FirstOrDefaultAsync(s =>
                     s.Name == name &&
@@ -33,7 +33,7 @@ public class EfCoreResourcePermissionGrantRepository : EfCoreRepository<IPermiss
 
     public virtual async Task<List<ResourcePermissionGrant>> GetListAsync(string resourceName, string resourceKey, string providerName, string providerKey, CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .Where(s =>
                 s.ResourceName == resourceName &&
                 s.ResourceKey == resourceKey &&
@@ -44,7 +44,7 @@ public class EfCoreResourcePermissionGrantRepository : EfCoreRepository<IPermiss
 
     public virtual async Task<List<ResourcePermissionGrant>> GetListAsync(string[] names, string resourceName, string resourceKey, string providerName, string providerKey, CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .Where(s =>
                 names.Contains(s.Name) &&
                 s.ResourceName == resourceName &&
@@ -56,7 +56,7 @@ public class EfCoreResourcePermissionGrantRepository : EfCoreRepository<IPermiss
 
     public virtual async Task<List<ResourcePermissionGrant>> GetListAsync(string providerName, string providerKey, CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .Where(s =>
                 s.ProviderName == providerName &&
                 s.ProviderKey == providerKey
@@ -65,7 +65,7 @@ public class EfCoreResourcePermissionGrantRepository : EfCoreRepository<IPermiss
 
     public virtual async Task<List<ResourcePermissionGrant>> GetPermissionsAsync(string resourceName, string resourceKey, CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .Where(s =>
                 s.ResourceName == resourceName &&
                 s.ResourceKey == resourceKey
@@ -74,7 +74,7 @@ public class EfCoreResourcePermissionGrantRepository : EfCoreRepository<IPermiss
 
     public virtual async Task<List<ResourcePermissionGrant>> GetResourceKeys(string resourceName, string name, CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
+        return await (await GetQueryableAsync())
             .Where(s =>
                 s.ResourceName == resourceName &&
                 s.Name == name

--- a/modules/permission-management/test/Volo.Abp.PermissionManagement.Application.Tests/Volo/Abp/PermissionManagement/PermissionAppService_Tests.cs
+++ b/modules/permission-management/test/Volo.Abp.PermissionManagement.Application.Tests/Volo/Abp/PermissionManagement/PermissionAppService_Tests.cs
@@ -17,6 +17,7 @@ public class PermissionAppService_Tests : AbpPermissionManagementApplicationTest
     private readonly IPermissionGrantRepository _permissionGrantRepository;
     private readonly ICurrentPrincipalAccessor _currentPrincipalAccessor;
     private readonly FakePermissionChecker _fakePermissionChecker;
+    private readonly TestPermissionManagementProvider _testPermissionManagementProvider;
 
     public PermissionAppService_Tests()
     {
@@ -24,6 +25,7 @@ public class PermissionAppService_Tests : AbpPermissionManagementApplicationTest
         _permissionGrantRepository = GetRequiredService<IPermissionGrantRepository>();
         _currentPrincipalAccessor = GetRequiredService<ICurrentPrincipalAccessor>();
         _fakePermissionChecker = GetRequiredService<FakePermissionChecker>();
+        _testPermissionManagementProvider = GetRequiredService<TestPermissionManagementProvider>();
     }
 
     [Fact]
@@ -136,6 +138,47 @@ public class PermissionAppService_Tests : AbpPermissionManagementApplicationTest
 
         (await _permissionGrantRepository.FindAsync("MyPermission1", "Test",
             "Test")).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Update_Should_Apply_Grants_And_Revokes_Together()
+    {
+        await _permissionGrantRepository.InsertAsync(
+            new PermissionGrant(
+                Guid.NewGuid(),
+                "MyPermission1",
+                "Test",
+                "Test"
+            )
+        );
+        await _permissionGrantRepository.InsertAsync(
+            new PermissionGrant(
+                Guid.NewGuid(),
+                "MyPermission2",
+                "Test",
+                "Test"
+            )
+        );
+
+        await _permissionAppService.UpdateAsync("Test",
+            "Test", new UpdatePermissionsDto()
+            {
+                Permissions = new UpdatePermissionDto[]
+                {
+                        new UpdatePermissionDto() { IsGranted = true, Name = "MyPermission1" },
+                        new UpdatePermissionDto() { IsGranted = false, Name = "MyPermission2" },
+                        new UpdatePermissionDto() { IsGranted = true, Name = "MyPermission7" },
+                        new UpdatePermissionDto() { IsGranted = false, Name = "MyPermission8" }
+                }
+            });
+
+        _testPermissionManagementProvider.CheckCalls.ShouldNotBeEmpty();
+        _testPermissionManagementProvider.CheckCalls.ShouldAllBe(x => x.Length == 4);
+
+        (await _permissionGrantRepository.FindAsync("MyPermission1", "Test", "Test")).ShouldNotBeNull();
+        (await _permissionGrantRepository.FindAsync("MyPermission2", "Test", "Test")).ShouldBeNull();
+        (await _permissionGrantRepository.FindAsync("MyPermission7", "Test", "Test")).ShouldNotBeNull();
+        (await _permissionGrantRepository.FindAsync("MyPermission8", "Test", "Test")).ShouldBeNull();
     }
 
     [Fact]

--- a/modules/permission-management/test/Volo.Abp.PermissionManagement.Domain.Tests/Volo/Abp/PermissionManagement/PermissionManager_Tests.cs
+++ b/modules/permission-management/test/Volo.Abp.PermissionManagement.Domain.Tests/Volo/Abp/PermissionManagement/PermissionManager_Tests.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Shouldly;
 using Volo.Abp.Authorization.Permissions;
+using Volo.Abp.MultiTenancy;
 using Xunit;
 
 namespace Volo.Abp.PermissionManagement;
@@ -13,11 +14,15 @@ public class PermissionManager_Tests : PermissionTestBase
 {
     private readonly IPermissionManager _permissionManager;
     private readonly IPermissionGrantRepository _permissionGrantRepository;
+    private readonly TestPermissionManagementProvider _testPermissionManagementProvider;
+    private readonly ICurrentTenant _currentTenant;
 
     public PermissionManager_Tests()
     {
         _permissionManager = GetRequiredService<IPermissionManager>();
         _permissionGrantRepository = GetRequiredService<IPermissionGrantRepository>();
+        _testPermissionManagementProvider = GetRequiredService<TestPermissionManagementProvider>();
+        _currentTenant = GetRequiredService<ICurrentTenant>();
     }
 
     [Fact]
@@ -123,6 +128,260 @@ public class PermissionManager_Tests : PermissionTestBase
         (await _permissionGrantRepository.FindAsync("MyPermission2",
             "Test",
             "Test")).ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task Multiple_SetAsync()
+    {
+        await _permissionManager.SetAsync(
+            new[]
+            {
+                new KeyValuePair<string, bool>("MyPermission1", true),
+                new KeyValuePair<string, bool>("MyPermission2", true)
+            },
+            "Test",
+            "Test");
+
+        (await _permissionGrantRepository.FindAsync("MyPermission1", "Test", "Test")).ShouldNotBeNull();
+        (await _permissionGrantRepository.FindAsync("MyPermission2", "Test", "Test")).ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task Multiple_SetAsync_Should_Grant_And_Revoke_Together()
+    {
+        await _permissionGrantRepository.InsertAsync(new PermissionGrant(
+            Guid.NewGuid(),
+            "MyPermission1",
+            "Test",
+            "Test")
+        );
+
+        await _permissionManager.SetAsync(
+            new[]
+            {
+                new KeyValuePair<string, bool>("MyPermission1", false),
+                new KeyValuePair<string, bool>("MyPermission2", true)
+            },
+            "Test",
+            "Test");
+
+        (await _permissionGrantRepository.FindAsync("MyPermission1", "Test", "Test")).ShouldBeNull();
+        (await _permissionGrantRepository.FindAsync("MyPermission2", "Test", "Test")).ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task Multiple_SetAsync_Should_Do_Nothing_When_No_Permission_Is_Passed()
+    {
+        await _permissionManager.SetAsync(
+            Array.Empty<KeyValuePair<string, bool>>(),
+            "Test",
+            "Test");
+
+        _testPermissionManagementProvider.CheckCalls.ShouldBeEmpty();
+        _testPermissionManagementProvider.SetCalls.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Multiple_SetAsync_Should_Query_The_Current_State_Only_Once()
+    {
+        await _permissionManager.SetAsync(
+            new[]
+            {
+                new KeyValuePair<string, bool>("MyPermission1", true),
+                new KeyValuePair<string, bool>("MyPermission2", true),
+                new KeyValuePair<string, bool>("MyPermission7", true),
+                new KeyValuePair<string, bool>("MyPermission8", true)
+            },
+            "Test",
+            "Test");
+
+        _testPermissionManagementProvider.CheckCalls.ShouldHaveSingleItem();
+        _testPermissionManagementProvider.CheckCalls.Single().ShouldBe(
+            new[] { "MyPermission1", "MyPermission2", "MyPermission7", "MyPermission8" });
+    }
+
+    [Fact]
+    public async Task Multiple_SetAsync_Should_Throw_Exception_If_A_Permission_Is_Not_Compatible_With_The_Multi_Tenancy_Side()
+    {
+        using (_currentTenant.Change(Guid.NewGuid()))
+        {
+            var exception = await Assert.ThrowsAsync<ApplicationException>(async () =>
+            {
+                await _permissionManager.SetAsync(
+                    new[]
+                    {
+                        new KeyValuePair<string, bool>("MyPermission1", true),
+                        new KeyValuePair<string, bool>("MyPermission3", true)
+                    },
+                    "Test",
+                    "Test");
+            });
+
+            exception.Message.ShouldContain("MyPermission3");
+            exception.Message.ShouldContain("multitenancy side");
+            _testPermissionManagementProvider.SetCalls.ShouldBeEmpty();
+        }
+    }
+
+    [Fact]
+    public async Task Multiple_SetAsync_Should_Not_Write_Unchanged_Permissions()
+    {
+        await _permissionGrantRepository.InsertAsync(new PermissionGrant(
+            Guid.NewGuid(),
+            "MyPermission1",
+            "Test",
+            "Test")
+        );
+
+        await _permissionManager.SetAsync(
+            new[]
+            {
+                new KeyValuePair<string, bool>("MyPermission1", true),
+                new KeyValuePair<string, bool>("MyPermission2", false)
+            },
+            "Test",
+            "Test");
+
+        _testPermissionManagementProvider.SetCalls.ShouldBeEmpty();
+        (await _permissionGrantRepository.FindAsync("MyPermission1", "Test", "Test")).ShouldNotBeNull();
+        (await _permissionGrantRepository.FindAsync("MyPermission2", "Test", "Test")).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Multiple_SetAsync_Should_Only_Write_Changed_Permissions()
+    {
+        await _permissionGrantRepository.InsertAsync(new PermissionGrant(
+            Guid.NewGuid(),
+            "MyPermission1",
+            "Test",
+            "Test")
+        );
+
+        await _permissionManager.SetAsync(
+            new[]
+            {
+                new KeyValuePair<string, bool>("MyPermission1", true),
+                new KeyValuePair<string, bool>("MyPermission2", true)
+            },
+            "Test",
+            "Test");
+
+        _testPermissionManagementProvider.SetCalls.ShouldHaveSingleItem();
+        _testPermissionManagementProvider.SetCalls.Single().Key.ShouldBe("MyPermission2");
+        _testPermissionManagementProvider.SetCalls.Single().Value.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Multiple_SetAsync_Should_Use_The_Last_State_Of_A_Repeated_Permission()
+    {
+        await _permissionManager.SetAsync(
+            new[]
+            {
+                new KeyValuePair<string, bool>("MyPermission1", true),
+                new KeyValuePair<string, bool>("MyPermission1", false)
+            },
+            "Test",
+            "Test");
+
+        /* The last state is "not granted", which is also the current state, so nothing is written. */
+        _testPermissionManagementProvider.SetCalls.ShouldBeEmpty();
+        (await _permissionGrantRepository.FindAsync("MyPermission1", "Test", "Test")).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Multiple_SetAsync_Should_Throw_Exception_If_A_Permission_Is_Disabled_By_A_State_Checker()
+    {
+        var exception = await Assert.ThrowsAsync<ApplicationException>(async () =>
+        {
+            await _permissionManager.SetAsync(
+                new[]
+                {
+                    new KeyValuePair<string, bool>("MyPermission1", true),
+                    new KeyValuePair<string, bool>("MyPermission5", true)
+                },
+                "Test",
+                "Test");
+        });
+
+        exception.Message.ShouldBe("The permission named 'MyPermission5' is disabled!");
+        _testPermissionManagementProvider.SetCalls.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Multiple_SetAsync_Should_Throw_Exception_If_A_Permission_Is_Not_Compatible_With_The_Provider()
+    {
+        var exception = await Assert.ThrowsAsync<ApplicationException>(async () =>
+        {
+            await _permissionManager.SetAsync(
+                new[]
+                {
+                    new KeyValuePair<string, bool>("MyPermission1", true),
+                    new KeyValuePair<string, bool>("MyPermission4", true)
+                },
+                "Test",
+                "Test");
+        });
+
+        exception.Message.ShouldBe("The permission named 'MyPermission4' is not compatible with the provider named 'Test'");
+        _testPermissionManagementProvider.SetCalls.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Multiple_SetAsync_Should_Not_Write_Anything_When_A_Permission_Is_Disabled()
+    {
+        var exception = await Assert.ThrowsAsync<ApplicationException>(async () =>
+        {
+            await _permissionManager.SetAsync(
+                new[]
+                {
+                    new KeyValuePair<string, bool>("MyPermission1", true),
+                    new KeyValuePair<string, bool>("MyDisabledPermission1", true)
+                },
+                "Test",
+                "Test");
+        });
+
+        exception.Message.ShouldBe("The permission named 'MyDisabledPermission1' is disabled!");
+        _testPermissionManagementProvider.SetCalls.ShouldBeEmpty();
+        (await _permissionGrantRepository.FindAsync("MyPermission1", "Test", "Test")).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Multiple_Set_Should_Silently_Ignore_When_Permission_Undefined()
+    {
+        await _permissionManager.SetAsync(
+            new[]
+            {
+                new KeyValuePair<string, bool>("MyPermission1NotExist", true),
+                new KeyValuePair<string, bool>("MyPermission1", true)
+            },
+            "Test",
+            "Test");
+
+        (await _permissionGrantRepository.FindAsync("MyPermission1", "Test", "Test")).ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task Multiple_Set_Should_Throw_Exception_If_Provider_Not_Found()
+    {
+        var exception = await Assert.ThrowsAsync<AbpException>(async () =>
+        {
+            await _permissionManager.SetAsync(
+                new[] { new KeyValuePair<string, bool>("MyPermission1", true) },
+                "UndefinedProvider",
+                "Test");
+        });
+
+        exception.Message.ShouldBe("Unknown permission management provider: UndefinedProvider");
+    }
+
+    [Fact]
+    public async Task Multiple_Set_Should_Not_Throw_Exception_If_Provider_Not_Found_But_Nothing_Changed()
+    {
+        await _permissionManager.SetAsync(
+            new[] { new KeyValuePair<string, bool>("MyPermission1", false) },
+            "UndefinedProvider",
+            "Test");
     }
 
     [Fact]

--- a/modules/permission-management/test/Volo.Abp.PermissionManagement.TestBase/Volo/Abp/PermissionManagement/TestPermissionManagementProvider.cs
+++ b/modules/permission-management/test/Volo.Abp.PermissionManagement.TestBase/Volo/Abp/PermissionManagement/TestPermissionManagementProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
 using Volo.Abp.Guids;
 using Volo.Abp.MultiTenancy;
 
@@ -9,6 +10,10 @@ namespace Volo.Abp.PermissionManagement;
 public class TestPermissionManagementProvider : PermissionManagementProvider
 {
     public override string Name => "Test";
+
+    public List<KeyValuePair<string, bool>> SetCalls { get; } = new List<KeyValuePair<string, bool>>();
+
+    public List<string[]> CheckCalls { get; } = new List<string[]>();
 
     public TestPermissionManagementProvider(
         IPermissionGrantRepository permissionGrantRepository,
@@ -20,5 +25,17 @@ public class TestPermissionManagementProvider : PermissionManagementProvider
             currentTenant)
     {
 
+    }
+
+    public override Task SetAsync(string name, string providerKey, bool isGranted)
+    {
+        SetCalls.Add(new KeyValuePair<string, bool>(name, isGranted));
+        return base.SetAsync(name, providerKey, isGranted);
+    }
+
+    public override Task<MultiplePermissionValueProviderGrantInfo> CheckAsync(string[] names, string providerName, string providerKey)
+    {
+        CheckCalls.Add(names);
+        return base.CheckAsync(names, providerName, providerKey);
     }
 }


### PR DESCRIPTION
Resolve #26117

`PermissionAppService.UpdateAsync` queried the current state once per permission, so saving the permission modal ran one database round-trip per submitted permission. It now reads the whole set once and writes only the changed permissions.

`DisableTracking` was silently ignored by the repositories whose queries start from `GetDbSetAsync()` instead of `GetQueryableAsync()`, which made the batched read track every row.