### PR TITLE
Show warning when stale cached docs are displayed

### DIFF
--- a/modules/docs/src/Volo.Docs.Application.Contracts/Volo/Docs/Documents/DocumentWithDetailsDto.cs
+++ b/modules/docs/src/Volo.Docs.Application.Contracts/Volo/Docs/Documents/DocumentWithDetailsDto.cs
@@ -34,6 +34,8 @@ namespace Volo.Docs.Documents
 
         public virtual DateTime LastCachedTime { get; set; }
 
+        public virtual bool IsStaleCacheFallback { get; set; }
+
         public ProjectDto Project { get; set; }
 
         public List<DocumentContributorDto> Contributors { get; set; }

--- a/modules/docs/src/Volo.Docs.Application/Volo/Docs/DocsApplicationMappers.cs
+++ b/modules/docs/src/Volo.Docs.Application/Volo/Docs/DocsApplicationMappers.cs
@@ -43,9 +43,11 @@ public partial class DocumentToDocumentWithDetailsDtoMapper : MapperBase<Documen
 {
     [MapperIgnoreTarget(nameof(DocumentWithDetailsDto.Project))]
     [MapperIgnoreTarget(nameof(DocumentWithDetailsDto.Contributors))]
+    [MapperIgnoreTarget(nameof(DocumentWithDetailsDto.IsStaleCacheFallback))]
     public override partial DocumentWithDetailsDto Map(Document source);
 
     [MapperIgnoreTarget(nameof(DocumentWithDetailsDto.Project))]
     [MapperIgnoreTarget(nameof(DocumentWithDetailsDto.Contributors))]
+    [MapperIgnoreTarget(nameof(DocumentWithDetailsDto.IsStaleCacheFallback))]
     public override partial void Map(Document source, DocumentWithDetailsDto destination);
 }

--- a/modules/docs/src/Volo.Docs.Application/Volo/Docs/Documents/DocumentAppService.cs
+++ b/modules/docs/src/Volo.Docs.Application/Volo/Docs/Documents/DocumentAppService.cs
@@ -390,7 +390,9 @@ namespace Volo.Docs.Documents
                 Logger.LogWarning(
                     "Could not retrieve the document ({documentName}, {languageCode}, {version}) from the source. Using the cached version.",
                     documentName, languageCode, version);
-                return CreateDocumentWithDetailsDto(project, document);
+                var documentDto = CreateDocumentWithDetailsDto(project, document);
+                documentDto.IsStaleCacheFallback = true;
+                return documentDto;
             }
         }
 

--- a/modules/docs/src/Volo.Docs.Domain/Volo/Docs/Localization/Domain/en.json
+++ b/modules/docs/src/Volo.Docs.Domain/Volo/Docs/Localization/Domain/en.json
@@ -25,6 +25,7 @@
     "ProjectNotFound": "Oops, the requested project was not found!",
     "NavigationDocumentNotFound": "This version does not have a navigation document!",
     "DocumentNotFoundInSelectedLanguage": "Document in the language you wanted is not found. Document in the default language is shown.",
+    "StaleCacheFallbackWarning": "Document refresh failed. The displayed document may be outdated or incorrect.",
     "FilterTopics": "Filter topics",
     "FullSearch": "Search in documents",
     "Volo.Docs.Domain:010001": "Elastic search is not enabled.",

