### PR TITLE
Remove duplicate article headings

### DIFF
--- a/docs/en/Community-Articles/2026-09-02-abp-studio-vs-aspire-ai-ides-and-crud-generators/Post.md
+++ b/docs/en/Community-Articles/2026-09-02-abp-studio-vs-aspire-ai-ides-and-crud-generators/Post.md
@@ -1,5 +1,3 @@
-# ABP Studio vs .NET Aspire, AI IDEs, and CRUD generators
-
 You already have an IDE. You might already have Aspire. You might already have Cursor. The remaining question is how those tools handle ABP solution structure, modules, run profiles, and generated application code.
 
 Teams compare [ABP Studio](https://abp.io/studio) with three neighbors. This is not an “IDE replacement” debate.

--- a/docs/en/Community-Articles/2026-09-02-abp-vs-clean-architecture-templates-and-starter-kits/Post.md
+++ b/docs/en/Community-Articles/2026-09-02-abp-vs-clean-architecture-templates-and-starter-kits/Post.md
@@ -1,5 +1,3 @@
-# ABP vs Clean Architecture templates, starter kits, and DIY ASP.NET Core
-
 Every serious .NET team hits the same whiteboard sooner or later. Do we build the multi-tenant SaaS from scratch? Grab a starter kit? Adopt a platform?
 
 Search “ABP vs …” and you will land on pages written by kits and tenancy libraries. Fair. Those pages exist because the question is real. They are not comparing two products of the same kind.


### PR DESCRIPTION
Drop the top-level markdown titles from two community article posts so the content starts directly with the article body, matching the expected docs/article rendering format.
