### PR TITLE
Upgrade `MongoDB.Driver` to 3.11.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -124,7 +124,7 @@
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.19.2" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.19.2" />
     <PackageVersion Include="Minio" Version="6.0.5" />
-    <PackageVersion Include="MongoDB.Driver" Version="3.11.1" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.11.2" />
     <PackageVersion Include="NEST" Version="7.17.5" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="Nito.AsyncEx.Context" Version="5.1.2" />

--- a/docs/en/package-version-changes.md
+++ b/docs/en/package-version-changes.md
@@ -7,6 +7,12 @@
 
 # Package Version Changes
 
+## 10.7.0-rc.4
+
+| Package | Old Version | New Version | PR |
+|---------|-------------|-------------|-----|
+| MongoDB.Driver | 3.11.1 | 3.11.2 | #26155 |
+
 ## 10.7.0-rc.3
 
 | Package | Old Version | New Version | PR |

--- a/docs/en/release-info/migration-guides/abp-10-7.md
+++ b/docs/en/release-info/migration-guides/abp-10-7.md
@@ -216,7 +216,7 @@ Until you can upgrade, give every authorization server its own client signing ke
 - `Microsoft.AspNetCore.DataProtection` is added as a direct dependency.
 - MudBlazor is upgraded from **9.4.0** to **9.7.0**, and the Blazorise packages from **2.2.1** to **2.3.0**.
 - `MySql.EntityFrameworkCore` is upgraded from **10.0.1** to **10.0.9**.
-- `MongoDB.Driver` is upgraded from **3.10.0** to **3.11.1**, and `AWSSDK.S3` and `AWSSDK.SecurityToken` to their current versions.
+- `MongoDB.Driver` is upgraded from **3.10.0** to **3.11.2**, and `AWSSDK.S3` and `AWSSDK.SecurityToken` to their current versions.
 - ABP maps `Guid[]` query parameters through its own type mapping plugin on MySQL, and stores `IdentityUserPasskey.Data` as a serialized `json` column, because the MySQL providers support neither EF Core JSON columns nor primitive collections. The column name and the stored content stay the same.
 
 **What to do**


### PR DESCRIPTION
Security patch release, it fixes CVE-2026-88026 (regex injection in the LINQ character-set translation) and CVE-2026-88025 (exact file ID match in GridFS delete). No public API changes.