--- a/modules/docs/src/Volo.Docs.Web/Pages/Documents/Project/Index.cshtml
+++ b/modules/docs/src/Volo.Docs.Web/Pages/Documents/Project/Index.cshtml
@@ -301,6 +301,13 @@
     @if (Model.Document != null)
     {
         <div class="docs-content">
+            @if (Model.Document.IsStaleCacheFallback)
+            {
+                <abp-alert alert-type="Warning" dismissible="true" class="mb-3">
+                    @L["StaleCacheFallbackWarning"]
+                </abp-alert>
+            }
+
             <div class="top-container mb-3">
                 <div class="w-100">
                     <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">

--- a/modules/docs/test/Volo.Docs.Application.Tests/Volo/Docs/ApplicationService_Tests.cs
+++ b/modules/docs/test/Volo.Docs.Application.Tests/Volo/Docs/ApplicationService_Tests.cs
@@ -1,17 +1,27 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
+using NSubstitute;
 using Shouldly;
 using Volo.Docs.Common.Projects;
+using Volo.Docs.Documents;
+using Volo.Docs.GitHub.Documents;
 using Xunit;
 
 namespace Volo.Docs
 {
     public class ApplicationService_Tests : DocsApplicationTestBase
     {
+        private readonly IDocumentAppService _documentAppService;
+        private readonly IDocumentRepository _documentRepository;
+        private readonly IGithubRepositoryManager _githubRepositoryManager;
         private readonly IProjectAppService _projectAppService;
         private readonly DocsTestData _testData;
 
         public ApplicationService_Tests()
         {
+            _documentAppService = GetRequiredService<IDocumentAppService>();
+            _documentRepository = GetRequiredService<IDocumentRepository>();
+            _githubRepositoryManager = GetRequiredService<IGithubRepositoryManager>();
             _projectAppService = GetRequiredService<IProjectAppService>();
             _testData = GetRequiredService<DocsTestData>();
         }
@@ -40,6 +50,66 @@ namespace Volo.Docs
             versions.ShouldNotBeNull();
             versions.Items.Count.ShouldBe(1);
             versions.Items.ShouldContain(x => x.Name == "0.15.0" && x.DisplayName == "0.15.0");
+        }
+
+        [Fact]
+        public async Task GetAsync_Should_Not_Set_Stale_Cache_Fallback_Flag_For_Fresh_Cache()
+        {
+            var document = await _documentAppService.GetAsync(CreateDocumentInput());
+
+            document.IsStaleCacheFallback.ShouldBeFalse();
+            document.Content.ShouldBe("this is abp cli");
+        }
+
+        [Fact]
+        public async Task GetAsync_Should_Set_Stale_Cache_Fallback_Flag_When_Refresh_Fails()
+        {
+            await MakeDocumentStaleAsync();
+            ConfigureRefreshFailure();
+
+            var document = await _documentAppService.GetAsync(CreateDocumentInput());
+
+            document.IsStaleCacheFallback.ShouldBeTrue();
+            document.Content.ShouldBe("this is abp cli");
+        }
+
+        [Fact]
+        public async Task GetAsync_Should_Not_Set_Stale_Cache_Fallback_Flag_When_Refresh_Succeeds()
+        {
+            await MakeDocumentStaleAsync();
+
+            var document = await _documentAppService.GetAsync(CreateDocumentInput());
+
+            document.IsStaleCacheFallback.ShouldBeFalse();
+            document.Content.ShouldBe("stringContent");
+        }
+
+        private GetDocumentInput CreateDocumentInput()
+        {
+            return new GetDocumentInput
+            {
+                ProjectId = _testData.ProjectId,
+                Name = "CLI.md",
+                LanguageCode = "en",
+                Version = "2.0.0"
+            };
+        }
+
+        private async Task MakeDocumentStaleAsync()
+        {
+            await _documentRepository.UpdateProjectLastCachedTimeAsync(_testData.ProjectId, DateTime.MinValue);
+        }
+
+        private void ConfigureRefreshFailure()
+        {
+            _githubRepositoryManager.GetFileRawStringContentAsync(
+                    Arg.Is<string>(url =>
+                        url.EndsWith("/en/CLI.md", StringComparison.OrdinalIgnoreCase) ||
+                        url.EndsWith("/en/CLI/index.md", StringComparison.OrdinalIgnoreCase) ||
+                        url.EndsWith("/en/CLI/Index.md", StringComparison.OrdinalIgnoreCase)),
+                    Arg.Any<string>(),
+                    Arg.Any<string>())
+                .Returns(_ => Task.FromException<string>(new Exception("Simulated refresh failure")));
         }
     }
 }

--- a/modules/docs/test/Volo.Docs.Application.Tests/Volo/Docs/DocsApplicationTestModule.cs
+++ b/modules/docs/test/Volo.Docs.Application.Tests/Volo/Docs/DocsApplicationTestModule.cs
@@ -1,4 +1,7 @@
-﻿using Volo.Abp.Modularity;
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NSubstitute;
+using Volo.Abp.Modularity;
 
 namespace Volo.Docs
 {
@@ -8,6 +11,11 @@ namespace Volo.Docs
         )]
     public class DocsApplicationTestModule : AbpModule
     {
-
+        public override void ConfigureServices(ServiceConfigurationContext context)
+        {
+            var hostEnvironment = Substitute.For<IHostEnvironment>();
+            hostEnvironment.EnvironmentName.Returns(Environments.Production);
+            context.Services.AddSingleton(hostEnvironment);
+        }
     }
 }


### PR DESCRIPTION
### Description

Resolves #20271

When refreshing an expired cached document fails, the Docs application service now marks the returned fallback DTO with `IsStaleCacheFallback`. The MVC document page uses that flag to show a localized warning that the displayed document may be outdated or incorrect.

Fresh cached documents and successfully refreshed documents keep the flag false. The DTO change is additive, and the existing cache refresh and fallback behavior is unchanged.

### Checklist

- [x] I fully tested it as developer / designer and created unit / integration tests
- [x] No external documentation change is needed; the user-facing behavior is explained by the localized warning

### How to test it?

Run:

```powershell
dotnet test .\modules\docs\test\Volo.Docs.Application.Tests\Volo.Docs.Application.Tests.csproj --filter FullyQualifiedName~ApplicationService_Tests
dotnet build .\modules\docs\src\Volo.Docs.Web\Volo.Docs.Web.csproj
```

The application-service suite covers fresh cache, successful stale-cache refresh, and failed refresh with old-cache fallback. All 6 tests pass, and the Docs web project builds with 0 errors.
