### PR TITLE
Don't fail startup when static web assets can not be loaded

### DIFF
--- a/framework/src/Volo.Abp.AspNetCore/Volo/Abp/AspNetCore/AbpAspNetCoreModule.cs
+++ b/framework/src/Volo.Abp.AspNetCore/Volo/Abp/AspNetCore/AbpAspNetCoreModule.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging;
 using MyCSharp.HttpUserAgentParser.DependencyInjection;
 using Volo.Abp.AspNetCore.Auditing;
 using Volo.Abp.AspNetCore.VirtualFileSystem;
@@ -64,7 +65,14 @@ public class AbpAspNetCoreModule : AbpModule
         context.Services.AddObjectAccessor<IEndpointRouteBuilder>();
         context.Services.AddAbpDynamicOptions<RequestLocalizationOptions, AbpRequestLocalizationOptionsManager>();
 
-        StaticWebAssetsLoader.UseStaticWebAssets(context.Services.GetHostingEnvironment(), context.Services.GetConfiguration());
+        try
+        {
+            StaticWebAssetsLoader.UseStaticWebAssets(context.Services.GetHostingEnvironment(), context.Services.GetConfiguration());
+        }
+        catch (Exception ex)
+        {
+            context.Services.GetInitLogger<AbpAspNetCoreModule>().LogWarning(ex, "Could not load the static web assets manifest, static web assets will not be available. This usually happens when the application runs with build output instead of publish output.");
+        }
 
         context.Services.AddHttpUserAgentCachedParser();
     }


### PR DESCRIPTION
`StaticWebAssetsLoader.UseStaticWebAssets` throws if the manifest points to a path that does not exist on the running machine, which aborts the application startup in `AbpAspNetCoreModule.ConfigureServices`. Log a warning and continue instead.