### PR TITLE
Update React dependencies with abp update (rel-10.6)

### DIFF
--- a/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/PackageJsonFileFinder.cs
+++ b/framework/src/Volo.Abp.Cli.Core/Volo/Abp/Cli/ProjectModification/PackageJsonFileFinder.cs
@@ -33,6 +33,8 @@ public class PackageJsonFileFinder : ITransientDependency
 
         return
             Directory.GetFiles(directory, "*.csproj", searchOption: SearchOption.TopDirectoryOnly).Any() ||
-            File.Exists(Path.Combine(directory, "angular.json"));
+            File.Exists(Path.Combine(directory, "angular.json")) ||
+            File.Exists(Path.Combine(directory, "vite.config.ts")) ||
+            File.Exists(Path.Combine(directory, "next.config.ts"));
     }
 }

--- a/framework/test/Volo.Abp.Cli.Core.Tests/Volo/Abp/Cli/ProjectModification/PackageJsonFileFinder_Tests.cs
+++ b/framework/test/Volo.Abp.Cli.Core.Tests/Volo/Abp/Cli/ProjectModification/PackageJsonFileFinder_Tests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.IO;
+using Shouldly;
+using Volo.Abp.Cli.ProjectModification;
+using Xunit;
+
+namespace Volo.Abp.Cli;
+
+public class PackageJsonFileFinder_Tests
+{
+    [Theory]
+    [InlineData("Test.csproj", true)]
+    [InlineData("angular.json", true)]
+    [InlineData("vite.config.ts", true)]
+    [InlineData("next.config.ts", true)]
+    [InlineData("", false)]
+    public void Should_Find_Package_Json_For_Supported_Project_Types(string projectFileName, bool expected)
+    {
+        var testDirectory = Path.Combine(Path.GetTempPath(), "abp-cli-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(testDirectory);
+
+        try
+        {
+            var packageJsonPath = Path.Combine(testDirectory, "package.json");
+            File.WriteAllText(packageJsonPath, "{}");
+
+            if (!projectFileName.IsNullOrEmpty())
+            {
+                File.WriteAllText(Path.Combine(testDirectory, projectFileName), string.Empty);
+            }
+
+            var result = new PackageJsonFileFinder().Find(testDirectory);
+
+            result.Contains(packageJsonPath).ShouldBe(expected);
+        }
+        finally
+        {
+            Directory.Delete(testDirectory, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
Backport of #25990 to `rel-10.6`.

`abp update` now also updates React project dependencies by including the React `package.json` files in `PackageJsonFileFinder`.