### PR TITLE
Improve the child unit of work and enum adapter tests

### DIFF
--- a/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/DataAnnotations/AbpValidationAttributeAdapterProvider_Tests.cs
+++ b/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/DataAnnotations/AbpValidationAttributeAdapterProvider_Tests.cs
@@ -17,7 +17,7 @@ public class AbpValidationAttributeAdapterProvider_Tests
     [Fact]
     public void Should_Return_An_Adapter_For_The_EnumDataTypeAttribute()
     {
-        //The default ASP.NET Core provider returns null for it, that's why we supply our own adapter.
+        //ABP supplies its own adapter for the EnumDataTypeAttribute.
         _provider.GetAttributeAdapter(new EnumDataTypeAttribute(typeof(MyEnum)), null)
             .ShouldBeOfType<EnumDataTypeAttributeAdapter>();
     }

--- a/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/DataAnnotations/AbpValidationAttributeAdapterProvider_Tests.cs
+++ b/framework/test/Volo.Abp.AspNetCore.Mvc.Tests/Volo/Abp/AspNetCore/Mvc/DataAnnotations/AbpValidationAttributeAdapterProvider_Tests.cs
@@ -17,11 +17,7 @@ public class AbpValidationAttributeAdapterProvider_Tests
     [Fact]
     public void Should_Return_An_Adapter_For_The_EnumDataTypeAttribute()
     {
-        //ASP.NET Core does not provide an adapter for the EnumDataTypeAttribute.
-        new ValidationAttributeAdapterProvider()
-            .GetAttributeAdapter(new EnumDataTypeAttribute(typeof(MyEnum)), null)
-            .ShouldBeNull();
-
+        //The default ASP.NET Core provider returns null for it, that's why we supply our own adapter.
         _provider.GetAttributeAdapter(new EnumDataTypeAttribute(typeof(MyEnum)), null)
             .ShouldBeOfType<EnumDataTypeAttributeAdapter>();
     }

--- a/framework/test/Volo.Abp.Uow.Tests/Volo/Abp/Uow/UnitOfWork_Child_Events_Tests.cs
+++ b/framework/test/Volo.Abp.Uow.Tests/Volo/Abp/Uow/UnitOfWork_Child_Events_Tests.cs
@@ -56,6 +56,32 @@ public class UnitOfWork_Child_Events_Tests : AbpIntegratedTest<AbpUnitOfWorkModu
         disposed.ShouldBeTrue();
     }
 
+    [Fact]
+    public void Should_Not_Trigger_Disposed_Event_Unsubscribed_Over_A_Child_UnitOfWork()
+    {
+        var disposed = false;
+
+        using (var parentUow = _unitOfWorkManager.Begin())
+        {
+            var handlerCount = GetEventHandlerCount(parentUow, nameof(IUnitOfWork.Disposed));
+
+            using (var childUow = _unitOfWorkManager.Begin())
+            {
+                childUow.Disposed += OnDisposed;
+                childUow.Disposed -= OnDisposed;
+            }
+
+            GetEventHandlerCount(parentUow, nameof(IUnitOfWork.Disposed)).ShouldBe(handlerCount);
+        }
+
+        disposed.ShouldBeFalse();
+
+        void OnDisposed(object? sender, UnitOfWorkEventArgs args)
+        {
+            disposed = true;
+        }
+    }
+
     private static int GetEventHandlerCount(IUnitOfWork unitOfWork, string eventName)
     {
         var field = unitOfWork.GetType().GetField(eventName, BindingFlags.Instance | BindingFlags.NonPublic);

--- a/framework/test/Volo.Abp.Uow.Tests/Volo/Abp/Uow/UnitOfWork_Child_Events_Tests.cs
+++ b/framework/test/Volo.Abp.Uow.Tests/Volo/Abp/Uow/UnitOfWork_Child_Events_Tests.cs
@@ -67,6 +67,8 @@ public class UnitOfWork_Child_Events_Tests : AbpIntegratedTest<AbpUnitOfWorkModu
 
             using (var childUow = _unitOfWorkManager.Begin())
             {
+                childUow.Id.ShouldBe(parentUow.Id); //It's a child of the parent UOW.
+
                 childUow.Disposed += OnDisposed;
                 childUow.Disposed -= OnDisposed;
             }


### PR DESCRIPTION
The `ChildUnitOfWork` event `remove` accessor had no test coverage. The enum adapter test also asserted that the default ASP.NET Core provider returns no adapter, which would fail if that provider ever gains one, without ABP being broken.